### PR TITLE
Change fromFuture to take a cats.Eval param

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -351,7 +351,7 @@ sealed abstract class IO[+A] {
    * only be used if interoperating with legacy code which uses Scala
    * futures.
    *
-   * @see [[IO.deferFuture]]
+   * @see [[IO.fromFuture]]
    */
   final def unsafeToFuture(): Future[A] = {
     val p = Promise[A]
@@ -516,14 +516,31 @@ object IO extends IOInstances {
   def raiseError[A](e: Throwable): IO[A] = RaiseError(e)
 
   /**
-   * Constructs an `IO` which evaluates the suspended `Future` and
+   * Constructs an `IO` which evaluates the given `Future` and
    * produces the result (or failure).
    *
    * Because `Future` eagerly evaluates, as well as because it
-   * memoizes, this function takes its parameter lazily.  If this
-   * laziness is appropriately threaded back to the definition site of
-   * the `Future`, it ensures that the computation is fully managed by
+   * memoizes, this function takes its parameter as a `cats.Eval`,
+   * which could be lazily evaluated.  If this laziness is
+   * appropriately threaded back to the definition site of the
+   * `Future`, it ensures that the computation is fully managed by
    * `IO` and thus referentially transparent.
+   *
+   * The `cats.Eval` type allows fine grained control of how the
+   * passed `Future` reference gets evaluated. Example:
+   *
+   * {{{
+   *   import cats.Eval.{always, later, now}
+   *
+   *   // Lazy evaluation, equivalent with by-name params
+   *   IO.fromFuture(always(f))
+   *
+   *   // Memoized, lazy evaluation, equivalent with lazy val
+   *   IO.fromFuture(later(f))
+   *
+   *   // Eager evaluation
+   *   IO.fromFuture(now(f))
+   * }}}
    *
    * Note that the ''continuation'' of the computation resulting from
    * a `Future` will run on the future's thread pool.  There is no
@@ -533,19 +550,21 @@ object IO extends IOInstances {
    * Roughly speaking, the following identities hold:
    *
    * {{{
-   * IO.deferFuture(f).unsafeToFuture === f     // true-ish (except for memoization)
-   * IO.deferFuture(ioa.unsafeToFuture) === ioa // true!
+   *   IO.fromFuture(now(f)).unsafeToFuture === f
+   *   IO.fromFuture(always(ioa.unsafeToFuture())) === ioa
    * }}}
    *
    * @see [[IO#unsafeToFuture]]
    */
-  def deferFuture[A](f: => Future[A])(implicit ec: ExecutionContext): IO[A] = {
+  def fromFuture[A](f: Eval[Future[A]])(implicit ec: ExecutionContext): IO[A] = {
     IO async { cb =>
       import scala.util.{Success, Failure}
 
-      f onComplete {
-        case Failure(t) => cb(Left(t))
+      try f.value onComplete {
+        case Failure(e) => cb(Left(e))
         case Success(a) => cb(Right(a))
+      } catch {
+        case NonFatal(e) => cb(Left(e))
       }
     }
   }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -550,7 +550,7 @@ object IO extends IOInstances {
    * Roughly speaking, the following identities hold:
    *
    * {{{
-   * IO.fromFuture(always(f)).unsafeToFuture === f // true-ish (except for memoization)
+   * IO.fromFuture(always(f)).unsafeToFuture() === f // true-ish (except for memoization)
    * IO.fromFuture(always(ioa.unsafeToFuture())) === ioa // true
    * }}}
    *

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -351,7 +351,7 @@ sealed abstract class IO[+A] {
    * only be used if interoperating with legacy code which uses Scala
    * futures.
    *
-   * @see [[IO.fromFuture]]
+   * @see [[IO.deferFuture]]
    */
   final def unsafeToFuture(): Future[A] = {
     val p = Promise[A]
@@ -513,12 +513,12 @@ object IO extends IOInstances {
    *
    * @see [[IO#attempt]]
    */
-  def raiseError(e: Throwable): IO[Nothing] = RaiseError(e)
+  def raiseError[A](e: Throwable): IO[A] = RaiseError(e)
 
   /**
-   * Constructs an `IO` which evalutes the thunked `Future` and
+   * Constructs an `IO` which evaluates the suspended `Future` and
    * produces the result (or failure).
-   * 
+   *
    * Because `Future` eagerly evaluates, as well as because it
    * memoizes, this function takes its parameter lazily.  If this
    * laziness is appropriately threaded back to the definition site of
@@ -533,13 +533,13 @@ object IO extends IOInstances {
    * Roughly speaking, the following identities hold:
    *
    * {{{
-   * IO.fromFuture(f).unsafeToFuture === f     // true-ish (except for memoization)
-   * IO.fromFuture(ioa.unsafeToFuture) === ioa // true!
+   * IO.deferFuture(f).unsafeToFuture === f     // true-ish (except for memoization)
+   * IO.deferFuture(ioa.unsafeToFuture) === ioa // true!
    * }}}
    *
    * @see [[IO#unsafeToFuture]]
    */
-  def fromFuture[A](f: => Future[A])(implicit ec: ExecutionContext): IO[A] = {
+  def deferFuture[A](f: => Future[A])(implicit ec: ExecutionContext): IO[A] = {
     IO async { cb =>
       import scala.util.{Success, Failure}
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -550,8 +550,8 @@ object IO extends IOInstances {
    * Roughly speaking, the following identities hold:
    *
    * {{{
-   *   IO.fromFuture(now(f)).unsafeToFuture === f
-   *   IO.fromFuture(always(ioa.unsafeToFuture())) === ioa
+   * IO.fromFuture(always(f)).unsafeToFuture === f // true-ish (except for memoization)
+   * IO.fromFuture(always(ioa.unsafeToFuture())) === ioa // true
    * }}}
    *
    * @see [[IO#unsafeToFuture]]
@@ -560,11 +560,9 @@ object IO extends IOInstances {
     IO async { cb =>
       import scala.util.{Success, Failure}
 
-      try f.value onComplete {
+      f.value onComplete {
         case Failure(e) => cb(Left(e))
         case Success(a) => cb(Right(a))
-      } catch {
-        case NonFatal(e) => cb(Left(e))
       }
     }
   }

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestInstances.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestInstances.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.laws.util
+
+import cats.effect.IO
+import cats.kernel.Eq
+import scala.concurrent.{ExecutionException, Future}
+import scala.util.{Failure, Success}
+
+/**
+ * Defines instances for `Future` and for `IO`, meant for law testing
+ * by means of [[TestContext]].
+ *
+ * The [[TestContext]] interpreter is used here for simulating
+ * asynchronous execution.
+ */
+trait TestInstances {
+  /**
+   * Defines equality for `IO` references that can
+   * get interpreted by means of a [[TestContext]].
+   */
+  implicit def eqIO[A](implicit A: Eq[A], ec: TestContext): Eq[IO[A]] =
+    new Eq[IO[A]] {
+      def eqv(x: IO[A], y: IO[A]): Boolean =
+        eqFuture[A].eqv(x.unsafeToFuture(), y.unsafeToFuture())
+    }
+
+  /**
+   * Defines equality for `Future` references that can
+   * get interpreted by means of a [[TestContext]].
+   */
+  implicit def eqFuture[A](implicit A: Eq[A], ec: TestContext): Eq[Future[A]] =
+    new Eq[Future[A]] {
+      def eqv(x: Future[A], y: Future[A]): Boolean = {
+        // Executes the whole pending queue of runnables
+        ec.tick()
+
+        x.value match {
+          case None =>
+            y.value.isEmpty
+          case Some(Success(a)) =>
+            y.value match {
+              case Some(Success(b)) => A.eqv(a, b)
+              case _ => false
+            }
+          case Some(Failure(ex1)) =>
+            y.value match {
+              case Some(Failure(ex2)) =>
+                extractEx(ex1) == extractEx(ex2)
+              case _ =>
+                false
+            }
+        }
+      }
+
+      // Unwraps exceptions that got caught by Future's implementation
+      // and that got wrapped in ExecutionException (`Future(throw ex)`)
+      def extractEx(ex: Throwable): Throwable =
+        ex match {
+          case ref: ExecutionException =>
+            Option(ref.getCause).getOrElse(ref)
+          case _ => ex
+        }
+    }
+}
+
+object TestInstances extends TestInstances

--- a/laws/shared/src/test/scala/cats/effect/BaseTestsSuite.scala
+++ b/laws/shared/src/test/scala/cats/effect/BaseTestsSuite.scala
@@ -16,17 +16,15 @@
 
 package cats.effect
 
-import cats.effect.laws.util.TestContext
+import cats.effect.laws.util.{TestContext, TestInstances}
 import cats.kernel.Eq
 import org.scalactic.source
 import org.scalatest.prop.Checkers
 import org.scalatest.{FunSuite, Matchers, Tag}
 import org.typelevel.discipline.Laws
 import org.typelevel.discipline.scalatest.Discipline
-import scala.concurrent.{ExecutionException, Future}
-import scala.util.{Failure, Success}
 
-class BaseTestsSuite extends FunSuite with Matchers with Checkers with Discipline {
+class BaseTestsSuite extends FunSuite with Matchers with Checkers with Discipline with TestInstances {
   /** For tests that need a usable [[TestContext]] reference. */
   def testAsync[A](name: String, tags: Tag*)(f: TestContext => Unit)
     (implicit pos: source.Position): Unit = {
@@ -47,52 +45,4 @@ class BaseTestsSuite extends FunSuite with Matchers with Checkers with Disciplin
 
   implicit def eqThrowable: Eq[Throwable] =
     Eq.fromUniversalEquals[Throwable]
-
-  /**
-   * Defines equality for `IO` references that can
-   * get interpreted by means of a [[TestContext]].
-   */
-  implicit def eqIO[A](implicit A: Eq[A], ec: TestContext): Eq[IO[A]] =
-    new Eq[IO[A]] {
-      def eqv(x: IO[A], y: IO[A]): Boolean =
-        eqFuture[A].eqv(x.unsafeToFuture(), y.unsafeToFuture())
-    }
-
-  /**
-   * Defines equality for `Future` references that can
-   * get interpreted by means of a [[TestContext]].
-   */
-  implicit def eqFuture[A](implicit A: Eq[A], ec: TestContext): Eq[Future[A]] =
-    new Eq[Future[A]] {
-      def eqv(x: Future[A], y: Future[A]): Boolean = {
-        // Executes the whole pending queue of runnables
-        ec.tick()
-
-        x.value match {
-          case None =>
-            y.value.isEmpty
-          case Some(Success(a)) =>
-            y.value match {
-              case Some(Success(b)) => A.eqv(a, b)
-              case _ => false
-            }
-          case Some(Failure(ex1)) =>
-            y.value match {
-              case Some(Failure(ex2)) =>
-                extractEx(ex1) == extractEx(ex2)
-              case _ =>
-                false
-            }
-        }
-      }
-
-      // Unwraps exceptions that got caught by Future's implementation
-      // and that got wrapped in ExecutionException (`Future(throw ex)`)
-      def extractEx(ex: Throwable): Throwable =
-        ex match {
-          case ref: ExecutionException =>
-            Option(ref.getCause).getOrElse(ref)
-          case _ => ex
-        }
-    }
 }


### PR DESCRIPTION
~~This is a proposal to rename `fromFuture` to `deferFuture`.~~

Scala is by default an eager language, which is why one of the first WTFs of people learning Scalaz is in noticing that by-name parameters are used everywhere. And then the second WTF you have is when moving from Scalaz to Cats and noticing that everything is eager by default, as it should be, since this is Scala.

The most obvious example is `Applicative.pure`, which in Cats takes an eager parameter. Now this is problematic because the lazy by-name variant doesn't exist yet, but given that this is Scala, having an eager `pure` makes a lot of sense and avoids a lot of gotchas.

By-name parameters are problematic in themselves, because changing the code a little, you get a different behavior. This has been the rationale for pushing `Eval` in Cats and recommending it for usage instead of by-name params and `lazy val`s.

~~So, the reason for why I would prefer a `deferFuture` is because the name makes it more visible that this function gets a by-name parameter, instead of a strict value.~~

~~In my mind a `fromFuture` function, in the context of cats, should take a strict value. Now you may not want an eager `fromFuture` in `IO`, which is totally fine, but I would still prefer `deferFuture` (or `suspendFuture`?) for the explicitness (I know, I know, some folks prefer to only read the types and not care about descriptive names, I'm not one of those people :-P).~~

This PR makes the param of `fromFuture` a `cats.Eval`, thus allowing the user to control the evaluation (e.g. eager, lazy, memoized).

Full list of changes:

- changed signature: `def fromFuture[A](f: cats.Eval[Future[A]]): IO[A]`
- added tests, refactored `IOTests` a little
- made the `Eq[IO]` depend on `TestContext`, which now makes it possible to test for `IO.never` ;-)
- moved `Eq[IO]` and `Eq[Future]` test instances into `cats.effect.laws.util.TestInstances` for reuse

I don't mind if you don't like it, I'm not dying on this hill :-)