### PR TITLE
Fixed what looks like to be a typo in the Async laws discipline

### DIFF
--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
@@ -60,7 +60,7 @@ trait AsyncTests[F[_]] extends SyncTests[F] {
         "async right is pure" -> forAll(laws.asyncRightIsPure[A] _),
         "async left is raiseError" -> forAll(laws.asyncLeftIsRaiseError[A] _),
         "repeated async evaluation not memoized" -> forAll(laws.repeatedAsyncEvaluationNotMemoized[A] _),
-        "propagate errors through bind (async)" -> forAll(laws.propagateErrorsThroughBindSuspend[A] _))
+        "propagate errors through bind (async)" -> forAll(laws.propagateErrorsThroughBindAsync[A] _))
     }
   }
 }


### PR DESCRIPTION
I'm opening this directly without creating an issue as it looks really trivial. One of the Async laws is not checked.