### PR TITLE
Add missing headers, bump BaseVersion

### DIFF
--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/AttemptBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/AttemptBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/DeepBindBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/DeepBindBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/HandleErrorBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/HandleErrorBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapCallsBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapCallsBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapStreamBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapStreamBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/ShallowBindBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/ShallowBindBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -296,7 +296,7 @@ lazy val benchmarksNext = project.in(file("benchmarks/vNext"))
  * version bump of 1.0.  Again, this is all to avoid pre-committing
  * to a major/minor bump before the work is done (see: Scala 2.8).
  */
-val BaseVersion = "0.7"
+val BaseVersion = "0.10"
 
 licenses in ThisBuild += ("Apache-2.0", url("http://www.apache.org/licenses/"))
 

--- a/core/js/src/main/scala/cats/effect/internals/Logger.scala
+++ b/core/js/src/main/scala/cats/effect/internals/Logger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/internals/Logger.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/Logger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/Fiber.scala
+++ b/core/shared/src/main/scala/cats/effect/Fiber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/internals/Callback.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/Callback.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/internals/Cancelable.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/Cancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/internals/ForwardCancelable.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/ForwardCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/internals/IOCancel.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOCancel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/internals/IOConnection.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOConnection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/internals/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOFiber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/internals/IOStart.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOStart.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/test/scala/cats/effect/internals/BooleanCancelable.scala
+++ b/core/shared/src/test/scala/cats/effect/internals/BooleanCancelable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/test/scala/cats/effect/internals/CallbackTests.scala
+++ b/core/shared/src/test/scala/cats/effect/internals/CallbackTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/test/scala/cats/effect/internals/CancelableTests.scala
+++ b/core/shared/src/test/scala/cats/effect/internals/CancelableTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/test/scala/cats/effect/internals/ForwardCancelableTests.scala
+++ b/core/shared/src/test/scala/cats/effect/internals/ForwardCancelableTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/test/scala/cats/effect/internals/IOConnectionTests.scala
+++ b/core/shared/src/test/scala/cats/effect/internals/IOConnectionTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/test/scala/cats/effect/internals/TestUtils.scala
+++ b/core/shared/src/test/scala/cats/effect/internals/TestUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/IOCancelableTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOCancelableTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Typelevel
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
When I committed the headers change, relied on the plugin to generate headers for all files, but it did not catch all files in its build.

This PR also bumps the `BaseVersion` to `0.10`, so we can do hash releases. It's a zero `0.10` because the current `master` breaks compatibility with the released `0.9`.