### PR TITLE
Fixes #23: tests for runAsync

### DIFF
--- a/laws/js/src/test/scala/cats/effect/IOJSTests.scala
+++ b/laws/js/src/test/scala/cats/effect/IOJSTests.scala
@@ -17,6 +17,7 @@
 package cats.effect
 
 import org.scalatest.{AsyncFunSuite, Matchers}
+
 import scala.concurrent.duration.{FiniteDuration, _}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.scalajs.js.timers.setTimeout

--- a/laws/shared/src/test/scala/cats/effect/IOAsyncTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOAsyncTests.scala
@@ -30,7 +30,7 @@ class IOAsyncTests extends AsyncFunSuite with Matchers {
   implicit override def executionContext =
     ExecutionContext.global
 
-  def testEffect(source: IO[Int], expected: Try[Int])
+  def testEffectOnRunAsync(source: IO[Int], expected: Try[Int])
     (implicit pos: Position): Future[Assertion] = {
 
     val effect = Promise[Int]()
@@ -48,24 +48,24 @@ class IOAsyncTests extends AsyncFunSuite with Matchers {
   }
 
   test("IO.pure#runAsync") {
-    testEffect(IO.pure(10), Success(10))
+    testEffectOnRunAsync(IO.pure(10), Success(10))
   }
 
   test("IO.apply#runAsync") {
-    testEffect(IO(10), Success(10))
+    testEffectOnRunAsync(IO(10), Success(10))
   }
 
   test("IO.apply#shift#runAsync") {
-    testEffect(IO(10).shift, Success(10))
+    testEffectOnRunAsync(IO(10).shift, Success(10))
   }
 
   test("IO.raiseError#runAsync") {
     val dummy = new RuntimeException("dummy")
-    testEffect(IO.raiseError(dummy), Failure(dummy))
+    testEffectOnRunAsync(IO.raiseError(dummy), Failure(dummy))
   }
 
   test("IO.raiseError#shift#runAsync") {
     val dummy = new RuntimeException("dummy")
-    testEffect(IO.raiseError(dummy).shift, Failure(dummy))
+    testEffectOnRunAsync(IO.raiseError(dummy).shift, Failure(dummy))
   }
 }


### PR DESCRIPTION
Added a new `IOAsyncTests` that execute for both the JVM and JS, piggybacking on ScalaTest's async stuff.