### PR TITLE
Fix Bracket law

### DIFF
--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/SyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/SyncTests.scala
@@ -62,7 +62,7 @@ trait SyncTests[F[_]] extends BracketTests[F, Throwable] {
 
 
       val props = Seq(
-        "bracket release is called for success" -> forAll(laws.bracketReleaseCalledForSuccess[A, B] _),
+        "bracket release is called for success" -> forAll(laws.bracketReleaseCalledForSuccess[A, B, C] _),
         "bracket release is called for error" -> forAll(laws.bracketReleaseCalledForError[A] _),
         "delay constant is pure" -> forAll(laws.delayConstantIsPure[A] _),
         "suspend constant is pure join" -> forAll(laws.suspendConstantIsPureJoin[A] _),


### PR DESCRIPTION
`bracketReleaseCalledForSuccess` in `SyncLaws` is currently broken for streams.

The reason is that in order to *observe* the side effect, it relies on `F.flatMap`, however this particular `F.flatMap` usage assumes sequencing like what happens in `IO` (i.e. execute this, after the source is *done*), but this isn't what happens for streams, where `flatMap` inserts its result for *each element of the source*.

The other problem with this law is that it is incomplete for streaming types.  For `monix.tail.Iterant` we now have this `bracket` method:

```scala
  final def bracket[B](use: A => Iterant[F, B])(release: A => Iterant[F, Unit])
    (implicit F: Sync[F]): Iterant[F, B] = ???
```

How it works is that `release` happens for each `A`, it's actually implied in the signature and this behavior isn't captured by the current law.

So I've got two changes:

1. we cannot test against any arbitrary `F[B]`, unfortunately we have to relax this requirement, because there's no way to observe the call to `release` without a `flatMap` that happens *after* `release` is called, which can only happen if we are talking of streams of size 1
2. we are using `fa.map(a => f(a, c))` as the expected value and thus we can test that `release` happens for each `a`
