### PR TITLE
Implement the never helper function

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -250,7 +250,9 @@ val mimaSettings = Seq(
       // Not a problem: IOPlatform is private
       exclude[DirectMissingMethodProblem]("cats.effect.internals.IOPlatform.onceOnly"),
       // Not a problem: IORunLoop is private
-      exclude[MissingClassProblem]("cats.effect.internals.IORunLoop$RestartCallback$")
+      exclude[MissingClassProblem]("cats.effect.internals.IORunLoop$RestartCallback$"),
+      // Not a problem: Async.never implementation is just moved
+      exclude[ReversedMissingMethodProblem]("cats.effect.Async.never")
     )
   })
 

--- a/core/shared/src/main/scala/cats/effect/Async.scala
+++ b/core/shared/src/main/scala/cats/effect/Async.scala
@@ -126,6 +126,12 @@ trait Async[F[_]] extends Sync[F] with LiftIO[F] {
     Async.liftIO(ioa)(this)
 
   /**
+    * Returns a non-terminating `F[_]`, that never completes
+    * with a result, being equivalent to `async(_ => ())`
+    */
+  def never[A]: F[A] = async(_ => ())
+
+  /**
    * DEPRECATED — moved to [[Async$.shift]].
    *
    * The reason for the deprecation is that there's no potential
@@ -148,8 +154,9 @@ object Async {
    * Returns an non-terminating `F[_]`, that never completes
    * with a result, being equivalent with `async(_ => ())`.
    */
+  @deprecated("Moved to Async[F]", "0.10")
   def never[F[_], A](implicit F: Async[F]): F[A] =
-    F.async(_ => ())
+    F.never
 
   /**
    * Generic shift operation, defined for any `Async` data type.

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -60,6 +60,11 @@ trait AsyncLaws[F[_]] extends SyncLaws[F] {
     val fa = F.attempt(F.async[A](_(Left(t))).flatMap(x => F.pure(x)))
     fa <-> F.pure(Left(t))
   }
+
+  def neverIsDerivedFromAsync[A](a: A): IsEq[F[A]] = {
+    F.never[A] <-> F.async[A]( _ => ())
+  }
+
 }
 
 object AsyncLaws {

--- a/laws/shared/src/main/scala/cats/effect/laws/ConcurrentLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ConcurrentLaws.scala
@@ -70,7 +70,7 @@ trait ConcurrentLaws[F[_]] extends AsyncLaws[F] {
   }
 
   def onCancelRaiseErrorTerminatesOnCancel[A](e: Throwable) = {
-    val never = F.onCancelRaiseError(F.async[A](_ => ()), e)
+    val never = F.onCancelRaiseError(F.never[A], e)
     val received =
       for {
         fiber <- F.start(never)
@@ -127,7 +127,7 @@ trait ConcurrentLaws[F[_]] extends AsyncLaws[F] {
   }
 
   def racePairMirrorsLeftWinner[A](fa: F[A]) = {
-    val never = F.async[A](_ => ())
+    val never = F.never[A]
     val received =
       F.racePair(fa, never).flatMap {
         case Left((a, fiberB)) =>
@@ -139,7 +139,7 @@ trait ConcurrentLaws[F[_]] extends AsyncLaws[F] {
   }
 
   def racePairMirrorsRightWinner[B](fb: F[B]) = {
-    val never = F.async[B](_ => ())
+    val never = F.never[B]
     val received =
       F.racePair(never, fb).flatMap {
         case Right((fiberA, b)) =>

--- a/laws/shared/src/main/scala/cats/effect/laws/ConcurrentLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ConcurrentLaws.scala
@@ -91,11 +91,11 @@ trait ConcurrentLaws[F[_]] extends AsyncLaws[F] {
   }
 
   def raceMirrorsLeftWinner[A](fa: F[A], default: A) = {
-    F.race(fa, Async.never[F, A]).map(_.left.getOrElse(default)) <-> fa
+    F.race(fa, F.never[A]).map(_.left.getOrElse(default)) <-> fa
   }
 
   def raceMirrorsRightWinner[A](fa: F[A], default: A) = {
-    F.race(Async.never[F, A], fa).map(_.right.getOrElse(default)) <-> fa
+    F.race(F.never[A], fa).map(_.right.getOrElse(default)) <-> fa
   }
 
   def raceCancelsLoser[A, B](r: Either[Throwable, A], leftWinner: Boolean, b: B) = {

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
@@ -61,7 +61,9 @@ trait AsyncTests[F[_]] extends SyncTests[F] {
         "async right is pure" -> forAll(laws.asyncRightIsPure[A] _),
         "async left is raiseError" -> forAll(laws.asyncLeftIsRaiseError[A] _),
         "repeated async evaluation not memoized" -> forAll(laws.repeatedAsyncEvaluationNotMemoized[A] _),
-        "propagate errors through bind (async)" -> forAll(laws.propagateErrorsThroughBindAsync[A] _))
+        "propagate errors through bind (async)" -> forAll(laws.propagateErrorsThroughBindAsync[A] _),
+        "never is derived from async" -> forAll(laws.neverIsDerivedFromAsync[A] _))
+
     }
   }
 }


### PR DESCRIPTION
Commit implements the never helper function inside the async trait and
uses that function in the Companion Object that previously implemented
the same function

This addresses the Issue #141