### PR TITLE
Linearized Effect hierarchy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -211,7 +211,7 @@ lazy val lawsJS = laws.js
  * version bump of 1.0.  Again, this is all to avoid pre-committing
  * to a major/minor bump before the work is done (see: Scala 2.8).
  */
-val BaseVersion = "0.1"
+val BaseVersion = "0.2"
 
 licenses in ThisBuild += ("Apache-2.0", url("http://www.apache.org/licenses/"))
 

--- a/core/shared/src/main/scala/cats/effect/Async.scala
+++ b/core/shared/src/main/scala/cats/effect/Async.scala
@@ -22,14 +22,15 @@ import scala.annotation.implicitNotFound
 import scala.util.Either
 
 /**
- * A monad that can describe asynchronous computations that
+ * A monad that can describe asynchronous or synchronous computations that
  * produce exactly one result.
  */
 @typeclass
 @implicitNotFound("""Cannot find implicit value for Async[${F}].
 Building this implicit value might depend on having an implicit
 s.c.ExecutionContext in scope, a Strategy or some equivalent type.""")
-trait Async[F[_]] extends MonadError[F, Throwable] {
+trait Async[F[_]] extends Sync[F] {
+
   /**
    * Creates an `F[A]` instance from a provided function
    * that will have a callback injected for signaling the

--- a/core/shared/src/main/scala/cats/effect/Effect.scala
+++ b/core/shared/src/main/scala/cats/effect/Effect.scala
@@ -30,7 +30,7 @@ import scala.util.Either
 @implicitNotFound("""Cannot find implicit value for Effect[${F}].
 Building this implicit value might depend on having an implicit
 s.c.ExecutionContext in scope, a Strategy or some equivalent type.""")
-trait Effect[F[_]] extends Sync[F] with Async[F] with LiftIO[F] {
+trait Effect[F[_]] extends Async[F] with LiftIO[F] {
 
   def runAsync[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit]
 

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -21,7 +21,7 @@ package laws
 import cats.implicits._
 import cats.laws._
 
-trait AsyncLaws[F[_]] extends MonadErrorLaws[F, Throwable] {
+trait AsyncLaws[F[_]] extends SyncLaws[F] {
   implicit def F: Async[F]
 
   def asyncRightIsPure[A](a: A) =

--- a/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
@@ -21,7 +21,7 @@ package laws
 import cats.implicits._
 import cats.laws._
 
-trait EffectLaws[F[_]] extends AsyncLaws[F] with SyncLaws[F] {
+trait EffectLaws[F[_]] extends AsyncLaws[F] {
   implicit def F: Effect[F]
 
   def runAsyncPureProducesRightIO[A](a: A) = {


### PR DESCRIPTION
Now, `Async <: Sync`.  The reason for this is it's generally impossible to implement `Effect[F]` for an MTL stack which does not involve exclusively copointed effects.  Which is to say, not a particularly interesting stack.  So most stacks end up implementing both `Sync` and `Async`, but this is a problem because then two `Monad` instances are in scope.  Since it is always possible to suspend `Sync` effects in an `Async` (though not necessarily stack-safely), I think it's somewhat reasonable for the latter to extend the former.  I prefer having them split, but there's nothing for it.

Without this change, the typeclass hierarchy is considerably less useful.