### PR TITLE
Remove "throw in register" law to avoid over-constraining impls

### DIFF
--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -30,9 +30,6 @@ trait AsyncLaws[F[_]] extends MonadErrorLaws[F, Throwable] {
   def asyncLeftIsRaiseError[A](t: Throwable) =
     F.async[A](_(Left(t))) <-> F.raiseError(t)
 
-  def thrownInRegisterIsRaiseError[A](t: Throwable) =
-    F.async[A](_ => throw t) <-> F.raiseError(t)
-
   def repeatedAsyncEvaluationNotMemoized[A](a: A, f: A => A) = {
     var cur = a
 

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
@@ -57,7 +57,6 @@ trait AsyncTests[F[_]] extends MonadErrorTests[F, Throwable] {
       val props = Seq(
         "async right is pure" -> forAll(laws.asyncRightIsPure[A] _),
         "async left is raiseError" -> forAll(laws.asyncLeftIsRaiseError[A] _),
-        "throw in register is raiseError" -> forAll(laws.thrownInRegisterIsRaiseError[A] _),
         "repeated async evaluation not memoized" -> forAll(laws.repeatedAsyncEvaluationNotMemoized[A] _))
     }
   }

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -22,6 +22,7 @@ import cats.kernel._
 import cats.kernel.laws.GroupLaws
 import cats.effect.laws.discipline.EffectTests
 
+import org.scalacheck._
 import org.scalatest._
 import org.typelevel.discipline.scalatest.Discipline
 
@@ -37,6 +38,12 @@ class IOTests extends FunSuite with Matchers with Discipline {
     run shouldEqual false
     ioa.unsafeRunSync()
     run shouldEqual true
+  }
+
+  test("throw in register is fail") {
+    Prop.forAll { t: Throwable =>
+      Eq[IO[Unit]].eqv(IO.async[Unit](_ => throw t), IO.fail(t))
+    }
   }
 
   test("catch exceptions within main block") {


### PR DESCRIPTION
We can add a the weakened version of the law (as suggested by @alexandru in #15) if we think there is value in that.  For the time being, I just removed the law and added a corresponding test on `IO`.