### PR TITLE
Add IO#to conversion method

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Effect.scala
+++ b/core/shared/src/main/scala/cats/effect/Effect.scala
@@ -52,4 +52,10 @@ trait Effect[F[_]] extends Async[F] with LiftIO[F] {
       })
     }
   }
+
+  override def liftIO[A](ioa: IO[A]): F[A] = {
+    // Implementation for `IO#to` depends on the `Async` type class,
+    // and not on `Effect`, so this shouldn't create a cyclic dependency
+    ioa.to[F](this)
+  }
 }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -390,7 +390,7 @@ sealed abstract class IO[+A] {
       case Pure(a) => F.pure(a)
       case RaiseError(e) => F.raiseError(e)
       case _ => F.suspend {
-        // Evaluating until finished or the next async boundary
+        // Evaluating until finished or the first async boundary
         unsafeStep match {
           case Pure(a) => F.pure(a)
           case RaiseError(e) => F.raiseError(e)

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -17,9 +17,7 @@
 package cats
 package effect
 
-import cats.effect.{Async => AsyncType}
 import cats.effect.internals.{AndThen, IOPlatform, NonFatal}
-
 import scala.annotation.tailrec
 import scala.annotation.unchecked.{uncheckedVariance => uV}
 import scala.concurrent.{ExecutionContext, Future, Promise}

--- a/core/shared/src/test/scala/cats/effect/Generators.scala
+++ b/core/shared/src/test/scala/cats/effect/Generators.scala
@@ -36,6 +36,14 @@ object Generators {
       10 -> genFlatMap[A])
   }
 
+  def genSyncIO[A: Arbitrary: Cogen]: Gen[IO[A]] = {
+    Gen.frequency(
+      5 -> genPure[A],
+      5 -> genApply[A],
+      1 -> genFail[A],
+      10 -> genFlatMap[A])
+  }
+
   def genPure[A: Arbitrary]: Gen[IO[A]] = arbitrary[A].map(IO.pure(_))
 
   def genApply[A: Arbitrary]: Gen[IO[A]] = arbitrary[A].map(IO.apply(_))

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -357,6 +357,7 @@ object IOTests {
   /** Implementation for testing default methods. */
   val ioEffectDefaults = new Effect[IO] {
     private val ref = implicitly[Effect[IO]]
+
     def async[A](k: ((Either[Throwable, A]) => Unit) => Unit): IO[A] =
       ref.async(k)
     def raiseError[A](e: Throwable): IO[A] =
@@ -373,7 +374,5 @@ object IOTests {
       ref.runAsync(fa)(cb)
     def suspend[A](thunk: =>IO[A]): IO[A] =
       ref.suspend(thunk)
-    def liftIO[A](ioa: IO[A]): IO[A] =
-      ref.liftIO(ioa)
   }
 }

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -365,8 +365,7 @@ class IOTests extends BaseTestsSuite {
   testAsync("sync.to[IO] is stack-safe") { implicit ec =>
     // Override default generator to only generate
     // synchronous instances that are stack-safe
-    implicit val arbIO: Arbitrary[IO[Int]] =
-      Arbitrary(Gen.delay(genSyncIO[Int]))
+    implicit val arbIO = Arbitrary(genSyncIO[Int])
 
     check { (io: IO[Int]) =>
       repeatedTransformLoop(10000, io) <-> io


### PR DESCRIPTION
This is a follow up on https://github.com/typelevel/cats-effect/pull/47

Adding a conversion utility to `IO` that can convert from any type implementing the `Async` type-class:

```scala
def to[F[_]](implicit F: cats.effect.Async[F]): F[A @uV]
```

Notes:

- internal implementation tries to do conversion as efficient as possible, being one raison for why it exists because doing `F.async(io.unsafeRunAsync)` can be inefficient, besides being dangerous
- we are using `@uncheckedVariance` to avoid introducing a `B >: A` type (due to covariance), which would wreck our signature; Scala's standard library also does it for the conversions in the standard collections