### PR TITLE
IO.runAsync should report errors in its handler

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -172,7 +172,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    *      token that can be used to send a cancel signal
    */
   final def runAsync(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] = IO {
-    unsafeRunAsync(cb.andThen(_.unsafeRunAsync(_ => ())))
+    unsafeRunAsync(cb.andThen(_.unsafeRunAsync(Callback.report)))
   }
 
   /**


### PR DESCRIPTION
If an error happens in the async handler, it gets swallowed without a report.  It's reasonable not to re-raise it (see `EffectLaws.runAsyncIgnoresErrorInHandler`), but this can mask fatal errors without a trace.  For one http4s user, this hid a linker error due to mill putting two versions of cats on the classpath.

This ought to be tested, but I didn't immediately see a cross-platform way, and I wanted to make sure there is agreement on the change before I hurt my brain finding a way.

If we don't want this, we could use `Callback.dummy1`.