### PR TITLE
Change IO's run-loop to encode error handlers

### DIFF
--- a/core/shared/src/main/scala/cats/effect/internals/AndThen.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/AndThen.scala
@@ -18,79 +18,78 @@ package cats.effect.internals
 
 import java.io.Serializable
 
-import cats.effect.IO
-
 /**
  * A type-aligned seq for representing function composition in
  * constant stack space with amortized linear time application (in the
  * number of constituent functions).
- * 
+ *
  * Implementation is enormously uglier than it should be since
- * `@tailrec` doesn't work properly on functions with existential
+ * `tailrec` doesn't work properly on functions with existential
  * types.
  */
 private[effect] sealed abstract class AndThen[-A, +B] extends Product with Serializable {
   import AndThen._
 
-  final def apply(a: A): B = {
+  final def apply(a: A): B =
+    runLoop(a, null, isSuccess = true)
+
+  final def error[R >: B](e: Throwable, orElse: Throwable => R): R =
+    try runLoop(null.asInstanceOf[A], e, isSuccess = false)
+    catch { case NonFatal(e2) => orElse(e2) }
+
+  private def runLoop(success: A, failure: Throwable, isSuccess: Boolean): B = {
     var self: AndThen[Any, Any] = this.asInstanceOf[AndThen[Any, Any]]
-    var cur: Any = a.asInstanceOf[Any]
+    var successRef: Any = success.asInstanceOf[Any]
+    var failureRef = failure
+    var hasSuccessRef = isSuccess
     var continue = true
+
+    @inline def processRight(f: (Any) => Any): Unit =
+      try successRef = f(successRef) catch {
+        case NonFatal(e) =>
+          failureRef = e
+          hasSuccessRef = false
+      }
+
+    @inline def processLeft(f: Throwable => Any): Unit =
+      try {
+        successRef = f(failureRef)
+        hasSuccessRef = true
+      } catch {
+        case NonFatal(e2) => failureRef = e2
+      }
+
     while (continue) {
       self match {
         case Single(f) =>
-          cur = f(cur).asInstanceOf[Any]
+          if (hasSuccessRef) processRight(f)
           continue = false
 
         case Concat(Single(f), right) =>
-          cur = f(cur).asInstanceOf[Any]
+          if (hasSuccessRef) processRight(f)
           self = right.asInstanceOf[AndThen[Any, Any]]
 
-        case Concat(left @ Concat(_, _), right) => self = left.rotateAccum(right)
+        case Concat(left @ Concat(_, _), right) =>
+          self = left.rotateAccum(right)
 
-        case Concat(ss, right) =>
-          val left = ss.asInstanceOf[ShortCircuit[Any, Any]]
+        case Concat(ErrorHandler(fa, fe), right) =>
+          if (hasSuccessRef) processRight(fa)
+          else processLeft(fe)
+          self = right.asInstanceOf[AndThen[Any, Any]]
 
-          cur match {
-            case Left(t: Throwable) =>
-              cur = IO.pure(Left(t))
-              self = right.asInstanceOf[AndThen[Any, Any]]
-
-            case Right(a) =>
-              self = left.inner.andThen(right).asInstanceOf[AndThen[Any, Any]]
-              cur = a.asInstanceOf[Any]
-
-            case _ => throw new AssertionError("types got screwy somewhere halp!!!")
-          }
-
-        case ss =>
-          val ssc = ss.asInstanceOf[ShortCircuit[Any, Any]]
-
-          cur match {
-            case Left(t: Throwable) =>
-              cur = IO.pure(Left(t))
-              continue = false
-
-            case Right(a) =>
-              self = ssc.inner.asInstanceOf[AndThen[Any, Any]]
-              cur = a.asInstanceOf[Any]
-
-            case _ => throw new AssertionError("types got screwy somewhere halp!!!")
-          }
+        case ErrorHandler(fa, fe) =>
+          if (hasSuccessRef) processRight(fa)
+          else processLeft(fe)
+          continue = false
       }
     }
 
-    cur.asInstanceOf[B]
+    if (hasSuccessRef) successRef.asInstanceOf[B]
+    else throw failureRef
   }
 
   final def andThen[X](right: AndThen[B, X]): AndThen[A, X] = Concat(this, right)
   final def compose[X](right: AndThen[X, A]): AndThen[X, B] = Concat(right, this)
-
-  final def shortCircuit[E](implicit ev: B <:< IO[Either[Throwable, E]]) = {
-    val _ = ev
-
-    ShortCircuit[A, E](this.asInstanceOf[AndThen[A, IO[Either[Throwable, E]]]])
-  }
 
   // converts left-leaning to right-leaning
   protected final def rotateAccum[E](_right: AndThen[B, E]): AndThen[A, E] = {
@@ -103,7 +102,7 @@ private[effect] sealed abstract class AndThen[-A, +B] extends Product with Seria
           self = left.asInstanceOf[AndThen[Any, Any]]
           right = inner.andThen(right)
 
-        // either Single or ShortCircuit; the latter doesn't typecheck
+        // Either Single or ErrorHandler
         case _ =>
           self = self.andThen(right)
           continue = false
@@ -113,14 +112,20 @@ private[effect] sealed abstract class AndThen[-A, +B] extends Product with Seria
     self.asInstanceOf[AndThen[A, E]]
   }
 
-  override def toString = "AndThen$" + System.identityHashCode(this)
+  override def toString =
+    "AndThen$" + System.identityHashCode(this)
 }
 
 private[effect] object AndThen {
+  /** Builds simple [[AndThen]] reference by wrapping a function. */
+  def apply[A, B](f: A => B): AndThen[A, B] =
+    Single(f)
 
-  def apply[A, B](f: A => B): AndThen[A, B] = Single(f)
+  /** Builds [[AndThen]] reference that can handle errors. */
+  def apply[A, B](fa: A => B, fe: Throwable => B): AndThen[A, B] =
+    ErrorHandler(fa, fe)
 
   final case class Single[-A, +B](f: A => B) extends AndThen[A, B]
+  final case class ErrorHandler[-A, +B](fa: A => B, fe: Throwable => B) extends AndThen[A, B]
   final case class Concat[-A, E, +B](left: AndThen[A, E], right: AndThen[E, B]) extends AndThen[A, B]
-  final case class ShortCircuit[-A, +B](inner: AndThen[A, IO[Either[Throwable, B]]]) extends AndThen[Either[Throwable, A], IO[Either[Throwable, B]]]
 }

--- a/core/shared/src/main/scala/cats/effect/internals/AndThen.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/AndThen.scala
@@ -44,14 +44,14 @@ private[effect] sealed abstract class AndThen[-A, +B] extends Product with Seria
     var hasSuccessRef = isSuccess
     var continue = true
 
-    @inline def processRight(f: (Any) => Any): Unit =
+    def processRight(f: (Any) => Any): Unit =
       try successRef = f(successRef) catch {
         case NonFatal(e) =>
           failureRef = e
           hasSuccessRef = false
       }
 
-    @inline def processLeft(f: Throwable => Any): Unit =
+    def processLeft(f: Throwable => Any): Unit =
       try {
         successRef = f(failureRef)
         hasSuccessRef = true

--- a/core/shared/src/test/scala/cats/effect/internals/AndThenTests.scala
+++ b/core/shared/src/test/scala/cats/effect/internals/AndThenTests.scala
@@ -18,12 +18,13 @@ package cats.effect.internals
 
 import org.scalacheck._
 import org.scalatest._
+import org.scalatest.prop.Checkers
 
-class AndThenTests extends FunSuite with Matchers {
+class AndThenTests extends FunSuite with Matchers with Checkers {
   import Prop._
 
-  test("compose a chain of functions") {
-    forAll { (i: Int, fs: List[Int => Int]) =>
+  test("compose a chain of functions with andThen") {
+    check { (i: Int, fs: List[Int => Int]) =>
       val result = fs.map(AndThen(_)).reduceOption(_.andThen(_)).map(_(i))
       val expect = fs.reduceOption(_.andThen(_)).map(_(i))
 
@@ -31,10 +32,88 @@ class AndThenTests extends FunSuite with Matchers {
     }
   }
 
+  test("compose a chain of functions with compose") {
+    check { (i: Int, fs: List[Int => Int]) =>
+      val result = fs.map(AndThen(_)).reduceOption(_.compose(_)).map(_(i))
+      val expect = fs.reduceOption(_.compose(_)).map(_(i))
+
+      result == expect
+    }
+  }
+
+
   test("be stack safe") {
     val fs = (0 until 50000).map(_ => { i: Int => i + 1 })
     val result = fs.map(AndThen(_)).reduceLeft(_.andThen(_))(42)
 
     result shouldEqual 50042
   }
+
+  test("handles error if handler is in chain") {
+    val dummy = new RuntimeException("dummy")
+
+    check { (i: Int, fs1: List[Int => Int], fs2: List[Int => Int]) =>
+      val result = {
+        val before = fs1.map(AndThen(_)).reduceOption(_.andThen(_)).getOrElse(id)
+        val after = fs2.map(rethrow).reduceOption(_.andThen(_)).getOrElse(id)
+
+        val handler = AndThen((x: Int) => x, {
+          case `dummy` => i
+          case e => throw e
+        })
+
+        before.andThen(handler).andThen(after)
+          .error(dummy, e => throw e)
+      }
+
+      val expect = fs2
+        .reduceOption(_.andThen(_))
+        .getOrElse((x: Int) => x)
+        .apply(i)
+
+      result == expect
+    }
+  }
+
+  test("if Simple function throws, tries to recover") {
+    val dummy = new RuntimeException("dummy")
+
+    val f = AndThen((_: Int) => throw dummy).andThen(
+      AndThen((x: Int) => x, {
+        case `dummy` => 100
+        case e => throw e
+      }))
+
+    f(0) shouldEqual 100
+  }
+
+  test("if ErrorHandler throws, tries to recover") {
+    val dummy = new RuntimeException("dummy")
+
+    val f = AndThen((_: Int) => throw dummy, e => throw e).andThen(
+      AndThen((x: Int) => x, {
+        case `dummy` => 100
+        case e => throw e
+      }))
+
+    f(0) shouldEqual 100
+  }
+
+  test("throws if no ErrorHandler defined in chain") {
+    val dummy1 = new RuntimeException("dummy1")
+    val f = AndThen((_: Int) => throw dummy1).andThen(AndThen((x: Int) => x + 1))
+
+    try f(0) catch { case `dummy1` => () }
+
+    val dummy2 = new RuntimeException("dummy2")
+    try f.error(dummy2, e => throw e) catch { case `dummy2` => () }
+  }
+
+  test("toString") {
+    AndThen((x: Int) => x).toString should startWith("AndThen$")
+  }
+
+  // Utils
+  val id = AndThen((x: Int) => x)
+  def rethrow(f: Int => Int) = AndThen(f, e => throw e)
 }


### PR DESCRIPTION
I discovered a weird  space leak that I talked about in https://github.com/typelevel/cats-effect/issues/42#issuecomment-298256710 by debugging the behavior of this law:

```scala
  lazy val stackSafetyOnRepeatedAttempts = {
    val result = (0 until 10000).foldLeft(F.delay(())) { (acc, _) =>
      F.attempt(acc).map(_ => ())
    }

    F.runAsync(result)(_ => IO.unit).unsafeRunSync() <-> (())
  }
```

This PR fixes this space leak by changing the behavior of `IO#attempt`:

- removes the `AndThen.ShortCircuit` logic
- adds the notion of `AndThen.ErrorHandler`, which is meant to process errors
- upon an error being signaled, in the `AndThen` implementation we discard `Single` references until we reach an `ErrorHandler` that can process our error, or until we've got no more `AndThen` nodes to process, in which case we rethrow the error ... this is basically how Java's call-stack also works

This implementation also opens up the possibility of a more optimized `handleErrorWith`, since now we don't necessarily need `attempt.flatMap` to express it.