### PR TITLE
Fix AsyncLaws.neverIsDerivedFromAsync, add param for disabling it

### DIFF
--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -61,10 +61,9 @@ trait AsyncLaws[F[_]] extends SyncLaws[F] {
     fa <-> F.pure(Left(t))
   }
 
-  def neverIsDerivedFromAsync[A](a: A): IsEq[F[A]] = {
+  def neverIsDerivedFromAsync[A] = {
     F.never[A] <-> F.async[A]( _ => ())
   }
-
 }
 
 object AsyncLaws {


### PR DESCRIPTION
Related to the changes in PR #168.

The law for `F.never <-> F.async(_ => ())` is causing problems in Monix because `Task` tests the provided laws multiple times depending on the evaluation mode and now we have a `runSyncUnsafe(timeout)` operation, only allowed on the JVM, that blocks the current thread. And the laws are tested with an `Eq` based on it as well, in addition to the regular tests that make use of the fake and safe `TestScheduler`.

Unfortunately when blocking threads the only way to detect non-termination is to block the thread with a timeout.

Changes in this commit:

1. allow for disabling this law via `Params`
2. fix the law to not require an `a: A` param, because it is unused and the result is that the test runs multiple times (due to ScalaCheck generating random `A` values) for no reason