### PR TITLE
Fix #92: Sync.map should suspend evaluation

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -294,9 +294,8 @@ private[effect] trait IOLowPriorityInstances {
 }
 
 private[effect] trait IOInstances extends IOLowPriorityInstances {
-  /** [[Effect]] implementation for [[IO]]. */
-  implicit val ioEffect: Effect[IO] = new Effect[IO] {
 
+  implicit val ioEffect: Effect[IO] = new Effect[IO] {
     override def pure[A](a: A): IO[A] =
       IO.pure(a)
     override def flatMap[A, B](ioa: IO[A])(f: A => IO[B]): IO[B] =

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -90,11 +90,7 @@ sealed abstract class IO[+A] {
    * never terminate on evaluation.
    */
   final def map[B](f: A => B): IO[B] =
-    this match {
-      case Pure(a) => try Pure(f(a)) catch { case NonFatal(e) => RaiseError(e) }
-      case ref @ RaiseError(_) => ref
-      case _ => flatMap(a => Pure(f(a)))
-    }
+    flatMap(a => Pure(f(a)))
 
   /**
    * Monadic bind on `IO`, used for sequentially composing two `IO`
@@ -287,36 +283,43 @@ private[effect] trait IOLowPriorityInstances {
 }
 
 private[effect] trait IOInstances extends IOLowPriorityInstances {
-
+  /** [[Effect]] implementation for [[IO]]. */
   implicit val ioEffect: Effect[IO] = new Effect[IO] {
 
-    def pure[A](a: A) = IO.pure(a)
-
-    def flatMap[A, B](ioa: IO[A])(f: A => IO[B]): IO[B] = ioa.flatMap(f)
+    override def pure[A](a: A): IO[A] =
+      IO.pure(a)
+    override def flatMap[A, B](ioa: IO[A])(f: A => IO[B]): IO[B] =
+      ioa.flatMap(f)
+    override def map[A, B](fa: IO[A])(f: A => B): IO[B] =
+      fa.map(f)
+    override def delay[A](thunk: => A): IO[A] =
+      IO(thunk)
+    override def unit: IO[Unit] =
+      IO.unit
+    override def attempt[A](ioa: IO[A]): IO[Either[Throwable, A]] =
+      ioa.attempt
+    override def handleErrorWith[A](ioa: IO[A])(f: Throwable => IO[A]): IO[A] =
+      IO.Bind(ioa, IOFrame.errorHandler(f))
+    override def raiseError[A](e: Throwable): IO[A] =
+      IO.raiseError(e)
+    override def suspend[A](thunk: => IO[A]): IO[A] =
+      IO.suspend(thunk)
+    override def async[A](k: (Either[Throwable, A] => Unit) => Unit): IO[A] =
+      IO.async(k)
+    override def runAsync[A](ioa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] =
+      ioa.runAsync(cb)
+    // creates a new call-site, so *very* slightly faster than using the default
+    override def shift(implicit ec: ExecutionContext): IO[Unit] =
+      IO.shift(ec)
+    override def liftIO[A](ioa: IO[A]): IO[A] =
+      ioa
 
     // this will use stack proportional to the maximum number of joined async suspensions
-    def tailRecM[A, B](a: A)(f: A => IO[Either[A, B]]): IO[B] = f(a) flatMap {
-      case Left(a) => tailRecM(a)(f)
-      case Right(b) => pure(b)
-    }
-
-    override def attempt[A](ioa: IO[A]): IO[Either[Throwable, A]] = ioa.attempt
-
-    def handleErrorWith[A](ioa: IO[A])(f: Throwable => IO[A]): IO[A] =
-      IO.Bind(ioa, IOFrame.errorHandler(f))
-
-    def raiseError[A](e: Throwable): IO[A] = IO.raiseError(e)
-
-    def suspend[A](thunk: => IO[A]): IO[A] = IO.suspend(thunk)
-
-    def async[A](k: (Either[Throwable, A] => Unit) => Unit): IO[A] = IO.async(k)
-
-    def runAsync[A](ioa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] = ioa.runAsync(cb)
-
-    // creates a new call-site, so *very* slightly faster than using the default
-    override def shift(implicit ec: ExecutionContext) = IO.shift(ec)
-
-    override def liftIO[A](ioa: IO[A]) = ioa
+    override def tailRecM[A, B](a: A)(f: A => IO[Either[A, B]]): IO[B] =
+      f(a) flatMap {
+        case Left(a) => tailRecM(a)(f)
+        case Right(b) => pure(b)
+      }
   }
 
   implicit def ioMonoid[A: Monoid]: Monoid[IO[A]] = new IOSemigroup[A] with Monoid[IO[A]] {

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
@@ -95,8 +95,8 @@ trait SyncLaws[F[_]] extends MonadErrorLaws[F, Throwable] {
   }
 
   lazy val stackSafetyOnRepeatedAttempts = {
-    // Note due to usage of `delay` this isn't enough to guarantee 
-    // stack-safety, unless coupled with `bindSuspendsEvaluation`
+    // Note this isn't enough to guarantee stack safety, unless 
+    // coupled with `bindSuspendsEvaluation`
     val result = (0 until 10000).foldLeft(F.delay(())) { (acc, _) =>
       F.attempt(acc).map(_ => ())
     }
@@ -104,8 +104,8 @@ trait SyncLaws[F[_]] extends MonadErrorLaws[F, Throwable] {
   }
 
   lazy val stackSafetyOnRepeatedMaps = {
-    // Note due to usage of `delay` this isn't enough to guarantee 
-    // stack-safety, unless coupled with `mapSuspendsEvaluation`
+    // Note this isn't enough to guarantee stack safety, unless 
+    // coupled with `mapSuspendsEvaluation`
     val result = (0 until 10000).foldLeft(F.delay(0)) { (acc, _) =>
       F.map(acc)(_ + 1)
     }

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
@@ -64,7 +64,7 @@ trait SyncLaws[F[_]] extends MonadErrorLaws[F, Throwable] {
       state = f(state, a2)
       F.pure(state)
     }
-
+    // Observing `state` before and after `evolve`
     F.map2(F.pure(state), evolve)(f) <-> F.map(fa)(a2 => f(a1, f(a1, a2)))
   }
 
@@ -74,7 +74,7 @@ trait SyncLaws[F[_]] extends MonadErrorLaws[F, Throwable] {
       state = f(state, a2)
       state
     }
-
+    // Observing `state` before and after `evolve`
     F.map2(F.pure(state), evolve)(f) <-> F.map(fa)(a2 => f(a1, f(a1, a2)))
   }
 
@@ -95,18 +95,20 @@ trait SyncLaws[F[_]] extends MonadErrorLaws[F, Throwable] {
   }
 
   lazy val stackSafetyOnRepeatedAttempts = {
+    // Note due to usage of `delay` this isn't enough to guarantee 
+    // stack-safety, unless coupled with `bindSuspendsEvaluation`
     val result = (0 until 10000).foldLeft(F.delay(())) { (acc, _) =>
       F.attempt(acc).map(_ => ())
     }
-
     result <-> F.pure(())
   }
 
   lazy val stackSafetyOnRepeatedMaps = {
+    // Note due to usage of `delay` this isn't enough to guarantee 
+    // stack-safety, unless coupled with `mapSuspendsEvaluation`
     val result = (0 until 10000).foldLeft(F.delay(0)) { (acc, _) =>
       F.map(acc)(_ + 1)
     }
-
     result <-> F.pure(10000)
   }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/SyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/SyncTests.scala
@@ -64,12 +64,15 @@ trait SyncTests[F[_]] extends MonadErrorTests[F, Throwable] with TestsPlatform {
         "throw in suspend is raiseError" -> forAll(laws.suspendThrowIsRaiseError[A] _),
         "unsequenced delay is no-op" -> forAll(laws.unsequencedDelayIsNoop[A] _),
         "repeated sync evaluation not memoized" -> forAll(laws.repeatedSyncEvaluationNotMemoized[A] _),
-        "propagate errors through bind (suspend)" -> forAll(laws.propagateErrorsThroughBindSuspend[A] _))
+        "propagate errors through bind (suspend)" -> forAll(laws.propagateErrorsThroughBindSuspend[A] _),
+        "bind suspends evaluation" -> forAll(laws.bindSuspendsEvaluation[A] _),
+        "map suspends evaluation" -> forAll(laws.mapSuspendsEvaluation[A] _))
 
       val jvmProps = Seq(
         "stack-safe on left-associated binds" -> Prop.lzy(laws.stackSafetyOnRepeatedLeftBinds),
         "stack-safe on right-associated binds" -> Prop.lzy(laws.stackSafetyOnRepeatedRightBinds),
-        "stack-safe on repeated attempts" -> Prop.lzy(laws.stackSafetyOnRepeatedAttempts))
+        "stack-safe on repeated attempts" -> Prop.lzy(laws.stackSafetyOnRepeatedAttempts),
+        "stack-safe on repeated maps" -> Prop.lzy(laws.stackSafetyOnRepeatedMaps))
 
       val jsProps = Seq()
 


### PR DESCRIPTION
PR adds laws in `SyncLaws`.

This can be coupled with the "map fusion" changes for PR #95 — I've separated it because this PR is about the laws in `SyncLaws`.

The laws we are adding:

1. bind suspends evaluation
2. map suspends evaluation
3. stack-safe on repeated maps

Note the first 2 laws need to take an `fa: F[A]` parameter because we want this suspension of effects regardless of what the source `F[A]` is (`Pure` or not). If we don't do this, then as mentioned in issue #92 the implementation is not stack safe because the passed closure can contain a recursive function call.

I've also changed `IO.ioEffect` because interestingly we weren't overriding `map` or `unit`, so we couldn't see that `IO.map` wasn't suspending the evaluation because it wasn't being used in the tests.

Note that I prefer `override def` everywhere because this makes it easier to spot incompatible changes in `cats-core` or in our own type classes for methods that have default implementations.

---

Extra clarification for the added laws ...

Adding a law about `stackSafetyOnRepeatedMaps` is not enough to guarantee stack safety.

This is because that code by itself is stack safe even if `Pure(a).map(f)` has strict behavior — this is because there's no recursion in `f`. Thus this needs to be coupled with a law that says `map` needs to suspend execution, no matter what the source `F[A]` is.

This point is a little subtle because it needs a clear sample, like the one described in issue #92.