### PR TITLE
Fix #108: re-throw exception in IO.async after callback was called once

### DIFF
--- a/core/js/src/main/scala/cats/effect/internals/IOPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOPlatform.scala
@@ -36,10 +36,16 @@ private[effect] object IOPlatform {
    * that has the idempotency property, making sure that its
    * side effects get triggered only once
    */
-  def onceOnly[A](f: A => Unit): A => Unit = {
+  def onceOnly[A](f: Either[Throwable, A] => Unit): Either[Throwable, A] => Unit = {
     var wasCalled = false
 
-    a => if (wasCalled) () else {
+    a => if (wasCalled) {
+      // Re-throwing error in case we can't signal it
+      a match {
+        case Left(err) => throw err
+        case Right(_) => ()
+      }
+    } else {
       wasCalled = true
       f(a)
     }

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -51,6 +51,24 @@ class IOTests extends BaseTestsSuite {
     }
   }
 
+  testAsync("thrown exceptions after callback was called once are re-thrown") { implicit ec =>
+    val dummy = new RuntimeException("dummy")
+    val io = IO.async[Int] { cb =>
+      cb(Right(10))
+      throw dummy
+    }
+
+    var effect: Option[Either[Throwable, Int]] = None
+    try {
+      io.unsafeRunAsync { v => effect = Some(v) }
+      ec.tick()
+      fail("should have thrown exception")
+    } catch {
+      case `dummy` =>
+        effect shouldEqual Some(Right(10))
+    }
+  }
+
   test("catch exceptions within main block") {
     case object Foo extends Exception
 


### PR DESCRIPTION
Fixes #108 by re-throwing thrown exceptions in `IO.async` after the callback was called once.

As I said in [my comment](https://github.com/typelevel/cats-effect/issues/108#issuecomment-355314764):

`IO.async` represents an async communication protocol between a producer and a consumer and unhandled exceptions represent a **protocol violation**, at which point the behavior can be considered to be undefined.

We can agree however that swallowing exceptions with no error reporting is bad. But it's also not correct to do a `printStackTrace` because many web services will just throw $stderr into `/dev/null`, relying on logging libraries like [Logback](https://logback.qos.ch/) to report any errors that happen.

And because `cats.effect.IO` does not have an underlying `Scheduler` or `ExecutionContext` that can report errors in such instances, the only sensible thing to do is to re-throw the error.

Re-throwing the error will either blow the main application thread, or the thread of a thread-pool that has exception reporting in place. With a sane thread-pool implementation and configuration (N.B. not all of them are sane), you can then get error reporting for unhandled errors.