### PR TITLE
Improve the JVM blocking in IOPlatform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 
 # Ignore [ce]tags files
 tags
+.idea

--- a/core/jvm/src/main/scala/cats/effect/IOPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOPlatform.scala
@@ -17,28 +17,57 @@
 package cats
 package effect
 
-import scala.concurrent.duration.Duration
+import java.util.concurrent.locks.AbstractQueuedSynchronizer
+import scala.concurrent.blocking
+import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.Either
 
-import java.util.concurrent.{CountDownLatch, TimeUnit}
-import java.util.concurrent.atomic.AtomicReference
-
 private[effect] object IOPlatform {
-
+  /** 
+   * JVM-specific function that blocks for the result of an IO task.
+   *
+   * Uses the [[scala.concurrent.BlockContext]], instructing the
+   * underlying thread-pool that this is a blocking operation, thus
+   * allowing for defensive measures, like adding more threads or
+   * executing other queued tasks first.
+   */
   def unsafeResync[A](ioa: IO[A], limit: Duration): Option[A] = {
-    val latch = new CountDownLatch(1)
-    val ref = new AtomicReference[Either[Throwable, A]](null)
+    val latch = new OneShotLatch
+    var ref: Either[Throwable, A] = null
 
     ioa unsafeRunAsync { a =>
-      ref.set(a)
-      latch.countDown()
+      // Reading from `ref` happens after the block on `latch` is
+      // over, there's a happens-before relationship, so no extra
+      // synchronization is needed for visibility
+      ref = a
+      latch.releaseShared(1)
     }
 
-    if (limit == Duration.Inf)
-      latch.await()
-    else
-      latch.await(limit.toMillis, TimeUnit.MILLISECONDS)
+    limit match {
+      case e if e eq Duration.Undefined =>
+        throw new IllegalArgumentException("Cannot wait for Undefined period")
+      case Duration.Inf =>
+        blocking(latch.acquireSharedInterruptibly(1))
+      case f: FiniteDuration if f > Duration.Zero =>
+        blocking(latch.tryAcquireSharedNanos(1, f.toNanos))
+      case _ =>
+        () // Do nothing
+    }
 
-    Option(ref.get()).map(_.fold(throw _, a => a))
+    ref match {
+      case null => None
+      case Right(a) => Some(a)
+      case Left(ex) => throw ex
+    }
+  }
+
+  private final class OneShotLatch extends AbstractQueuedSynchronizer {
+    override protected def tryAcquireShared(ignored: Int): Int =
+      if (getState != 0) 1 else -1
+
+    override protected def tryReleaseShared(ignore: Int): Boolean = {
+      setState(1)
+      true
+    }
   }
 }


### PR DESCRIPTION
The original implementation does not use Scala's [BlockContext](http://www.scala-lang.org/api/current/scala/concurrent/BlockContext.html).

I know that the original rationale for providing `unsafeRunSync` is that this method should be executed at the "*edge of the program*", however that differs from user to use ... e.g. if somebody uses Play Framework, the edge of the program might be the end of the controller `Action`.

Users are also unpredictable. You might preach to them that they should describe whole pure programs as `IO` through composition and then evaluate that only once in `main`, however the fact is that many users won't do that.

Using Scala's `BlockContext` has the benefit that it instructs the underlying thread-pool (if there is one that is listening) to take defensive measures. This alleviates the error-proneness of blocking. For example this code dead-locks and it's not obvious why, unless you look at the thread-pool's configuration:

```scala
implicit val ec = ExecutionContext
  .fromExecutor(Executors.newFixedThreadPool(1))

def addOne(x: Int) = Future(x + 1)

def multiply(x: Int, y: Int) = Future {
  val a = addOne(x)
  val b = addOne(y)
  val result = for (r1 <- a; r2 <- b) yield r1 * r2

  // This can dead-lock due to the limited size 
  // of our thread-pool!
  Await.result(result, Duration.Inf)
}
```

And given that Scala's `global` is by default limited to a number of threads directly proportional to the number of CPU cores, it really needs this hint.

What implementing `ExecutionContext` implementations can do when observing a blocking operation is:

1. to add more threads in the thread-pool, which is what Scala's `global` does
2. to execute other enqueued tasks first, in order to prevent a deadlock by waiting for a callback that's already scheduled but that can't execute

So if we provide a blocking operation, at least it should play nice with Scala's standard mechanism
for coping with blocking operations.

Other changes:

- changed the implementation to use a `AbstractQueuedSynchronizer`, which is what the `CountDownLatch` is based on, to remove some overhead - Scala's `Future` does the same thing
- `ref` does not need to be an `AtomicReference`, it does not need extra synchronisation, because there's a happens before relationship between its assignment and the `latch`, on which we block on the consumer's side, so we have `volatile` acquire / release semantics there
- this is low level stuff, a manual `match` is in order versus a `.map(_.fold(...))` ... not everything needs to be elegant and actually I find that match more readable