### PR TITLE
Remove Effect.liftIO

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Async.scala
+++ b/core/shared/src/main/scala/cats/effect/Async.scala
@@ -45,8 +45,6 @@ trait Async[F[_]] extends Sync[F] with LiftIO[F] {
    */
   def async[A](k: (Either[Throwable, A] => Unit) => Unit): F[A]
 
-  def liftIO[A](ioa: IO[A]): F[A] = ioa.to[F](this)
-
   /**
    * @see [[IO#shift]]
    */
@@ -56,6 +54,11 @@ trait Async[F[_]] extends Sync[F] with LiftIO[F] {
         def run() = cb(Right(()))
       })
     }
+  }
+
+  override def liftIO[A](ioa: IO[A]): F[A] = {
+    // Able to provide default with `IO#to`, given this `Async[F]`
+    ioa.to[F](this)
   }
 }
 

--- a/core/shared/src/main/scala/cats/effect/Effect.scala
+++ b/core/shared/src/main/scala/cats/effect/Effect.scala
@@ -35,12 +35,6 @@ s.c.ExecutionContext in scope, a Strategy or some equivalent type.""")
 trait Effect[F[_]] extends Async[F] {
 
   def runAsync[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit]
-
-  override def liftIO[A](ioa: IO[A]): F[A] = {
-    // Implementation for `IO#to` depends on the `Async` type class,
-    // and not on `Effect`, so this shouldn't create a cyclic dependency
-    ioa.to[F](this)
-  }
 }
 
 private[effect] trait EffectInstances {


### PR DESCRIPTION
We forgot about this override when we overrode it in `Async`.