### PR TITLE
Docs: add TOC to IO article

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -348,7 +348,7 @@ lazy val siteSettings = Seq(
     micrositeFooterText := None,
     micrositeHighlightTheme := "atom-one-light",
     micrositePushSiteWith := GitHub4s,
-    micrositeGithubToken := getEnvVar("GITHUB_TOKEN"),
+    micrositeGithubToken := sys.env.get("GITHUB_TOKEN"),
     micrositePalette := Map(
       "brand-primary" -> "#5B5988",
       "brand-secondary" -> "#292E53",

--- a/build.sbt
+++ b/build.sbt
@@ -345,6 +345,7 @@ lazy val siteSettings = Seq(
     micrositeBaseUrl := "/cats-effect",
     micrositeTwitterCreator := "@typelevel",
     micrositeDocumentationUrl := "https://www.javadoc.io/doc/org.typelevel/cats-effect_2.12",
+    micrositeFooterText := None,
     micrositeHighlightTheme := "atom-one-light",
     micrositePalette := Map(
       "brand-primary" -> "#5B5988",

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ val ScalaCheckVersion = "1.13.5"
 val DisciplineVersion = "0.8"
 
 addCommandAlias("ci", ";test ;mimaReportBinaryIssues; doc")
-addCommandAlias("release", ";project root ;reload ;+publishSigned ;sonatypeReleaseAll")
+addCommandAlias("release", ";project root ;reload ;+publishSigned ;sonatypeReleaseAll ;microsite/publishMicrosite")
 
 val commonSettings = Seq(
   scalacOptions in (Compile, console) ~= (_ filterNot Set("-Xfatal-warnings", "-Ywarn-unused-import").contains),
@@ -347,8 +347,6 @@ lazy val siteSettings = Seq(
     micrositeDocumentationUrl := "https://www.javadoc.io/doc/org.typelevel/cats-effect_2.12",
     micrositeFooterText := None,
     micrositeHighlightTheme := "atom-one-light",
-    micrositePushSiteWith := GitHub4s,
-    micrositeGithubToken := sys.env.get("GITHUB_TOKEN"),
     micrositePalette := Map(
       "brand-primary" -> "#5B5988",
       "brand-secondary" -> "#292E53",

--- a/build.sbt
+++ b/build.sbt
@@ -347,6 +347,8 @@ lazy val siteSettings = Seq(
     micrositeDocumentationUrl := "https://www.javadoc.io/doc/org.typelevel/cats-effect_2.12",
     micrositeFooterText := None,
     micrositeHighlightTheme := "atom-one-light",
+    micrositePushSiteWith := GitHub4s,
+    micrositeGithubToken := getEnvVar("GITHUB_TOKEN"),
     micrositePalette := Map(
       "brand-primary" -> "#5B5988",
       "brand-secondary" -> "#292E53",

--- a/site/src/main/resources/microsite/css/toc.css
+++ b/site/src/main/resources/microsite/css/toc.css
@@ -1,0 +1,32 @@
+
+#toc.styling {
+    border-top: 1px solid #eee;
+    border-bottom: 1px solid #eee;
+    padding: 0;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    margin-bottom: 20px;    
+}
+
+#toc h2 {
+    margin: 0;
+    margin-top: 12.5px;
+    margin-bottom: 12.5px;
+    color: #888;
+    font-size: 24px;
+}
+
+#toc ul {
+    margin: 0;
+    margin-right: 10px;
+    list-style-position: inside;
+    padding: 0;
+}
+
+#toc ul li {
+    margin-left: 10px;
+}
+
+#toc > ul > li {
+    margin-left: 0;
+}

--- a/site/src/main/resources/microsite/js/toc.js
+++ b/site/src/main/resources/microsite/js/toc.js
@@ -1,0 +1,116 @@
+document.addEventListener('DOMContentLoaded', function () {  
+  jQuery(function ($) {
+    $.fn.toc = function(options) {
+      var defaults = {
+        noBackToTopLinks: false,
+        title: '<i>Jump to...</i>',
+        minimumHeaders: 3,
+        headers: 'h1, h2, h3, h4, h5, h6',
+        listType: 'ol', // values: [ol|ul]
+        showEffect: 'show', // values: [show|slideDown|fadeIn|none]
+        showSpeed: 'slow', // set to 0 to deactivate effect
+        classes: {
+          wrapper: '',
+          list: '',
+          item: ''
+        }
+      },
+      settings = $.extend(defaults, options);
+  
+      function fixedEncodeURIComponent (str) {
+        return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
+          return '%' + c.charCodeAt(0).toString(16);
+        });
+      }
+      
+      function createLink (header) {
+        return "<a href='#" + fixedEncodeURIComponent(header.id) + "'>" + header.innerHTML + "</a>";
+      }
+  
+      var headers = $(settings.headers).filter(function() {
+        // get all headers with an ID
+        var previousSiblingName = $(this).prev().attr( "name" );
+        if (!this.id && previousSiblingName) {
+          this.id = $(this).attr( "id", previousSiblingName.replace(/\./g, "-") );
+        }
+        return this.id;
+      }), output = $(this);
+
+      if (!headers.length || headers.length < settings.minimumHeaders || !output.length) {
+        $(this).hide();
+        return;
+      } else if (settings.classes.wrapper) {
+        $(this).addClass(settings.classes.wrapper)
+      }
+  
+      if (0 === settings.showSpeed) {
+        settings.showEffect = 'none';
+      }
+  
+      var render = {
+        show: function() { output.hide().html(html).show(settings.showSpeed); },
+        slideDown: function() { output.hide().html(html).slideDown(settings.showSpeed); },
+        fadeIn: function() { output.hide().html(html).fadeIn(settings.showSpeed); },
+        none: function() { output.html(html); }
+      };
+  
+      var get_level = function(ele) { return parseInt(ele.nodeName.replace("H", ""), 10); };
+      var highest_level = headers.map(function(_, ele) { return get_level(ele); }).get().sort()[0];
+      var return_to_top = '<i class="icon-arrow-up back-to-top"> </i>';      
+
+      var level = get_level(headers[0]),
+        this_level,
+        html = settings.title + " <" +settings.listType + " class=\"" + settings.classes.list +"\">";
+
+      headers.on('click', function() {
+        if (!settings.noBackToTopLinks) {
+          window.location.hash = this.id;
+        }
+      })
+      .addClass('clickable-header')
+      .each(function(_, header) {
+        this_level = get_level(header);
+        if (!settings.noBackToTopLinks && this_level === highest_level) {
+          $(header).addClass('top-level-header').after(return_to_top);
+        }
+        if (this_level === level) // same level as before; same indenting
+          html += "<li class=\"" + settings.classes.item + "\">" + createLink(header);
+        else if (this_level <= level){ // higher level than before; end parent ol
+          for(i = this_level; i < level; i++) {
+            html += "</li></"+settings.listType+">"
+          }
+          html += "<li class=\"" + settings.classes.item + "\">" + createLink(header);
+        }
+        else if (this_level > level) { // lower level than before; expand the previous to contain a ol
+          for(i = this_level; i > level; i--) {
+            html += "<" + settings.listType + " class=\"" + settings.classes.list + "\">" +
+                    "<li class=\"" + settings.classes.item + "\">"
+          }
+          html += createLink(header);
+        }
+        level = this_level; // update for the next one
+      });
+      html += "</"+settings.listType+">";
+      if (!settings.noBackToTopLinks) {
+        $(document).on('click', '.back-to-top', function() {
+          $(window).scrollTop(0);
+          window.location.hash = '';
+        });
+      }
+  
+      render[settings.showEffect]();
+    };
+    
+    $('#toc').toc({
+      title: '',
+      headers: 'h2, h3',
+      listType: 'ul',
+      showSpeed: 0,
+      classes: {
+        wrapper: 'styling',
+        list: '',
+        item: ''
+      }
+    });
+  });
+}, false);

--- a/site/src/main/resources/microsite/layouts/docsplus.html
+++ b/site/src/main/resources/microsite/layouts/docsplus.html
@@ -1,0 +1,10 @@
+---
+layout: docs
+---
+
+<h1>{{ page.title }}</h1>
+
+{{ content }}
+
+<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/toc.css"></link>
+<script type="text/javascript" src="{{ site.baseurl }}/js/toc.js"></script>

--- a/site/src/main/tut/datatypes/fiber.md
+++ b/site/src/main/tut/datatypes/fiber.md
@@ -1,12 +1,10 @@
 ---
-layout: docs
+layout: docsplus
 title:  "Fiber"
 number: 10
 source: "shared/src/main/scala/cats/effect/Fiber.scala"
 scaladoc: "#cats.effect.Fiber"
 ---
-
-# Fiber
 
 It represents the (pure) result of an `Async` data type (e.g. `IO`) being started concurrently and that can be either joined or cancelled.
 

--- a/site/src/main/tut/datatypes/io.md
+++ b/site/src/main/tut/datatypes/io.md
@@ -1,14 +1,18 @@
 ---
-layout: docs
+layout: docsplus
 title:  "IO"
 number: 9
 source: "shared/src/main/scala/cats/effect/IO.scala"
 scaladoc: "#cats.effect.IO"
 ---
 
-# IO
-
 A data type for encoding side effects as pure values, capable of expressing both synchronous and asynchronous computations.
+
+<nav role="navigation" id="toc"></nav>
+
+## Introduction
+
+A value of type `IO[A]` is a computation which, when evaluated, can perform effects before returning a value of type `A`.
 
 Effects contained within this abstraction are not evaluated until the "end of the world", which is to say, when one of the "unsafe" methods are used. Effectful results are not memoized, meaning that memory overhead is minimal (and no leaks), and also that a single effect may be run multiple times in a referentially-transparent manner. For example:
 
@@ -28,7 +32,7 @@ program.unsafeRunSync()
 
 The above example prints "hey!" twice, as the effect re-runs each time it is sequenced in the monadic chain.
 
-## On Referential Transparency and Lazy Evaluation
+### On Referential Transparency and Lazy Evaluation
 
 `IO` can suspend side effects and is thus a lazily evaluated data type, being many times compared with `Future` from the standard library and to understand the landscape in terms of the evaluation model (in Scala), consider this classification:
 

--- a/site/src/main/tut/datatypes/timer.md
+++ b/site/src/main/tut/datatypes/timer.md
@@ -1,12 +1,10 @@
 ---
-layout: docs
+layout: docsplus
 title:  "Timer"
 number: 11
 source: "shared/src/main/scala/cats/effect/Timer.scala"
 scaladoc: "#cats.effect.Timer"
 ---
-
-# Timer
 
 It is a scheduler of tasks. You can think of it as the purely functional equivalent of:
 

--- a/site/src/main/tut/typeclasses/async.md
+++ b/site/src/main/tut/typeclasses/async.md
@@ -1,12 +1,10 @@
 ---
-layout: docs
+layout: docsplus
 title:  "Async"
 number: 5
 source: "core/shared/src/main/scala/cats/effect/Async.scala"
 scaladoc: "#cats.effect.Async"
 ---
-
-# Async
 
 A `Monad` that can describe asynchronous or synchronous computations that produce exactly one result.
 

--- a/site/src/main/tut/typeclasses/bracket.md
+++ b/site/src/main/tut/typeclasses/bracket.md
@@ -1,12 +1,10 @@
 ---
-layout: docs
+layout: docsplus
 title:  "Bracket"
 number: 2
 source: "core/shared/src/main/scala/cats/effect/Bracket.scala"
 scaladoc: "#cats.effect.Bracket"
 ---
-
-# Bracket
 
 A `Monad` that can acquire, use and release resources in a safe way.
 

--- a/site/src/main/tut/typeclasses/concurrent-effect.md
+++ b/site/src/main/tut/typeclasses/concurrent-effect.md
@@ -1,12 +1,10 @@
 ---
-layout: docs
+layout: docsplus
 title:  "ConcurrentEffect"
 number: 8
 source: "core/shared/src/main/scala/cats/effect/ConcurrentEffect.scala"
 scaladoc: "#cats.effect.ConcurrentEffect"
 ---
-
-# ConcurrentEffect
 
 Type class describing effect data types that are cancelable and can be evaluated concurrently.
 

--- a/site/src/main/tut/typeclasses/concurrent.md
+++ b/site/src/main/tut/typeclasses/concurrent.md
@@ -1,12 +1,10 @@
 ---
-layout: docs
+layout: docsplus
 title:  "Concurrent"
 number: 6
 source: "core/shared/src/main/scala/cats/effect/Concurrent.scala"
 scaladoc: "#cats.effect.Concurrent"
 ---
-
-# Concurrent
 
 Type class for `Async` data types that are cancelable and can be started concurrently.
 

--- a/site/src/main/tut/typeclasses/effect.md
+++ b/site/src/main/tut/typeclasses/effect.md
@@ -1,11 +1,10 @@
 ---
-layout: docs
+layout: docsplus
 title:  "Effect"
 number: 7
 source: "shared/src/main/scala/cats/effect/Effect.scala"
 scaladoc: "#cats.effect.Effect"
 ---
-# Effect
 
 A `Monad` that can suspend side effects into the `F[_]` context and supports lazy and potentially asynchronous evaluation.
 

--- a/site/src/main/tut/typeclasses/liftio.md
+++ b/site/src/main/tut/typeclasses/liftio.md
@@ -1,12 +1,10 @@
 ---
-layout: docs
+layout: docsplus
 title:  "LiftIO"
 number: 4
 source: "shared/src/main/scala/cats/effect/LiftIO.scala"
 scaladoc: "#cats.effect.LiftIO"
 ---
-
-# LiftIO
 
 A `Monad` that can convert any given `IO[A]` into a `F[A]`, useful for defining parametric signatures and composing monad transformer stacks.
 

--- a/site/src/main/tut/typeclasses/sync.md
+++ b/site/src/main/tut/typeclasses/sync.md
@@ -1,12 +1,10 @@
 ---
-layout: docs
+layout: docsplus
 title:  "Sync"
 number: 3
 source: "core/shared/src/main/scala/cats/effect/Sync.scala"
 scaladoc: "#cats.effect.Sync"
 ---
-
-# Sync
 
 A `Monad` that can suspend the execution of side effects in the `F[_]` context.
 


### PR DESCRIPTION
The `IO` article is getting pretty long and it's going to get longer.

This PR adds the possibility of adding a table of contents to articles that need it, generated via JavaScript.

Screenshot:

![image](https://user-images.githubusercontent.com/11753/37430969-82972668-27dc-11e8-929a-aef518ca5340.png)
