### PR TITLE
Pull up laws

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Async.scala
+++ b/core/shared/src/main/scala/cats/effect/Async.scala
@@ -19,7 +19,7 @@ package effect
 
 import simulacrum._
 
-import cats.data.{EitherT, Kleisli, OptionT, StateT, WriterT}
+import cats.data.{EitherT, OptionT, StateT, WriterT}
 
 import scala.annotation.implicitNotFound
 import scala.concurrent.ExecutionContext
@@ -67,9 +67,6 @@ private[effect] trait AsyncInstances {
   implicit def catsEitherTAsync[F[_]: Async, L]: Async[EitherT[F, L, ?]] =
     new EitherTAsync[F, L] { def F = Async[F] }
 
-  implicit def catsKleisliAsync[F[_]: Async, R]: Async[Kleisli[F, R, ?]] =
-    new KleisliAsync[F, R] { def F = Async[F] }
-
   implicit def catsOptionTAsync[F[_]: Async]: Async[OptionT[F, ?]] =
     new OptionTAsync[F] { def F = Async[F] }
 
@@ -90,17 +87,6 @@ private[effect] trait AsyncInstances {
 
     def async[A](k: (Either[Throwable, A] => Unit) => Unit): EitherT[F, L, A] =
       EitherT.liftT(F.async(k))
-  }
-
-  private[effect] trait KleisliAsync[F[_], R]
-      extends Async[Kleisli[F, R, ?]]
-      with Sync.KleisliSync[F, R]
-      with LiftIO.KleisliLiftIO[F, R] {
-
-    override protected def F: Async[F]
-
-    def async[A](k: (Either[Throwable, A] => Unit) => Unit): Kleisli[F, R, A] =
-      Kleisli.lift(F.async(k))
   }
 
   private[effect] trait OptionTAsync[F[_]]

--- a/laws/js/src/main/scala/cats/effect/laws/discipline/TestsPlatform.scala
+++ b/laws/js/src/main/scala/cats/effect/laws/discipline/TestsPlatform.scala
@@ -19,6 +19,6 @@ package effect
 package laws
 package discipline
 
-private[discipline] trait EffectTestsPlatform {
+private[discipline] trait TestsPlatform {
   final def isJVM = false
 }

--- a/laws/jvm/src/main/scala/cats/effect/laws/discipline/TestsPlatform.scala
+++ b/laws/jvm/src/main/scala/cats/effect/laws/discipline/TestsPlatform.scala
@@ -19,6 +19,6 @@ package effect
 package laws
 package discipline
 
-private[discipline] trait EffectTestsPlatform {
+private[discipline] trait TestsPlatform {
   final def isJVM = true
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -42,6 +42,12 @@ trait AsyncLaws[F[_]] extends SyncLaws[F] {
 
     change >> change >> read <-> F.pure(f(f(a)))
   }
+
+  def propagateErrorsThroughBindAsync[A](t: Throwable) = {
+    val fa = F.attempt(F.async[A](_(Left(t))).flatMap(x => F.pure(x)))
+
+    fa <-> F.pure(Left(t))
+  }
 }
 
 object AsyncLaws {

--- a/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
@@ -54,25 +54,6 @@ trait EffectLaws[F[_]] extends AsyncLaws[F] {
 
     test >> readResult <-> IO.pure(f(a))
   }
-
-  // the following law(s) should really be on MonadError
-  def propagateErrorsThroughBindSuspend[A](t: Throwable) = {
-    val fa = F.attempt(F.delay[A](throw t).flatMap(x => F.pure(x)))
-
-    var result: Either[Throwable, Either[Throwable, A]] = Left(new AssertionError)
-    val read = IO { result }
-
-    F.runAsync(fa)(e => IO { result = e }) >> read <-> IO.pure(Right(Left(t)))
-  }
-
-  def propagateErrorsThroughBindAsync[A](t: Throwable) = {
-    val fa = F.attempt(F.async[A](_(Left(t))).flatMap(x => F.pure(x)))
-
-    var result: Either[Throwable, Either[Throwable, A]] = Left(new AssertionError)
-    val read = IO { result }
-
-    F.runAsync(fa)(e => IO { result = e }) >> read <-> IO.pure(Right(Left(t)))
-  }
 }
 
 object EffectLaws {

--- a/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
@@ -55,30 +55,6 @@ trait EffectLaws[F[_]] extends AsyncLaws[F] {
     test >> readResult <-> IO.pure(f(a))
   }
 
-  lazy val stackSafetyOnRepeatedLeftBinds = {
-    val result = (0 until 10000).foldLeft(F.delay(())) { (acc, _) =>
-      acc.flatMap(_ => F.delay(()))
-    }
-
-    F.runAsync(result)(_ => IO.unit).unsafeRunSync() <-> (())
-  }
-
-  lazy val stackSafetyOnRepeatedRightBinds = {
-    val result = (0 until 10000).foldRight(F.delay(())) { (_, acc) =>
-      F.delay(()).flatMap(_ => acc)
-    }
-
-    F.runAsync(result)(_ => IO.unit).unsafeRunSync() <-> (())
-  }
-
-  lazy val stackSafetyOnRepeatedAttempts = {
-    val result = (0 until 10000).foldLeft(F.delay(())) { (acc, _) =>
-      F.attempt(acc).map(_ => ())
-    }
-
-    F.runAsync(result)(_ => IO.unit).unsafeRunSync() <-> (())
-  }
-
   // the following law(s) should really be on MonadError
   def propagateErrorsThroughBindSuspend[A](t: Throwable) = {
     val fa = F.attempt(F.delay[A](throw t).flatMap(x => F.pure(x)))

--- a/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
@@ -40,6 +40,11 @@ trait EffectLaws[F[_]] extends AsyncLaws[F] {
     F.runAsync(fa)(e => IO { result = Some(e) }) >> read <-> IO.pure(Left(e))
   }
 
+  def runAsyncIgnoresErrorInHandler[A](e: Throwable) = {
+    val fa = F.pure(())
+    F.runAsync(fa)(_ => IO.raiseError(e)) <-> IO.pure(())
+  }
+
   def repeatedCallbackIgnored[A](a: A, f: A => A) = {
     var cur = a
     val change = F.delay(cur = f(cur))

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
@@ -51,6 +51,30 @@ trait SyncLaws[F[_]] extends MonadErrorLaws[F, Throwable] {
 
     change >> change >> read <-> F.pure(f(f(a)))
   }
+
+  lazy val stackSafetyOnRepeatedLeftBinds = {
+    val result = (0 until 10000).foldLeft(F.delay(())) { (acc, _) =>
+      acc.flatMap(_ => F.delay(()))
+    }
+
+    result <-> F.pure(())
+  }
+
+  lazy val stackSafetyOnRepeatedRightBinds = {
+    val result = (0 until 10000).foldRight(F.delay(())) { (_, acc) =>
+      F.delay(()).flatMap(_ => acc)
+    }
+
+    result <-> F.pure(())
+  }
+
+  lazy val stackSafetyOnRepeatedAttempts = {
+    val result = (0 until 10000).foldLeft(F.delay(())) { (acc, _) =>
+      F.attempt(acc).map(_ => ())
+    }
+
+    result <-> F.pure(())
+  }
 }
 
 object SyncLaws {

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
@@ -52,6 +52,12 @@ trait SyncLaws[F[_]] extends MonadErrorLaws[F, Throwable] {
     change >> change >> read <-> F.pure(f(f(a)))
   }
 
+  def propagateErrorsThroughBindSuspend[A](t: Throwable) = {
+    val fa = F.attempt(F.delay[A](throw t).flatMap(x => F.pure(x)))
+
+    fa <-> F.pure(Left(t))
+  }
+
   lazy val stackSafetyOnRepeatedLeftBinds = {
     val result = (0 until 10000).foldLeft(F.delay(())) { (acc, _) =>
       acc.flatMap(_ => F.delay(()))

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
@@ -58,7 +58,8 @@ trait AsyncTests[F[_]] extends SyncTests[F] {
       val props = Seq(
         "async right is pure" -> forAll(laws.asyncRightIsPure[A] _),
         "async left is raiseError" -> forAll(laws.asyncLeftIsRaiseError[A] _),
-        "repeated async evaluation not memoized" -> forAll(laws.repeatedAsyncEvaluationNotMemoized[A] _))
+        "repeated async evaluation not memoized" -> forAll(laws.repeatedAsyncEvaluationNotMemoized[A] _),
+        "propagate errors through bind (async)" -> forAll(laws.propagateErrorsThroughBindSuspend[A] _))
     }
   }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
@@ -43,6 +43,7 @@ trait AsyncTests[F[_]] extends SyncTests[F] {
       EqFA: Eq[F[A]],
       EqFB: Eq[F[B]],
       EqFC: Eq[F[C]],
+      EqFU: Eq[F[Unit]],
       EqT: Eq[Throwable],
       EqFEitherTU: Eq[F[Either[Throwable, Unit]]],
       EqFEitherTA: Eq[F[Either[Throwable, A]]],

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/EffectTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/EffectTests.scala
@@ -50,7 +50,6 @@ trait EffectTests[F[_]] extends AsyncTests[F] {
       EqFInt: Eq[F[Int]],
       EqIOA: Eq[IO[A]],
       EqIOEitherTA: Eq[IO[Either[Throwable, A]]],
-      EqIOEitherEitherTA: Eq[IO[Either[Throwable, Either[Throwable, A]]]],
       iso: Isomorphisms[F]): RuleSet = {
     new RuleSet {
       val name = "effect"
@@ -60,9 +59,7 @@ trait EffectTests[F[_]] extends AsyncTests[F] {
       val props = Seq(
         "runAsync pure produces right IO" -> forAll(laws.runAsyncPureProducesRightIO[A] _),
         "runAsync raiseError produces left IO" -> forAll(laws.runAsyncRaiseErrorProducesLeftIO[A] _),
-        "repeated callback ignored" -> forAll(laws.repeatedCallbackIgnored[A] _),
-        "propagate errors through bind (suspend)" -> forAll(laws.propagateErrorsThroughBindSuspend[A] _),
-        "propagate errors through bind (async)" -> forAll(laws.propagateErrorsThroughBindSuspend[A] _))
+        "repeated callback ignored" -> forAll(laws.repeatedCallbackIgnored[A] _))
     }
   }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/EffectTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/EffectTests.scala
@@ -49,6 +49,7 @@ trait EffectTests[F[_]] extends AsyncTests[F] {
       EqFABC: Eq[F[(A, B, C)]],
       EqFInt: Eq[F[Int]],
       EqIOA: Eq[IO[A]],
+      EqIOU: Eq[IO[Unit]],
       EqIOEitherTA: Eq[IO[Either[Throwable, A]]],
       iso: Isomorphisms[F]): RuleSet = {
     new RuleSet {
@@ -59,6 +60,7 @@ trait EffectTests[F[_]] extends AsyncTests[F] {
       val props = Seq(
         "runAsync pure produces right IO" -> forAll(laws.runAsyncPureProducesRightIO[A] _),
         "runAsync raiseError produces left IO" -> forAll(laws.runAsyncRaiseErrorProducesLeftIO[A] _),
+        "runAsync ignores error in handler" -> forAll(laws.runAsyncIgnoresErrorInHandler[A] _),
         "repeated callback ignored" -> forAll(laws.repeatedCallbackIgnored[A] _))
     }
   }

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/SyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/SyncTests.scala
@@ -62,7 +62,8 @@ trait SyncTests[F[_]] extends MonadErrorTests[F, Throwable] with TestsPlatform {
         "throw in delay is raiseError" -> forAll(laws.delayThrowIsRaiseError[A] _),
         "throw in suspend is raiseError" -> forAll(laws.suspendThrowIsRaiseError[A] _),
         "unsequenced delay is no-op" -> forAll(laws.unsequencedDelayIsNoop[A] _),
-        "repeated sync evaluation not memoized" -> forAll(laws.repeatedSyncEvaluationNotMemoized[A] _))
+        "repeated sync evaluation not memoized" -> forAll(laws.repeatedSyncEvaluationNotMemoized[A] _),
+        "propagate errors through bind (suspend)" -> forAll(laws.propagateErrorsThroughBindSuspend[A] _))
 
       val jvmProps = Seq(
         "stack-safe on left-associated binds" -> Prop.lzy(laws.stackSafetyOnRepeatedLeftBinds),

--- a/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
@@ -27,7 +27,6 @@ import cats.implicits._
 import cats.laws.discipline.arbitrary.{
   catsLawsArbitraryForEitherT,
   catsLawsArbitraryForEval,
-  catsLawsArbitraryForKleisli,
   catsLawsArbitraryForOptionT,
   catsLawsArbitraryForWriterT
 }
@@ -49,9 +48,6 @@ class InstancesTests extends BaseTestsSuite {
 
   checkAllAsync("OptionT[IO, ?]",
     implicit ec => AsyncTests[OptionT[IO, ?]].async[Int, Int, Int])
-
-  checkAllAsync("Kleisli[IO, Int, ?]",
-    implicit ec => AsyncTests[Kleisli[IO, Int, ?]].async[Int, Int, Int])
 
   checkAllAsync("EitherT[IO, Throwable, ?]",
     implicit ec => EffectTests[EitherT[IO, Throwable, ?]].effect[Int, Int, Int])


### PR DESCRIPTION
Fixes #52 

Moves stack-safety laws up into `SyncLaws`, as well as some of the error propagation laws.  Also adds a law which stipulates that errors in the `runAsync` handler effect must be discarded (previously this was unspecified).

I had to remove the `Async[Kleisli[F, R, ?]]` instance with the laws moving up, because `Kleisli` is stack-unsafe on left-associated binds (see: https://github.com/typelevel/cats/issues/1733).  This is a shame, but not entirely unexpected.