### PR TITLE
Re-add Kleisli instances for Sync, Async and Concurrent

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Sync.scala
+++ b/core/shared/src/main/scala/cats/effect/Sync.scala
@@ -221,12 +221,11 @@ object Sync {
   }
 
   private[effect] trait KleisliSync[F[_], R] extends Sync[Kleisli[F, R, ?]] {
-    protected def F: Sync[F]
-    private implicit def _F = F
+    protected implicit def F: Sync[F]
 
-    def pure[A](x: A): Kleisli[F, R, A] = Kleisli.pure(x)
+    def pure[A](x: A): Kleisli[F, R, A] = 
+      Kleisli.pure(x)
 
-    // remove duplication when we upgrade to cats 1.0
     def handleErrorWith[A](fa: Kleisli[F, R, A])(f: Throwable => Kleisli[F, R, A]): Kleisli[F, R, A] =
       Kleisli { r => F.suspend(F.handleErrorWith(fa.run(r))(e => f(e).run(r))) }
 

--- a/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
@@ -34,6 +34,9 @@ class InstancesTests extends BaseTestsSuite {
   checkAllAsync("OptionT[IO, ?]",
     implicit ec => ConcurrentTests[OptionT[IO, ?]].concurrent[Int, Int, Int])
 
+  checkAllAsync("Kleisli[IO, ?]",
+    implicit ec => ConcurrentTests[Kleisli[IO, Int, ?]].concurrent[Int, Int, Int])
+
   checkAllAsync("EitherT[IO, Throwable, ?]",
     implicit ec => ConcurrentEffectTests[EitherT[IO, Throwable, ?]].concurrentEffect[Int, Int, Int])
 


### PR DESCRIPTION
Instances for `cats.data.Kleisli` where initially added but then removed in https://github.com/typelevel/cats-effect/pull/69 due to `Kleisli` not being stack safe for left associative binds.

There is now a still opened issue in the Cats repo at: https://github.com/typelevel/cats/issues/1733

In this commit I'm providing lawful instances with a non-broken `flatMap`, the same thing I did for `StateT`.

However as mentioned in my comment [on that issue](https://github.com/typelevel/cats/issues/1733#issuecomment-371982346), the problem with this solution is that the `Sync` instance now lacks coherence with `Kleisli`'s own Monad implementation.

Therefore the plan is to also push these changes in the Cats repository, as the problem is fixable by essentially triggering the `F[_]` context earlier than `Kleisli#run`, so the `flatMap` could look like this, which is what we are doing:

```scala
def flatMap[A, B](fa: Kleisli[F, R, A])(f: A => Kleisli[F, R, B]): Kleisli[F, R, B] =
  Kleisli[F, R, B] { r =>
    F.now(r).flatMap(r => fa.run(r).flatMap(f.andThen(_.run(r))))
  }
```

And without this, then `Kleisli` simply cannot be fixed with its current `A => F[B]` encoding, because you can't avoid growing the stack on `flatMap` without suspending execution in `F[_]`, if the underlying `F[_]` is capable.

So the plan is to push this in `cats-effect`, then open a PR in Cats and when merged then the two implementations will become coherent.

---

Note that if we don't push this in `cats-effect`, then we have to either change the laws, or remove the `StateT` instance, because `StateT` is also stack unsafe on left associative binds, see https://github.com/typelevel/cats-effect/issues/139

And to be realistic about expectations, Cats is at 1.0.1 so `Kleisli` won't have a changed encoding at least until Cats 2.0 and this proposed solution is reasonable for everybody.

---

## Update

We now have PRs in Cats as well: 

- for `Kleisli`: https://github.com/typelevel/cats/pull/2185
- for `StateT`: https://github.com/typelevel/cats/pull/2187

When these get merged in Cats, then the `cats-effect` instances will become coherent.