### PR TITLE
Resource

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -100,14 +100,14 @@ object Resource extends ResourceInstances {
     * @param a the value to lift into a resource
     */
   def pure[F[_], A](a: A)(implicit F: Applicative[F]) =
-    Resource(F.pure(a -> F.pure(())))
+    Resource(F.pure(a -> F.unit))
 
   /** Lifts an applicative into a resource.  The resource has a no-op release.
     *
     * @param fa the value to lift into a resource
     */
   def liftF[F[_], A](fa: F[A])(implicit F: Applicative[F]) =
-    make(fa)(_ => F.pure(()))
+    make(fa)(_ => F.unit)
 }
 
 private[effect] abstract class ResourceInstances extends ResourceInstances0 {
@@ -141,7 +141,7 @@ private[effect] abstract class ResourceMonadError[F[_], E] extends MonadError[Re
   protected implicit def F: Bracket[F, E]
 
   def pure[A](a: A): Resource[F, A] =
-    Resource(F.pure(a -> F.pure(())))
+    Resource(F.pure(a -> F.unit))
 
   def flatMap[A, B](fa: Resource[F,A])(f: A => Resource[F, B]): Resource[F, B] =
     Resource(fa.allocate.flatMap { case (a, disposeA) =>
@@ -164,7 +164,7 @@ private[effect] abstract class ResourceMonadError[F[_], E] extends MonadError[Re
       }
     }
 
-    Resource(F.tailRecM((a, F.pure(())))(step))
+    Resource(F.tailRecM((a, F.unit))(step))
   }
 
   def handleErrorWith[A](fa: Resource[F, A])(f: E => Resource[F, A]): Resource[F, A] =

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -92,8 +92,15 @@ object Resource extends ResourceInstances {
     * @param acquire a function to effectfully acquire a resource
     * @param release a function to effectfully release the resource returned by `acquire`
     */
-  def make[F[_]: Functor, A](acquire: F[A])(release: A => F[Unit]): Resource[F, A] =
+  def make[F[_], A](acquire: F[A])(release: A => F[Unit])(implicit F: Functor[F]): Resource[F, A] =
     apply(acquire.map(a => (a -> release(a))))
+
+  /** Lifts an applicative into a resource.  The resource hsa a no-op release.
+    *
+    * @param fa the value to be lifted into a resource
+    */
+  def liftF[F[_], A](fa: F[A])(implicit F: Applicative[F]) =
+    make(fa)(_ => F.pure(()))
 }
 
 private[effect] abstract class ResourceInstances {

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -181,13 +181,6 @@ private[effect] abstract class ResourceSemigroup[F[_], A, E] extends Semigroup[R
     } yield A.combine(x, y)
 }
 
-private[effect] abstract class ResourceMonoidK[F[_], E] extends ResourceSemigroupK[F, E]
-    with MonoidK[Resource[F, ?]] {
-  protected implicit def K: MonoidK[F]
-
-  def empty[A]: Resource[F, A] = Resource.liftF(K.empty)
-}
-
 private[effect] abstract class ResourceSemigroupK[F[_], E] extends SemigroupK[Resource[F, ?]] {
   protected implicit def F: Bracket[F, E]  
   protected implicit def K: SemigroupK[F]

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats._
+import cats.implicits._
+
+final class Resource[F[_], A] private (val allocate: F[(A, F[Unit])]) {
+  def apply[B](use: A => F[B])(implicit F: Bracket[F, Throwable]): F[B] =
+    F.bracket(allocate)(a => use(a._1))(a => a._2)
+}
+
+object Resource {
+  def apply[F[_]: Functor, A](acquire: F[A])(release: A => F[Unit]): Resource[F, A] =
+    new Resource[F, A](acquire.map(a => (a -> release(a))))
+
+  def allocatedBy[F[_], A](allocate: F[(A, F[Unit])]): Resource[F, A] =
+    new Resource(allocate)
+
+  implicit def resourceEffect[F[_]](implicit F: Effect[F]): Effect[Resource[F, ?]] = new Effect[Resource[F, ?]] {
+    def pure[A](a: A): Resource[F, A] = allocatedBy(F.pure(a -> F.pure(())))
+    
+    def handleErrorWith[A](fa: Resource[F,A])(f: Throwable => Resource[F,A]): Resource[F,A] =
+      allocatedBy(fa.allocate.handleErrorWith(t => f(t).allocate))
+
+    def raiseError[A](e: Throwable): Resource[F,A] =
+      allocatedBy(F.raiseError(e))
+    
+    def async[A](k: (Either[Throwable, A] => Unit) => Unit): Resource[F, A] =
+      allocatedBy(F.async(k).map(a => a -> F.pure(())))
+    
+    def bracketCase[A, B](acquire: Resource[F,A])(use: A => Resource[F,B])(release: (A, ExitCase[Throwable]) => Resource[F,Unit]): Resource[F,B] =
+      allocatedBy(acquire.allocate.flatMap { case (a, disposeA) =>
+        use(a).allocate.map { case (b, disposeB) =>
+          b -> F.bracketCase(disposeB)(F.pure)((_, _) => disposeA)
+        }
+      })
+    
+    def runAsync[A](fa: Resource[F,A])(cb: scala.util.Either[Throwable, A] => IO[Unit]): IO[Unit] =
+      F.runAsync(fa(F.pure))(cb)
+    
+    def flatMap[A, B](fa: Resource[F,A])(f: A => Resource[F,B]): Resource[F,B] =
+      allocatedBy(F.flatMap(fa.allocate) { case (a, disposeA) =>
+        f(a).allocate.map { case (b, disposeB) =>
+          b -> F.bracket(disposeB)(F.pure)(_ => disposeA)
+        }
+      })
+
+    def tailRecM[A, B](a: A)(f: A => Resource[F,Either[A,B]]): Resource[F,B] = ???
+    
+    def suspend[A](thunk: => Resource[F,A]): Resource[F, A] =
+      allocatedBy(F.suspend(thunk.allocate))
+  }
+}
+
+

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/Arbitrary.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/Arbitrary.scala
@@ -97,4 +97,13 @@ object arbitrary {
         case _ => seed
       }
     }
+
+  implicit def catsEffectLawsArbitraryForResource[F[_], A](implicit F: Functor[F], AFA: Arbitrary[F[A]], AFU: Arbitrary[F[Unit]]): Arbitrary[Resource[F, A]] =
+    Arbitrary(Gen.delay(genResource[F, A]))
+
+  def genResource[F[_], A](implicit F: Functor[F], AFA: Arbitrary[F[A]], AFU: Arbitrary[F[Unit]]): Gen[Resource[F, A]] =
+    for {
+      alloc <- getArbitrary[F[A]]
+      dispose <- getArbitrary[F[Unit]]
+    } yield Resource(F.map(alloc)(a => a -> dispose))
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestInstances.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestInstances.scala
@@ -16,7 +16,8 @@
 
 package cats.effect.laws.util
 
-import cats.effect.IO
+import cats.Functor
+import cats.effect.{IO, Resource}
 import cats.kernel.Eq
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
@@ -87,6 +88,17 @@ trait TestInstances {
         // that wraps them (e.g. ExecutionException)
         (x ne null) == (y ne null)
       }
+    }
+
+  /**
+   * Defines equality for a [[Resource]].  Two resources are deemed
+   * equivalent if they allocate an equivalent resource.  Cleanup,
+   * which is run purely for effect, is not considered.
+   */
+  implicit def eqResource[F[_], A](implicit E: Eq[F[A]], F: Functor[F]): Eq[Resource[F, A]] =
+    new Eq[Resource[F, A]] {
+      def eqv(x: Resource[F, A], y: Resource[F, A]): Boolean =
+        E.eqv(F.map(x.allocate)(_._1), F.map(y.allocate)(_._1))
     }
 }
 

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestInstances.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestInstances.scala
@@ -91,7 +91,7 @@ trait TestInstances {
     }
 
   /**
-   * Defines equality for a [[Resource]].  Two resources are deemed
+   * Defines equality for a `Resource`.  Two resources are deemed
    * equivalent if they allocate an equivalent resource.  Cleanup,
    * which is run purely for effect, is not considered.
    */

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+
+import cats.effect.laws.discipline.arbitrary._
+import cats.laws._
+import cats.laws.discipline._
+import cats.implicits._
+import org.scalacheck._
+
+class ResourceTests extends BaseTestsSuite {
+  checkAllAsync("Resource[IO, ?]", implicit ec => MonadErrorTests[Resource[IO, ?], Throwable].monadError[Int, Int, Int])
+
+  testAsync("Resource.make is equivalent to a partially applied bracket") { implicit ec =>
+    Prop.forAll { (acquire: IO[String], release: String => IO[Unit], f: String => IO[String]) =>
+      acquire.bracket(f)(release) <-> Resource.make(acquire)(release).use(f)
+    }
+  }
+
+  test("releases resources in reverse order of acquisition") {
+    Prop.forAll { as: List[(String, Either[Throwable, Unit])] =>
+      var released: List[String] = Nil
+      val r = as.traverse { case (a, e) =>
+        Resource.make(IO(a))(a => IO { released = a :: released } *> IO.fromEither(e))
+      }
+      r.use(IO.pure).unsafeRunSync()
+      released <-> as.map(_._1)
+    }
+  }
+}

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -18,6 +18,7 @@ package cats
 package effect
 
 import cats.effect.laws.discipline.arbitrary._
+import cats.kernel.laws.discipline.MonoidTests
 import cats.laws._
 import cats.laws.discipline._
 import cats.implicits._
@@ -25,6 +26,7 @@ import org.scalacheck._
 
 class ResourceTests extends BaseTestsSuite {
   checkAllAsync("Resource[IO, ?]", implicit ec => MonadErrorTests[Resource[IO, ?], Throwable].monadError[Int, Int, Int])
+  checkAllAsync("Resource[IO, Int]", implicit ec => MonoidTests[Resource[IO, Int]].monoid)
 
   testAsync("Resource.make is equivalent to a partially applied bracket") { implicit ec =>
     Prop.forAll { (acquire: IO[String], release: String => IO[Unit], f: String => IO[String]) =>
@@ -40,6 +42,17 @@ class ResourceTests extends BaseTestsSuite {
       }
       r.use(IO.pure).unsafeRunSync()
       released <-> as.map(_._1)
+    }
+  }
+
+  test("releases both resources on combine") {
+    Prop.forAll { (rx: Resource[IO, String], ry: Resource[IO, String]) =>
+      var released: Set[String] = Set.empty
+      def observeRelease(r: Resource[IO, String]) = r.flatMap { a =>
+        Resource.make(a.pure[IO])(a => IO { released += a }).map(Set(_))
+      }
+      val acquired = (observeRelease(rx) combine observeRelease(ry)).use(IO.pure).unsafeRunSync()
+      released <-> acquired
     }
   }
 

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -42,4 +42,10 @@ class ResourceTests extends BaseTestsSuite {
       released <-> as.map(_._1)
     }
   }
+
+  testAsync("liftF") { implicit ec =>
+    Prop.forAll { fa: IO[String] =>
+      Resource.liftF(fa).use(IO.pure) <-> fa
+    }
+  }
 }

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -17,7 +17,6 @@
 package cats
 package effect
 
-import cats.data.OptionT
 import cats.effect.laws.discipline.arbitrary._
 import cats.kernel.laws.discipline.MonoidTests
 import cats.laws._
@@ -29,7 +28,7 @@ import org.scalacheck._
 class ResourceTests extends BaseTestsSuite {
   checkAllAsync("Resource[IO, ?]", implicit ec => MonadErrorTests[Resource[IO, ?], Throwable].monadError[Int, Int, Int])
   checkAllAsync("Resource[IO, Int]", implicit ec => MonoidTests[Resource[IO, Int]].monoid)
-  checkAllAsync("OptionT[Resource[IO, ?], ?]", implicit ec => MonoidKTests[OptionT[Resource[IO, ?], ?]].monoidK[Int])
+  checkAllAsync("Resource[IO, ?]", implicit ec => SemigroupKTests[Resource[IO, ?]].semigroupK[Int])
 
   testAsync("Resource.make is equivalent to a partially applied bracket") { implicit ec =>
     Prop.forAll { (acquire: IO[String], release: String => IO[Unit], f: String => IO[String]) =>


### PR DESCRIPTION
A resource monad.  Will work on tests and docs if this is wanted.  This is a sketch and enough type tetris to get an instance compiling.

Nesting brackets is awkard.  The printlns appear in source order, but the parens get a bit lispy:

```scala
  IO(println("acquired outer")).bracket(
    _ => IO(println("acquired inner")).bracket(
      _ => IO(println("Using 1")))(
      _ => IO(println("released inner"))))(
    _ => IO(println("released outer")))
    .flatMap(_ => IO(println("Using 2")))
    .unsafeRunSync
```

The resource monad lets us acquire and compose resources monadically, releasing them in inverse order of acquisition.  This is identical to the above:

```scala
  val outer = Resource(IO(println("acquired outer")))(_ => IO(println("released outer")))
  val inner = Resource(IO(println("acquired inner")))(_ => IO(println("released inner")))

  // Monadic syntax to compose resources
  (for {
    _ <- outer
    _ <- inner
  } yield ())
    .use(_ => IO(println("Using 1")))
    .flatMap(_ => IO(println("Using 2")))
    .unsafeRunSync
```

Note that resources are closed at the completion of the effect returned by `use` (i.e., "Using 2" always appears after the "released" lines).  A streaming bracket is capable of tracking nested resource life cycles across multiple outputs.  An idiom in fs2 is to return a singleton stream, flatMap that to potentially multiple outputs, and release the resources after the final output.  Both fs2 `Stream` and monix `Iterant` should be able to exploit this:

```scala
  import fs2._
  def streamResource[F[_]: Functor, A](resource: Resource[F, A]) =
    Stream.bracket(resource.allocate)(a => Stream.emit(a._1), _._2)

  (for {
    // Stream resources are singleton streams of the resource
    _ <- streamResource(outer)
    _ <- streamResource(inner)
    // And kept open for multiple outputs
    i <- Stream(1, 2).covary[IO]
    _ <- Stream.eval(IO(println(s"Using $i")))
  } yield ()).compile.drain.unsafeRunSync
```

In this example, "Using 2" happens _before_ the releases, from the same resource definitions as used in `F.bracket`.

Anticipated use cases for `Resource`:
- http4s server and client builders could return a `Resource` and fit nicely with both `fs2.StreamApp` or the proposed `SafeApp`
- http4s client could be built on an abstract `Request[F] => Resource[F, Response[F]]`.  This:
  - easily composable for client middleware
  - support both `F[A]` and `Stream[F, A]` outputs with resource safety

This could go into a separate library, or into the theoretical contrib, but fs2 has expressed interest in it for core types.  I've written variations of this a few times, and wanted to integrate it into other libraries, but all withered due to being Yet Another Dependency.  If this type appears in a foundation library, the hope is that the concept gains traction, and multiple libraries can start returning these resources.