### PR TITLE
IO.fromFuture now takes an IO

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -227,7 +227,7 @@ lazy val lawsJS = laws.js
  * version bump of 1.0.  Again, this is all to avoid pre-committing
  * to a major/minor bump before the work is done (see: Scala 2.8).
  */
-val BaseVersion = "0.5"
+val BaseVersion = "0.6"
 
 licenses in ThisBuild += ("Apache-2.0", url("http://www.apache.org/licenses/"))
 


### PR DESCRIPTION
`IO.fromFuture` now takes an `IO` (fixes #78). Also change the param name of `IO.eval` so as not to suggest that it could be effectful.