### PR TITLE
Add Timer and purify the IO API

### DIFF
--- a/core/js/src/main/scala/cats/effect/internals/IOTimer.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOTimer.scala
@@ -18,7 +18,7 @@ package cats.effect
 package internals
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.{FiniteDuration, MILLISECONDS, TimeUnit}
+import scala.concurrent.duration.{FiniteDuration, MILLISECONDS, NANOSECONDS, TimeUnit}
 import scala.scalajs.js
 
 /**
@@ -33,8 +33,13 @@ import scala.scalajs.js
 private[internals] class IOTimer extends Timer[IO] {
   import IOTimer.{Tick, setTimeout, clearTimeout, setImmediateRef}
 
-  final def currentTime(unit: TimeUnit): IO[Long] =
-    IO(unit.convert(System.currentTimeMillis(), MILLISECONDS))
+  final def currentTime(unit: TimeUnit, tryMonotonic: Boolean): IO[Long] =
+    IO {
+      if (tryMonotonic)
+        unit.convert(System.nanoTime(), NANOSECONDS)
+      else
+        unit.convert(System.currentTimeMillis(), MILLISECONDS)
+    }
 
   final def sleep(timespan: FiniteDuration): IO[Unit] =
     IO.cancelable { cb =>

--- a/core/js/src/main/scala/cats/effect/internals/IOTimer.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOTimer.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package internals
+
+import scala.concurrent.duration.FiniteDuration
+import scala.scalajs.js
+
+/**
+ * Internal API — JavaScript specific implementation for a [[Timer]]
+ * powered by `IO`.
+ *
+ * Deferring to JavaScript's own `setTimeout` and to `setImmediate` for
+ * `shift`, if available (`setImmediate` is not standard, but is available
+ * on top of Node.js and has much better performance since `setTimeout`
+ * introduces latency even when the specified delay is zero).
+ */
+private[internals] object IOTimer extends Timer[IO] {
+
+  override def currentTimeMillis: IO[Long] =
+    IO(System.currentTimeMillis())
+
+  override def sleep(timespan: FiniteDuration): IO[Unit] =
+    IO.cancelable { cb =>
+      val task = setTimeout(timespan.toMillis, new Tick(cb))
+      IO(clearTimeout(task))
+    }
+
+  override def shift: IO[Unit] =
+    IO.async(cb => setImmediate(new Tick(cb)))
+
+  private final class Tick(cb: Either[Throwable, Unit] => Unit)
+    extends Runnable {
+    def run() = cb(Callback.rightUnit)
+  }
+
+  private def setImmediate(r: Runnable): Unit =
+    setImmediateRef(() =>
+      try r.run()
+      catch { case e: Throwable => e.printStackTrace() })
+
+  private def setTimeout(delayMillis: Long, r: Runnable): js.Dynamic = {
+    val lambda: js.Function = () =>
+      try { r.run() }
+      catch { case e: Throwable => e.printStackTrace() }
+
+    js.Dynamic.global.setTimeout(lambda, delayMillis)
+  }
+
+  private def clearTimeout(task: js.Dynamic): js.Dynamic = {
+    js.Dynamic.global.clearTimeout(task)
+  }
+
+  // N.B. setImmediate is not standard
+  private final val setImmediateRef: js.Dynamic = {
+    if (!js.isUndefined(js.Dynamic.global.setImmediate))
+      js.Dynamic.global.setImmediate
+    else
+      js.Dynamic.global.setTimeout
+  }
+}

--- a/core/js/src/main/scala/cats/effect/internals/IOTimerRef.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOTimerRef.scala
@@ -17,16 +17,36 @@
 package cats.effect
 package internals
 
+import scala.concurrent.ExecutionContext
+
 /**
  * Internal API — gets mixed-in the `IO` companion object.
  */
-private[effect] abstract class IOTimerRef {
+private[effect] abstract class IOTimerRef extends IOTimerRef0 {
+  /**
+   * Returns a [[Timer]] instance for [[IO]].
+   *
+   * @param ec is a Scala `ExecutionContext` that's used for
+   *        the `shift` operation. Without one the implementation
+   *        would fallback to `setImmediate` (if available) or
+   *        to `setTimeout`
+   */
+  implicit def timer(implicit ec: ExecutionContext): Timer[IO] =
+    ec match {
+      case ExecutionContext.Implicits.global =>
+        IOTimer.global
+      case _ =>
+        IOTimer.deferred(ec)
+    }
+}
+
+private[effect] abstract class IOTimerRef0 {
   /**
    * Returns a [[Timer]] instance for [[IO]].
    *
    * This is the JavaScript version, based on the standard `setTimeout`
    * and `setImmediate` where available.
    */
-  implicit val timer: Timer[IO] =
-    IOTimer
+  implicit val timerGlobal: Timer[IO] =
+    IOTimer.global
 }

--- a/core/js/src/main/scala/cats/effect/internals/IOTimerRef.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOTimerRef.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package internals
+
+/**
+ * Internal API — gets mixed-in the `IO` companion object.
+ */
+private[effect] abstract class IOTimerRef {
+  /**
+   * Returns a [[Timer]] instance for [[IO]].
+   *
+   * This is the JavaScript version, based on the standard `setTimeout`
+   * and `setImmediate` where available.
+   */
+  implicit val timer: Timer[IO] =
+    IOTimer
+}

--- a/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package internals
+
+import java.util.concurrent.{Executors, ScheduledExecutorService, ThreadFactory}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
+
+private[internals] final class IOTimer private (
+  ec: ExecutionContext, sc: ScheduledExecutorService)
+  extends Timer[IO] {
+
+  import IOTimer._
+
+  override def currentTimeMillis: IO[Long] =
+    IO(System.currentTimeMillis())
+
+  override def sleep(timespan: FiniteDuration): IO[Unit] =
+    IO.cancelable { cb =>
+      val f = sc.schedule(new ShiftTick(cb, ec), timespan.length, timespan.unit)
+      IO(f.cancel(false))
+    }
+
+  override def shift: IO[Unit] =
+    IO.async(cb => ec.execute(new Tick(cb)))
+}
+
+private[internals] object IOTimer {
+  /** Builder. */
+  def apply(ec: ExecutionContext): Timer[IO] =
+    apply(ec, scheduler)
+
+  /** Builder. */
+  def apply(ec: ExecutionContext, sc: ScheduledExecutorService): Timer[IO] =
+    new IOTimer(ec, scheduler)
+
+  private lazy val scheduler: ScheduledExecutorService =
+    Executors.newScheduledThreadPool(2, new ThreadFactory {
+      def newThread(r: Runnable): Thread = {
+        val th = new Thread(r)
+        th.setName("cats-effect")
+        th.setDaemon(true)
+        th
+      }
+    })
+
+  private final class ShiftTick(
+    cb: Either[Throwable, Unit] => Unit, ec: ExecutionContext)
+    extends Runnable {
+    def run() = {
+      // Shifts actual execution on our `ExecutionContext`, because
+      // the scheduler is in charge only of ticks and the execution
+      // needs to shift because the tick might continue with whatever
+      // bind continuation is linked to it, keeping the current thread
+      // occupied
+      ec.execute(new Tick(cb))
+    }
+  }
+
+  private final class Tick(cb: Either[Throwable, Unit] => Unit)
+    extends Runnable {
+    def run() = cb(Callback.rightUnit)
+  }
+}

--- a/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
@@ -22,6 +22,13 @@ import java.util.concurrent.{Executors, ScheduledExecutorService, ThreadFactory}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
+/**
+ * Internal API — JVM specific implementation of a `Timer[IO]`.
+ *
+ * Depends on having a Scala `ExecutionContext` for the actual
+ * execution of tasks (i.e. bind continuations) and on a Java
+ * `ScheduledExecutorService` for scheduling ticks with a delay.
+ */
 private[internals] final class IOTimer private (
   ec: ExecutionContext, sc: ScheduledExecutorService)
   extends Timer[IO] {

--- a/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
@@ -20,7 +20,8 @@ package internals
 import java.util.concurrent.{Executors, ScheduledExecutorService, ThreadFactory}
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{FiniteDuration, TimeUnit}
+import scala.concurrent.duration.MILLISECONDS
 
 /**
  * Internal API — JVM specific implementation of a `Timer[IO]`.
@@ -35,8 +36,8 @@ private[internals] final class IOTimer private (
 
   import IOTimer._
 
-  override def currentTimeMillis: IO[Long] =
-    IO(System.currentTimeMillis())
+  override def currentTime(unit: TimeUnit): IO[Long] =
+    IO(unit.convert(System.currentTimeMillis(), MILLISECONDS))
 
   override def sleep(timespan: FiniteDuration): IO[Unit] =
     IO.cancelable { cb =>

--- a/core/jvm/src/main/scala/cats/effect/internals/IOTimerRef.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOTimerRef.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package internals
+
+import java.util.concurrent.ScheduledExecutorService
+import scala.concurrent.ExecutionContext
+
+/**
+ * Internal API — gets mixed-in the `IO` companion object.
+ */
+private[effect] abstract class IOTimerRef {
+  /**
+   * Returns a [[Timer]] instance for [[IO]], built from a
+   * Scala `ExecutionContext`.
+   *
+   * N.B. this is the JVM-specific version. On top of JavaScript
+   * the implementation needs no `ExecutionContext`.
+   *
+   * @param ec is the execution context used for actual execution
+   *        tasks (e.g. bind continuations)
+   */
+  implicit def timer(implicit ec: ExecutionContext): Timer[IO] =
+    ec match {
+      case ExecutionContext.Implicits.global =>
+        IOTimerRef.defaultIOTimer
+      case _ =>
+        IOTimer(ec)
+    }
+
+  /**
+   * Returns a [[Timer]] instance for [[IO]], built from a
+   * Scala `ExecutionContext` and a Java `ScheduledExecutorService`.
+   *
+   * N.B. this is the JVM-specific version. On top of JavaScript
+   * the implementation needs no `ExecutionContext`.
+   *
+   * @param ec is the execution context used for actual execution
+   *        tasks (e.g. bind continuations)
+   *
+   * @param sc is the `ScheduledExecutorService` used for scheduling
+   *        ticks with a delay
+   */
+  def timer(ec: ExecutionContext, sc: ScheduledExecutorService): Timer[IO] =
+    IOTimer(ec, sc)
+}
+
+private[internals] object IOTimerRef {
+  /** Default, reusable instance, using Scala's `global`. */
+  private final lazy val defaultIOTimer: Timer[IO] =
+    IOTimer(ExecutionContext.Implicits.global)
+}

--- a/core/shared/src/main/scala/cats/effect/Async.scala
+++ b/core/shared/src/main/scala/cats/effect/Async.scala
@@ -45,7 +45,7 @@ trait Async[F[_]] extends Sync[F] with LiftIO[F] {
   def async[A](k: (Either[Throwable, A] => Unit) => Unit): F[A]
 
   /**
-   * @see [[IO#shift]]
+   * @see [[IO.shift(ec* IO#shift]]
    */
   def shift(implicit ec: ExecutionContext): F[Unit] = {
     async { (cb: Either[Throwable, Unit] => Unit) =>

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -18,15 +18,15 @@ package cats
 package effect
 
 import cats.arrow.FunctionK
-import cats.effect.internals.IOFrame.ErrorHandler
 import cats.effect.internals._
 import cats.effect.internals.Callback.Extensions
+import cats.effect.internals.TrampolineEC.immediate
 import cats.effect.internals.IOPlatform.fusionMaxStackDepth
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration._
-import scala.util.{Left, Right}
+import scala.util.{Failure, Left, Right, Success}
 
 /**
  * A pure abstraction representing the intention to perform a
@@ -95,7 +95,7 @@ sealed abstract class IO[+A] {
   final def map[B](f: A => B): IO[B] =
     this match {
       case Map(source, g, index) =>
-        // Allowed to do fixed number of map operations fused before 
+        // Allowed to do fixed number of map operations fused before
         // resetting the counter in order to avoid stack overflows;
         // See `IOPlatform` for details on this maximum.
         if (index != fusionMaxStackDepth) Map(source, g.andThen(f), index + 1)
@@ -139,18 +139,79 @@ sealed abstract class IO[+A] {
     Bind(this, AttemptIO.asInstanceOf[A => IO[Either[Throwable, A]]])
 
   /**
-   * Produces an `IO` reference that is guaranteed to be safe to run
-   * synchronously (i.e. [[unsafeRunSync]]), being the safe analogue
-   * to [[unsafeRunAsync]].
+   * Produces an `IO` reference that should execute the source on
+   * evaluation, without waiting for its result, being the safe
+   * analogue to [[unsafeRunAsync]].
    *
    * This operation is isomorphic to [[unsafeRunAsync]]. What it does
    * is to let you describe asynchronous execution with a function
    * that stores off the results of the original `IO` as a
    * side effect, thus ''avoiding'' the usage of impure callbacks or
    * eager evaluation.
+   *
+   * The returned `IO` is guaranteed to execute immediately,
+   * and does not wait on any async action to complete, thus this
+   * is safe to do, even on top of runtimes that cannot block threads
+   * (e.g. JavaScript):
+   *
+   * {{{
+   *   // Sample
+   *   val source = IO.shift *> IO(1)
+   *   // Describes execution
+   *   val start = source.runAsync
+   *   // Safe, because it does not block for the source to finish
+   *   start.unsafeRunSync
+   * }}}
+   *
+   * @return an `IO` value that upon evaluation will execute the source,
+   *         but will not wait for its completion
+   *
+   * @see [[runCancelable]] for the version that gives you a cancelable
+   *      token that can be used to send a cancel signal
    */
   final def runAsync(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] = IO {
     unsafeRunAsync(cb.andThen(_.unsafeRunAsync(_ => ())))
+  }
+
+  /**
+   * Produces an `IO` reference that should execute the source on evaluation,
+   * without waiting for its result and return a cancellable token, being the
+   * safe analogue to [[unsafeRunCancelable]].
+   *
+   * This operation is isomorphic to [[unsafeRunCancelable]]. Just like
+   * [[runAsync]], this operation avoids the usage of impure callbacks or
+   * eager evaluation.
+   *
+   * The returned `IO` boxes an `IO[Unit]` that can be used to cancel the
+   * running asynchronous computation (if the source can be cancelled).
+   *
+   * The returned `IO` is guaranteed to execute immediately,
+   * and does not wait on any async action to complete, thus this
+   * is safe to do, even on top of runtimes that cannot block threads
+   * (e.g. JavaScript):
+   *
+   * {{{
+   *   val source: IO[Int] = ???
+   *   // Describes interruptible execution
+   *   val start: IO[IO[Unit]] = source.runCancelable
+   *
+   *   // Safe, because it does not block for the source to finish
+   *   val cancel: IO[Unit] = start.unsafeRunSync
+   *
+   *   // Safe, because cancellation only sends a signal,
+   *   // but doesn't back-pressure on anything
+   *   cancel.unsafeRunSync
+   * }}}
+   *
+   * @return an `IO` value that upon evaluation will execute the source,
+   *         but will not wait for its completion, yielding a cancellation
+   *         token that can be used to cancel the async process
+   *
+   * @see [[runAsync]] for the simple, uninterruptible version
+   */
+  final def runCancelable(cb: Either[Throwable, A] => IO[Unit]): IO[IO[Unit]] = IO {
+    val cancel = unsafeRunCancelable(cb.andThen(_.unsafeRunAsync(_ => ())))
+    IO.Delay(cancel)
   }
 
   /**
@@ -246,7 +307,7 @@ sealed abstract class IO[+A] {
       case _ =>
         // $COVERAGE-OFF$
         throw new AssertionError("unreachable")
-        // $COVERAGE-ON$
+      // $COVERAGE-ON$
     }
 
   /**
@@ -290,9 +351,10 @@ sealed abstract class IO[+A] {
    * which creates a potential memory leak.
    *
    * IMPORTANT — this operation does not start with an asynchronous boundary.
-   * But you can use [[IO.shift]] to force an async boundary just before `start`.
+   * But you can use [[IO.shift(implicit* IO.shift]] to force an async
+   * boundary just before start`.
    */
-  final def start: IO[Fiber[IO, A]] =
+  final def start: IO[Fiber[IO, A @uncheckedVariance]] =
     IOStart(this)
 
   /**
@@ -322,28 +384,16 @@ sealed abstract class IO[+A] {
   final def to[F[_]](implicit F: cats.effect.Async[F]): F[A @uncheckedVariance] =
     this match {
       case Pure(a) => F.pure(a)
-      case Delay(thunk) => F.delay(thunk())
       case RaiseError(e) => F.raiseError(e)
-      case Suspend(thunk) => F.suspend(thunk().to[F])
-      case Async(k) => F.async(cb => k(IOConnection.alreadyCanceled, cb))
-      case Bind(source, frame) =>
-        frame match {
-          case m: IOFrame[_, _] =>
-            if (!m.isInstanceOf[ErrorHandler[_]]) {
-              val lh = F.attempt(F.suspend(source.to[F]))
-              val f = m.asInstanceOf[IOFrame[Any, IO[A]]]
-              F.flatMap(lh)(e => f.fold(e).to[F])
-            } else {
-              val lh = F.suspend(source.to[F]).asInstanceOf[F[A]]
-              F.handleErrorWith(lh) { e =>
-                m.asInstanceOf[ErrorHandler[A]].recover(e).to[F]
-              }
-            }
-          case f =>
-            F.flatMap(F.suspend(source.to[F]))(e => f(e).to[F])
+      case Delay(thunk) => F.delay(thunk())
+      case _ =>
+        F.suspend {
+          IORunLoop.step(this) match {
+            case Pure(a) => F.pure(a)
+            case RaiseError(e) => F.raiseError(e)
+            case async => F.async(async.unsafeRunAsync)
+          }
         }
-      case Map(source, f, _) =>
-        F.map(source.to[F])(f.asInstanceOf[Any => A])
     }
 
   override def toString = this match {
@@ -353,23 +403,23 @@ sealed abstract class IO[+A] {
   }
 }
 
-private[effect] abstract class IOParallelNewtype {
+private[effect] abstract class IOParallelNewtype extends internals.IOTimerRef {
   /** Newtype encoding for an `IO` datatype that has a `cats.Applicative`
-    * capable of doing parallel processing in `ap` and `map2`, needed
-    * for implementing `cats.Parallel`.
-    *
-    * Helpers are provided for converting back and forth in `Par.apply`
-    * for wrapping any `IO` value and `Par.unwrap` for unwrapping.
-    *
-    * The encoding is based on the "newtypes" project by
-    * Alexander Konovalov, chosen because it's devoid of boxing issues and
-    * a good choice until opaque types will land in Scala.
-    */
+   * capable of doing parallel processing in `ap` and `map2`, needed
+   * for implementing `cats.Parallel`.
+   *
+   * Helpers are provided for converting back and forth in `Par.apply`
+   * for wrapping any `IO` value and `Par.unwrap` for unwrapping.
+   *
+   * The encoding is based on the "newtypes" project by
+   * Alexander Konovalov, chosen because it's devoid of boxing issues and
+   * a good choice until opaque types will land in Scala.
+   */
   type Par[+A] = Par.Type[A]
 
   /** Newtype encoding, see the [[IO.Par]] type alias
-    * for more details.
-    */
+   * for more details.
+   */
   object Par extends IONewtype
 }
 
@@ -387,7 +437,7 @@ private[effect] abstract class IOInstances extends IOLowPriorityInstances {
   implicit val parApplicative: Applicative[IO.Par] = new Applicative[IO.Par] {
     import IO.Par.unwrap
     import IO.Par.{apply => par}
-    
+
     override def pure[A](x: A): IO.Par[A] =
       par(IO.pure(x))
     override def map2[A, B, Z](fa: IO.Par[A], fb: IO.Par[B])(f: (A, B) => Z): IO.Par[Z] =
@@ -425,12 +475,8 @@ private[effect] abstract class IOInstances extends IOLowPriorityInstances {
       IO.async(k)
     override def runAsync[A](ioa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] =
       ioa.runAsync(cb)
-    // creates a new call-site, so *very* slightly faster than using the default
-    override def shift(implicit ec: ExecutionContext): IO[Unit] =
-      IO.shift(ec)
     override def liftIO[A](ioa: IO[A]): IO[A] =
       ioa
-
     // this will use stack proportional to the maximum number of joined async suspensions
     override def tailRecM[A, B](a: A)(f: A => IO[Either[A, B]]): IO[B] =
       f(a) flatMap {
@@ -461,6 +507,104 @@ private[effect] abstract class IOInstances extends IOLowPriorityInstances {
   }
 }
 
+/**
+ * @define shiftDesc For example we can introduce an asynchronous
+ *         boundary in the `flatMap` chain before a certain task:
+ *         {{{
+ *           IO.shift.flatMap(_ => task)
+ *         }}}
+ *
+ *         Or using Cats syntax:
+ *         {{{
+ *           import cats.syntax.all._
+ *
+ *           Task.shift *> task
+ *         }}}
+ *
+ *         Or we can specify an asynchronous boundary ''after'' the
+ *         evaluation of a certain task:
+ *         {{{
+ *           task.flatMap(a => IO.shift.map(_ => a))
+ *         }}}
+ *
+ *         Or using Cats syntax:
+ *         {{{
+ *           task <* IO.shift
+ *         }}}
+ *
+ *         Example of where this might be useful:
+ *         {{{
+ *         for {
+ *           _ <- IO.shift(BlockingIO)
+ *           bytes <- readFileUsingJavaIO(file)
+ *           _ <- IO.shift(DefaultPool)
+ *
+ *           secure = encrypt(bytes, KeyManager)
+ *           _ <- sendResponse(Protocol.v1, secure)
+ *
+ *           _ <- IO { println("it worked!") }
+ *         } yield ()
+ *         }}}
+ *
+ *         In the above, `readFileUsingJavaIO` will be shifted to the
+ *         pool represented by `BlockingIO`, so long as it is defined
+ *         using `apply` or `suspend` (which, judging by the name, it
+ *         probably is).  Once its computation is complete, the rest
+ *         of the `for`-comprehension is shifted ''again'', this time
+ *         onto the `DefaultPool`.  This pool is used to compute the
+ *         encrypted version of the bytes, which are then passed to
+ *         `sendResponse`.  If we assume that `sendResponse` is
+ *         defined using `async` (perhaps backed by an NIO socket
+ *         channel), then we don't actually know on which pool the
+ *         final `IO` action (the `println`) will be run.  If we
+ *         wanted to ensure that the `println` runs on `DefaultPool`,
+ *         we would insert another `shift` following `sendResponse`.
+ *
+ *         Another somewhat less common application of `shift` is to
+ *         reset the thread stack and yield control back to the
+ *         underlying pool. For example:
+ *
+ *         {{{
+ *         lazy val repeat: IO[Unit] = for {
+ *           _ <- doStuff
+ *           _ <- IO.shift
+ *           _ <- repeat
+ *         } yield ()
+ *         }}}
+ *
+ *         In this example, `repeat` is a very long running `IO`
+ *         (infinite, in fact!) which will just hog the underlying
+ *         thread resource for as long as it continues running.  This
+ *         can be a bit of a problem, and so we inject the `IO.shift`
+ *         which yields control back to the underlying thread pool,
+ *         giving it a chance to reschedule things and provide better
+ *         fairness.  This shifting also "bounces" the thread stack,
+ *         popping all the way back to the thread pool and effectively
+ *         trampolining the remainder of the computation.  This sort
+ *         of manual trampolining is unnecessary if `doStuff` is
+ *         defined using `suspend` or `apply`, but if it was defined
+ *         using `async` and does ''not'' involve any real
+ *         concurrency, the call to `shift` will be necessary to avoid
+ *         a `StackOverflowError`.
+ *
+ *         Thus, this function has four important use cases:
+ *
+ *          - shifting blocking actions off of the main compute pool,
+ *          - defensively re-shifting asynchronous continuations back
+ *            to the main compute pool
+ *          - yielding control to some underlying pool for fairness
+ *            reasons, and
+ *          - preventing an overflow of the call stack in the case of
+ *            improperly constructed `async` actions
+ *
+ *         Note there are 2 overloads of this function:
+ *
+ *          - one that takes an [[Timer]] ([[IO.shift(implicit* link]])
+ *          - one that takes a Scala `ExecutionContext` ([[IO.shift(ec* link]])
+ *
+ *         Use the former by default, use the later for fine grained
+ *         control over the thread pool used.
+ */
 object IO extends IOInstances {
 
   /**
@@ -601,11 +745,6 @@ object IO extends IOInstances {
    *   IO.fromFuture(IO.pure(f))
    * }}}
    *
-   * Note that the ''continuation'' of the computation resulting from
-   * a `Future` will run on the future's thread pool.  There is no
-   * thread shifting here; the `ExecutionContext` is solely for the
-   * benefit of the `Future`.
-   *
    * Roughly speaking, the following identities hold:
    *
    * {{{
@@ -615,16 +754,15 @@ object IO extends IOInstances {
    *
    * @see [[IO#unsafeToFuture]]
    */
-  def fromFuture[A](iof: IO[Future[A]])(implicit ec: ExecutionContext): IO[A] = iof flatMap { f =>
-    IO async { cb =>
-      import scala.util.{Success, Failure}
-
-      f onComplete {
-        case Failure(e) => cb(Left(e))
-        case Success(a) => cb(Right(a))
+  def fromFuture[A](iof: IO[Future[A]]): IO[A] =
+    iof.flatMap { f =>
+      IO.async { cb =>
+        f.onComplete(r => cb(r match {
+          case Success(a) => Right(a)
+          case Failure(e) => Left(e)
+        }))(immediate)
       }
     }
-  }
 
   /**
    * Lifts an Either[Throwable, A] into the IO[A] context raising the throwable
@@ -633,78 +771,33 @@ object IO extends IOInstances {
   def fromEither[A](e: Either[Throwable, A]): IO[A] = e.fold(IO.raiseError, IO.pure)
 
   /**
-   * Shifts the bind continuation of the `IO` onto the specified thread
-   * pool.
+   * Asynchronous boundary described as an effectful `IO`, managed
+   * by the provided [[Timer]].
    *
-   * Asynchronous actions cannot be shifted, since they are scheduled
-   * rather than run. Also, no effort is made to re-shift synchronous
-   * actions which *follow* asynchronous actions within a bind chain;
-   * those actions will remain on the continuation thread inherited
-   * from their preceding async action.  The only computations which
-   * are shifted are those which are defined as synchronous actions and
-   * are contiguous in the bind chain ''following'' the `shift`.
+   * This operation can be used in `flatMap` chains to "shift" the
+   * continuation of the run-loop to another thread or call stack.
    *
-   * As an example:
+   * $shiftDesc
    *
-   * {{{
-   * for {
-   *   _ <- IO.shift(BlockingIO)
-   *   bytes <- readFileUsingJavaIO(file)
-   *   _ <- IO.shift(DefaultPool)
-   *
-   *   secure = encrypt(bytes, KeyManager)
-   *   _ <- sendResponse(Protocol.v1, secure)
-   *
-   *   _ <- IO { println("it worked!") }
-   * } yield ()
-   * }}}
-   *
-   * In the above, `readFileUsingJavaIO` will be shifted to the pool
-   * represented by `BlockingIO`, so long as it is defined using `apply`
-   * or `suspend` (which, judging by the name, it probably is).  Once
-   * its computation is complete, the rest of the `for`-comprehension is
-   * shifted ''again'', this time onto the `DefaultPool`.  This pool is
-   * used to compute the encrypted version of the bytes, which are then
-   * passed to `sendResponse`.  If we assume that `sendResponse` is
-   * defined using `async` (perhaps backed by an NIO socket channel),
-   * then we don't actually know on which pool the final `IO` action (the
-   * `println`) will be run.  If we wanted to ensure that the `println`
-   * runs on `DefaultPool`, we would insert another `shift` following
-   * `sendResponse`.
-   *
-   * Another somewhat less common application of `shift` is to reset the
-   * thread stack and yield control back to the underlying pool.  For
-   * example:
-   *
-   * {{{
-   * lazy val repeat: IO[Unit] = for {
-   *   _ <- doStuff
-   *   _ <- IO.shift
-   *   _ <- repeat
-   * } yield ()
-   * }}}
-   *
-   * In this example, `repeat` is a very long running `IO` (infinite, in
-   * fact!) which will just hog the underlying thread resource for as long
-   * as it continues running.  This can be a bit of a problem, and so we
-   * inject the `IO.shift` which yields control back to the underlying
-   * thread pool, giving it a chance to reschedule things and provide
-   * better fairness.  This shifting also "bounces" the thread stack, popping
-   * all the way back to the thread pool and effectively trampolining the
-   * remainder of the computation.  This sort of manual trampolining is
-   * unnecessary if `doStuff` is defined using `suspend` or `apply`, but if
-   * it was defined using `async` and does ''not'' involve any real
-   * concurrency, the call to `shift` will be necessary to avoid a
-   * `StackOverflowError`.
-   *
-   * Thus, this function has four important use cases: shifting blocking
-   * actions off of the main compute pool, defensively re-shifting
-   * asynchronous continuations back to the main compute pool, yielding
-   * control to some underlying pool for fairness reasons, and preventing
-   * an overflow of the call stack in the case of improperly constructed
-   * `async` actions.
+   * @param timer is the [[Timer]] that's managing the thread-pool
+   *        used to trigger this async boundary
    */
-  def shift(implicit ec: ExecutionContext): IO[Unit] = {
+  def shift(implicit timer: Timer[IO]): IO[Unit] =
+    timer.shift
+
+  /**
+   * Asynchronous boundary described as an effectful `IO`, managed
+   * by the provided Scala `ExecutionContext`.
+   *
+   * This operation can be used in `flatMap` chains to "shift" the
+   * continuation of the run-loop to another thread or call stack.
+   *
+   * $shiftDesc
+   *
+   * @param ec is the Scala `ExecutionContext` that's managing the
+   *        thread-pool used to trigger this async boundary
+   */
+  def shift(ec: ExecutionContext): IO[Unit] = {
     IO.Async { (_, cb: Either[Throwable, Unit] => Unit) =>
       ec.execute(new Runnable {
         def run() = cb(Callback.rightUnit)
@@ -717,8 +810,9 @@ object IO extends IOInstances {
    * cancellation status of the run-loop and does not allow for the
    * bind continuation to keep executing in case cancellation happened.
    *
-   * This operation is very similar to [[IO.shift]], as it can be dropped
-   * in `flatMap` chains in order to make loops cancelable.
+   * This operation is very similar to [[IO.shift(implicit* IO.shift]],
+   * as it can be dropped in `flatMap` chains in order to make loops
+   * cancelable.
    *
    * Example:
    *
@@ -759,9 +853,9 @@ object IO extends IOInstances {
     extends IO[A]
 
   /** State for representing `map` ops that itself is a function in
-    * order to avoid extraneous memory allocations when building the
-    * internal call-stack.
-    */
+   * order to avoid extraneous memory allocations when building the
+   * internal call-stack.
+   */
   private[effect] final case class Map[E, +A](source: IO[E], f: E => A, index: Int)
     extends IO[A] with (E => IO[A]) {
 
@@ -770,8 +864,8 @@ object IO extends IOInstances {
   }
 
   /** Internal reference, used as an optimization for [[IO.attempt]]
-    * in order to avoid extraneous memory allocations.
-    */
+   * in order to avoid extraneous memory allocations.
+   */
   private object AttemptIO extends IOFrame[Any, IO[Either[Throwable, Any]]] {
     override def apply(a: Any) =
       Pure(Right(a))

--- a/core/shared/src/main/scala/cats/effect/Timer.scala
+++ b/core/shared/src/main/scala/cats/effect/Timer.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import scala.annotation.implicitNotFound
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * Timer is a scheduler of tasks.
+ *
+ * This is the purely functional equivalent of Java's
+ * [[https://docs.oracle.com/javase/9/docs/api/java/util/concurrent/ScheduledExecutorService.html ScheduledExecutorService]]
+ * or of JavaScript's
+ * [[https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout setTimeout]].
+ *
+ * It provides:
+ *
+ *  1. the ability to get the current time
+ *  2. thread / call-stack shifting
+ *  3. ability to delay the execution of a task with a specified time duration
+ *
+ * It does all of that in an `F` monadic context that can suspend
+ * side effects and is capable of asynchronous execution (e.g. [[IO]]).
+ *
+ * This is NOT a type-class, as it does not have the coherence
+ * requirement.
+ */
+@implicitNotFound("""Cannot find implicit value for Timer[${F}].
+Note that ${F} needs to be a cats.effect.Async data type. You might also
+need a scala.concurrent.ExecutionContext in scope, or equivalent, try to
+import scala.concurrent.ExecutionContext.Implicits.global
+""")
+trait Timer[F[_]] {
+  /**
+   * Returns the current time in milliseconds, suspended in `F[_]`.
+   *
+   * This is the pure equivalent to Java's
+   * [[https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#currentTimeMillis-- System.currentTimeMillis]].
+   *
+   * Note that while the unit of time of the return value is a millisecond,
+   * the granularity of the value depends on the underlying operating
+   * system and may be larger. For example, some operating systems
+   * measure time in units of tens of milliseconds.
+   *
+   * Also implementations of this interface might implement this
+   * in terms of `System.nanoTime`, which is possible, but the
+   * granularity returned must remain in milliseconds.
+   */
+  def currentTimeMillis: F[Long]
+
+  /**
+   * Creates a new task that will sleep for the given duration,
+   * emitting a tick when that time span is over.
+   *
+   * As an example on evaluation this will print "Hello!" after
+   * 3 seconds:
+   *
+   * {{{
+   *   import cats.effect._
+   *   import scala.concurrent.duration._
+   *
+   *   Timer[IO].sleep(3.seconds).flatMap { _ =>
+   *     IO(println("Hello!"))
+   *   }
+   * }}}
+   *
+   * Note that `sleep` is required to introduce an asynchronous
+   * boundary, even if the provided `timespan` is less or
+   * equal to zero.
+   */
+  def sleep(timespan: FiniteDuration): F[Unit]
+
+  /**
+   * Asynchronous boundary described as an effectful `F[_]` that
+   * can be used in `flatMap` chains to "shift" the continuation
+   * of the run-loop to another thread or call stack.
+   *
+   * This is the [[Async.shift]] operation, without the need for an
+   * `ExecutionContext` taken as a parameter.
+   *
+   * This `shift` operation can usually be derived from `sleep`:
+   *
+   * {{{
+   *   timer.shift <-> timer.sleep(Duration.Zero)
+   * }}}
+   */
+  def shift: F[Unit]
+}
+
+object Timer {
+  /**
+   * For a given `F` data type fetches the implicit [[Timer]]
+   * instance available implicitly in the local scope.
+   */
+  def apply[F[_]](implicit timer: Timer[F]): Timer[F] = timer
+
+  /**
+   * Derives a [[Timer]] for any type that has a [[LiftIO]] instance,
+   * from the implicitly available `Timer[IO]` that should be in scope.
+   */
+  def derive[F[_]](implicit F: LiftIO[F], timer: Timer[IO]): Timer[F] =
+    new Timer[F] {
+      def shift: F[Unit] =
+        F.liftIO(timer.shift)
+      def sleep(timespan: FiniteDuration): F[Unit] =
+        F.liftIO(timer.sleep(timespan))
+      def currentTimeMillis: F[Long] =
+        F.liftIO(timer.currentTimeMillis)
+    }
+}

--- a/core/shared/src/main/scala/cats/effect/Timer.scala
+++ b/core/shared/src/main/scala/cats/effect/Timer.scala
@@ -82,7 +82,7 @@ trait Timer[F[_]] {
    * boundary, even if the provided `timespan` is less or
    * equal to zero.
    */
-  def sleep(timespan: FiniteDuration): F[Unit]
+  def sleep(duration: FiniteDuration): F[Unit]
 
   /**
    * Asynchronous boundary described as an effectful `F[_]` that

--- a/core/shared/src/main/scala/cats/effect/Timer.scala
+++ b/core/shared/src/main/scala/cats/effect/Timer.scala
@@ -22,16 +22,18 @@ import scala.concurrent.duration.FiniteDuration
 /**
  * Timer is a scheduler of tasks.
  *
- * This is the purely functional equivalent of Java's
- * [[https://docs.oracle.com/javase/9/docs/api/java/util/concurrent/ScheduledExecutorService.html ScheduledExecutorService]]
- * or of JavaScript's
- * [[https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout setTimeout]].
+ * This is the purely functional equivalent of:
+ *
+ *  - Java's
+ *    [[https://docs.oracle.com/javase/9/docs/api/java/util/concurrent/ScheduledExecutorService.html ScheduledExecutorService]]
+ *  - JavaScript's
+ *    [[https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout setTimeout]].
  *
  * It provides:
  *
  *  1. the ability to get the current time
- *  2. thread / call-stack shifting
- *  3. ability to delay the execution of a task with a specified time duration
+ *  1. thread / call-stack shifting
+ *  1. ability to delay the execution of a task with a specified time duration
  *
  * It does all of that in an `F` monadic context that can suspend
  * side effects and is capable of asynchronous execution (e.g. [[IO]]).

--- a/core/shared/src/main/scala/cats/effect/internals/Callback.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/Callback.scala
@@ -65,10 +65,10 @@ private[effect] object Callback {
   /**
    * Callback wrapper used in `IO.async` that:
    *
-   *  1. guarantees (thread safe) idempotency
-   *  2. triggers light (trampolined) async boundary for stack safety
-   *  3. pops the given `Connection` (only if != null)
-   *  4. logs extraneous errors after callback was already called once
+   *  - guarantees (thread safe) idempotency
+   *  - triggers light (trampolined) async boundary for stack safety
+   *  - pops the given `Connection` (only if != null)
+   *  - logs extraneous errors after callback was already called once
    */
   def asyncIdempotent[A](conn: IOConnection, cb: Type[A]): Type[A] =
     new AsyncIdempotentCallback[A](conn, cb)

--- a/core/shared/src/main/scala/cats/effect/internals/IOConnection.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOConnection.scala
@@ -26,8 +26,8 @@ import scala.annotation.tailrec
  *
  * Implementation notes:
  *
- *  1. `cancel()` is idempotent
- *  2. all methods are thread-safe / atomic
+ *  - `cancel()` is idempotent
+ *  - all methods are thread-safe / atomic
  *
  * Used in the implementation of `cats.effect.IO`. Inspired by the
  * implementation of `StackedCancelable` from the Monix library.

--- a/laws/js/src/test/scala/cats/effect/internals/IOTimerTests.scala
+++ b/laws/js/src/test/scala/cats/effect/internals/IOTimerTests.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package internals
+
+import scala.util.Success
+
+class IOTimerTests extends BaseTestsSuite {
+  test("Timer[IO] default instance") {
+    val ref1 = Timer[IO]
+    ref1 shouldBe Timer[IO]
+  }
+
+  testAsync("Timer[IO] instance based on implicit ExecutionContext") { implicit ec =>
+    val timer = Timer[IO]
+
+    val f = timer.shift.map(_ => 1).unsafeToFuture()
+    f.value shouldBe None
+
+    ec.tick()
+    f.value shouldBe Some(Success(1))
+  }
+}

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
@@ -19,9 +19,10 @@ package cats.effect.laws.util
 import cats.effect.internals.Cancelable.{Type => Cancelable}
 import cats.effect.internals.NonFatal
 import cats.effect.{IO, LiftIO, Timer}
+
 import scala.collection.immutable.SortedSet
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.duration.{Duration, FiniteDuration, TimeUnit}
 import scala.util.Random
 
 /**
@@ -152,8 +153,11 @@ final class TestContext private () extends ExecutionContext { self =>
           val cancel = self.schedule(timespan, tick(cb))
           IO(cancel())
         })
-      override def currentTimeMillis: F[Long] =
-        F.liftIO(IO(self.state.clock.toMillis))
+      override def currentTime(unit: TimeUnit): F[Long] =
+        F.liftIO(IO {
+          val d = self.state.clock
+          unit.convert(d.length, d.unit)
+        })
     }
 
   /**

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
@@ -153,7 +153,7 @@ final class TestContext private () extends ExecutionContext { self =>
           val cancel = self.schedule(timespan, tick(cb))
           IO(cancel())
         })
-      override def currentTime(unit: TimeUnit): F[Long] =
+      override def currentTime(unit: TimeUnit, tryMonotonic: Boolean): F[Long] =
         F.liftIO(IO {
           val d = self.state.clock
           unit.convert(d.length, d.unit)

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
@@ -26,7 +26,7 @@ import scala.util.Random
 
 /**
  * A `scala.concurrent.ExecutionContext` implementation and a provider
- * of [[cats.effect.Timer]] instances, that can simulate async boundaries
+ * of `cats.effect.Timer` instances, that can simulate async boundaries
  * and time passage, useful for testing purposes.
  *
  * Usage for simulating an `ExecutionContext`):
@@ -54,8 +54,8 @@ import scala.util.Random
  * }}}
  *
  * Our `TestContext` can also simulate time passage, as we are able
- * to builds a [[cats.effect.Timer Timer]] instance for any data type that
- * has a [[cats.effect.LiftIO LiftIO]] instance:
+ * to builds a `cats.effect.Timer` instance for any data type that
+ * has a `LiftIO` instance:
  *
  * {{{
  *   val ctx = TestContext()
@@ -134,8 +134,8 @@ final class TestContext private () extends ExecutionContext { self =>
   )
 
   /**
-   * Derives a [[cats.effect.Timer]] from this `TestContext`, for any data
-   * type that has a [[cats.effect.LiftIO LiftIO]] instance.
+   * Derives a `cats.effect.Timer` from this `TestContext`, for any data
+   * type that has a `LiftIO` instance.
    *
    * Example:
    *
@@ -237,7 +237,7 @@ final class TestContext private () extends ExecutionContext { self =>
    * }}}
    *
    * The optional parameter can be used for simulating time, to be used in
-   * combination with [[cats.effect.Timer]]. See the
+   * combination with `cats.effect.Timer`. See the
    * [[TestContext.timer timer]] method.
    *
    * Example:

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
@@ -16,20 +16,20 @@
 
 package cats.effect.laws.util
 
+import cats.effect.internals.Cancelable.{Type => Cancelable}
 import cats.effect.internals.NonFatal
-import cats.effect.laws.util.TestContext.State
-
-import scala.annotation.tailrec
-import scala.collection.immutable.Queue
+import cats.effect.{IO, LiftIO, Timer}
+import scala.collection.immutable.SortedSet
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.Random
 
 /**
- * A `scala.concurrent.ExecutionContext` implementation that can be
- * used for testing purposes.
+ * A `scala.concurrent.ExecutionContext` implementation and a provider
+ * of [[cats.effect.Timer]] instances, that can simulate async boundaries
+ * and time passage, useful for testing purposes.
  *
- * Usage:
- *
+ * Usage for simulating an `ExecutionContext`):
  * {{{
  *   implicit val ec = TestContext()
  *
@@ -52,15 +52,122 @@ import scala.util.Random
  *   assert(ec.state.tasks.isEmpty)
  *   assert(ec.state.lastReportedFailure == None)
  * }}}
+ *
+ * Our `TestContext` can also simulate time passage, as we are able
+ * to builds a [[cats.effect.Timer Timer]] instance for any data type that
+ * has a [[cats.effect.LiftIO LiftIO]] instance:
+ *
+ * {{{
+ *   val ctx = TestContext()
+ *
+ *   val timer: Timer[IO] = ctx.timer[IO]
+ * }}}
+ *
+ * We can now simulate actual time:
+ *
+ * {{{
+ *   val io = timer.sleep(10.seconds) *> IO(1 + 1)
+ *   val f = io.unsafeToFuture()
+ *
+ *   // This invariant holds true, because our IO is async
+ *   assert(f.value == None)
+ *
+ *   // Not yet completed, because this does not simulate time passing:
+ *   ctx.tick()
+ *   assert(f.value == None)
+ *
+ *   // Simulating time passing:
+ *   ctx.tick(10.seconds)
+ *   assert(f.value == Some(Success(2))
+ * }}}
+ *
+ * Simulating time makes this pretty useful for testing race conditions:
+ *
+ * {{{
+ *   val never = IO.async[Int](_ => {})
+ *   val timeoutError = new TimeoutException
+ *   val timeout = timer.sleep(10.seconds) *> IO.raiseError[Int](timeoutError)
+ *
+ *   val pair = (never, timeout).parMapN(_ + _)
+ *
+ *   // Not yet
+ *   ctx.tick()
+ *   assert(f.value == None)
+ *   // Not yet
+ *   ctx.tick(5.seconds)
+ *   assert(f.value == None)
+ *
+ *   // Good to go:
+ *   ctx.tick(5.seconds)
+ *   assert(f.value, Some(Failure(timeoutError)))
+ * }}}
+ *
+ * @define timerExample {{{
+ *   val ctx = TestContext()
+ *   // Building a Timer[IO] from this:
+ *   implicit val timer: Timer[IO] = ctx.timer[IO]
+ *
+ *   // Can now simulate time
+ *   val io = timer.sleep(10.seconds) *> IO(1 + 1)
+ *   val f = io.unsafeToFuture()
+ *
+ *   // This invariant holds true, because our IO is async
+ *   assert(f.value == None)
+ *
+ *   // Not yet completed, because this does not simulate time passing:
+ *   ctx.tick()
+ *   assert(f.value == None)
+ *
+ *   // Simulating time passing:
+ *   ctx.tick(10.seconds)
+ *   assert(f.value == Some(Success(2))
+ * }}}
  */
-final class TestContext private () extends ExecutionContext {
-  private[this] var stateRef = State(Queue.empty, None)
+final class TestContext private () extends ExecutionContext { self =>
+  import TestContext.{State, Task}
 
-  def execute(r: Runnable): Unit =
-    synchronized {
-      stateRef = stateRef.copy(tasks = stateRef.tasks.enqueue(r))
+  private[this] var stateRef = State(
+    lastID = 0,
+    clock = Duration.Zero,
+    tasks = SortedSet.empty[Task],
+    lastReportedFailure = None
+  )
+
+  /**
+   * Derives a [[cats.effect.Timer]] from this `TestContext`, for any data
+   * type that has a [[cats.effect.LiftIO LiftIO]] instance.
+   *
+   * Example:
+   *
+   * $timerExample
+   */
+  def timer[F[_]](implicit F: LiftIO[F]): Timer[F] =
+    new Timer[F] {
+      def tick(cb: Either[Throwable, Unit] => Unit): Runnable =
+        new Runnable { def run() = cb(Right(())) }
+      override def shift: F[Unit] =
+        F.liftIO(IO.async { cb => self.execute(tick(cb))})
+      override def sleep(timespan: FiniteDuration): F[Unit] =
+        F.liftIO(IO.cancelable { cb =>
+          val cancel = self.schedule(timespan, tick(cb))
+          IO(cancel())
+        })
+      override def currentTimeMillis: F[Long] =
+        F.liftIO(IO(self.state.clock.toMillis))
     }
 
+  /**
+   * Inherited from `ExecutionContext`, schedules a runnable
+   * for execution.
+   */
+  def execute(r: Runnable): Unit =
+    synchronized {
+      stateRef = stateRef.execute(r)
+    }
+
+  /**
+   * Inherited from `ExecutionContext`, reports uncaught errors.
+   */
   def reportFailure(cause: Throwable): Unit =
     synchronized {
       stateRef = stateRef.copy(lastReportedFailure = Some(cause))
@@ -74,33 +181,128 @@ final class TestContext private () extends ExecutionContext {
     synchronized(stateRef)
 
   /**
+   * Executes just one tick, one task, from the internal queue, useful
+   * for testing that a some runnable will definitely be executed next.
+   *
+   * Returns a boolean indicating that tasks were available and that
+   * the head of the queue has been executed, so normally you have
+   * this equivalence:
+   *
+   * {{{
+   *   while (ec.tickOne()) {}
+   *   // ... is equivalent with:
+   *   ec.tick()
+   * }}}
+   *
+   * Note that ask extraction has a random factor, the behavior being like
+   * [[tick]], in order to simulate non-determinism. So you can't rely on
+   * some ordering of execution if multiple tasks are waiting execution.
+   *
+   * @return `true` if a task was available in the internal queue, and
+   *        was executed, or `false` otherwise
+   */
+  def tickOne(): Boolean = synchronized {
+    val current = stateRef
+
+    // extracting one task by taking the immediate tasks
+    extractOneTask(current, current.clock) match {
+      case Some((head, rest)) =>
+        stateRef = current.copy(tasks = rest)
+        // execute task
+        try head.task.run() catch { case NonFatal(ex) => reportFailure(ex) }
+        true
+      case None =>
+        false
+    }
+  }
+
+  /**
    * Triggers execution by going through the queue of scheduled tasks and
    * executing them all, until no tasks remain in the queue to execute.
    *
    * Order of execution isn't guaranteed, the queued `Runnable`s are
    * being shuffled in order to simulate the needed non-determinism
    * that happens with multi-threading.
+   *
+   * {{{
+   *   implicit val ec = TestContext()
+   *
+   *   val f = Future(1 + 1).flatMap(_ + 1)
+   *   // Execution is momentarily suspended in TestContext
+   *   assert(f.value == None)
+   *
+   *   // Simulating async execution:
+   *   ec.tick()
+   *   assert(f.value, Some(Success(2)))
+   * }}}
+   *
+   * The optional parameter can be used for simulating time, to be used in
+   * combination with [[cats.effect.Timer]]. See the
+   * [[TestContext.timer timer]] method.
+   *
+   * Example:
+   *
+   * $timerExample
+   *
+   * @param time is an optional parameter for simulating time passing;
+   *
    */
-  @tailrec def tick(): Unit = {
-    val queue = synchronized {
-      val ref = stateRef.tasks
-      stateRef = stateRef.copy(tasks = Queue.empty)
-      ref
-    }
+  def tick(time: FiniteDuration = Duration.Zero): Unit = {
+    var hasTasks = true
+    var timeLeft = time
 
-    if (queue.nonEmpty) {
-      // Simulating non-deterministic execution
-      val batch = Random.shuffle(queue)
-      for (r <- batch) try r.run() catch {
-        case NonFatal(ex) =>
-          synchronized {
-            stateRef = stateRef.copy(lastReportedFailure = Some(ex))
+    while (hasTasks) synchronized {
+      val current = this.stateRef
+      val currentClock = current.clock + time
+
+      extractOneTask(current, currentClock) match {
+        case Some((head, rest)) =>
+          stateRef = current.copy(clock = head.runsAt, tasks = rest)
+          // execute task
+          try head.task.run() catch {
+            case ex if NonFatal(ex) =>
+              reportFailure(ex)
           }
-      }
 
-      tick() // Next cycle please
+          // have to retry execution, as those pending tasks
+          // may have registered new tasks for immediate execution
+          timeLeft = currentClock - head.runsAt
+
+        case None =>
+          stateRef = current.copy(clock = currentClock)
+          hasTasks = false
+      }
     }
   }
+
+  private def extractOneTask(current: State, clock: FiniteDuration): Option[(Task, SortedSet[Task])] = {
+    current.tasks.headOption.filter(_.runsAt <= clock) match {
+      case Some(value) =>
+        val firstTick = value.runsAt
+        val forExecution = {
+          val arr = current.tasks.iterator.takeWhile(_.runsAt == firstTick).take(10).toArray
+          arr(Random.nextInt(arr.length))
+        }
+
+        val remaining = current.tasks - forExecution
+        Some((forExecution, remaining))
+
+      case None =>
+        None
+    }
+  }
+
+  private def cancelTask(t: Task): Unit = synchronized {
+    stateRef = stateRef.copy(tasks = stateRef.tasks - t)
+  }
+
+  private def schedule(delay: FiniteDuration, r: Runnable): Cancelable =
+    synchronized {
+      val current: State = stateRef
+      val (cancelable, newState) = current.scheduleOnce(delay, r, cancelTask)
+      stateRef = newState
+      cancelable
+    }
 }
 
 object TestContext {
@@ -108,11 +310,70 @@ object TestContext {
   def apply(): TestContext =
     new TestContext
 
-  /**
-   * The internal state of [[TestContext]].
+  /** Used internally by [[TestContext]], represents the internal
+   * state used for task scheduling and execution.
    */
   final case class State(
-    tasks: Queue[Runnable],
-    lastReportedFailure: Option[Throwable]
-  )
+    lastID: Long,
+    clock: FiniteDuration,
+    tasks: SortedSet[Task],
+    lastReportedFailure: Option[Throwable]) {
+
+    // $COVERAGE-OFF$
+    assert(
+      !tasks.headOption.exists(_.runsAt < clock),
+      "The runsAt for any task must never be in the past")
+    // $COVERAGE-ON$
+
+    /**
+     * Returns a new state with the runnable scheduled for execution.
+     */
+    private[TestContext]
+    def execute(runnable: Runnable): State = {
+      val newID = lastID + 1
+      val task = Task(newID, runnable, clock)
+      copy(lastID = newID, tasks = tasks + task)
+    }
+
+    /**
+     * Returns a new state with a scheduled task included.
+     */
+    private[TestContext]
+    def scheduleOnce(delay: FiniteDuration, r: Runnable, cancelTask: Task => Unit): (Cancelable, State) = {
+      val d = if (delay >= Duration.Zero) delay else Duration.Zero
+      val newID = lastID + 1
+
+      val task = Task(newID, r, this.clock + d)
+      val cancelable = () => cancelTask(task)
+
+      (cancelable, copy(
+        lastID = newID,
+        tasks = tasks + task
+      ))
+    }
+  }
+
+  /**
+   * Used internally by [[TestContext]], represents a unit of work
+   * pending execution.
+   */
+  final case class Task(id: Long, task: Runnable, runsAt: FiniteDuration)
+
+  /**
+   * Internal API — defines ordering for [[Task]], to be used by `SortedSet`.
+   */
+  private[TestContext] object Task {
+    implicit val ordering: Ordering[Task] =
+      new Ordering[Task] {
+        val longOrd = implicitly[Ordering[Long]]
+
+        def compare(x: Task, y: Task): Int =
+          x.runsAt.compare(y.runsAt) match {
+            case nonZero if nonZero != 0 =>
+              nonZero
+            case _ =>
+              longOrd.compare(x.id, y.id)
+          }
+      }
+  }
 }

--- a/laws/shared/src/test/scala/cats/effect/IOAsyncTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOAsyncTests.scala
@@ -19,6 +19,7 @@ package cats.effect
 import org.scalactic.source.Position
 import org.scalatest.{Assertion, AsyncFunSuite, Matchers}
 import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -66,5 +67,37 @@ class IOAsyncTests extends AsyncFunSuite with Matchers {
   test("IO.raiseError#shift#runAsync") {
     val dummy = new RuntimeException("dummy")
     testEffectOnRunAsync(IO.shift.flatMap(_ => IO.raiseError(dummy)), Failure(dummy))
+  }
+
+  test("Timer[IO].shift") {
+    for (_ <- Timer[IO].shift.unsafeToFuture()) yield {
+      assert(1 == 1)
+    }
+  }
+
+  test("Timer[IO].currentTimeMillis") {
+    val time = System.currentTimeMillis()
+    val io = Timer[IO].currentTimeMillis
+
+    for (t2 <- io.unsafeToFuture()) yield {
+      time should be > 0L
+      time should be <= t2
+    }
+  }
+
+  test("Timer[IO].sleep(10.ms)") {
+    val io = Timer[IO].sleep(10.millis).map(_ => 10)
+
+    for (r <- io.unsafeToFuture()) yield {
+      r shouldBe 10
+    }
+  }
+
+  test("Timer[IO].sleep(negative)") {
+    val io = Timer[IO].sleep(-10.seconds).map(_ => 10)
+
+    for (r <- io.unsafeToFuture()) yield {
+      r shouldBe 10
+    }
   }
 }

--- a/laws/shared/src/test/scala/cats/effect/IOAsyncTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOAsyncTests.scala
@@ -77,7 +77,7 @@ class IOAsyncTests extends AsyncFunSuite with Matchers {
 
   test("Timer[IO].currentTimeMillis") {
     val time = System.currentTimeMillis()
-    val io = Timer[IO].currentTimeMillis
+    val io = Timer[IO].currentTime(MILLISECONDS)
 
     for (t2 <- io.unsafeToFuture()) yield {
       time should be > 0L

--- a/laws/shared/src/test/scala/cats/effect/IOAsyncTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOAsyncTests.scala
@@ -69,32 +69,16 @@ class IOAsyncTests extends AsyncFunSuite with Matchers {
     testEffectOnRunAsync(IO.shift.flatMap(_ => IO.raiseError(dummy)), Failure(dummy))
   }
 
-  test("Timer[IO].shift") {
-    for (_ <- Timer[IO].shift.unsafeToFuture()) yield {
-      assert(1 == 1)
-    }
-  }
-
-  test("Timer[IO].currentTimeMillis") {
-    val time = System.currentTimeMillis()
-    val io = Timer[IO].currentTime(MILLISECONDS)
-
-    for (t2 <- io.unsafeToFuture()) yield {
-      time should be > 0L
-      time should be <= t2
-    }
-  }
-
-  test("Timer[IO].sleep(10.ms)") {
-    val io = Timer[IO].sleep(10.millis).map(_ => 10)
+  test("IO.sleep(10.ms)") {
+    val io = IO.sleep(10.millis).map(_ => 10)
 
     for (r <- io.unsafeToFuture()) yield {
       r shouldBe 10
     }
   }
 
-  test("Timer[IO].sleep(negative)") {
-    val io = Timer[IO].sleep(-10.seconds).map(_ => 10)
+  test("IO.sleep(negative)") {
+    val io = IO.sleep(-10.seconds).map(_ => 10)
 
     for (r <- io.unsafeToFuture()) yield {
       r shouldBe 10

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -163,7 +163,7 @@ class IOTests extends BaseTestsSuite {
     ec.tick(9.seconds)
     f.value shouldEqual None
     ec.tick(1.second)
-    f.value shouldEqual Some(2)
+    f.value shouldEqual Some(Success(2))
   }
 
   testAsync("IO.async protects against multiple callback calls") { implicit ec =>

--- a/laws/shared/src/test/scala/cats/effect/TestContextTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/TestContextTests.scala
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package cats.effect.laws.util
+package cats.effect
 
-import cats.effect.{BaseTestsSuite, IO}
-
-import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration._
+import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success}
 
 class TestContextTests extends BaseTestsSuite {
@@ -110,15 +108,15 @@ class TestContextTests extends BaseTestsSuite {
   testAsync("timer.currentTimeMillis") { ec =>
     val timer = ec.timer[IO]
 
-    val t1 = timer.currentTimeMillis.unsafeRunSync()
+    val t1 = timer.currentTime(MILLISECONDS).unsafeRunSync()
     assert(t1 === 0)
 
     ec.tick(5.seconds)
-    val t2 = timer.currentTimeMillis.unsafeRunSync()
+    val t2 = timer.currentTime(MILLISECONDS).unsafeRunSync()
     assert(t2 === 5000)
 
     ec.tick(10.seconds)
-    val t3 = timer.currentTimeMillis.unsafeRunSync()
+    val t3 = timer.currentTime(MILLISECONDS).unsafeRunSync()
     assert(t3 === 15000)
   }
 

--- a/laws/shared/src/test/scala/cats/effect/TimerTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/TimerTests.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.data.EitherT
+import org.scalatest.{AsyncFunSuite, Matchers}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+class TimerTests extends AsyncFunSuite with Matchers {
+  implicit override def executionContext =
+    ExecutionContext.global
+
+  type EitherIO[A] = EitherT[IO, Throwable, A]
+
+  test("Timer[IO].shift") {
+    for (_ <- Timer[IO].shift.unsafeToFuture()) yield {
+      assert(1 == 1)
+    }
+  }
+
+  test("Timer[IO].currentTime(tryMonotonic = false)") {
+    val time = System.currentTimeMillis()
+    val io = Timer[IO].currentTime(MILLISECONDS)
+
+    for (t2 <- io.unsafeToFuture()) yield {
+      time should be > 0L
+      time should be <= t2
+    }
+  }
+
+  test("Timer[IO].currentTime(tryMonotonic = true)") {
+    val time = System.nanoTime()
+    val io = Timer[IO].currentTime(NANOSECONDS, tryMonotonic = true)
+
+    for (t2 <- io.unsafeToFuture()) yield {
+      time should be > 0L
+      time should be <= t2
+    }
+  }
+
+  test("Timer[IO].sleep(10.ms)") {
+    implicit val timer = Timer[IO]
+    val io = for {
+      start <- timer.currentTime(MILLISECONDS, tryMonotonic = true)
+      _ <- timer.sleep(10.millis)
+      end <- timer.currentTime(MILLISECONDS, tryMonotonic = true)
+    } yield {
+      end - start
+    }
+
+    for (r <- io.unsafeToFuture()) yield {
+      r should be >= 10L
+    }
+  }
+
+  test("Timer[IO].sleep(negative)") {
+    val io = Timer[IO].sleep(-10.seconds).map(_ => 10)
+
+    for (r <- io.unsafeToFuture()) yield {
+      r shouldBe 10
+    }
+  }
+
+  test("Timer[EitherT].shift") {
+    for (r <- Timer.derive[EitherIO].shift.value.unsafeToFuture()) yield {
+      r shouldBe Right(())
+    }
+  }
+
+
+  test("Timer[EitherT].currentTime(tryMonotonic = false)") {
+    val time = System.currentTimeMillis()
+    val io = Timer.derive[EitherIO].currentTime(MILLISECONDS, tryMonotonic = false)
+
+    for (t2 <- io.value.unsafeToFuture()) yield {
+      time should be > 0L
+      time should be <= t2.right.getOrElse(0L)
+    }
+  }
+
+  test("Timer[EitherT].currentTime(tryMonotonic = true)") {
+    val time = System.nanoTime()
+    val io = Timer.derive[EitherIO].currentTime(NANOSECONDS, tryMonotonic = true)
+
+    for (t2 <- io.value.unsafeToFuture()) yield {
+      time should be > 0L
+      time should be <= t2.right.getOrElse(0L)
+    }
+  }
+
+  test("Timer[EitherT].sleep(10.ms)") {
+    implicit val timer = Timer.derive[EitherIO]
+    val io = for {
+      start <- timer.currentTime(MILLISECONDS, tryMonotonic = true)
+      _ <- timer.sleep(10.millis)
+      end <- timer.currentTime(MILLISECONDS, tryMonotonic = true)
+    } yield {
+      end - start
+    }
+
+    for (r <- io.value.unsafeToFuture()) yield {
+      r.right.getOrElse(0L) should be >= 10L
+    }
+  }
+
+  test("Timer[EitherT].sleep(negative)") {
+    val io = Timer.derive[EitherIO].sleep(-10.seconds).map(_ => 10)
+
+    for (r <- io.value.unsafeToFuture()) yield {
+      r.right.getOrElse(0) shouldBe 10
+    }
+  }
+}


### PR DESCRIPTION
`cats.effect.IO` has one great weakness, with these being the symptoms:

- its reliance on `ExecutionContext` for triggering async boundaries (e.g. `IO.shift`), which makes its API in common use to be in fact impure, because reliance on `ExecutionContext` can affect its referential transparency
- it has no way to schedule execution with a delay (e.g. `Thread.sleep`) without reliance on Java's `ScheduledExecutorService` or on JavaScript's `setTimeout`
- this problem is made worse by Scala not providing its own interface, an analogue to `ExecutionContext` that we could use for delays, with libraries like Monix and FS2 implementing their own `Scheduler` interface

So the answer to that is currently ¯\_(ツ)_/¯

**How does Haskell do it?**

Haskell provides among others:

1. [threadDelay](https://hackage.haskell.org/package/base-4.10.1.0/docs/Control-Concurrent.html#v:threadDelay)
2. [getCurrentTime](https://hackage.haskell.org/package/time-1.9/docs/Data-Time-Clock.html#v%3agetCurrentTime)

These operations are simply part of Haskell's Runtime System (RTS), they are simply available. But we need to workaround lacking such a RTS, because we don't have one. The solution in the Monix `Task` was to require a `Scheduler` in its `runAsync` (`unsafePerformIO`), being Monix's notion of a runtime system, being injected in `Task.create` for users to use.

But `IO`'s design is simpler, on purpose, so the alternative proposed here is to describe this environment with a pure "Scheduler" alternative, which is supposed to be provided by the runtime...

## Timer

```scala
trait Timer[F[_]] {

  def currentTime(unit: TimeUnit, tryMonotonic: Boolean = false): F[Long]

  def sleep(duration: FiniteDuration): F[Unit]

  def shift: F[Unit]
}

object Timer {

  def apply[F[_]](implicit timer: Timer[F]): Timer[F] = timer

  def derive[F[_]](implicit F: LiftIO[F], timer: Timer[IO]): Timer[F] = ???
}
```

Notes:

1. `currentTime` is needed as the alternative to `System.currentTimeMillis` or `System.nano` and it has the advantage that it can be faked (e.g. in tests) ... if we have a `sleep`, then we definitely need to know the current time, otherwise we couldn't describe for example "interval at fixed rate" operations 😉
2. providing a `shift` operation might seem like complecting two notions, however note that `shift` can be derived from `sleep(zero)`

Note that if we have an `Timer[IO]` available in context, and we do, we can derive an implementation for any `F[_]` data type that implements `LiftIO`:

```scala
type EitherIO[A] = EitherT[IO, Throwable, A]

val timer = Timer.derive[EitherIO]
```

### Monotonic time

Added a `tryMonotonic` parameter to `currentTime`, being a recommendation for the underlying implementation to return a monotonically increasing value. It's a recommendation, as the underlying implementation may or may not support it.

```scala
timer.currentTime(NANOSECONDS, tryMonotonic = true)
```

The default `Timer[IO]` implementation uses `System.currentTimeMillis` in case `tryMonotonic = false` (the default) and it uses `System.nanoTime` in case `tryMonotonic = true`. As a matter of implementation detail, as mentioned in the ScalaDoc, the JVM will use `CLOCK_MONOTONIC` for this operation, when available, instead of `CLOCK_REALTIME` (see for example `clock_gettime()` on Linux) and it is up to the underlying platform to implement it correctly.

The difference between `nanoTime` and `currentTimeMillis` is that a monotonic clock is more accurate when doing time measurements of execution, because the clock value returned by `currentTimeMillis` is subject to fluctuations.

This interface does NOT guarantee that a monotonic clock measurement is actually returned, because the JVM itself cannot guarantee that and in fact there are platforms where `CLOCK_MONOTONIC` is not supported (AFAIK Windows XP is one). And at the moment of writing it's not supported on Node.js / JavaScript — there are possible non-standard solutions, but I'd rather see that make it into Scala.js.

### Timer[F] comes from the "Runtime"

To understand this, consider that:

1. on top of JavaScript a `Timer[IO]` is simply available (e.g. the new and implicit `IO.timerGlobal`), because it's based on `setTimeout`, which is readily available
2. Monix's `Task`, due to the way its run-loop works, can describe a pure `Timer` implementation without any dependencies

On top of the JVM, for `Timer[IO]` we are doing a trick:

```scala
implicit def timer(implicit ec: ExecutionContext): Timer[IO] = ???
```

So we still need an `ExecutionContext` in scope for having a `Timer`, for things to work. But this is related strictly to `IO`'s implementation, on top of the JVM, plus we can always imagine the alternative:

```scala
abstract class SafeApp {
  // Part of the environment ;-)
  protected implicit val timer: Timer[IO] = 
    IO.timer(ExecutionContext.Implicits.global)

  abstract def main(args: List[String]): IO[Unit]

  final def main(args: Array[String]): Unit =
    main(args.toList).unsafeRunSync()
}
```

## TestContext

Our `cats.effect.laws.util.TestContext` implementation has been expanded with super powers, now being able to produce `Timer` instances and simulate time passing:

```scala
val ctx = TestContext()
// Building a Timer[IO] from this:
implicit val timer: Timer[IO] = ctx.timer[IO]

// Can now simulate time
val io = timer.sleep(10.seconds) *> IO(1 + 1)
val f = io.unsafeToFuture()

// This invariant holds true, because our IO is async
assert(f.value == None)

// Not yet completed, because this does not simulate time passing:
ctx.tick()
assert(f.value == None)

// Simulating a 5 seconds delay
ctx.tick(5.seconds)
// Not yet complete
assert(f.value == None)

// Simulating another 5 seconds delay
ctx.tick(5.seconds)
// Done!
assert(f.value == Some(Success(2))
```

## Other Changes ...

`IO.shift` no longer takes an implicit `ExecutionContext`:

```scala
// Pure version
def shift(implicit timer: Timer[IO]): IO[Unit] = ???

// Old version, for precise fine tuning of the thread-pool
def shift(ec: ExecutionContext): IO[Unit]
```

Note that this preserves both source and binary compatibility because the JVM doesn't care about implicit parameters, so old compiled bytecode should be fine, plus the new implementation takes a `Timer` that's also built from the currently available `ExecutionContext`.

`IO.fromFuture` no longer takes an implicit `ExecutionContext`, now the definition being just:

```scala
def fromFuture[A](iof: IO[Future[A]]): IO[A]
```

No reason to require an `ExecutionContext` when we have our internal `TrampolineEC`. And now this function too, is pure.

N.B. this has the drawback of being *less fair*, fairness in scheduling being one of `Future`'s advantages. But there's nothing fair about our `cats.effect.IO` implementation, async boundaries have to be explicit anyway, so I don't see why `fromFuture` should be any special.

We also have a short-hand for `IO.sleep`, to mirror `IO.shift`:

```scala
object IO {
  def sleep(duration: FiniteDuration)(implicit timer: Timer[IO]): IO[Unit] =
    timer.sleep(duration)
}
```

And so we can do:

```scala
val timeout = IO.sleep(10.seconds).flatMap { _ =>
  IO.raiseError(new TimeoutException("10 seconds"))
}
```

---

## Actual Use-case

Currently in Monix we've got these operations for `Iterant` that are specialized for `Task`:

```scala
def intervalAtFixedRate(period: FiniteDuration): Iterant[Task, Long] 

def intervalAtFixedRate(initialDelay: FiniteDuration, period: FiniteDuration): Iterant[Task, Long]

def intervalWithFixedDelay(delay: FiniteDuration): Iterant[Task, Long]

def intervalWithFixedDelay(initialDelay: FiniteDuration, delay: FiniteDuration): Iterant[Task, Long]
```

These are doing what they say, being equivalent with Java's `scheduleAtFixedRate` and `scheduleWithFixedDelay` available on your average `ScheduledExecutorService`.

But I can't describe those for any `F[_]` and I'd like to do that very much.
This has been the scope of a recent PR: https://github.com/monix/monix/pull/598

The PR introduces `Timer` in Monix, because that's the only reasonable way to do it. And note `Task`'s purity in this regard:

```scala
implicit val forTask: Timer[Task] =
  new Timer[Task] {
    val shift: Task[Unit] =
      Task.shift
    val currentTimeMillis: Task[Long] =
      Task.deferAction(sc => Task.now(sc.currentTimeMillis()))
    def sleep(timespan: FiniteDuration): Task[Unit] =
      Task.sleep(timespan)
  }
```

But this data type does not belong in Monix, being very generic and useful IMO, belonging in `cats-effect`.

---

Cool sample:

```scala
import cats.effect._
import cats.syntax.all._
import scala.concurrent.duration._

def repeatAtFixedRate(period: FiniteDuration, task: IO[Unit])
  (implicit timer: Timer[IO]): IO[Unit] = {

  timer.currentTime(MILLISECONDS).flatMap { start =>
    task *> timer.currentTime(MILLISECONDS).flatMap { finish =>
      val nextDelay = period.toMillis - (finish - start)
      timer.sleep(nextDelay.millis) *> repeatAtFixedRate(period, task)
    }
  }
}
```

Given the latest changes on master for the cancelable `IO`, this is now doable and pure and we could make this to work with any `F[_]` ;-)