### PR TITLE
Remove 2.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ language: scala
 matrix:
   include:
     - jdk: oraclejdk8
-      scala: 2.10.7
-      env: COVERAGE=
-    - jdk: oraclejdk8
       scala: 2.11.12
       env: COVERAGE=coverage
     - jdk: oraclejdk8

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ libraryDependencies += "org.typelevel" %% "cats-effect" % "0.10"
 
 If your project uses Scala.js, replace the double-`%` with a triple.  Note that **cats-effect** has an upstream dependency on **cats-core** version 1.0.1.
 
-Cross-builds are available for Scala 2.12, 2.11 and 2.10, Scala.js major version 0.6.x.
+Cross-builds are available for Scala 2.12 and 2.11, Scala.js major version 0.6.x.
 
 The most current snapshot (or major release) can be found in the maven badge at the top of this readme.  If you are a very brave sort, you are free to depend on snapshots; they are stable versions, as they are derived from the git hash rather than an unstable `-SNAPSHOT` suffix, but they do not come with any particular confidence or compatibility guarantees.
 

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,8 @@ addCommandAlias("ci", ";test ;mimaReportBinaryIssues; doc")
 addCommandAlias("release", ";project root ;reload ;+publishSigned ;sonatypeReleaseAll ;microsite/publishMicrosite")
 
 val commonSettings = Seq(
+  crossScalaVersions := Seq("2.11.12", "2.12.4"),
+
   scalacOptions in (Compile, console) ~= (_ filterNot Set("-Xfatal-warnings", "-Ywarn-unused-import").contains),
 
   scalacOptions in (Compile, doc) ++= {
@@ -49,17 +51,8 @@ val commonSettings = Seq(
     Seq("-doc-source-url", path, "-sourcepath", baseDirectory.in(LocalRootProject).value.getAbsolutePath)
   },
 
-  sources in (Compile, doc) := {
-    val log = streams.value.log
-
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 10)) =>
-        log.warn("scaladoc generation is disabled on Scala 2.10")
-        Nil
-
-      case _ => (sources in (Compile, doc)).value
-    }
-  },
+  sources in (Compile, doc) :=
+    (sources in (Compile, doc)).value,
 
   scalacOptions in (Compile, doc) ++=
     Seq("-doc-root-content", (baseDirectory.value.getParentFile / "shared" / "rootdoc.txt").getAbsolutePath),
@@ -444,18 +437,11 @@ scalacOptions in ThisBuild ++= Seq(
   "-Ywarn-dead-code"
 )
 
-scalacOptions in ThisBuild ++= {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, major)) if major >= 11 => Seq(
-      "-Ywarn-unused-import", // Not available in 2.10
-      "-Ywarn-numeric-widen", // In 2.10 this produces a some strange spurious error
-      "-Xlint:-missing-interpolator,_"
-    )
-    case _ => Seq(
-      "-Xlint" // Scala 2.10
-    )
-  }
-}
+scalacOptions in ThisBuild ++= Seq(
+  "-Ywarn-unused-import",
+  "-Ywarn-numeric-widen",
+  "-Xlint:-missing-interpolator,_"
+)
 
 scalacOptions in Test += "-Yrangepos"
 

--- a/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
@@ -49,7 +49,4 @@ class InstancesTests extends BaseTestsSuite {
   implicit def stateTEq[F[_]: FlatMap, S: Monoid, A](implicit FSA: Eq[F[(S, A)]]): Eq[StateT[F, S, A]] =
     Eq.by[StateT[F, S, A], F[(S, A)]](state => state.run(Monoid[S].empty))
 
-  // this is required to avoid diverging implicit expansion issues on 2.10
-  implicit def eitherTEq: Eq[EitherT[EitherT[Eval, Throwable, ?], Throwable, Int]] =
-    Eq.by[EitherT[EitherT[Eval, Throwable, ?], Throwable, Int], EitherT[Eval, Throwable, Either[Throwable, Int]]](_.value)
 }

--- a/versioning.md
+++ b/versioning.md
@@ -22,7 +22,7 @@ Within a single *major/minor* version (e.g. the **1.0** in **1.0.5**), all relea
 
 *Backward binary compatibility* is not guaranteed.  Thus, code compiled against 1.0.5 may not run with the same semantics against 1.0, though it is *very* likely that it will.
 
-Please note that there are some limits in Scala's binary compatibility story prior to Scala 2.12.  At the present time, the guarantees in this section hold for all cats-effect cross-builds: 2.10, 2.11 and 2.12; but we reserve the right to restrict certain guarantees to just 2.12 in the future.
+Please note that there are some limits in Scala's binary compatibility story prior to Scala 2.12.  At the present time, the guarantees in this section hold for all cats-effect cross-builds: 2.11 and 2.12; but we reserve the right to restrict certain guarantees to just 2.12 in the future.
 
 ## Snapshots
 


### PR DESCRIPTION
Should fix #179. Seems like we're close to consensus on this one. I don't think there's anything that's blocking us in 2.10 (I resolved my issue from yesterday), but I'd decided to put this together anyway, we can still not merge this or merge it a later date.