### PR TITLE
Remove unsafeRunSync from EffectLaws

### DIFF
--- a/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
@@ -55,7 +55,7 @@ trait EffectLaws[F[_]] extends AsyncLaws[F] with SyncLaws[F] {
     test >> readResult <-> IO.pure(f(a))
   }
 
-  lazy val stackSafetyOnRepeatedLeftBinds = {
+  lazy val stackSafetyOnRepeatedLeftBinds: IsEq[IO[Unit]] = {
     val result = (0 until 10000).foldLeft(F.delay(())) { (acc, _) =>
       acc.flatMap(_ => F.delay(()))
     }
@@ -63,7 +63,7 @@ trait EffectLaws[F[_]] extends AsyncLaws[F] with SyncLaws[F] {
     F.runAsync(result)(_ => IO.unit) <-> IO.unit
   }
 
-  lazy val stackSafetyOnRepeatedRightBinds = {
+  lazy val stackSafetyOnRepeatedRightBinds: IsEq[IO[Unit]] = {
     val result = (0 until 10000).foldRight(F.delay(())) { (_, acc) =>
       F.delay(()).flatMap(_ => acc)
     }
@@ -71,7 +71,7 @@ trait EffectLaws[F[_]] extends AsyncLaws[F] with SyncLaws[F] {
     F.runAsync(result)(_ => IO.unit) <-> IO.unit
   }
 
-  lazy val stackSafetyOnRepeatedAttempts = {
+  lazy val stackSafetyOnRepeatedAttempts: IsEq[IO[Unit]] = {
     val result = (0 until 10000).foldLeft(F.delay(())) { (acc, _) =>
       F.attempt(acc).map(_ => ())
     }

--- a/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
@@ -60,7 +60,7 @@ trait EffectLaws[F[_]] extends AsyncLaws[F] with SyncLaws[F] {
       acc.flatMap(_ => F.delay(()))
     }
 
-    F.runAsync(result)(_ => IO.unit).unsafeRunSync() <-> (())
+    F.runAsync(result)(_ => IO.unit) <-> IO.unit
   }
 
   lazy val stackSafetyOnRepeatedRightBinds = {
@@ -68,7 +68,7 @@ trait EffectLaws[F[_]] extends AsyncLaws[F] with SyncLaws[F] {
       F.delay(()).flatMap(_ => acc)
     }
 
-    F.runAsync(result)(_ => IO.unit).unsafeRunSync() <-> (())
+    F.runAsync(result)(_ => IO.unit) <-> IO.unit
   }
 
   lazy val stackSafetyOnRepeatedAttempts = {
@@ -76,7 +76,7 @@ trait EffectLaws[F[_]] extends AsyncLaws[F] with SyncLaws[F] {
       F.attempt(acc).map(_ => ())
     }
 
-    F.runAsync(result)(_ => IO.unit).unsafeRunSync() <-> (())
+    F.runAsync(result)(_ => IO.unit) <-> IO.unit
   }
 
   // the following law(s) should really be on MonadError

--- a/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
@@ -55,7 +55,7 @@ trait EffectLaws[F[_]] extends AsyncLaws[F] with SyncLaws[F] {
     test >> readResult <-> IO.pure(f(a))
   }
 
-  lazy val stackSafetyOnRepeatedLeftBinds: IsEq[IO[Unit]] = {
+  lazy val stackSafetyOnRepeatedLeftBinds = {
     val result = (0 until 10000).foldLeft(F.delay(())) { (acc, _) =>
       acc.flatMap(_ => F.delay(()))
     }
@@ -63,7 +63,7 @@ trait EffectLaws[F[_]] extends AsyncLaws[F] with SyncLaws[F] {
     F.runAsync(result)(_ => IO.unit) <-> IO.unit
   }
 
-  lazy val stackSafetyOnRepeatedRightBinds: IsEq[IO[Unit]] = {
+  lazy val stackSafetyOnRepeatedRightBinds = {
     val result = (0 until 10000).foldRight(F.delay(())) { (_, acc) =>
       F.delay(()).flatMap(_ => acc)
     }
@@ -71,7 +71,7 @@ trait EffectLaws[F[_]] extends AsyncLaws[F] with SyncLaws[F] {
     F.runAsync(result)(_ => IO.unit) <-> IO.unit
   }
 
-  lazy val stackSafetyOnRepeatedAttempts: IsEq[IO[Unit]] = {
+  lazy val stackSafetyOnRepeatedAttempts = {
     val result = (0 until 10000).foldLeft(F.delay(())) { (acc, _) =>
       F.attempt(acc).map(_ => ())
     }

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/EffectTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/EffectTests.scala
@@ -20,11 +20,10 @@ package laws
 package discipline
 
 import cats.data._
-import cats.instances.all._
-import cats.laws.discipline._
 import cats.laws.discipline.CartesianTests.Isomorphisms
-
-import org.scalacheck._, Prop.forAll
+import cats.laws.discipline._
+import org.scalacheck.Prop.forAll
+import org.scalacheck._
 
 trait EffectTests[F[_]] extends AsyncTests[F] with SyncTests[F] {
   def laws: EffectLaws[F]
@@ -53,6 +52,7 @@ trait EffectTests[F[_]] extends AsyncTests[F] with SyncTests[F] {
       EqIOA: Eq[IO[A]],
       EqIOEitherTA: Eq[IO[Either[Throwable, A]]],
       EqIOEitherEitherTA: Eq[IO[Either[Throwable, Either[Throwable, A]]]],
+      EqIOUnit: Eq[IO[Unit]],
       iso: Isomorphisms[F]): RuleSet = {
     new RuleSet {
       val name = "effect"


### PR DESCRIPTION
By using `unsafeRunSync` in `EffectLaws` we're assuming a hell of a lot about the execution model and this cannot be, because:

1. these laws cannot be executed on top of Javascript
2. it's also assuming that `attempt.map(...)` keeps execution on the current thread forever

So because in Monix's test I'm using a `TestScheduler` (my own `TestContext`), these laws dead-lock, because they are freezing the current thread before `TestScheduler` has a chance to execute. And Monix does by default batched async execution, so after a certain configurable threshold, async boundaries get inserted. In other words in a loop of 10,000 cycles you're guaranteed to have async boundaries, since the threshold is configured at about 1024 or something.

Anyway, your kind reminder to stop using `unsafeRunSync` 😜