### PR TITLE
Correct IO.runAsync scaladoc

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -161,7 +161,10 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    *   // Sample
    *   val source = IO.shift *> IO(1)
    *   // Describes execution
-   *   val start = source.runAsync
+   *   val start = source.runAsync {
+   *     case Left(e) => IO(e.printStackTrace())
+   *     case Right(_) => IO.unit
+   *   }
    *   // Safe, because it does not block for the source to finish
    *   start.unsafeRunSync
    * }}}


### PR DESCRIPTION
Demonstrates the callback.  The example as provided does not compile.