### PR TITLE
Split Timer.currentTime in clockMonotonic and clockRealTime

### DIFF
--- a/core/js/src/main/scala/cats/effect/internals/IOTimer.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOTimer.scala
@@ -33,13 +33,11 @@ import scala.scalajs.js
 private[internals] class IOTimer extends Timer[IO] {
   import IOTimer.{Tick, setTimeout, clearTimeout, setImmediateRef}
 
-  final def currentTime(unit: TimeUnit, tryMonotonic: Boolean): IO[Long] =
-    IO {
-      if (tryMonotonic)
-        unit.convert(System.nanoTime(), NANOSECONDS)
-      else
-        unit.convert(System.currentTimeMillis(), MILLISECONDS)
-    }
+  final def clockRealTime(unit: TimeUnit): IO[Long] =
+    IO(unit.convert(System.currentTimeMillis(), MILLISECONDS))
+
+  final def clockMonotonic(unit: TimeUnit): IO[Long] =
+    IO(unit.convert(System.nanoTime(), NANOSECONDS))
 
   final def sleep(timespan: FiniteDuration): IO[Unit] =
     IO.cancelable { cb =>

--- a/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
@@ -35,13 +35,11 @@ private[internals] final class IOTimer private (
 
   import IOTimer._
 
-  override def currentTime(unit: TimeUnit, tryMonotonic: Boolean): IO[Long] =
-    IO {
-      if (tryMonotonic)
-        unit.convert(System.nanoTime(), NANOSECONDS)
-      else
-        unit.convert(System.currentTimeMillis(), MILLISECONDS)
-    }
+  override def clockRealTime(unit: TimeUnit): IO[Long] =
+    IO(unit.convert(System.currentTimeMillis(), MILLISECONDS))
+
+  override def clockMonotonic(unit: TimeUnit): IO[Long] =
+    IO(unit.convert(System.nanoTime(), NANOSECONDS))
 
   override def sleep(timespan: FiniteDuration): IO[Unit] =
     IO.cancelable { cb =>

--- a/core/shared/src/main/scala/cats/effect/Timer.scala
+++ b/core/shared/src/main/scala/cats/effect/Timer.scala
@@ -100,7 +100,8 @@ trait Timer[F[_]] {
    * compute differences between such values, for example in order to
    * measure the time it took to execute a task.
    *
-   * As a matter of implementation detail, the JVM will use
+   * As a matter of implementation detail, the default `Timer[IO]`
+   * implementation uses `System.nanoTime` and the JVM will use
    * `CLOCK_MONOTONIC` when available, instead of `CLOCK_REALTIME`
    * (see `clock_gettime()` on Linux) and it is up to the underlying
    * platform to implement it correctly.
@@ -114,6 +115,9 @@ trait Timer[F[_]] {
    *  - [[https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6458294 bug report]]
    *  - [[http://cs.oswego.edu/pipermail/concurrency-interest/2012-January/008793.html concurrency-interest]]
    *    discussion on the X86 tsc register
+   *
+   * The JVM tries to do the right thing and at worst the resolution
+   * and behavior will be that of `System.currentTimeMillis`.
    *
    * The recommendation is to use this monotonic clock when doing
    * measurements of execution time, or if you value monotonically

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
@@ -153,11 +153,13 @@ final class TestContext private () extends ExecutionContext { self =>
           val cancel = self.schedule(timespan, tick(cb))
           IO(cancel())
         })
-      override def currentTime(unit: TimeUnit, tryMonotonic: Boolean): F[Long] =
+      override def clockRealTime(unit: TimeUnit): F[Long] =
         F.liftIO(IO {
           val d = self.state.clock
           unit.convert(d.length, d.unit)
         })
+      override def clockMonotonic(unit: TimeUnit): F[Long] =
+        clockRealTime(unit)
     }
 
   /**

--- a/laws/shared/src/test/scala/cats/effect/TestContextTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/TestContextTests.scala
@@ -105,18 +105,33 @@ class TestContextTests extends BaseTestsSuite {
     assert(f.value === Some(Success(2)))
   }
 
-  testAsync("timer.currentTimeMillis") { ec =>
+  testAsync("timer.clockRealTime") { ec =>
     val timer = ec.timer[IO]
 
-    val t1 = timer.currentTime(MILLISECONDS).unsafeRunSync()
+    val t1 = timer.clockRealTime(MILLISECONDS).unsafeRunSync()
     assert(t1 === 0)
 
     ec.tick(5.seconds)
-    val t2 = timer.currentTime(MILLISECONDS).unsafeRunSync()
+    val t2 = timer.clockRealTime(MILLISECONDS).unsafeRunSync()
     assert(t2 === 5000)
 
     ec.tick(10.seconds)
-    val t3 = timer.currentTime(MILLISECONDS).unsafeRunSync()
+    val t3 = timer.clockRealTime(MILLISECONDS).unsafeRunSync()
+    assert(t3 === 15000)
+  }
+
+  testAsync("timer.clockMonotonic") { ec =>
+    val timer = ec.timer[IO]
+
+    val t1 = timer.clockMonotonic(MILLISECONDS).unsafeRunSync()
+    assert(t1 === 0)
+
+    ec.tick(5.seconds)
+    val t2 = timer.clockMonotonic(MILLISECONDS).unsafeRunSync()
+    assert(t2 === 5000)
+
+    ec.tick(10.seconds)
+    val t3 = timer.clockMonotonic(MILLISECONDS).unsafeRunSync()
     assert(t3 === 15000)
   }
 

--- a/laws/shared/src/test/scala/cats/effect/TimerTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/TimerTests.scala
@@ -33,9 +33,9 @@ class TimerTests extends AsyncFunSuite with Matchers {
     }
   }
 
-  test("Timer[IO].currentTime(tryMonotonic = false)") {
+  test("Timer[IO].clockRealTime") {
     val time = System.currentTimeMillis()
-    val io = Timer[IO].currentTime(MILLISECONDS)
+    val io = Timer[IO].clockRealTime(MILLISECONDS)
 
     for (t2 <- io.unsafeToFuture()) yield {
       time should be > 0L
@@ -43,9 +43,9 @@ class TimerTests extends AsyncFunSuite with Matchers {
     }
   }
 
-  test("Timer[IO].currentTime(tryMonotonic = true)") {
+  test("Timer[IO].clockMonotonic") {
     val time = System.nanoTime()
-    val io = Timer[IO].currentTime(NANOSECONDS, tryMonotonic = true)
+    val io = Timer[IO].clockMonotonic(NANOSECONDS)
 
     for (t2 <- io.unsafeToFuture()) yield {
       time should be > 0L
@@ -56,9 +56,9 @@ class TimerTests extends AsyncFunSuite with Matchers {
   test("Timer[IO].sleep(10.ms)") {
     implicit val timer = Timer[IO]
     val io = for {
-      start <- timer.currentTime(MILLISECONDS, tryMonotonic = true)
+      start <- timer.clockMonotonic(MILLISECONDS)
       _ <- timer.sleep(10.millis)
-      end <- timer.currentTime(MILLISECONDS, tryMonotonic = true)
+      end <- timer.clockMonotonic(MILLISECONDS)
     } yield {
       end - start
     }
@@ -83,9 +83,9 @@ class TimerTests extends AsyncFunSuite with Matchers {
   }
 
 
-  test("Timer[EitherT].currentTime(tryMonotonic = false)") {
+  test("Timer[EitherT].clockRealTime") {
     val time = System.currentTimeMillis()
-    val io = Timer.derive[EitherIO].currentTime(MILLISECONDS, tryMonotonic = false)
+    val io = Timer.derive[EitherIO].clockRealTime(MILLISECONDS)
 
     for (t2 <- io.value.unsafeToFuture()) yield {
       time should be > 0L
@@ -93,9 +93,9 @@ class TimerTests extends AsyncFunSuite with Matchers {
     }
   }
 
-  test("Timer[EitherT].currentTime(tryMonotonic = true)") {
+  test("Timer[EitherT].clockMonotonic") {
     val time = System.nanoTime()
-    val io = Timer.derive[EitherIO].currentTime(NANOSECONDS, tryMonotonic = true)
+    val io = Timer.derive[EitherIO].clockMonotonic(NANOSECONDS)
 
     for (t2 <- io.value.unsafeToFuture()) yield {
       time should be > 0L
@@ -106,9 +106,9 @@ class TimerTests extends AsyncFunSuite with Matchers {
   test("Timer[EitherT].sleep(10.ms)") {
     implicit val timer = Timer.derive[EitherIO]
     val io = for {
-      start <- timer.currentTime(MILLISECONDS, tryMonotonic = true)
+      start <- timer.clockMonotonic(MILLISECONDS)
       _ <- timer.sleep(10.millis)
-      end <- timer.currentTime(MILLISECONDS, tryMonotonic = true)
+      end <- timer.clockMonotonic(MILLISECONDS)
     } yield {
       end - start
     }

--- a/laws/shared/src/test/scala/cats/effect/TimerTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/TimerTests.scala
@@ -64,7 +64,7 @@ class TimerTests extends AsyncFunSuite with Matchers {
     }
 
     for (r <- io.unsafeToFuture()) yield {
-      r should be >= 10L
+      r should be >= 9L
     }
   }
 
@@ -114,7 +114,7 @@ class TimerTests extends AsyncFunSuite with Matchers {
     }
 
     for (r <- io.value.unsafeToFuture()) yield {
-      r.right.getOrElse(0L) should be >= 10L
+      r.right.getOrElse(0L) should be >= 9L
     }
   }
 


### PR DESCRIPTION
A change discussed in #132, but that didn't make it yesterday, splitting `Timer.currentTime` in two, to avoid confusion with its `tryMonotonic` boolean parameter:

```scala
def clockRealTime(unit: TimeUnit): F[Long]

def clockMonotonic(unit: TimeUnit): F[Long]
```

The names refer to `CLOCK_REALTIME` and `CLOCK_MONOTONIC` from Linux's `clock_gettime()`, which are being used by the JVM when doing `System.currentTimeMillis` and `System.nanoTime` respectively.