### PR TITLE
Lots of convenience instances

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Effect.scala
+++ b/core/shared/src/main/scala/cats/effect/Effect.scala
@@ -20,6 +20,7 @@ package effect
 import simulacrum._
 
 import cats.data.{EitherT, StateT, WriterT}
+import cats.syntax.either._
 
 import scala.annotation.implicitNotFound
 import scala.concurrent.ExecutionContext

--- a/core/shared/src/main/scala/cats/effect/Effect.scala
+++ b/core/shared/src/main/scala/cats/effect/Effect.scala
@@ -20,7 +20,6 @@ package effect
 import simulacrum._
 
 import cats.data.{EitherT, StateT, WriterT}
-import cats.syntax.either._
 
 import scala.annotation.implicitNotFound
 import scala.concurrent.ExecutionContext
@@ -66,7 +65,7 @@ private[effect] trait EffectInstances {
       protected def FF = Effect[F]
 
       def runAsync[A](fa: EitherT[F, Throwable, A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] =
-        F.runAsync(fa.value)(cb.compose(_.flatMap(x => x)))
+        F.runAsync(fa.value)(cb.compose(_.right.flatMap(x => x)))
     }
 
   implicit def catsStateTEffect[F[_]: Effect, S: Monoid]: Effect[StateT[F, S, ?]] =
@@ -85,7 +84,7 @@ private[effect] trait EffectInstances {
       protected def L = Monoid[L]
 
       def runAsync[A](fa: WriterT[F, L, A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] =
-        F.runAsync(fa.run)(cb.compose(_.map(_._2)))
+        F.runAsync(fa.run)(cb.compose(_.right.map(_._2)))
     }
 }
 

--- a/core/shared/src/main/scala/cats/effect/LiftIO.scala
+++ b/core/shared/src/main/scala/cats/effect/LiftIO.scala
@@ -19,7 +19,7 @@ package effect
 
 import simulacrum._
 
-import cats.data.{EitherT, OptionT, StateT}
+import cats.data.{EitherT, Kleisli, OptionT, StateT}
 
 import scala.annotation.implicitNotFound
 
@@ -35,6 +35,12 @@ private[effect] trait LiftIOInstances {
 
   implicit def catsEitherTLiftIO[F[_]: LiftIO: Functor, L]: LiftIO[EitherT[F, L, ?]] =
     new EitherTLiftIO[F, L] { def F = LiftIO[F]; def FF = Functor[F] }
+
+  implicit def catsKleisliLiftIO[F[_]: LiftIO, R]: LiftIO[Kleisli[F, R, ?]] =
+    new LiftIO[Kleisli[F, R, ?]] {
+      def liftIO[A](ioa: IO[A]): Kleisli[F, R, A] =
+        Kleisli.lift(LiftIO[F].liftIO(ioa))
+    }
 
   implicit def catsOptionTLiftIO[F[_]: LiftIO: Functor]: LiftIO[OptionT[F, ?]] =
     new LiftIO[OptionT[F, ?]] {

--- a/core/shared/src/main/scala/cats/effect/LiftIO.scala
+++ b/core/shared/src/main/scala/cats/effect/LiftIO.scala
@@ -19,7 +19,7 @@ package effect
 
 import simulacrum._
 
-import cats.data.{EitherT, StateT}
+import cats.data.{EitherT, OptionT, StateT}
 
 import scala.annotation.implicitNotFound
 
@@ -35,6 +35,12 @@ private[effect] trait LiftIOInstances {
 
   implicit def catsEitherTLiftIO[F[_]: LiftIO: Functor, L]: LiftIO[EitherT[F, L, ?]] =
     new EitherTLiftIO[F, L] { def F = LiftIO[F]; def FF = Functor[F] }
+
+  implicit def catsOptionTLiftIO[F[_]: LiftIO: Functor]: LiftIO[OptionT[F, ?]] =
+    new LiftIO[OptionT[F, ?]] {
+      def liftIO[A](ioa: IO[A]): OptionT[F, A] =
+        OptionT.liftF(LiftIO[F].liftIO(ioa))
+    }
 
   implicit def catsStateTLiftIO[F[_]: LiftIO: Applicative, S]: LiftIO[StateT[F, S, ?]] =
     new StateTLiftIO[F, S] { def F = LiftIO[F]; def FA = Applicative[F] }

--- a/core/shared/src/main/scala/cats/effect/Sync.scala
+++ b/core/shared/src/main/scala/cats/effect/Sync.scala
@@ -60,12 +60,8 @@ private[effect] trait SyncInstances {
 
     def flatMap[A, B](fa: Eval[A])(f: A => Eval[B]): Eval[B] = fa.flatMap(f)
 
-    def tailRecM[A, B](a: A)(f: A => Eval[Either[A,B]]): Eval[B] = {
-      f(a) flatMap {
-        case Left(nextA) => tailRecM(nextA)(f)
-        case Right(b) => pure(b)
-      }
-    }
+    def tailRecM[A, B](a: A)(f: A => Eval[Either[A,B]]): Eval[B] =
+      Eval.catsBimonadForEval.tailRecM(a)(f)
 
     def suspend[A](thunk: => Eval[A]): Eval[A] = Eval.defer(thunk)
 

--- a/core/shared/src/main/scala/cats/effect/Sync.scala
+++ b/core/shared/src/main/scala/cats/effect/Sync.scala
@@ -117,12 +117,8 @@ private[effect] trait SyncInstances {
       fa.flatMap(f)
 
     // overwriting the pre-existing one, since flatMap is guaranteed stack-safe
-    def tailRecM[A, B](a: A)(f: A => StateT[F, S, Either[A, B]]): StateT[F, S, B] = {
-      f(a) flatMap {
-        case Left(nextA) => tailRecM(nextA)(f)
-        case Right(b) => pure(b)
-      }
-    }
+    def tailRecM[A, B](a: A)(f: A => StateT[F, S, Either[A, B]]): StateT[F, S, B] =
+      StateT.catsDataMonadForStateT[F, S].tailRecM(a)(f)
 
     def suspend[A](thunk: => StateT[F, S, A]): StateT[F, S, A] =
       StateT.applyF(F.suspend(thunk.runF))

--- a/core/shared/src/main/scala/cats/effect/Sync.scala
+++ b/core/shared/src/main/scala/cats/effect/Sync.scala
@@ -19,7 +19,7 @@ package effect
 
 import simulacrum._
 
-import cats.data.{EitherT, OptionT, StateT}
+import cats.data.{EitherT, Kleisli, OptionT, StateT}
 
 /**
  * A monad that can suspend the execution of side effects
@@ -71,6 +71,9 @@ private[effect] trait SyncInstances {
   implicit def catsEitherTSync[F[_]: Sync, L]: Sync[EitherT[F, L, ?]] =
     new EitherTSync[F, L] { def F = Sync[F] }
 
+  implicit def catsKleisliSync[F[_]: Sync, R]: Sync[Kleisli[F, R, ?]] =
+    new KleisliSync[F, R] { def F = Sync[F] }
+
   implicit def catsOptionTSync[F[_]: Sync]: Sync[OptionT[F, ?]] =
     new OptionTSync[F] { def F = Sync[F] }
 
@@ -98,6 +101,33 @@ private[effect] trait SyncInstances {
 
     def suspend[A](thunk: => EitherT[F, L, A]): EitherT[F, L, A] =
       EitherT(F.suspend(thunk.value))
+  }
+
+  private[effect] trait KleisliSync[F[_], R] extends Sync[Kleisli[F, R, ?]] {
+    protected def F: Sync[F]
+    private implicit def _F = F
+
+    def pure[A](x: A): Kleisli[F, R, A] = Kleisli.pure(x)
+
+    // remove duplication when we upgrade to cats 1.0
+    def handleErrorWith[A](fa: Kleisli[F, R, A])(f: Throwable => Kleisli[F, R, A]): Kleisli[F, R, A] = {
+      Kleisli { r: R =>
+        F.handleErrorWith(fa.run(r))(e => f(e).run(r))
+      }
+    }
+
+    // remove duplication when we upgrade to cats 1.0
+    def raiseError[A](e: Throwable): Kleisli[F, R, A] =
+      Kleisli.lift(F.raiseError(e))
+
+    def flatMap[A, B](fa: Kleisli[F, R, A])(f: A => Kleisli[F, R, B]): Kleisli[F, R, B] =
+      fa.flatMap(f)
+
+    def tailRecM[A, B](a: A)(f: A => Kleisli[F, R, Either[A, B]]): Kleisli[F, R, B] =
+      Kleisli.catsDataMonadReaderForKleisli[F, R].tailRecM(a)(f)
+
+    def suspend[A](thunk: => Kleisli[F, R, A]): Kleisli[F, R, A] =
+      Kleisli(r => F.suspend(thunk.run(r)))
   }
 
   private[effect] trait OptionTSync[F[_]] extends Sync[OptionT[F, ?]] {

--- a/core/shared/src/main/scala/cats/effect/Sync.scala
+++ b/core/shared/src/main/scala/cats/effect/Sync.scala
@@ -48,26 +48,6 @@ trait Sync[F[_]] extends MonadError[F, Throwable] {
 
 private[effect] trait SyncInstances {
 
-  implicit object catsSyncForEval extends Sync[Eval] {
-    def pure[A](a: A): Eval[A] = Now(a)
-
-    // TODO replace with delegation when we upgrade to cats 1.0
-    def handleErrorWith[A](fa: Eval[A])(f: Throwable => Eval[A]): Eval[A] =
-      suspend(try Now(fa.value) catch { case internals.NonFatal(t) => f(t) })
-
-    // TODO replace with delegation when we upgrade to cats 1.0
-    def raiseError[A](e: Throwable): Eval[A] = suspend(throw e)
-
-    def flatMap[A, B](fa: Eval[A])(f: A => Eval[B]): Eval[B] = fa.flatMap(f)
-
-    def tailRecM[A, B](a: A)(f: A => Eval[Either[A,B]]): Eval[B] =
-      Eval.catsBimonadForEval.tailRecM(a)(f)
-
-    def suspend[A](thunk: => Eval[A]): Eval[A] = Eval.defer(thunk)
-
-    override def delay[A](thunk: => A): Eval[A] = Eval.always(thunk)
-  }
-
   implicit def catsEitherTSync[F[_]: Sync, L]: Sync[EitherT[F, L, ?]] =
     new EitherTSync[F, L] { def F = Sync[F] }
 

--- a/core/shared/src/test/scala/cats/effect/Generators.scala
+++ b/core/shared/src/test/scala/cats/effect/Generators.scala
@@ -19,6 +19,7 @@ package effect
 
 import org.scalacheck._
 
+import scala.concurrent.Future
 import scala.util.Either
 
 object Generators {
@@ -51,4 +52,7 @@ object Generators {
     ioa <- arbitrary[IO[A]]
     f <- arbitrary[A => IO[A]]
   } yield ioa.flatMap(f)
+
+  implicit def cogenIO[A](implicit cgfa: Cogen[Future[A]]): Cogen[IO[A]] =
+    cgfa.contramap((ioa: IO[A]) => ioa.unsafeToFuture)
 }

--- a/laws/js/src/main/scala/cats/effect/laws/discipline/EffectTestsPlatform.scala
+++ b/laws/js/src/main/scala/cats/effect/laws/discipline/EffectTestsPlatform.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package laws
+package discipline
+
+private[discipline] trait EffectTestsPlatform {
+  final def isJVM = false
+}

--- a/laws/jvm/src/main/scala/cats/effect/laws/discipline/EffectTestsPlatform.scala
+++ b/laws/jvm/src/main/scala/cats/effect/laws/discipline/EffectTestsPlatform.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package laws
+package discipline
+
+private[discipline] trait EffectTestsPlatform {
+  final def isJVM = true
+}

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -38,7 +38,7 @@ trait AsyncLaws[F[_]] extends SyncLaws[F] {
       cb(Right(()))
     }
 
-    val read: F[A] = F.async(_(Right(cur)))
+    val read: F[A] = F.delay(cur)
 
     change >> change >> read <-> F.pure(f(f(a)))
   }

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/EffectTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/EffectTests.scala
@@ -19,7 +19,6 @@ package effect
 package laws
 package discipline
 
-import cats.data._
 import cats.instances.all._
 import cats.laws.discipline._
 import cats.laws.discipline.CartesianTests.Isomorphisms
@@ -47,7 +46,6 @@ trait EffectTests[F[_]] extends AsyncTests[F] with SyncTests[F] {
       EqT: Eq[Throwable],
       EqFEitherTU: Eq[F[Either[Throwable, Unit]]],
       EqFEitherTA: Eq[F[Either[Throwable, A]]],
-      EqEitherTFTA: Eq[EitherT[F, Throwable, A]],
       EqFABC: Eq[F[(A, B, C)]],
       EqFInt: Eq[F[Int]],
       EqIOA: Eq[IO[A]],

--- a/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
@@ -18,7 +18,7 @@ package cats
 package effect
 
 import cats.data.{EitherT, Kleisli, OptionT, StateT, WriterT}
-import cats.effect.laws.discipline.{AsyncTests, EffectTests, SyncTests}
+import cats.effect.laws.discipline.{AsyncTests, EffectTests}
 import cats.effect.laws.util.TestContext
 import cats.implicits._
 import cats.laws.discipline.arbitrary._
@@ -31,8 +31,6 @@ import scala.util.Try
 
 class InstancesTests extends BaseTestsSuite {
   import Generators._
-
-  checkAll("Eval", SyncTests[Eval].sync[Int, Int, Int])
 
   checkAllAsync("StateT[IO, S, ?]",
     implicit ec => EffectTests[StateT[IO, Int, ?]].effect[Int, Int, Int])

--- a/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
@@ -17,7 +17,7 @@
 package cats
 package effect
 
-import cats.data.StateT
+import cats.data.{EitherT, StateT}
 import cats.effect.laws.discipline.{EffectTests, SyncTests}
 import cats.effect.laws.util.TestContext
 import cats.implicits._
@@ -36,6 +36,9 @@ class InstancesTests extends BaseTestsSuite {
 
   checkAllAsync("StateT[IO, S, ?]",
     implicit ec => EffectTests[StateT[IO, Int, ?]].effect[Int, Int, Int])
+
+  checkAllAsync("EitherT[IO, Throwable, ?]",
+    implicit ec => EffectTests[EitherT[IO, Throwable, ?]].effect[Int, Int, Int])
 
   // assume exceptions are equivalent if the exception name + message
   // match as strings.

--- a/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+
+import cats.effect.laws.discipline.SyncTests
+import cats.implicits._
+import cats.laws.discipline.arbitrary._
+
+import scala.util.Try
+
+class InstancesTests extends BaseTestsSuite {
+
+  checkAll("Eval", SyncTests[Eval].sync[Int, Int, Int])
+
+  // assume exceptions are equivalent if the exception name + message
+  // match as strings.
+  implicit def throwableEq: Eq[Throwable] =
+    Eq[String].contramap((t: Throwable) => t.toString)
+
+  // we want exceptions which occur during .value calls to be equal to
+  // each other, assuming the exceptions seem equivalent.
+  implicit def eqWithTry[A: Eq]: Eq[Eval[A]] =
+    Eq[Try[A]].on((e: Eval[A]) => Try(e.value))
+}

--- a/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
@@ -17,7 +17,7 @@
 package cats
 package effect
 
-import cats.data.{EitherT, Kleisli, OptionT, StateT}
+import cats.data.{EitherT, Kleisli, OptionT, StateT, WriterT}
 import cats.effect.laws.discipline.{AsyncTests, EffectTests, SyncTests}
 import cats.effect.laws.util.TestContext
 import cats.implicits._
@@ -45,6 +45,9 @@ class InstancesTests extends BaseTestsSuite {
 
   checkAllAsync("EitherT[IO, Throwable, ?]",
     implicit ec => EffectTests[EitherT[IO, Throwable, ?]].effect[Int, Int, Int])
+
+  checkAllAsync("WriterT[IO, Int, ?]",
+    implicit ec => EffectTests[WriterT[IO, Int, ?]].effect[Int, Int, Int])
 
   // assume exceptions are equivalent if the exception name + message
   // match as strings.

--- a/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
@@ -17,8 +17,8 @@
 package cats
 package effect
 
-import cats.data.{EitherT, StateT}
-import cats.effect.laws.discipline.{EffectTests, SyncTests}
+import cats.data.{EitherT, OptionT, StateT}
+import cats.effect.laws.discipline.{AsyncTests, EffectTests, SyncTests}
 import cats.effect.laws.util.TestContext
 import cats.implicits._
 import cats.laws.discipline.arbitrary._
@@ -36,6 +36,9 @@ class InstancesTests extends BaseTestsSuite {
 
   checkAllAsync("StateT[IO, S, ?]",
     implicit ec => EffectTests[StateT[IO, Int, ?]].effect[Int, Int, Int])
+
+  checkAllAsync("OptionT[IO, ?]",
+    implicit ec => AsyncTests[OptionT[IO, ?]].async[Int, Int, Int])
 
   checkAllAsync("EitherT[IO, Throwable, ?]",
     implicit ec => EffectTests[EitherT[IO, Throwable, ?]].effect[Int, Int, Int])

--- a/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
@@ -17,7 +17,7 @@
 package cats
 package effect
 
-import cats.data.{EitherT, OptionT, StateT}
+import cats.data.{EitherT, Kleisli, OptionT, StateT}
 import cats.effect.laws.discipline.{AsyncTests, EffectTests, SyncTests}
 import cats.effect.laws.util.TestContext
 import cats.implicits._
@@ -40,6 +40,9 @@ class InstancesTests extends BaseTestsSuite {
   checkAllAsync("OptionT[IO, ?]",
     implicit ec => AsyncTests[OptionT[IO, ?]].async[Int, Int, Int])
 
+  checkAllAsync("Kleisli[IO, Int, ?]",
+    implicit ec => AsyncTests[Kleisli[IO, Int, ?]].async[Int, Int, Int])
+
   checkAllAsync("EitherT[IO, Throwable, ?]",
     implicit ec => EffectTests[EitherT[IO, Throwable, ?]].effect[Int, Int, Int])
 
@@ -57,6 +60,9 @@ class InstancesTests extends BaseTestsSuite {
     implicit
       arbFSA: Arbitrary[F[S => F[(S, A)]]]): Arbitrary[StateT[F, S, A]] =
     Arbitrary(arbFSA.arbitrary.map(StateT.applyF(_)))
+
+  implicit def keisliEq[F[_], R: Monoid, A](implicit FA: Eq[F[A]]): Eq[Kleisli[F, R, A]] =
+    Eq.by(_.run(Monoid[R].empty))
 
   // for some reason, the function1Eq in cats causes spurious test failures?
   implicit def stateTEq[F[_]: FlatMap, S: Monoid, A](implicit FSA: Eq[F[(S, A)]]): Eq[StateT[F, S, A]] =


### PR DESCRIPTION
Most notably, this adds `Sync[Eval]`, but we also get a number of other things related to transformer stacks.  Automatic derivation of `Async` in a basic transformer stack is now possible under most circumstances, though the usual caveats around ambiguity remain (since `Async <: Monad`), and automatic derivation of `Effect` is possible under *specific* circumstances.  Specifically: `StateT[F, S, ?]` given `Monoid[S]`, `WriterT` and `EitherT[F, Throwable, ?]` (which it implements by flattening the inner context into the outer).

Closes #48.