### PR TITLE
Third optimization batch — map fusion

### DIFF
--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapBenchmark.scala
@@ -39,30 +39,44 @@ import org.openjdk.jmh.annotations._
 class MapBenchmark {
   @Benchmark
   def one(): Int = {
-    IO(0).map(_ + 1).unsafeRunSync()
+    def loop(io: IO[Int], count: Int): IO[Int] =
+      if (count > 0)
+        io.flatMap(_ => io.map(_ + 1))
+      else
+        io
+    
+    loop(IO(0), 1000).unsafeRunSync()
   }
 
   @Benchmark
   def batch(): Int = {
-    var io = IO(0)
-    var i = 0
-    while (i < 30) {
-      io = io.map(_ + 1)
-      i += 1
-    }
+    def loop(io: IO[Int], count: Int): IO[Int] =
+      if (count <= 0) io else io.flatMap { _ =>
+        var io2 = io
+        var i = 0
+        while (i < 30) {
+          io2 = io2.map(_ + 1)
+          i += 1
+        }
+        io2
+      }
 
-    io.unsafeRunSync()
+    loop(IO(0), 1000).unsafeRunSync()
   }
 
   @Benchmark
   def many(): Int = {
-    var io = IO(0)
-    var i = 0
-    while (i < 1000) {
-      io = io.map(_ + 1)
-      i += 1
-    }
+    def loop(io: IO[Int], count: Int): IO[Int] =
+      if (count <= 0) io else io.flatMap { _ =>
+        var io2 = io
+        var i = 0
+        while (i < 1000) {
+          io2 = io2.map(_ + 1)
+          i += 1
+        }
+        io2
+      }
 
-    io.unsafeRunSync()
+    loop(IO(0), 1000).unsafeRunSync()
   }
 }

--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapBenchmark.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cats.effect.benchmarks
+
+import java.util.concurrent.TimeUnit
+import cats.effect.IO
+import org.openjdk.jmh.annotations._
+
+/** To do comparative benchmarks between versions:
+  *
+  *     benchmarks/run-benchmark MapBenchmark
+  *
+  * This will generate results in `benchmarks/results`.
+  *
+  * Or to run the benchmark from within SBT:
+  *
+  *     jmh:run -i 10 -wi 10 -f 2 -t 1 cats.effect.benchmarks.MapBenchmark
+  *
+  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  * Please note that benchmarks should be usually executed at least in
+  * 10 iterations (as a rule of thumb), but more is better.
+  */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class MapBenchmark {
+  @Benchmark
+  def one(): Int = {
+    IO(0).map(_ + 1).unsafeRunSync()
+  }
+
+  @Benchmark
+  def batch(): Int = {
+    var io = IO(0)
+    var i = 0
+    while (i < 30) {
+      io = io.map(_ + 1)
+      i += 1
+    }
+
+    io.unsafeRunSync()
+  }
+
+  @Benchmark
+  def many(): Int = {
+    var io = IO(0)
+    var i = 0
+    while (i < 1000) {
+      io = io.map(_ + 1)
+      i += 1
+    }
+
+    io.unsafeRunSync()
+  }
+}

--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapStreamBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapStreamBenchmark.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cats.effect.benchmarks
+
+import java.util.concurrent.TimeUnit
+import cats.effect.IO
+import org.openjdk.jmh.annotations._
+
+/** To do comparative benchmarks between versions:
+  *
+  *     benchmarks/run-benchmark MapStreamBenchmark
+  *
+  * This will generate results in `benchmarks/results`.
+  *
+  * Or to run the benchmark from within SBT:
+  *
+  *     jmh:run -i 10 -wi 10 -f 2 -t 1 cats.effect.benchmarks.MapStreamBenchmark
+  *
+  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+  * Please note that benchmarks should be usually executed at least in
+  * 10 iterations (as a rule of thumb), but more is better.
+  */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class MapStreamBenchmark {
+  import MapStreamBenchmark.streamTest
+
+  @Benchmark
+  def one(): Long = streamTest(12000, 1)
+
+  @Benchmark
+  def batch30(): Long = streamTest(1000, 30)
+
+  @Benchmark
+  def batch120(): Long = streamTest(100, 120)
+}
+
+object MapStreamBenchmark {
+  def streamTest(times: Int, batchSize: Int): Long = {
+    var stream = range(0, times)
+    var i = 0
+    while (i < batchSize) {
+      stream = mapStream(addOne)(stream)
+      i += 1
+    }
+    sum(0)(stream).unsafeRunSync()
+  }
+
+  final case class Stream(value: Int, next: IO[Option[Stream]])
+  val addOne = (x: Int) => x + 1
+
+  def range(from: Int, until: Int): Option[Stream] =
+    if (from < until)
+      Some(Stream(from, IO(range(from + 1, until))))
+    else
+      None
+
+  def mapStream(f: Int => Int)(box: Option[Stream]): Option[Stream] =
+    box match {
+      case Some(Stream(value, next)) =>
+        Some(Stream(f(value), next.map(mapStream(f))))
+      case None =>
+        None
+    }
+
+  def sum(acc: Long)(box: Option[Stream]): IO[Long] =
+    box match {
+      case Some(Stream(value, next)) =>
+        next.flatMap(sum(acc + value))
+      case None =>
+        IO.pure(acc)
+    }
+}

--- a/core/js/src/main/scala/cats/effect/internals/IOPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOPlatform.scala
@@ -17,7 +17,9 @@
 package cats.effect.internals
 
 import cats.effect.IO
+
 import scala.concurrent.duration.Duration
+import scala.util.Try
 
 private[effect] object IOPlatform {
   /**
@@ -44,4 +46,10 @@ private[effect] object IOPlatform {
       f(a)
     }
   }
+
+  /**
+   * Establishes the maximum stack depth for `IO#map` operations
+   * for JavaScript.
+   */
+  private[effect] final val fusionMaxStackDepth = 32
 }

--- a/core/js/src/main/scala/cats/effect/internals/IOPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOPlatform.scala
@@ -17,9 +17,7 @@
 package cats.effect.internals
 
 import cats.effect.IO
-
 import scala.concurrent.duration.Duration
-import scala.util.Try
 
 private[effect] object IOPlatform {
   /**

--- a/core/js/src/main/scala/cats/effect/internals/IOPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOPlatform.scala
@@ -49,7 +49,10 @@ private[effect] object IOPlatform {
 
   /**
    * Establishes the maximum stack depth for `IO#map` operations
-   * for JavaScript.
+   * for JavaScript. 
+   *
+   * The default for JavaScript is 32, from which we substract 1
+   * as an optimization.
    */
-  private[effect] final val fusionMaxStackDepth = 32
+  private[effect] final val fusionMaxStackDepth = 31
 }

--- a/core/jvm/src/main/scala/cats/effect/internals/IOPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOPlatform.scala
@@ -88,7 +88,8 @@ private[effect] object IOPlatform {
   /**
    * Establishes the maximum stack depth for `IO#map` operations.
    *
-   * The default is `128`. This default has been reached like this:
+   * The default is `128`, from which we substract one as an 
+   * optimization. This default has been reached like this:
    *
    *  - according to official docs, the default stack size on 32-bits
    *    Windows and Linux was 320 KB, whereas for 64-bits it is 1024 KB

--- a/core/jvm/src/main/scala/cats/effect/internals/IOPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOPlatform.scala
@@ -23,7 +23,7 @@ import cats.effect.IO
 
 import scala.concurrent.blocking
 import scala.concurrent.duration.{Duration, FiniteDuration}
-import scala.util.Either
+import scala.util.{Either, Try}
 
 private[effect] object IOPlatform {
   /** 
@@ -84,4 +84,34 @@ private[effect] object IOPlatform {
       true
     }
   }
+
+  /**
+   * Establishes the maximum stack depth for `IO#map` operations.
+   *
+   * The default is `128`. This default has been reached like this:
+   *
+   *  - according to official docs, the default stack size on 32-bits
+   *    Windows and Linux was 320 KB, whereas for 64-bits it is 1024 KB
+   *  - according to measurements chaining `Function1` references uses
+   *    approximately 32 bytes of stack space on a 64 bits system;
+   *    this could be lower if "compressed oops" is activated
+   *  - therefore a "map fusion" that goes 128 in stack depth can use
+   *    about 4 KB of stack space
+   *
+   * If this parameter becomes a problem, it can be tuned by setting
+   * the `cats.effect.fusionMaxStackDepth` environment variable when
+   * executing the Java VM:
+   *
+   * <pre>
+   *   java -Dcats.effect.fusionMaxStackDepth=32 \
+   *        ...
+   * </pre>
+   */
+  private[effect] final val fusionMaxStackDepth =
+    Option(System.getProperty("cats.effect.fusionMaxStackDepth", ""))
+      .filter(s => s != null && s.nonEmpty)
+      .flatMap(s => Try(s.toInt).toOption)
+      .filter(_ > 0)
+      .map(_ - 1)
+      .getOrElse(127)
 }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -91,10 +91,10 @@ sealed abstract class IO[+A] {
    */
   final def map[B](f: A => B): IO[B] =
     this match {
-      case ref @ RaiseError(_) => ref
       case Map(source, g, index) =>
-        // Allowed to do 128 map operations in sequence before
-        // triggering `flatMap` in order to avoid stack overflows
+        // Allowed to do fixed number of map operations fused before 
+        // triggering `flatMap` in order to avoid stack overflows;
+        // See `IOPlatform` for details on this maximum.
         if (index != fusionMaxStackDepth) Map(source, g.andThen(f), index + 1)
         else flatMap(a => Pure(f(a)))
       case _ =>

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -91,9 +91,14 @@ sealed abstract class IO[+A] {
    */
   final def map[B](f: A => B): IO[B] =
     this match {
-      case Pure(a) => try Pure(f(a)) catch { case NonFatal(e) => RaiseError(e) }
       case ref @ RaiseError(_) => ref
-      case _ => flatMap(a => Pure(f(a)))
+      case Map(source, g, index) =>
+        if (index < 32)
+          Map(source, g.andThen(f), index + 1)
+        else
+          flatMap(a => Pure(f(a)))
+      case _ =>
+        Map(this, f, 0)
     }
 
   /**
@@ -261,12 +266,14 @@ sealed abstract class IO[+A] {
             } else {
               val lh = F.suspend(source.to[F]).asInstanceOf[F[A]]
               F.handleErrorWith(lh) { e =>
-                m.asInstanceOf[ErrorHandler[IO[A]]].recover(e).to[F]
+                m.asInstanceOf[ErrorHandler[A]].recover(e).to[F]
               }
             }
           case f =>
             F.flatMap(F.suspend(source.to[F]))(e => f(e).to[F])
         }
+      case Map(source, f, _) =>
+        F.map(source.to[F])(f.asInstanceOf[Any => A])
     }
 
   override def toString = this match {
@@ -571,6 +578,17 @@ object IO extends IOInstances {
     extends IO[A]
   private[effect] final case class Bind[E, +A](source: IO[E], f: E => IO[A])
     extends IO[A]
+
+  /** State for representing `map` ops that itself is a function in
+    * order to avoid extraneous memory allocations when building the
+    * internal call-stack.
+    */
+  private[effect] final case class Map[E, +A](source: IO[E], f: E => A, index: Int)
+    extends IO[A] with (E => IO[A]) {
+
+    override def apply(value: E): IO[A] =
+      IO.pure(f(value))
+  }
 
   /** Internal reference, used as an optimization for [[IO.attempt]]
     * in order to avoid extraneous memory allocations.

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -93,10 +93,10 @@ sealed abstract class IO[+A] {
     this match {
       case Map(source, g, index) =>
         // Allowed to do fixed number of map operations fused before 
-        // triggering `flatMap` in order to avoid stack overflows;
+        // resetting the counter in order to avoid stack overflows;
         // See `IOPlatform` for details on this maximum.
         if (index != fusionMaxStackDepth) Map(source, g.andThen(f), index + 1)
-        else flatMap(a => Pure(f(a)))
+        else Map(this, f, 0)
       case _ =>
         Map(this, f, 0)
     }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -93,10 +93,10 @@ sealed abstract class IO[+A] {
     this match {
       case ref @ RaiseError(_) => ref
       case Map(source, g, index) =>
-        if (index < 32)
-          Map(source, g.andThen(f), index + 1)
-        else
-          flatMap(a => Pure(f(a)))
+        // Allowed to do 32 map operations in sequence before
+        // triggering `flatMap` in order to avoid stack overflows
+        if (index != 31) Map(source, g.andThen(f), index + 1)
+        else flatMap(a => Pure(f(a)))
       case _ =>
         Map(this, f, 0)
     }

--- a/core/shared/src/main/scala/cats/effect/internals/IOFrame.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOFrame.scala
@@ -16,6 +16,8 @@
 
 package cats.effect.internals
 
+import cats.effect.IO
+
 /** A mapping function that is also able to handle errors,
   * being the equivalent of:
   *
@@ -43,20 +45,16 @@ private[effect] object IOFrame {
   /** Builds a [[IOFrame]] instance that maps errors, but that isn't
     * defined for successful values (a partial function)
     */
-  def errorHandler[R](fe: Throwable => R): IOFrame[Any, R] =
+  def errorHandler[A](fe: Throwable => IO[A]): IOFrame[A, IO[A]] =
     new ErrorHandler(fe)
 
   /** [[IOFrame]] reference that only handles errors, useful for
     * quick filtering of `onErrorHandleWith` frames.
     */
-  final class ErrorHandler[+R](fe: Throwable => R)
-    extends IOFrame[Any, R] {
+  final class ErrorHandler[A](fe: Throwable => IO[A])
+    extends IOFrame[A, IO[A]] {
 
-    def recover(e: Throwable): R = fe(e)
-    def apply(a: Any): R = {
-      // $COVERAGE-OFF$
-      throw new NotImplementedError("IOFrame protocol breach")
-      // $COVERAGE-ON$
-    }
+    def recover(e: Throwable): IO[A] = fe(e)
+    def apply(a: A): IO[A] = IO.pure(a)
   }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/Arbitrary.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/Arbitrary.scala
@@ -36,6 +36,8 @@ object arbitrary {
       1 -> genFail[A],
       5 -> genAsync[A],
       5 -> genNestedAsync[A],
+      5 -> getMapOne[A],
+      5 -> getMapTwo[A],
       10 -> genFlatMap[A])
   }
 
@@ -71,6 +73,19 @@ object arbitrary {
       ioa <- getArbitrary[IO[A]]
       f <- getArbitrary[A => IO[A]]
     } yield ioa.flatMap(f)
+
+  def getMapOne[A: Arbitrary: Cogen]: Gen[IO[A]] =
+    for {
+      ioa <- getArbitrary[IO[A]]
+      f <- getArbitrary[A => A]
+    } yield ioa.map(f)
+
+  def getMapTwo[A: Arbitrary: Cogen]: Gen[IO[A]] =
+    for {
+      ioa <- getArbitrary[IO[A]]
+      f1 <- getArbitrary[A => A]
+      f2 <- getArbitrary[A => A]
+    } yield ioa.map(f1).map(f2)
 
   implicit def catsEffectLawsCogenForIO[A](implicit cgfa: Cogen[Future[A]]): Cogen[IO[A]] =
     cgfa.contramap((ioa: IO[A]) => ioa.unsafeToFuture)


### PR DESCRIPTION
Third PR addressing performance issues. Previous ones are #90 and #91.

Also addresses issue #92, but without the proposed laws.

---

In order to avoid stack-overflow errors, repeated `.map` calls trigger a `.flatMap` every 128 calls.

The rationale is thus — from my research the default stack size ranges from 320 KB on 32-bits operating systems to 1 MB on 64-bits operating systems. From my own tests a stack frame triggered by a `Function1` chaining consumes aproximately 32 bytes. So 128 fused `map` calls will consume `32 bytes * 128 = 4 KB` at a minimum (to which you add whatever else the user is doing on that stack).

In a real `flatMap` chain, which is what happens with `IO`, the performance does end up being dominated by `.flatMap` calls even with `.map` calls being mixed-in (a benchmark proving this will follow), however the improvements for `.map` are still good.

The important thing to watch out for in this optimization is that a degrading `.flatMap` isn't acceptable to make `.map` faster, but if we can manage a performance boost for fused `.map` calls without a `.flatMap` regression, then it's all good.

---

For benchmarking I've introduced 2 new benchmarks:

1. `MapCallsBenchmark` measures the performance of pure `map` calls (without being mixed within `.flatMap` loops)
2. `MapStreamBenchmark` measures the performance impact of a real-world use-case, showing what to expect from Monix's `Iterant` and possibly FS2

| Benchmark                          | 0.6-a581664 |       This PR |
|:-----------------------------------|------------:|--------------:|
| MapCallsBenchmark.batch120         |    5552.051 | **14680.810** |
| MapCallsBenchmark.batch30          |    4941.152 | **16196.342** |
| MapCallsBenchmark.one              |    6682.469 |      6167.908 |
| MapStreamBenchmark.batch120        |    2259.460 |      3176.587 |
| MapStreamBenchmark.batch30         |     918.054 |      1389.750 |
| MapStreamBenchmark.one             |    1418.865 |      1540.653 |

The other benchmarks:

| Benchmark                          | 0.6-a581664 |       This PR |
|:-----------------------------------|------------:|--------------:|
| AttemptBenchmark.errorRaised       |    1729.587 |      1750.409 |
| AttemptBenchmark.happyPath         |    2373.812 |      2316.602 |
| HandleErrorBenchmark.errorRaised   |    1974.071 |      2001.132 |
| HandleErrorBenchmark.happyPath     |    3005.539 |      2944.564 |
| DeepBindBenchmark.async            |     396.694 |       401.805 |
| DeepBindBenchmark.delay            |    6887.681 |      6601.429 |
| DeepBindBenchmark.pure             |    7849.842 |      7697.621 |
| ShallowBindBenchmark.async         |      90.336 |        83.502 |
| ShallowBindBenchmark.delay         |    5355.337 |      5324.081 |
| ShallowBindBenchmark.pure          |    6059.119 |      6239.963 |

Here I seem to have suffered a slight regression — not sure if this is a fluke or not, since the differences are very small, however if this is real, I need to investigate whether I can gain some extra throughput from somewhere else (win some, lose some).