### PR TITLE
Backports for v0.10.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ startYear in ThisBuild := Some(2017)
 
 val CompileTime = config("CompileTime").hide
 
-val CatsVersion = "1.0.1"
+val CatsVersion = "1.1.0"
 val SimulacrumVersion = "0.11.0"
 
 val ScalaTestVersion = "3.0.4"

--- a/core/shared/src/main/scala/cats/effect/Effect.scala
+++ b/core/shared/src/main/scala/cats/effect/Effect.scala
@@ -59,7 +59,7 @@ trait Effect[F[_]] extends Async[F] {
 
 object Effect {
   /**
-   * [[Effect]] instance built for `cats.data.WriterT` values initialized
+   * [[Effect]] instance built for `cats.data.EitherT` values initialized
    * with any `F` data type that also implements `Effect`.
    */
   implicit def catsEitherTEffect[F[_]: Effect]: Effect[EitherT[F, Throwable, ?]] =

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -172,7 +172,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    *      token that can be used to send a cancel signal
    */
   final def runAsync(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] = IO {
-    unsafeRunAsync(cb.andThen(_.unsafeRunAsync(_ => ())))
+    unsafeRunAsync(cb.andThen(_.unsafeRunAsync(Callback.report)))
   }
 
   /**


### PR DESCRIPTION
Backport of:
- #161
- #167
- #182

If approved, I will tag and release as 0.10.1.  The patch release is new for us, but will help reduce complaints about "suspected binary incompatibilities" and communicate more clearly to people who see it in a dependencyUpdates list.