### PR TITLE
Fixes #11: Configure sbt-scoverage + Codecov.io for test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,14 @@ scala:
   - 2.11.11
   - 2.12.2
 
+env:
+  global:
+    - MAIN_SCALA_VERSION=2.11.11
+
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION ci
+  - project/travis-build.sh
+after_success:
+  - project/travis-post-build.sh
 
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cats-effect [![Build Status](https://travis-ci.org/typelevel/cats-effect.svg?branch=master)](https://travis-ci.org/typelevel/cats-effect) [![Gitter](https://img.shields.io/gitter/room/typelevel/cats.svg)](https://gitter.im/typelevel/cats) [![Maven Central](https://img.shields.io/maven-central/v/org.typelevel/cats-effect_2.12.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.typelevel%22%20AND%20a%3Acats-effect*)
+# cats-effect [![Build Status](https://travis-ci.org/typelevel/cats-effect.svg?branch=master)](https://travis-ci.org/typelevel/cats-effect) [![Gitter](https://img.shields.io/gitter/room/typelevel/cats.svg)](https://gitter.im/typelevel/cats) [![Maven Central](https://img.shields.io/maven-central/v/org.typelevel/cats-effect_2.12.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.typelevel%22%20AND%20a%3Acats-effect*) [![Coverage Status](https://codecov.io/gh/typelevel/cats-effect/coverage.svg?branch=master)](https://codecov.io/gh/typelevel/cats-effect?branch=master)
 
 > For when purity just isn't impure enough.
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,9 @@
 
 import de.heikoseeberger.sbtheader.license.Apache2_0
 
+import scala.xml.Elem
+import scala.xml.transform.{RewriteRule, RuleTransformer}
+
 organization in ThisBuild := "org.typelevel"
 
 val CatsVersion = "0.9.0"
@@ -57,7 +60,20 @@ val commonSettings = Seq(
 
   scmInfo := Some(ScmInfo(url("https://github.com/typelevel/cats-effect"), "git@github.com:typelevel/cats-effect.git")),
 
-  addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.3" cross CrossVersion.binary))
+  // For evicting Scoverage out of the generated POM
+  // See: https://github.com/scoverage/sbt-scoverage/issues/153
+  pomPostProcess := { (node: xml.Node) =>
+    new RuleTransformer(new RewriteRule {
+      override def transform(node: xml.Node): Seq[xml.Node] = node match {
+        case e: Elem
+          if e.label == "dependency" && e.child.exists(child => child.label == "groupId" && child.text == "org.scoverage") => Nil
+        case _ => Seq(node)
+      }
+    }).transform(node).head
+  },
+
+  addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.3" cross CrossVersion.binary)
+)
 
 val mimaSettings = Seq(
   mimaPreviousArtifacts := {
@@ -73,15 +89,27 @@ val mimaSettings = Seq(
   }
 )
 
+lazy val cmdlineProfile =
+  sys.props.getOrElse("sbt.profile", default = "")
+
+def profile: Project ⇒ Project = pr => cmdlineProfile match {
+  case "coverage" => pr
+  case _ => pr.disablePlugins(scoverage.ScoverageSbtPlugin)
+}
+
+lazy val scalaJSSettings = Seq(
+  coverageExcludedFiles := ".*"
+)
+
 lazy val root = project.in(file("."))
   .aggregate(coreJVM, coreJS, lawsJVM, lawsJS)
+  .configure(profile)
   .settings(
     publish := (),
     publishLocal := (),
     publishArtifact := false)
 
-lazy val core = crossProject
-  .in(file("core"))
+lazy val core = crossProject.in(file("core"))
   .settings(commonSettings: _*)
   .settings(
     name := "cats-effect",
@@ -101,7 +129,9 @@ lazy val core = crossProject
   .jsConfigure(_.enablePlugins(AutomateHeaderPlugin))
 
 lazy val coreJVM = core.jvm
+  .configure(profile)
 lazy val coreJS = core.js
+  .settings(scalaJSSettings)
 
 lazy val laws = crossProject
   .in(file("laws"))
@@ -120,7 +150,9 @@ lazy val laws = crossProject
   .jsConfigure(_.enablePlugins(AutomateHeaderPlugin))
 
 lazy val lawsJVM = laws.jvm
+  .configure(profile)
 lazy val lawsJS = laws.js
+  .settings(scalaJSSettings)
 
 /*
  * Compatibility version.  Use this to declare what version with

--- a/core/jvm/src/test/scala/cats/effect/IOJVMTests.scala
+++ b/core/jvm/src/test/scala/cats/effect/IOJVMTests.scala
@@ -79,7 +79,7 @@ class IOJVMTests extends FunSuite with Matchers {
     val received = never.unsafeRunTimed(100.millis)
     val elapsed = System.currentTimeMillis() - start
 
-    assert(received === None)
+    received shouldEqual None
     assert(elapsed >= 100)
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,5 +6,6 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "1.8.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype"    % "1.1")
 addSbtPlugin("com.jsuereth"   % "sbt-pgp"         % "1.0.0")
 addSbtPlugin("com.typesafe"   % "sbt-mima-plugin" % "0.1.14")
+addSbtPlugin("org.scoverage"  % "sbt-scoverage"   % "1.5.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")

--- a/project/travis-build.sh
+++ b/project/travis-build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+cd `dirname $0`/..
+
+if [ -z "$MAIN_SCALA_VERSION" ]; then
+    >&2 echo "Environment MAIN_SCALA_VERSION is not set. Check .travis.yml."
+    exit 1
+elif [ -z "$TRAVIS_SCALA_VERSION" ]; then
+    >&2 echo "Environment TRAVIS_SCALA_VERSION is not set."
+    exit 1
+else
+    echo
+    echo "TRAVIS_SCALA_VERSION=$TRAVIS_SCALA_VERSION"
+    echo "MAIN_SCALA_VERSION=$MAIN_SCALA_VERSION"
+fi
+
+if [ "$TRAVIS_SCALA_VERSION" = "$MAIN_SCALA_VERSION" ]; then
+    echo
+    echo "Executing build (with coverage):"
+    echo
+    sbt -Dsbt.profile=coverage ";++$TRAVIS_SCALA_VERSION;coverage;ci"
+else
+    echo
+    echo "Executing build:"
+    echo
+    sbt -Dsbt.profile=coverage ";++$TRAVIS_SCALA_VERSION;coverage;ci"
+fi

--- a/project/travis-post-build.sh
+++ b/project/travis-post-build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd `dirname $0`/..
+
+if [ -z "$MAIN_SCALA_VERSION" ]; then
+    >&2 echo "Environment MAIN_SCALA_VERSION is not set. Check .travis.yml."
+    exit 1
+elif [ -z "$TRAVIS_SCALA_VERSION" ]; then
+    >&2 echo "Environment TRAVIS_SCALA_VERSION is not set."
+    exit 1
+else
+    echo "TRAVIS_SCALA_VERSION=$TRAVIS_SCALA_VERSION"
+    echo "MAIN_SCALA_VERSION=$MAIN_SCALA_VERSION"
+fi
+
+if [ "$TRAVIS_SCALA_VERSION" = "$MAIN_SCALA_VERSION" ]; then
+    echo "Uploading coverage for Scala $TRAVIS_SCALA_VERSION"
+    sbt -Dsbt.profile=coverage ";++$TRAVIS_SCALA_VERSION;coverageAggregate;coverageReport"
+    bash <(curl -s https://codecov.io/bash)
+else
+    echo "Skipping uploading coverage for Scala $TRAVIS_SCALA_VERSION"
+fi
+


### PR DESCRIPTION
Configuring Codecov.io

- in my experience `sbt-scoverage` is dirty, attaches itself to the generated POM, had problems with Scala 2.12, etc
- therefore I chose to enable coverage in builds only when required, by passing `-Dsbt.profile=coverage` to the `sbt` command
- in Travis coverage is measured and uploaded only for a `MAIN_SCALA_VERSION` configured in `.travis.yml`