### PR TITLE
WIP: Enable Unidoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,19 +93,14 @@ lazy val unidocSettings = Seq(
   unidocProjectFilter in (ScalaUnidoc, unidoc) :=
     inProjects(coreJVM, lawsJVM),
 
-  // Exclude monix.execution.atomic.internals from ScalaDoc
-  sources in (ScalaUnidoc, unidoc) ~= (_ filterNot { file =>
-    file.getCanonicalPath matches "^.*monix.execution.internals.*$"
-  }),
-
   scalacOptions in (ScalaUnidoc, unidoc) +=
     "-Xfatal-warnings",
   scalacOptions in (ScalaUnidoc, unidoc) -=
     "-Ywarn-unused-import",
   scalacOptions in (ScalaUnidoc, unidoc) ++=
-    Opts.doc.title(s"Monix"),
+    Opts.doc.title(s"cats-effect"),
   scalacOptions in (ScalaUnidoc, unidoc) ++=
-    Opts.doc.sourceUrl(s"https://github.com/monix/monix/tree/v${version.value}€{FILE_PATH}.scala"),
+    Opts.doc.sourceUrl(s"https://github.com/typelevel/cats-effect/tree/v${version.value}€{FILE_PATH}.scala"),
   scalacOptions in (ScalaUnidoc, unidoc) ++=
     Seq("-doc-root-content", file("rootdoc.txt").getAbsolutePath),
   scalacOptions in (ScalaUnidoc, unidoc) ++=

--- a/core/shared/src/main/scala/cats/effect/implicits/package.scala
+++ b/core/shared/src/main/scala/cats/effect/implicits/package.scala
@@ -18,9 +18,8 @@ package cats
 package effect
 
 package object implicits extends Effect.ToEffectOps {
-
-  // this has to be implicitly enriched to get around variance questions
+  // This has to be implicitly enriched to get around variance questions
   final implicit class IOSyntax[A](val self: IO[A]) extends AnyVal {
-    final def liftIO[F[_]: LiftIO]: F[A] = LiftIO[F].liftIO(self)
+    def liftIO[F[_]: LiftIO]: F[A] = LiftIO[F].liftIO(self)
   }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
@@ -24,7 +24,7 @@ import scala.concurrent.ExecutionContext
 import scala.util.Random
 
 /**
- * A [[scala.concurrent.ExecutionContext]] implementation that can be
+ * A `scala.concurrent.ExecutionContext` implementation that can be
  * used for testing purposes.
  *
  * Usage:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,5 +7,6 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype"    % "1.1")
 addSbtPlugin("com.jsuereth"   % "sbt-pgp"         % "1.0.0")
 addSbtPlugin("com.typesafe"   % "sbt-mima-plugin" % "0.1.14")
 addSbtPlugin("org.scoverage"  % "sbt-scoverage"   % "1.5.0")
+addSbtPlugin("com.eed3si9n"   %  "sbt-unidoc"     % "0.4.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")

--- a/project/travis-build.sh
+++ b/project/travis-build.sh
@@ -19,7 +19,7 @@ if [ "$TRAVIS_SCALA_VERSION" = "$MAIN_SCALA_VERSION" ]; then
     echo
     echo "Executing build (with coverage):"
     echo
-    sbt -Dsbt.profile=coverage ++$TRAVIS_SCALA_VERSION coverage ci
+    sbt -Dsbt.profile=coverage ++$TRAVIS_SCALA_VERSION coverage ci unidoc
 else
     echo
     echo "Executing build:"


### PR DESCRIPTION
Trying to enable the unidoc plugin, unfortunately it fails currently.

I'm creating the PR, then opening an issue on unidoc's repo.

The error I'm seeing:

```
> unidoc
[info] Compiling 9 Scala sources to cats-effect/core/jvm/target/scala-2.12/classes...
[info] Main Scala API documentation to cats-effect/target/scala-2.12/unidoc...
[error] Symbol 'type cats.effect.Effect.ToEffectOps' is missing from the classpath.
[error] This symbol is required by 'package cats.effect.implicits.package'.
[error] Make sure that type ToEffectOps is in your classpath and check for conflicting dependencies with `-Ylog-classpath`.
[error] A full rebuild may help if 'package.class' was compiled against an incompatible version of cats.effect.Effect.
[info] No documentation generated with unsuccessful compiler run
[error] one error found
[error] (root/scalaunidoc:doc) Scaladoc generation failed
[error] Total time: 9 s, completed Apr 24, 2017 11:04:43 PM
```

I've opened the issue at: https://github.com/sbt/sbt-unidoc/issues/35