### PR TITLE
Publish arbitrary instances in cats-effect-laws

### DIFF
--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -21,6 +21,7 @@ import cats.Eval.always
 import java.util.concurrent.atomic.AtomicInteger
 
 import cats.effect.laws.discipline.EffectTests
+import cats.effect.laws.discipline.arbitrary._
 import cats.implicits._
 import cats.kernel.laws.GroupLaws
 import cats.laws._
@@ -31,7 +32,6 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 class IOTests extends BaseTestsSuite {
-  import Generators._
 
   checkAllAsync("IO", implicit ec => EffectTests[IO].effect[Int, Int, Int])
   checkAllAsync("IO", implicit ec => GroupLaws[IO[Int]].monoid)

--- a/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
@@ -19,6 +19,7 @@ package effect
 
 import cats.data.{EitherT, Kleisli, OptionT, StateT, WriterT}
 import cats.effect.laws.discipline.{AsyncTests, EffectTests, SyncTests}
+import cats.effect.laws.discipline.arbitrary._
 import cats.effect.laws.util.TestContext
 import cats.implicits._
 
@@ -38,7 +39,6 @@ import scala.concurrent.Future
 import scala.util.Try
 
 class InstancesTests extends BaseTestsSuite {
-  import Generators._
 
   checkAll("EitherT[Eval, Throwable, ?]",
     SyncTests[EitherT[Eval, Throwable, ?]].sync[Int, Int, Int])


### PR DESCRIPTION
This makes `Arbitrary[IO]` and `Cogen[IO]` available to other projects that depend on cats-effect-laws.

- Repackaged to mirror `cats.laws.discipline.arbitrary`
- Implicits renamed to follow cats guidelines.

Fixes #74.
