### PR TITLE
Change check in SyncLaws to allow streaming types

### DIFF
--- a/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
@@ -61,7 +61,7 @@ trait SyncLaws[F[_]] extends MonadErrorLaws[F, Throwable] {
   def bindSuspendsEvaluation[A](fa: F[A], a1: A, f: (A, A) => A) = {
     var state = a1
     val evolve = F.flatMap(fa) { a2 =>
-      state = f(state, a2)
+      state = f(a1, a2)
       F.pure(state)
     }
     // Observing `state` before and after `evolve`
@@ -71,7 +71,7 @@ trait SyncLaws[F[_]] extends MonadErrorLaws[F, Throwable] {
   def mapSuspendsEvaluation[A](fa: F[A], a1: A, f: (A, A) => A) = {
     var state = a1
     val evolve = F.map(fa) { a2 =>
-      state = f(state, a2)
+      state = f(a1, a2)
       state
     }
     // Observing `state` before and after `evolve`


### PR DESCRIPTION
Fixes #118

I tested the change by attempting to add
```scala
case Pure(a) => try Pure(f(a)) catch { case NonFatal(ex) => RaiseError(ex) }
```
to the implementation of IO#map, and the law check failed as expected.