### PR TITLE
IO documentation for `v0.10`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ This project aims to provide a standard [`IO`](https://oss.sonatype.org/service/
 
 In this way, `IO` is more similar to common `Task` implementations than it is to the classic `scalaz.effect.IO` or even Haskell's `IO`, both of which are purely synchronous in nature.  As Haskell's runtime uses green threading, a synchronous `IO` (and the requisite thread blocking) makes a lot of sense.  With Scala though, we're either on a runtime with native threads (the JVM) or only a single thread (JavaScript), meaning that asynchronous effects are every bit as important as synchronous ones.
 
-This project does *not* attempt to provide any tools for concurrency or parallelism.  The only function which does any sort of thread or thread-pool manipulation of *any* sort is `shift` (on both `IO` and `Effect`), which takes a given computation and shifts it to a different thread pool.  This function mostly exists because it turns out to be somewhat difficult to do useful things with `IO` if you *don't* have this function.  At any rate, it is impossible to define *safe* and practical concurrent primitives solely in terms of `IO`.  If you want concurrency, you should use a streaming framework like fs2 or Monix.  Note that both of these frameworks are, at least conceptually, compatible with `IO`.
-
 ## Usage
 
 The most current stable release of cats-effect is **0.9**.  We are confident in the quality of this release, and do consider it "production-ready".  However, we will not be *guaranteeing* source compatibility until the 1.0 release, which will depend on cats-core 1.0 (when it is released).  See [compatibility and versioning](https://github.com/typelevel/cats-effect/blob/master/versioning.md) for more information on our compatibility and semantic versioning policies.
@@ -27,9 +25,9 @@ The most current snapshot (or major release) can be found in the maven badge at 
 
 Please see [this document](https://github.com/typelevel/cats-effect/blob/master/verifying-releases.md) for information on how to cryptographically verify the integrity of cats-effect releases.  You should *absolutely* be doing this!  It takes five minutes and eliminates the need to trust a third-party with your classpath.
 
-### Laws
+## Laws
 
-The **cats-effect-laws** artifact provides [Discipline-style](https://github.com/typelevel/discipline) laws for the `Async`, `Sync` and `Effect` typeclasses (`LiftIO` is lawless, but highly parametric).  It is relatively easy to use these laws to test your own implementations of these typeclasses.  For an example of this, see [`IOTests.scala`](https://github.com/djspiewak/cats-effect/blob/master/laws/shared/src/test/scala/cats/effect/IOTests.scala).
+The **cats-effect-laws** artifact provides [Discipline-style](https://github.com/typelevel/discipline) laws for the `Sync`, `Async`, `Concurrent`, `Effect` and `ConcurrentEffect` typeclasses (`LiftIO` is lawless, but highly parametric).  It is relatively easy to use these laws to test your own implementations of these typeclasses. Take a look [here](https://github.com/typelevel/cats-effect/tree/master/laws/shared/src/main/scala/cats/effect/laws) for more.
 
 ```sbt
 libraryDependencies += "org.typelevel" %% "cats-effect-laws" % "0.9" % "test"
@@ -37,69 +35,20 @@ libraryDependencies += "org.typelevel" %% "cats-effect-laws" % "0.9" % "test"
 
 These laws are compatible with both Specs2 and ScalaTest.
 
-## API
+## Adopters
 
-Most of the API documentation can be found [in the scaladoc](https://oss.sonatype.org/service/local/repositories/releases/archive/org/typelevel/cats-effect_2.12/0.5/cats-effect_2.12-0.5-javadoc.jar/!/cats/effect/index.html).  To summarize though, the typeclass hierarchy looks something like this:
+These are the projects making use of `Cats Effect` in alphabetical order:
 
-![cats-effect typeclasses](https://docs.google.com/drawings/d/1JIxtfEPKxUp402l8mYYDj7tDuEdEFAiqvJJpeAXAwG0/pub?w=1027&h=1076)
-
-All of the typeclasses are of kind `(* -> *) -> *`, as you would expect.  `MonadError` is of course provided by [cats-core](https://github.com/typelevel/cats), while the other four classes are in cats-effect.  For concision and reference, the abstract methods of each typeclass are given below:
-
-- `Sync[F]`
-  + `def suspend[A](thunk: => F[A]): F[A]`
-- `Async[F]`
-  + `def async[A](k: (Either[Throwable, A] => Unit) => Unit): F[A]`
-- `LiftIO[F]`
-  + `def liftIO[A](ioa: IO[A]): F[A]`
-- `Effect[F]`
-  + `def runAsync[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit]`
-
-The `runAsync` function is of particular interest here, since it returns the *concrete* type `IO[Unit]`.  Effectively, what this type is asserting is that all effect-ish things must be able to asynchronous interpret into `IO`, which is the canonical parametric type for managing side-effecting computation.  `IO` in turn has several functions for (unsafely!) running its constituent actions *as* side effects, for interoperability with legacy effectful APIs and for ending the world.  Of course, concrete `Effect` implementations are free to define their own unsafe runner functions, and we expect that most of them will do exactly this.
-
-Really, this type signature is saying that, ultimately, `IO` is side effects and side effects are `IO`, especially when taken together with the `liftIO` function.
-
-### JavaScript and `unsafeRunSync()`
-
-One of the trickiest functions to design from the perspective of `IO` is the `unsafeRunSync()` function, which has the very revealing (and terrifying) type signature `IO[A] => A`.  This function is extremely convenient for testing, as well as simplifying interoperability with legacy side-effecting APIs.  Unfortunately, it is also impossible to implement *safely* on JavaScript.
-
-The reason for this is the presence of async actions.  For any `IO` constructed with the `async` function, we have to somehow extract the `A` (or the `Throwable`) which is received by the callback and move that value (or exception) *back* to the call-site for `unsafeRunSync()`.  This is exactly as impossible as it sounds.  On the JVM, we can use a `CountDownLatch` to simply block the thread, hoping that the `async` callback will eventually get fired and we will receive a result.  Unfortunately, on JavaScript, this would be impossible since there is only one thread!  If that thread is blocked awaiting a callback, then there is no thread on which to fire the callback.  So we would have a deadlock.
-
-`IO` solves this problem by providing users with a lawful implementation of `runAsync`.  On a generic `Effect`, `runAsync` provides a means for asynchronously interpreting the effect into `IO`, a concrete type which can be run directly.  On `IO`, `runAsync` provides a means for asynchronously interpreting `IO` into *another* `IO` which is guaranteed to be synchronous.  Thus, it is safe – even on JavaScript! – to call `unsafeRunSync()` on the `IO` which results from `runAsync`.  Though, notably, `runAsync` returns an `IO[Unit]` rather than an `IO`.  So really calling `runAsync` on `IO` followed by `unsafeRunSync()`  is the same as calling `unsafeRunAsync`.
-
-It would be quite weird if this were *not* the case.
-
-### Testing and Timeouts
-
-One of the four unsafe functions provided by `IO` is `unsafeRunTimed`.  This function takes a `scala.concurrent.duration.Duration` and uses that value to set a timeout when blocking for an asynchronous result.  *Critically*, this timeout does not come into play if the `IO` is entirely synchronous!  Nor is it fully used when the `IO` is partially synchronous, and partially asynchronous (constructed via `flatMap`).  Thus, the name is slightly misleading: it is *not* a timeout on the overall `IO`, it is a timeout on the thread blocking associated with awaiting any `async` action contained within the `IO`.
-
-This function is useful for testing, and *no where* else!  It is not an appropriate function to use for implementing timeouts.  In fact, if you find this function *anywhere* in your production code path, you have a bug.  But it is *very* useful for testing.
-
-If the timeout is hit, the function will return `None`.
-
-### Stack-Safety
-
-`IO` is stack-safe… to a point.  Any `IO` actions which are synchronous are entirely stack-safe.  In other words it is safe to `flatMap`, `attempt`, and otherwise futz with synchronous `IO` inside of loop-ish constructs, and the interpretation of that `IO` will use constant stack.  The implementation of `tailRecM`, from the cats `Monad`, reflects this fact: it just delegates to `flatMap`!
-
-However, there's a catch: any `IO` constructed with `async` will *not* be stack-safe.  This is because `async` is fundamentally capturing a callback, and as the JVM does not support tail call elimination, it will always result in a new stack frame.  This problem is best illustrated with a unit test:
-
-```scala
-// this is expected behavior
-test("fail to provide stack safety with repeated async suspensions") {
-  val result = (0 until 10000).foldLeft(IO(0)) { (acc, i) =>
-    acc.flatMap(n => IO.async[Int](_(Right(n + 1))))
-  }
-
-  intercept[StackOverflowError] {
-    result.unsafeRunAsync(_ => ())
-  }
-}
-```
-
-What we're doing here is constructing 10000 `IO` instances using `async`, each nested within the `flatMap` of the previous one.  This will indeed blow the stack on any JVM with default parameters.  This is obviously not an issue for JavaScript, though this test does appear to use an enormous amount of memory on V8 (around 4 GB).
-
-Anyway, this stack unsafety is by design.  Realistically, the only way to avoid this problem would be to thread-shift (via `ExecutionContext`) the results of any callback threaded through `async`.  This would effectively reset the stack, avoiding the uneliminated tail call problem.  However, this is not always what you want.  Some frameworks, such as Netty, can provide a performance benefit to keeping short continuations on the event dispatch pool, rather than thread-shifting back to the application main pool.  Other frameworks, such as [SWT](https://www.eclipse.org/swt/), outright *require* that callback continuations remain on the *calling* thread, and will throw exceptions if you attempt otherwise.
-
-As `IO` is attempting to *not* be opinionated about applications or threading in general, it simply chooses not to thread-shift `async`.  If you need thread-shifting behavior, it is relatively easy to implement yourself, or you can simply use the built-in `shift` function.  The `shift` function takes an implicit `ExecutionContext` and moves as much of the `IO` as possible (its synchronous prefix and its asynchronous continuation) onto that thread pool.  If we were to modify the above test by inserting a call to `shift` *anywhere* in the body of the fold, the resulting `IO` would be stack-safe.
+| Project | Description |
+| ------- | ----------- |
+| [Doobie](http://tpolecat.github.io/doobie/) | A principled JDBC layer for Scala |
+| [Eff](http://atnos-org.github.io/eff/) | Extensible Effects for Scala |
+| [Fs2](https://functional-streams-for-scala.github.io/fs2/) | Functional Streams for Scala (Streaming I/O library) |
+| [Http4s](http://http4s.org/) | Typeful, functional, streaming HTTP for Scala |
+| [Monix](https://monix.io/) | Asynchronous Programming for Scala and Scala.js |
+| [Pure Config](https://pureconfig.github.io/) | A boilerplate-free library for loading configuration files |
+| [Scala Cache](https://cb372.github.io/scalacache/) | A facade for the most popular cache implementations for Scala |
+| [Sttp](http://sttp.readthedocs.io/en/latest/) | The Scala HTTP client you always wanted |
 
 ## Development
 

--- a/site/src/main/tut/io.md
+++ b/site/src/main/tut/io.md
@@ -29,7 +29,7 @@ The above example prints "hey!" twice, as the effect re-runs each time it is seq
 
 ## Basic Operations
 
-`IO` implements all the typeclasses shown in the hierarchy and it adds some extra functionality, therefore all the operations described in these typeclasses are available for `IO` as well.
+`IO` implements all the typeclasses shown in the hierarch. Therefore all these operations are available for `IO`, in addition to some others.
 
 ### apply
 
@@ -39,7 +39,7 @@ It probably is the most used operation and, as explained before, the equivalent 
 def apply[A](body: => A): IO[A] = ???
 ```
 
-The idea is to wrap side effects such as reading / writing from / to the console:
+The idea is to wrap synchronous side effects such as reading / writing from / to the console:
 
 ```tut:book
 def putStrlLn(value: String) = IO(println(value))
@@ -90,10 +90,12 @@ You should never use `pure` to wrap side effects, that is very much wrong, so pl
 IO.pure(println("THIS IS WRONG!"))
 ```
 
-See above in the previous example how from a pure value we `flatMap` with an `IO` that wraps a side effect. That's fine. However, you should never use `map` in similar cases since this function is only meant for pure transformations and not to enclose side effects. So this would be very wrong:
+This will be stricly evaluated (immediately) and that's something you wouldn't want when working with side effects.
+
+See above in the previous example how from a pure value we `flatMap` with an `IO` that wraps a side effect. That's fine. However, using `map` in similar cases is not recommended since this function is only meant for pure transformations and not to enclose side effects. For example, this works but it is fundamentally wrong:
 
 ```tut:book
-IO.pure(123).map(n => println(s"DON'T DO THIS EITHER! $n"))
+IO.pure(123).map(n => println(s"NOT RECOMMENDED! $n"))
 ```
 
 ### unit & never
@@ -130,14 +132,18 @@ Because `Future` eagerly evaluates, as well as because it memoizes, this functio
 Lazy evaluation, equivalent with by-name parameters:
 
 ```tut:book
-val f = Future.successful("I come from the Future!")
+import scala.concurrent.ExecutionContext.Implicits.global
 
-IO.fromFuture(IO(f))
+IO.fromFuture(IO {
+  Future(println("I come from the Future!"))
+})
 ```
 
-Eager evaluation, for pure futures:
+Eager evaluation:
 
 ```tut:book
+val f = Future.successful("I come from the Future!")
+
 IO.fromFuture(IO.pure(f))
 ```
 
@@ -190,7 +196,6 @@ By default, `Cats Effect` provides an instance of `Timer[IO]` that manages threa
 
 ```tut:book
 import cats.effect.Timer
-import scala.concurrent.ExecutionContext.Implicits.global
 
 val ioTimer = Timer[IO]
 ```
@@ -284,7 +289,7 @@ def loop(n: Int): IO[Int] =
 
 ## Parallelism
 
-Since the introduction of the [Parallel](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/Parallel.scala) typeclasss in the Cats library and its `IO` instance, it became possible to execute two given `IO`s in parallel.
+Since the introduction of the [Parallel](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/Parallel.scala) typeclasss in the Cats library and its `IO` instance, it became possible to execute two or more given `IO`s in parallel.
 
 TODO: `parMapN` example.
 

--- a/site/src/main/tut/io.md
+++ b/site/src/main/tut/io.md
@@ -27,81 +27,154 @@ program.unsafeRunSync()
 
 The above example prints "hey!" twice, as the effect re-runs each time it is sequenced in the monadic chain.
 
-`IO` implements all the typeclasses shown in the hierarchy and it adds some extra functionality as described below.
+## Basic Operations
 
-## "Unsafe" Operations
+`IO` implements all the typeclasses shown in the hierarchy and it adds some extra functionality, therefore all the operations described in these typeclasses are available for `IO` as well.
 
-All of the operations prefixed with `unsafe` are impure functions and perform side effects (for example Haskell has `unsafePerformIO`). But don't be scared by the name! You should write your programs in a monadic way using functions such as `map` and `flatMap` to compose other functions and ideally you should just call one of these unsafe operations only **once**, at the very end of your program.
+### apply
 
-### unsafeRunSync
-
-Produces the result by running the encapsulated effects as impure side effects.
-
-If any component of the computation is asynchronous, the current thread will block awaiting the results of the async computation. On JavaScript, an exception will be thrown instead to avoid generating a deadlock. By default, this blocking will be unbounded. To limit the thread block to some fixed time, use `unsafeRunTimed` instead.
-
-Any exceptions raised within the effect will be re-thrown during evaluation.
+It probably is the most used operation and, as explained before, the equivalent of `Sync[IO].delay`:
 
 ```tut:book
-IO(println("Sync!")).unsafeRunSync()
+def apply[A](body: => A): IO[A] = ???
 ```
 
-### unsafeRunAsync
-
-Passes the result of the encapsulated effects to the given callback by running them as impure side effects.
-
-Any exceptions raised within the effect will be passed to the callback in the `Either`. The callback will be invoked at most *once*. Note that it is very possible to construct an `IO` which never returns while still never blocking a thread, and attempting to evaluate that `IO` with this method will result in a situation where the callback is *never* invoked.
+The idea is to wrap side effects such as reading / writing from / to the console:
 
 ```tut:book
-IO(println("Async!")).unsafeRunAsync(_ => ())
+def putStrlLn(value: String) = IO(println(value))
+val readLn = IO(scala.io.StdIn.readLine)
 ```
 
-### unsafeRunCancelable
+A good practice is also to keep the granularity so please don't do something like this:
 
-Evaluates the source `IO`, passing the result of the encapsulated effects to the given callback. Note that this has the potential to be interrupted.
+```scala
+IO {
+  readingFile
+  writingToDatabase
+  sendBytesOverTcp
+  launchMissiles
+}
+```
+
+In FP we embrace reasoning about our programs and since `IO` is a `Monad` you can compose bigger programs from small ones in a `for-comprehention` for example:
+
+```
+val program =
+  for {
+    _     <- putStrlLn("Please enter your name:")
+    name  <- readLn
+    _     <- putStrlLn(s"Hi $name!")
+  } yield ()
+```
+
+Here you have a simple prompt program that is, at the same time, composable with other programs. Monads compose ;)
+
+### pure
+
+Sometimes you want to lift pure values into `IO`. For that purpose the following method is defined:
 
 ```tut:book
-IO(println("Potentially cancelable!")).unsafeRunCancelable(_ => ())
+def pure[A](a: A): IO[A] = ???
 ```
 
-### unsafeRunTimed
-
-Similar to `unsafeRunSync`, except with a bounded blocking duration when awaiting asynchronous results.
-
-Please note that the `limit` parameter does not limit the time of the total computation, but rather acts as an upper bound on any *individual* asynchronous block.  Thus, if you pass a limit of `5 seconds` to an `IO` consisting solely of synchronous actions, the evaluation may take considerably longer than 5 seconds!
-
-Furthermore, if you pass a limit of `5 seconds` to an `IO` consisting of several asynchronous actions joined together, evaluation may take up to `n * 5 seconds`, where `n` is the number of joined async actions.
-
-As soon as an async blocking limit is hit, evaluation "immediately" aborts and `None` is returned.
-
-Please note that this function is intended for **testing** purposes; it should never appear in your mainline production code!  It is absolutely not an appropriate function to use if you want to implement timeouts, or anything similar. If you need that sort of functionality, you should be using a streaming library (like [fs2](https://github.com/functional-streams-for-scala/fs2) or [Monix](https://monix.io/)).
+For example we can lift a number (pure value) into `IO` and compose it with another `IO` that wraps a side a effect in a safe manner, nothing is going to be executed:
 
 ```tut:book
-import scala.concurrent.duration._
-
-IO(println("Timed!")).unsafeRunTimed(5.seconds)
+IO.pure(25).flatMap(n => IO(println(s"Number is: $n")))
 ```
 
-### unsafeToFuture
-
-Evaluates the effect and produces the result in a `Future`.
-
-This is similar to `unsafeRunAsync` in that it evaluates the `IO` as a side effect in a non-blocking fashion, but uses a `Future` rather than an explicit callback.  This function should really only be used if interoperating with legacy code which uses Scala futures.
+You should never use `pure` to wrap side effects, that is very much wrong, so please don't do this:
 
 ```tut:book
-IO("Gimme a Future!").unsafeToFuture()
+IO.pure(println("THIS IS WRONG!"))
 ```
 
-## Additional Operations
+See above in the previous example how from a pure value we `flatMap` with an `IO` that wraps a side effect. That's fine. However, you should never use `map` in similar cases since this function is only meant for pure transformations and not to enclose side effects. So this would be very wrong:
+
+```tut:book
+IO.pure(123).map(n => println(s"DON'T DO THIS EITHER! $n"))
+```
+
+### unit & never
+
+In addition to `apply` and `pure` there are two useful functions that are just aliases, namely `unit` and `never`.
+
+`unit` is simply an alias for `pure(())`:
+
+```tut:book
+val unit: IO[Unit] = IO.pure(())
+```
+
+`never` represents a non-terminating `IO` defined in terms of `async`:
+```tut:book
+val never: IO[Nothing] = IO.async(_ => ())
+```
+
+## From Operations
+
+There are two useful operations defined in the `IO` companion object to lift both a scala `Future` and an `Either` into `IO`.
+
+### fromFuture
+
+Constructs an `IO` which evaluates the given `Future` and produces either a result or a failure. It is defined as follow:
+
+```tut:book
+import scala.concurrent.Future
+
+def fromFuture[A](iof: IO[Future[A]]): IO[A] = ???
+```
+
+Because `Future` eagerly evaluates, as well as because it memoizes, this function takes its parameter as an `IO`, which could be lazily evaluated. If this laziness is appropriately threaded back to the definition site of the `Future`, it ensures that the computation is fully managed by `IO` and thus referentially transparent.
+
+Lazy evaluation, equivalent with by-name parameters:
+
+```tut:book
+val f = Future.successful("I come from the Future!")
+
+IO.fromFuture(IO(f))
+```
+
+Eager evaluation, for pure futures:
+
+```tut:book
+IO.fromFuture(IO.pure(f))
+```
+
+### fromEither
+
+Lifts an `Either[Throwable, A]` into the `IO[A]` context raising the throwable if it exists.
+
+```tut:book
+def fromEither[A](e: Either[Throwable, A]): IO[A] = e.fold(IO.raiseError, IO.pure)
+```
+
+## Error Handling
+
+Since there is an instance of `MonadError[IO, Throwable]` available in Cats Effect, all the error handling is done through it. This means you can use all the operations available for `MonadError` and thus for `ApplicativeError` on `IO` as long as the error type is a `Throwable`. Operations such as `raiseError`, `attempt`, `handleErrorWith`, `recoverWith`, etc. Just make sure you have the syntax import in scope such as `cats.implicits._`.
+
+### raiseError
+
+Constructs an `IO` which sequences the specified exception.
+
+```tut:nofail
+val boom = IO.raiseError(new Exception("boom"))
+boom.unsafeRunSync()
+```
 
 ### attempt
 
 Materializes any sequenced exceptions into value space, where they may be handled. This is analogous to the `catch` clause in `try`/`catch`, being the inverse of `IO.raiseError`. Example:
 
 ```tut:book
-IO.raiseError(new Exception("boom")).attempt.unsafeRunSync()
+boom.attempt.unsafeRunSync()
 ```
 
-Note that this is provided by `IO`'s `MonadError` instance or more specifically by the `ApplicativeError` typeclass. So it can also be used when abstracting over the effect `F[_]`.
+Look at the [MonadError](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/MonadError.scala) typeclass for more.
+
+## Thread Shifting
+
+`IO` provides a function `shift` to give you more control over the execution of your operations.
 
 ### shift
 
@@ -207,5 +280,114 @@ def loop(n: Int): IO[Int] =
   signal(n).flatMap { x =>
     if (x > 0) loop(n - 1) else IO.pure(0)
   }
+```
+
+## Parallelism
+
+Since the introduction of the [Parallel](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/Parallel.scala) typeclasss in the Cats library and its `IO` instance, it became possible to execute two given `IO`s in parallel.
+
+TODO: `parMapN` example.
+
+## Concurrency
+
+There are two methods defined by the `Concurrent` typeclasss to help you achieve concurrency, namely `race` and `racePair`.
+
+### race
+
+Run two `IO` tasks concurrently, and return the first to finish, either in success or error. The loser of the race is cancelled.
+
+The two tasks are executed in parallel if asynchronous, the winner being the first that signals a result. As an example, this is how a `timeout` operation could be implemented in terms of `race`:
+
+```tut:book:silent
+import scala.concurrent.duration._
+
+def timeoutTo[A](io: IO[A], after: FiniteDuration, fallback: IO[A])(implicit timer: Timer[IO]): IO[A] = {
+  IO.race(io, timer.sleep(after)).flatMap {
+    case Left(a)  => IO.pure(a)
+    case Right(_) => fallback
+  }
+}
+
+def timeout[A](io: IO[A], after: FiniteDuration)(implicit timer: Timer[IO]): IO[A] = {
+  timeoutTo(io, after, IO.raiseError(new Exception(s"Timeout after: $after")))
+}
+```
+
+### racePair
+
+Run two `IO` tasks concurrently, and returns a pair containing both the winner's successful value and the loser represented as a still-unfinished task.
+
+If the first task completes in error, then the result will complete in error, the other task being cancelled. On usage the user has the option of cancelling the losing task, this being equivalent with plain `race`:
+
+```tut:book:silent
+def racing[A, B](ioA: IO[A], ioB: IO[B]) =
+  IO.racePair(ioA, ioB).flatMap {
+    case Left((a, fiberB)) =>
+       fiberB.cancel.map(_ => a)
+    case Right((fiberA, b)) =>
+      fiberA.cancel.map(_ => b)
+  }
+```
+
+## "Unsafe" Operations
+
+Pretty much we have been using some "unsafe" operations in the previous examples but we never explained any of them, so here it goes. All of the operations prefixed with `unsafe` are impure functions and perform side effects (for example Haskell has `unsafePerformIO`). But don't be scared by the name! You should write your programs in a monadic way using functions such as `map` and `flatMap` to compose other functions and ideally you should just call one of these unsafe operations only **once**, at the very end of your program.
+
+### unsafeRunSync
+
+Produces the result by running the encapsulated effects as impure side effects.
+
+If any component of the computation is asynchronous, the current thread will block awaiting the results of the async computation. On JavaScript, an exception will be thrown instead to avoid generating a deadlock. By default, this blocking will be unbounded. To limit the thread block to some fixed time, use `unsafeRunTimed` instead.
+
+Any exceptions raised within the effect will be re-thrown during evaluation.
+
+```tut:book
+IO(println("Sync!")).unsafeRunSync()
+```
+
+### unsafeRunAsync
+
+Passes the result of the encapsulated effects to the given callback by running them as impure side effects.
+
+Any exceptions raised within the effect will be passed to the callback in the `Either`. The callback will be invoked at most *once*. Note that it is very possible to construct an `IO` which never returns while still never blocking a thread, and attempting to evaluate that `IO` with this method will result in a situation where the callback is *never* invoked.
+
+```tut:book
+IO(println("Async!")).unsafeRunAsync(_ => ())
+```
+
+### unsafeRunCancelable
+
+Evaluates the source `IO`, passing the result of the encapsulated effects to the given callback. Note that this has the potential to be interrupted.
+
+```tut:book
+IO(println("Potentially cancelable!")).unsafeRunCancelable(_ => ())
+```
+
+### unsafeRunTimed
+
+Similar to `unsafeRunSync`, except with a bounded blocking duration when awaiting asynchronous results.
+
+Please note that the `limit` parameter does not limit the time of the total computation, but rather acts as an upper bound on any *individual* asynchronous block.  Thus, if you pass a limit of `5 seconds` to an `IO` consisting solely of synchronous actions, the evaluation may take considerably longer than 5 seconds!
+
+Furthermore, if you pass a limit of `5 seconds` to an `IO` consisting of several asynchronous actions joined together, evaluation may take up to `n * 5 seconds`, where `n` is the number of joined async actions.
+
+As soon as an async blocking limit is hit, evaluation "immediately" aborts and `None` is returned.
+
+Please note that this function is intended for **testing** purposes; it should never appear in your mainline production code!  It is absolutely not an appropriate function to use if you want to implement timeouts, or anything similar. If you need that sort of functionality, you should be using a streaming library (like [fs2](https://github.com/functional-streams-for-scala/fs2) or [Monix](https://monix.io/)).
+
+```tut:book
+import scala.concurrent.duration._
+
+IO(println("Timed!")).unsafeRunTimed(5.seconds)
+```
+
+### unsafeToFuture
+
+Evaluates the effect and produces the result in a `Future`.
+
+This is similar to `unsafeRunAsync` in that it evaluates the `IO` as a side effect in a non-blocking fashion, but uses a `Future` rather than an explicit callback.  This function should really only be used if interoperating with legacy code which uses Scala futures.
+
+```tut:book
+IO("Gimme a Future!").unsafeToFuture()
 ```
 


### PR DESCRIPTION
The aim of this PR is to:

- [x] Re-structure the sections: basic operations, from operations, error handling, thread shifting, parallelism, concurrency and unsafe operations, in that order.
- [x] Give good and bad practices examples: when to use `apply` and `pure`.
- [x] Add examples of `fromFuture` and `fromEither`.
- [x] Add examples of concurrency using `race` and `racePair`.
- [x] Add examples of `parMapN` or any of the functions provided by the `Parallel` typeclass.
- [x] Make README file consistent with the rest of the documentation.

The final objective is to have a decent / ready documentation in time for the publishing of the version `0.10`.

Suggestions and corrections are welcome.