### PR TITLE
Move AndThen implementation to cats.effect.internals

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -17,7 +17,7 @@
 package cats
 package effect
 
-import cats.effect.internals.{NonFatal, IOPlatform}
+import cats.effect.internals.{AndThen, IOPlatform, NonFatal}
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration._

--- a/core/shared/src/main/scala/cats/effect/internals/AndThen.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/AndThen.scala
@@ -14,16 +14,20 @@
  * limitations under the License.
  */
 
-package cats
-package effect
+package cats.effect.internals
 
 import java.io.Serializable
 
+import cats.effect.IO
+
 /**
- * A type-aligned seq for representing function composition in constant stack space with
- * ammortized linear time application (in the number of constituent functions).  Implementation
- * is enormously uglier than it should be since `@tailrec` doesn't work properly on functions
- * with existential types.
+ * A type-aligned seq for representing function composition in
+ * constant stack space with amortized linear time application (in the
+ * number of constituent functions).
+ * 
+ * Implementation is enormously uglier than it should be since
+ * `@tailrec` doesn't work properly on functions with existential
+ * types.
  */
 private[effect] sealed abstract class AndThen[-A, +B] extends Product with Serializable {
   import AndThen._

--- a/core/shared/src/test/scala/cats/effect/internals/AndThenTests.scala
+++ b/core/shared/src/test/scala/cats/effect/internals/AndThenTests.scala
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package cats
-package effect
+package cats.effect.internals
 
-import org.scalatest._
 import org.scalacheck._
+import org.scalatest._
 
 class AndThenTests extends FunSuite with Matchers {
   import Prop._


### PR DESCRIPTION
When I created the `internals` package, I missed moving `AndThen` into it.

I really like my root to be clean.