### PR TITLE
Cancellation docs

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -40,7 +40,7 @@ import scala.util.Either
  * Due to these restrictions, this type class also affords to describe
  * a [[Concurrent!.start start]] operation that can start async
  * processing, suspended in the context of `F[_]` and that can be
- * cancelled or joined.
+ * canceled or joined.
  *
  * Without cancellation being baked in, we couldn't afford to do it.
  * See below.
@@ -74,7 +74,7 @@ import scala.util.Either
  * tasks can also provide a way to cancel such processes, to be used
  * in race conditions in order to cleanup resources early, so a very
  * basic and side-effectful definition of asynchronous processes that
- * can be cancelled would be:
+ * can be canceled would be:
  *
  * {{{
  *   (A => Unit) => Cancelable
@@ -128,7 +128,7 @@ import scala.util.Either
  * The difference between a [[Concurrent]] data type and one that
  * is only [[Async]] is that you can go from any `F[A]` to a
  * `F[Fiber[F, A]]`, to participate in race conditions and that can be
- * cancelled should the need arise, in order to trigger an early
+ * canceled should the need arise, in order to trigger an early
  * release of allocated resources.
  *
  * Thus a [[Concurrent]] data type can safely participate in race
@@ -291,7 +291,7 @@ trait Concurrent[F[_]] extends Async[F] {
    *
    * In this example the `loud` reference will be completed with a
    * "CancellationException", as indicated via "onCancelRaiseError".
-   * The logic of the source won't get cancelled, because we've
+   * The logic of the source won't get canceled, because we've
    * embedded it all in [[uncancelable]]. But its bind continuation is
    * not allowed to continue after that, its final result not being
    * allowed to be signaled.
@@ -320,7 +320,7 @@ trait Concurrent[F[_]] extends Async[F] {
    * represented as a still-unfinished fiber.
    *
    * If the first task completes in error, then the result will
-   * complete in error, the other task being cancelled.
+   * complete in error, the other task being canceled.
    *
    * On usage the user has the option of canceling the losing task,
    * this being equivalent with plain [[race]]:
@@ -344,7 +344,7 @@ trait Concurrent[F[_]] extends Async[F] {
 
   /**
    * Run two tasks concurrently and return the first to finish,
-   * either in success or error. The loser of the race is cancelled.
+   * either in success or error. The loser of the race is canceled.
    *
    * The two tasks are potentially executed in parallel, the winner
    * being the first that signals a result.

--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -152,7 +152,7 @@ trait Concurrent[F[_]] extends Async[F] {
    *
    * The registration function is also supposed to return
    * an `IO[Unit]` that captures the logic necessary for
-   * cancelling the asynchronous process, for as long as it
+   * canceling the asynchronous process, for as long as it
    * is still active.
    *
    * Example:
@@ -203,7 +203,7 @@ trait Concurrent[F[_]] extends Async[F] {
    *   val tick = F.uncancelable(timer.sleep(10.seconds))
    *
    *   // This prints "Tick!" after 10 seconds, even if we are
-   *   // cancelling the Fiber after start:
+   *   // canceling the Fiber after start:
    *   for {
    *     fiber <- F.start(tick)
    *     _ <- fiber.cancel
@@ -322,7 +322,7 @@ trait Concurrent[F[_]] extends Async[F] {
    * If the first task completes in error, then the result will
    * complete in error, the other task being cancelled.
    *
-   * On usage the user has the option of cancelling the losing task,
+   * On usage the user has the option of canceling the losing task,
    * this being equivalent with plain [[race]]:
    *
    * {{{

--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -51,10 +51,10 @@ import scala.util.Either
  * builder is this:
  *
  * {{{
- *   (Either[Throwable, A] => Unit) => F[Unit]
+ *   (Either[Throwable, A] => Unit) => IO[Unit]
  * }}}
  *
- * `F[Unit]` is used to represent a cancellation action which will
+ * `IO[Unit]` is used to represent a cancellation action which will
  * send a signal to the producer, that may observe it and cancel the
  * asynchronous process.
  *
@@ -162,17 +162,17 @@ trait Concurrent[F[_]] extends Async[F] {
    *   import scala.concurrent.duration._
    *
    *   def sleep[F[_]](d: FiniteDuration)
-   *     (implicit F: Concurrent[F], ec: ScheduledExecutorService): F[A] = {
+   *     (implicit F: Concurrent[F], ec: ScheduledExecutorService): F[Unit] = {
    *
    *     F.cancelable { cb =>
    *       // Note the callback is pure, so we need to trigger evaluation
-   *       val run = new Runnable { def run() = cb(Right(())).unsafeRunSync }
+   *       val run = new Runnable { def run() = cb(Right(())) }
    *
    *       // Schedules task to run after delay
    *       val future = ec.schedule(run, d.length, d.unit)
    *
    *       // Cancellation logic, suspended in IO
-   *       IO(future.cancel())
+   *       IO(future.cancel(true))
    *     }
    *   }
    * }}}

--- a/core/shared/src/main/scala/cats/effect/ConcurrentEffect.scala
+++ b/core/shared/src/main/scala/cats/effect/ConcurrentEffect.scala
@@ -29,7 +29,7 @@ import scala.util.Either
  * [[Effect]], instances must also implement a
  * [[ConcurrentEffect!.runCancelable runCancelable]] operation that
  * triggers the evaluation, suspended in the `IO` context, but that
- * also returns a token that can be used for cancelling the running
+ * also returns a token that can be used for canceling the running
  * computation.
  *
  * Note this is the safe and generic version of [[IO.unsafeRunCancelable]].

--- a/core/shared/src/main/scala/cats/effect/Fiber.scala
+++ b/core/shared/src/main/scala/cats/effect/Fiber.scala
@@ -18,7 +18,7 @@ package cats.effect
 
 /**
  * `Fiber` represents the (pure) result of an [[Async]] data type (e.g. [[IO]])
- * being started concurrently and that can be either joined or cancelled.
+ * being started concurrently and that can be either joined or canceled.
  *
  * You can think of fibers as being lightweight threads, a fiber being a
  * concurrency primitive for doing cooperative multi-tasking.

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -45,7 +45,7 @@ import scala.util.{Failure, Left, Right, Success}
  *     `flatMap` chains get short-circuited (`IO` implementing
  *     the algebra of `MonadError`)
  *  1. can be canceled, but note this capability relies on the
- *     user to provide cancelation logic
+ *     user to provide cancellation logic
  *
  * Effects described via this abstraction are not evaluated until
  * the "end of the world", which is to say, when one of the "unsafe"
@@ -204,13 +204,13 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    *   // Safe, because it does not block for the source to finish
    *   val cancel: IO[Unit] = start.unsafeRunSync
    *
-   *   // Safe, because cancelation only sends a signal,
+   *   // Safe, because cancellation only sends a signal,
    *   // but doesn't back-pressure on anything
    *   cancel.unsafeRunSync
    * }}}
    *
    * @return an `IO` value that upon evaluation will execute the source,
-   *         but will not wait for its completion, yielding a cancelation
+   *         but will not wait for its completion, yielding a cancellation
    *         token that can be used to cancel the async process
    *
    * @see [[runAsync]] for the simple, uninterruptible version
@@ -269,7 +269,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * function ''once'', at the very end of your program.
    *
    * @return an side-effectful function that, when executed, sends a
-   *         cancelation reference to `IO`'s run-loop implementation,
+   *         cancellation reference to `IO`'s run-loop implementation,
    *         having the potential to interrupt it.
    */
   final def unsafeRunCancelable(cb: Either[Throwable, A] => Unit): () => Unit = {
@@ -338,7 +338,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    *
    * This can be used for non-deterministic / concurrent execution.
    * The following code is more or less equivalent with `parMap2`
-   * (minus the behavior on error handling and cancelation):
+   * (minus the behavior on error handling and cancellation):
    *
    * {{{
    *   def par2[A, B](ioa: IO[A], iob: IO[B]): IO[(A, B)] =
@@ -351,7 +351,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * }}}
    *
    * Note in such a case usage of `parMapN` (via `cats.Parallel`) is
-   * still recommended because of behavior on error and cancelation —
+   * still recommended because of behavior on error and cancellation —
    * consider in the example above what would happen if the first task
    * finishes in error. In that case the second task doesn't get cancelled,
    * which creates a potential memory leak.
@@ -365,12 +365,12 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
 
   /**
    * Returns a new `IO` that mirrors the source task for normal termination,
-   * but that triggers the given error on cancelation.
+   * but that triggers the given error on cancellation.
    *
    * Normally tasks that are cancelled become non-terminating.
    *
    * This `onCancelRaiseError` operator transforms a task that is
-   * non-terminating on cancelation into one that yields an error,
+   * non-terminating on cancellation into one that yields an error,
    * thus equivalent with [[IO.raiseError]].
    */
   final def onCancelRaiseError(e: Throwable): IO[A] =
@@ -400,7 +400,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    *
    * The `bracket` operation installs the necessary exception handler
    * to release the resource in the event of an exception being raised
-   * during the computation, or in case of cancelation.
+   * during the computation, or in case of cancellation.
    *
    * If an exception is raised, then `bracket` will re-raise the
    * exception ''after'' performing the `release`. If the resulting
@@ -439,7 +439,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    *   }
    * }}}
    *
-   * Note that in case of cancelation the underlying implementation
+   * Note that in case of cancellation the underlying implementation
    * cannot guarantee that the computation described by `use` doesn't
    * end up executed concurrently with the computation from
    * `release`. In the example above that ugly Java loop might end up
@@ -455,7 +455,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * For those cases you might want to do synchronization (e.g. usage
    * of locks and semaphores) and you might want to use [[bracketCase]],
    * the version that allows you to differentiate between normal
-   * termination and cancelation.
+   * termination and cancellation.
    *
    * '''NOTE on error handling''': one big difference versus
    * `try/finally` statements is that, in case both the `release`
@@ -497,7 +497,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * Returns a new `IO` task that treats the source task as the
    * acquisition of a resource, which is then exploited by the `use`
    * function and then `released`, with the possibility of
-   * distinguishing between normal termination and cancelation, such
+   * distinguishing between normal termination and cancellation, such
    * that an appropriate release of resources can be executed.
    *
    * The `bracketCase` operation is the equivalent of
@@ -506,11 +506,11 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    *
    * The `bracketCase` operation installs the necessary exception handler
    * to release the resource in the event of an exception being raised
-   * during the computation, or in case of cancelation.
+   * during the computation, or in case of cancellation.
    *
    * In comparison with the simpler [[bracket]] version, this one
    * allows the caller to differentiate between normal termination,
-   * termination in error and cancelation via an [[ExitCase]]
+   * termination in error and cancellation via an [[ExitCase]]
    * parameter.
    *
    * @see [[bracket]]
@@ -523,7 +523,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    *        terminates, either normally or in error, or if it gets
    *        canceled, receiving as input the resource that needs that
    *        needs release, along with the result of `use`
-   *        (cancelation, error or successful result)
+   *        (cancellation, error or successful result)
    */
   def bracketCase[B](use: A => IO[B])(release: (A, ExitCase[Throwable]) => IO[Unit]): IO[B] =
     IOBracket(this)(use)(release)
@@ -1012,8 +1012,8 @@ object IO extends IOInstances {
 
   /**
    * Returns a cancelable boundary — an `IO` task that checks for the
-   * cancelation status of the run-loop and does not allow for the
-   * bind continuation to keep executing in case cancelation happened.
+   * cancellation status of the run-loop and does not allow for the
+   * bind continuation to keep executing in case cancellation happened.
    *
    * This operation is very similar to [[IO.shift(implicit* IO.shift]],
    * as it can be dropped in `flatMap` chains in order to make loops
@@ -1027,7 +1027,7 @@ object IO extends IOInstances {
    *      if (n <= 0) IO.pure(a) else {
    *        val next = fib(n - 1, b, a + b)
    *
-   *        // Every 100-th cycle, check cancelation status
+   *        // Every 100-th cycle, check cancellation status
    *        if (n % 100 == 0)
    *          IO.cancelBoundary *> next
    *        else

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1091,7 +1091,7 @@ object IO extends IOInstances {
    * If the first task completes in error, then the result will
    * complete in error, the other task being cancelled.
    *
-   * On usage the user has the option of cancelling the losing task,
+   * On usage the user has the option of canceling the losing task,
    * this being equivalent with plain [[race]]:
    *
    * {{{

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -189,7 +189,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * eager evaluation.
    *
    * The returned `IO` boxes an `IO[Unit]` that can be used to cancel the
-   * running asynchronous computation (if the source can be cancelled).
+   * running asynchronous computation (if the source can be canceled).
    *
    * The returned `IO` is guaranteed to execute immediately,
    * and does not wait on any async action to complete, thus this
@@ -353,7 +353,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * Note in such a case usage of `parMapN` (via `cats.Parallel`) is
    * still recommended because of behavior on error and cancellation —
    * consider in the example above what would happen if the first task
-   * finishes in error. In that case the second task doesn't get cancelled,
+   * finishes in error. In that case the second task doesn't get canceled,
    * which creates a potential memory leak.
    *
    * IMPORTANT — this operation does not start with an asynchronous boundary.
@@ -367,7 +367,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * Returns a new `IO` that mirrors the source task for normal termination,
    * but that triggers the given error on cancellation.
    *
-   * Normally tasks that are cancelled become non-terminating.
+   * Normally tasks that are canceled become non-terminating.
    *
    * This `onCancelRaiseError` operator transforms a task that is
    * non-terminating on cancellation into one that yields an error,
@@ -404,7 +404,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    *
    * If an exception is raised, then `bracket` will re-raise the
    * exception ''after'' performing the `release`. If the resulting
-   * task gets cancelled, then `bracket` will still perform the
+   * task gets canceled, then `bracket` will still perform the
    * `release`, but the yielded task will be non-terminating
    * (equivalent with [[IO.never]]).
    *
@@ -444,7 +444,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * end up executed concurrently with the computation from
    * `release`. In the example above that ugly Java loop might end up
    * reading from a `BufferedReader` that is already closed due to the
-   * task being cancelled, thus triggering an error in the background
+   * task being canceled, thus triggering an error in the background
    * with nowhere to get signaled.
    *
    * In this particular example, given that we are just reading from a
@@ -487,7 +487,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    *
    * @param release is a function that gets called after `use`
    *        terminates, either normally or in error, or if it gets
-   *        cancelled, receiving as input the resource that needs to
+   *        canceled, receiving as input the resource that needs to
    *        be released
    */
   final def bracket[B](use: A => IO[B])(release: A => IO[Unit]): IO[B] =
@@ -1046,7 +1046,7 @@ object IO extends IOInstances {
   /**
    * Run two IO tasks concurrently, and return the first to
    * finish, either in success or error. The loser of the race is
-   * cancelled.
+   * canceled.
    *
    * The two tasks are executed in parallel if asynchronous,
    * the winner being the first that signals a result.
@@ -1089,7 +1089,7 @@ object IO extends IOInstances {
    * represented as a still-unfinished task.
    *
    * If the first task completes in error, then the result will
-   * complete in error, the other task being cancelled.
+   * complete in error, the other task being canceled.
    *
    * On usage the user has the option of canceling the losing task,
    * this being equivalent with plain [[race]]:

--- a/core/shared/src/main/scala/cats/effect/internals/ForwardCancelable.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/ForwardCancelable.scala
@@ -71,7 +71,7 @@ private[effect] object ForwardCancelable {
 
   /**
    * Builder for a `ForwardCancelable` that also cancels
-   * a second reference when cancelled.
+   * a second reference when canceled.
    */
   def plusOne(ref: () => Unit): ForwardCancelable =
     new ForwardCancelable(ref)

--- a/core/shared/src/main/scala/cats/effect/internals/IOConnection.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOConnection.scala
@@ -50,7 +50,7 @@ private[effect] sealed abstract class IOConnection {
 
   /**
    * Pushes a cancelable reference on the stack, to be
-   * popped or cancelled later in FIFO order.
+   * popped or canceled later in FIFO order.
    */
   def push(cancelable: Cancelable): Unit
 
@@ -69,14 +69,14 @@ private[effect] object IOConnection {
 
   /**
    * Reusable [[IOConnection]] reference that is already
-   * cancelled.
+   * canceled.
    */
   val alreadyCanceled: IOConnection =
     new AlreadyCanceled
 
   /**
    * Reusable [[IOConnection]] reference that cannot
-   * be cancelled.
+   * be canceled.
    */
   val uncancelable: IOConnection =
     new Uncancelable

--- a/core/shared/src/test/scala/cats/effect/internals/IOConnectionTests.scala
+++ b/core/shared/src/test/scala/cats/effect/internals/IOConnectionTests.scala
@@ -83,7 +83,7 @@ class IOConnectionTests extends FunSuite with Matchers {
     ref1 shouldBe ref2
   }
 
-  test("alreadyCanceled reference is already cancelled") {
+  test("alreadyCanceled reference is already canceled") {
     val ref = IOConnection.alreadyCanceled
     ref.isCanceled shouldBe true
     ref.cancel()
@@ -108,7 +108,7 @@ class IOConnectionTests extends FunSuite with Matchers {
     ref1 shouldBe ref2
   }
 
-  test("uncancelable reference cannot be cancelled") {
+  test("uncancelable reference cannot be canceled") {
     val ref = IOConnection.uncancelable
     ref.isCanceled shouldBe false
     ref.cancel()

--- a/laws/shared/src/test/scala/cats/effect/IOCancelableTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOCancelableTests.scala
@@ -32,7 +32,7 @@ class IOCancelableTests extends BaseTestsSuite {
     f.value shouldBe Some(Success(()))
   }
 
-  testAsync("IO.cancelBoundary can be cancelled") { implicit ec =>
+  testAsync("IO.cancelBoundary can be canceled") { implicit ec =>
     val f = (IO.shift *> IO.cancelBoundary).unsafeToFuture()
     f.value shouldBe None
     ec.tick()

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -534,45 +534,45 @@ class IOTests extends BaseTestsSuite {
 
   testAsync("parMap2 cancels first, when second terminates in error") { implicit ec =>
     val dummy = new RuntimeException("dummy")
-    var wasCancelled = false
+    var wasCanceled = false
 
-    val io1 = IO.cancelable[Int](_ => IO { wasCancelled = true })
+    val io1 = IO.cancelable[Int](_ => IO { wasCanceled = true })
     val io2 = IO.shift *> IO.raiseError[Int](dummy)
 
     val f = (io1, io2).parMapN((_, _) => ()).unsafeToFuture()
     ec.tick()
 
-    wasCancelled shouldBe true
+    wasCanceled shouldBe true
     f.value shouldBe Some(Failure(dummy))
   }
 
   testAsync("parMap2 cancels second, when first terminates in error") { implicit ec =>
     val dummy = new RuntimeException("dummy")
-    var wasCancelled = false
+    var wasCanceled = false
 
     val io1 = IO.shift *> IO.raiseError[Int](dummy)
-    val io2 = IO.cancelable[Int](_ => IO { wasCancelled = true })
+    val io2 = IO.cancelable[Int](_ => IO { wasCanceled = true })
 
     val f = (io1, io2).parMapN((_, _) => ()).unsafeToFuture()
     ec.tick()
 
-    wasCancelled shouldBe true
+    wasCanceled shouldBe true
     f.value shouldBe Some(Failure(dummy))
   }
 
   testAsync("IO.cancelable IOs can be canceled") { implicit ec =>
-    var wasCancelled = false
+    var wasCanceled = false
     val p = Promise[Int]()
 
-    val io1 = IO.shift *> IO.cancelable[Int](_ => IO { wasCancelled = true })
+    val io1 = IO.shift *> IO.cancelable[Int](_ => IO { wasCanceled = true })
     val cancel = io1.unsafeRunCancelable(Callback.promise(p))
 
     cancel()
     // Signal not observed yet due to IO.shift
-    wasCancelled shouldBe false
+    wasCanceled shouldBe false
 
     ec.tick()
-    wasCancelled shouldBe true
+    wasCanceled shouldBe true
     p.future.value shouldBe None
   }
 }

--- a/site/src/main/tut/datatypes/fiber.md
+++ b/site/src/main/tut/datatypes/fiber.md
@@ -6,7 +6,7 @@ source: "shared/src/main/scala/cats/effect/Fiber.scala"
 scaladoc: "#cats.effect.Fiber"
 ---
 
-It represents the (pure) result of an `Async` data type (e.g. `IO`) being started concurrently and that can be either joined or cancelled.
+It represents the (pure) result of an `Async` data type (e.g. `IO`) being started concurrently and that can be either joined or canceled.
 
 You can think of fibers as being lightweight threads, a fiber being a concurrency primitive for doing cooperative multi-tasking.
 

--- a/site/src/main/tut/datatypes/io.md
+++ b/site/src/main/tut/datatypes/io.md
@@ -880,7 +880,7 @@ Notes:
 2. this works with asynchronous `IO` actions
 3. the `release` action will happen regardless of the exit status 
    of the `use` action, so it will execute for successful completion,
-   for thrown errors or for cancelled execution
+   for thrown errors or for canceled execution
 4. if the `use` action throws an error and then the `release` action
    throws an error as well, the reported error will be that of
    `use`, whereas the error thrown by `release` will just get logged

--- a/site/src/main/tut/datatypes/io.md
+++ b/site/src/main/tut/datatypes/io.md
@@ -619,7 +619,7 @@ val cancel: () => Unit =
   io.unsafeRunCancelable(r => println(s"Done: $r"))
 
 // ... if a race condition happens, we can cancel it,
-// thus cancelling the scheduling of `IO.sleep`
+// thus canceling the scheduling of `IO.sleep`
 cancel()
 ```
 

--- a/site/src/main/tut/typeclasses/concurrent-effect.md
+++ b/site/src/main/tut/typeclasses/concurrent-effect.md
@@ -8,7 +8,7 @@ scaladoc: "#cats.effect.ConcurrentEffect"
 
 Type class describing effect data types that are cancelable and can be evaluated concurrently.
 
-In addition to the algebras of `Concurrent` and `Effect`, instances must also implement the `ConcurrentEffect.runCancelable` operation that triggers the evaluation, suspended in the `IO` context, but that also returns a token that can be used for cancelling the running computation.
+In addition to the algebras of `Concurrent` and `Effect`, instances must also implement the `ConcurrentEffect.runCancelable` operation that triggers the evaluation, suspended in the `IO` context, but that also returns a token that can be used for canceling the running computation.
 
 *Note this is the safe and generic version of `IO.unsafeRunCancelable`*.
 

--- a/site/src/main/tut/typeclasses/concurrent.md
+++ b/site/src/main/tut/typeclasses/concurrent.md
@@ -11,11 +11,11 @@ Type class for `Async` data types that are cancelable and can be started concurr
 Thus this type class allows abstracting over data types that:
 
 - Implement the `Async` algebra, with all its restrictions.
-- Can provide logic for cancelation, to be used in race conditions in order to release resources early (in its `Concurrent.cancelable` builder).
+- Can provide logic for cancellation, to be used in race conditions in order to release resources early (in its `Concurrent.cancelable` builder).
 
 Due to these restrictions, this type class also affords to describe a `Concurrent.start` operation that can start async processing, suspended in the context of `F[_]` and that can be canceled or joined.
 
-Without cancelation being baked in, we couldn't afford to do it.
+Without cancellation being baked in, we couldn't afford to do it.
 
 ```tut:book:silent
 import cats.effect.{Async, Fiber, IO}
@@ -35,9 +35,9 @@ The signature exposed by the `Concurrent.cancelable` builder is this:
 (Either[Throwable, A] => Unit) => F[Unit]
 ```
 
-`F[Unit]` is used to represent a cancelation action which will send a signal to the producer, that may observe it and cancel the asynchronous process.
+`F[Unit]` is used to represent a cancellation action which will send a signal to the producer, that may observe it and cancel the asynchronous process.
 
-### On Cancelation
+### On Cancellation
 
 Simple asynchronous processes, like Scala's `Future`, can be described with this very basic and side-effectful type and you should recognize what is more or less the signature of `Future.onComplete` or of `Async.async` (minus the error handling):
 
@@ -53,7 +53,7 @@ But many times the abstractions built to deal with asynchronous tasks can also p
 
 This is approximately the signature of JavaScript's `setTimeout`, which will return a "task ID" that can be used to cancel it. Or of Java's `ScheduledExecutorService.schedule`, which will return a Java `ScheduledFuture` that has a `.cancel()` operation on it.
 
-Similarly, for `Concurrent` data types, we can provide cancelation logic, that can be triggered in race conditions to cancel the on-going processing, only that `Concurrent`'s cancelable token is an action suspended in an `IO[Unit]`. See `IO.cancelable`.
+Similarly, for `Concurrent` data types, we can provide cancellation logic, that can be triggered in race conditions to cancel the on-going processing, only that `Concurrent`'s cancelable token is an action suspended in an `IO[Unit]`. See `IO.cancelable`.
 
 Suppose you want to describe a "sleep" operation, like that described by `Timer` to mirror Java's `ScheduledExecutorService.schedule` or JavaScript's `setTimeout`:
 
@@ -61,9 +61,9 @@ Suppose you want to describe a "sleep" operation, like that described by `Timer`
 def sleep(d: FiniteDuration): F[Unit]
 ```
 
-This signature is in fact incomplete for data types that are not cancelable, because such equivalent operations always return some cancelation token that can be used to trigger a forceful interruption of the timer. This is not a normal "dispose" or "finally" clause in a try/catch block, because "cancel" in the context of an asynchronous process is "concurrent" with the task's own run-loop.
+This signature is in fact incomplete for data types that are not cancelable, because such equivalent operations always return some cancellation token that can be used to trigger a forceful interruption of the timer. This is not a normal "dispose" or "finally" clause in a try/catch block, because "cancel" in the context of an asynchronous process is "concurrent" with the task's own run-loop.
 
-To understand what this means, consider that in the case of our `sleep` as described above, on cancelation we'd need a way to signal to the underlying `ScheduledExecutorService` to forcefully remove the scheduled `Runnable` from its internal queue of scheduled tasks, "before" its execution. Therefore, without a cancelable data type, a safe signature needs to return a cancelation token, so it would look like this:
+To understand what this means, consider that in the case of our `sleep` as described above, on cancellation we'd need a way to signal to the underlying `ScheduledExecutorService` to forcefully remove the scheduled `Runnable` from its internal queue of scheduled tasks, "before" its execution. Therefore, without a cancelable data type, a safe signature needs to return a cancellation token, so it would look like this:
 
 ```scala
 def sleep(d: FiniteDuration): F[(F[Unit], F[Unit])]
@@ -73,4 +73,4 @@ This function is returning a tuple, with one `F[Unit]` to wait for the completio
 
 The difference between a `Concurrent` data type and one that is only `Async` is that you can go from any `F[A]` to a `F[Fiber[F, A]]`, to participate in race conditions and that can be canceled should the need arise, in order to trigger an early release of allocated resources.
 
-Thus a `Concurrent` data type can safely participate in race conditions, whereas a data type that is only `Async` cannot without exposing and forcing the user to work with cancelation tokens. An `Async` data type cannot expose for example a `start` operation that is safe.
+Thus a `Concurrent` data type can safely participate in race conditions, whereas a data type that is only `Async` cannot without exposing and forcing the user to work with cancellation tokens. An `Async` data type cannot expose for example a `start` operation that is safe.

--- a/site/src/main/tut/typeclasses/concurrent.md
+++ b/site/src/main/tut/typeclasses/concurrent.md
@@ -32,7 +32,7 @@ trait Concurrent[F[_]] extends Async[F] {
 The signature exposed by the `Concurrent.cancelable` builder is this:
 
 ```scala
-(Either[Throwable, A] => Unit) => F[Unit]
+(Either[Throwable, A] => Unit) => IO[Unit]
 ```
 
 `F[Unit]` is used to represent a cancellation action which will send a signal to the producer, that may observe it and cancel the asynchronous process.


### PR DESCRIPTION
* Correct the example for `Concurrent.cancelable`
* Continue standardizing on American spellings
