### PR TITLE
Add link to hierarchy in IO doc and fix grammar error

### DIFF
--- a/site/src/main/tut/datatypes/io.md
+++ b/site/src/main/tut/datatypes/io.md
@@ -107,7 +107,7 @@ def fib(n: Int, a: Long = 0, b: Long = 1): IO[Long] =
   }
 ```
 
-`IO` implements all the typeclasses shown in the [hierarchy](https://typelevel.org/cats-effect/typeclasses/). Therefore
+`IO` implements all the typeclasses shown in the [hierarchy](../typeclasses/). Therefore
 all those operations are available for `IO`, in addition to some
 others.
 

--- a/site/src/main/tut/datatypes/io.md
+++ b/site/src/main/tut/datatypes/io.md
@@ -107,7 +107,7 @@ def fib(n: Int, a: Long = 0, b: Long = 1): IO[Long] =
   }
 ```
 
-`IO` implements all the typeclasses shown in the hierarchy. Therefore
+`IO` implements all the typeclasses shown in the [hierarchy](https://typelevel.org/cats-effect/typeclasses/). Therefore
 all those operations are available for `IO`, in addition to some
 others.
 
@@ -163,7 +163,7 @@ reference is returned.
 
 ### Synchronous Effects — IO.apply
 
-It's probably is the most used builder and the equivalent of
+It's probably the most used builder and the equivalent of
 `Sync[IO].delay`, describing `IO` operations that can be evaluated
 immediately, on the current thread and call-stack:
 


### PR DESCRIPTION
I'm reading docs and encountered small grammar error in IO section.

I also have suggestion to add link to the hierarchy - it is mentioned but it isn't anywhere near and if someone (like me) starts reading docs from the top they will see it much later.