### PR TITLE
Added Sync[EitherT[Eval, Throwable, ?]] instance

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,6 +120,16 @@ val mimaSettings = Seq(
       tags filter { _ startsWith s"v$major.$minor" } map { _ substring 1 }
 
     versions map { v => organization.value %% name.value % v } toSet
+  },
+
+  mimaBinaryIssueFilters ++= {
+    import com.typesafe.tools.mima.core._
+    import com.typesafe.tools.mima.core.ProblemFilters._
+
+    Seq(
+      // everything in SyncInstances is fine, since it's package-private
+      exclude[ReversedMissingMethodProblem]("cats.effect.SyncInstances.cats$effect$SyncInstances$_setter_$catsEitherTEvalSync_="),
+      exclude[ReversedMissingMethodProblem]("cats.effect.SyncInstances.catsEitherTEvalSync"))
   }
 )
 

--- a/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
@@ -18,7 +18,7 @@ package cats
 package effect
 
 import cats.data.{EitherT, Kleisli, OptionT, StateT, WriterT}
-import cats.effect.laws.discipline.{AsyncTests, EffectTests}
+import cats.effect.laws.discipline.{AsyncTests, EffectTests, SyncTests}
 import cats.effect.laws.util.TestContext
 import cats.implicits._
 import cats.laws.discipline.arbitrary._
@@ -31,6 +31,9 @@ import scala.util.Try
 
 class InstancesTests extends BaseTestsSuite {
   import Generators._
+
+  checkAll("EitherT[Eval, Throwable, ?]",
+    SyncTests[EitherT[Eval, Throwable, ?]].sync[Int, Int, Int])
 
   checkAllAsync("StateT[IO, S, ?]",
     implicit ec => EffectTests[StateT[IO, Int, ?]].effect[Int, Int, Int])


### PR DESCRIPTION
Given the removal of `MonadError[Sync, Throwable]`, it seems that something like this would be useful.