### PR TITLE
Modify SyncLaws to allow types to emit more than one value, thus allowing streams

### DIFF
--- a/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
@@ -53,9 +53,9 @@ trait SyncLaws[F[_]] extends MonadErrorLaws[F, Throwable] {
   }
 
   def propagateErrorsThroughBindSuspend[A](t: Throwable) = {
-    val fa = F.attempt(F.delay[A](throw t).flatMap(x => F.pure(x)))
+    val fa = F.delay[A](throw t).flatMap(x => F.pure(x))
 
-    fa <-> F.pure(Left(t))
+    fa <-> F.raiseError(t)
   }
 
   lazy val stackSafetyOnRepeatedLeftBinds = {


### PR DESCRIPTION
This law is in my opinion incorrectly defined:

```scala
def propagateErrorsThroughBindSuspend[A](t: Throwable) = {
    val fa = F.attempt(F.delay[A](throw t).flatMap(x => F.pure(x)))

    fa <-> F.pure(Left(t))
}
```

The problem is that I just implemented `Sync` for an `F` type that is a stream and that emits multiple `A` values. There's nothing in the `Sync` laws that prevent this and I don't see why I shouldn't do it, except for the law above, which indirectly prevents this usage.

The problem is that the given equivalence will not hold, because it's going to end up with something like `List(Right(a), Right(a), Left(e)) <-> List(Left(e))`.

This happens for `raiseError` as well, however in the case of `raiseError` you can clearly bend the `Eq` definition to allow 2 values to be equivalent, even if they emitted elements before that, since we are dealing with non-termination stuff. But if you materialize that error in `Left`, there's no reasonable `Eq` I can provide for my type for this to hold.

So this PR changes the law to use `F.raiseError(t)` instead.