### PR TITLE
WIP: Unexceptional IO and type classes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -178,6 +178,10 @@ val mimaSettings = Seq(
       exclude[ReversedMissingMethodProblem]("cats.effect.Effect#WriterTEffect.runSyncStep"),
       exclude[ReversedMissingMethodProblem]("cats.effect.Effect#EitherTEffect.runSyncStep"),
       exclude[ReversedMissingMethodProblem]("cats.effect.Effect#Ops.runSyncStep"),
+      exclude[DirectMissingMethodProblem]("cats.effect.Concurrent#Ops.race"),
+      exclude[DirectMissingMethodProblem]("cats.effect.Concurrent#Ops.uncancelable"),
+      exclude[DirectMissingMethodProblem]("cats.effect.Concurrent#Ops.racePair"),
+      exclude[DirectMissingMethodProblem]("cats.effect.Concurrent#Ops.start"),
       //
       // Following are all internal implementation details:
       //

--- a/core/shared/src/main/scala/cats/effect/Async.scala
+++ b/core/shared/src/main/scala/cats/effect/Async.scala
@@ -96,7 +96,7 @@ import scala.util.Either
 @implicitNotFound("""Cannot find implicit value for Async[${F}].
 Building this implicit value might depend on having an implicit
 s.c.ExecutionContext in scope, a Scheduler or some equivalent type.""")
-trait Async[F[_]] extends Sync[F] with LiftIO[F] {
+trait Async[F[_]] extends Sync[F] with LiftIO[F] with UAsync[F] {
   /**
    * Creates a simple, noncancelable `F[A]` instance that
    * executes an asynchronous process on evaluation.
@@ -129,7 +129,10 @@ trait Async[F[_]] extends Sync[F] with LiftIO[F] {
     * Returns a non-terminating `F[_]`, that never completes
     * with a result, being equivalent to `async(_ => ())`
     */
-  def never[A]: F[A] = async(_ => ())
+  override def never[A]: F[A] = async(_ => ())
+
+  override def asyncCatch[A](k: (Either[Throwable, A] => Unit) => Unit): F[Either[Throwable, A]] =
+    attempt(async(k))
 
   /**
    * DEPRECATED — moved to [[Async$.shift]].

--- a/core/shared/src/main/scala/cats/effect/Sync.scala
+++ b/core/shared/src/main/scala/cats/effect/Sync.scala
@@ -26,7 +26,7 @@ import cats.syntax.all._
  * in the `F[_]` context.
  */
 @typeclass
-trait Sync[F[_]] extends Bracket[F, Throwable] {
+trait Sync[F[_]] extends Bracket[F, Throwable] with USync[F] {
   /**
    * Suspends the evaluation of an `F` reference.
    *
@@ -44,6 +44,9 @@ trait Sync[F[_]] extends Bracket[F, Throwable] {
    * in `F`.
    */
   def delay[A](thunk: => A): F[A] = suspend(pure(thunk))
+
+  override def delayCatch[A](thunk: => A): F[Either[Throwable, A]] =
+    attempt(delay(thunk))
 }
 
 object Sync {

--- a/core/shared/src/main/scala/cats/effect/UAsync.scala
+++ b/core/shared/src/main/scala/cats/effect/UAsync.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import simulacrum._
+
+import scala.util.Either
+
+@typeclass
+trait UAsync[F[_]] extends USync[F] {
+  def asyncCatch[A](k: (Either[Throwable, A] => Unit) => Unit): F[Either[Throwable, A]]
+
+  def asyncUnit(k: (Either[Throwable, Unit] => Unit) => Unit): F[Unit] =
+    map(asyncCatch(k))(_.getOrElse(()))
+
+  def asyncDefault[A](k: (Either[Throwable, A] => Unit) => Unit)(a: A): F[A] =
+    map(asyncCatch(k))(_.getOrElse(a))
+
+  def never[A]: F[A] = map(asyncCatch[A](_ => ()))(_.right.get)
+}
+
+object UAsync {
+  def bewareAsyncNoCatch[F[_], A](k: (Either[Throwable, A] => Unit) => Unit)(implicit F: UAsync[F]): F[A] =
+    F.map(F.asyncCatch[A](k))(_.right.get)
+}

--- a/core/shared/src/main/scala/cats/effect/UAsync.scala
+++ b/core/shared/src/main/scala/cats/effect/UAsync.scala
@@ -31,9 +31,7 @@ trait UAsync[F[_]] extends USync[F] {
     map(asyncCatch(k))(_.getOrElse(a))
 
   def never[A]: F[A] = map(asyncCatch[A](_ => ()))(_.right.get)
-}
 
-object UAsync {
-  def bewareAsyncNoCatch[F[_], A](k: (Either[Throwable, A] => Unit) => Unit)(implicit F: UAsync[F]): F[A] =
-    F.map(F.asyncCatch[A](k))(_.right.get)
+  def bewareAsyncNoCatch[A](k: (Either[Throwable, A] => Unit) => Unit): F[A] =
+    map(asyncCatch[A](k))(_.right.get)
 }

--- a/core/shared/src/main/scala/cats/effect/UAsync.scala
+++ b/core/shared/src/main/scala/cats/effect/UAsync.scala
@@ -25,10 +25,10 @@ trait UAsync[F[_]] extends USync[F] {
   def asyncCatch[A](k: (Either[Throwable, A] => Unit) => Unit): F[Either[Throwable, A]]
 
   def asyncUnit(k: (Either[Throwable, Unit] => Unit) => Unit): F[Unit] =
-    map(asyncCatch(k))(_.getOrElse(()))
+    map(asyncCatch(k))(_.right.getOrElse(()))
 
   def asyncDefault[A](k: (Either[Throwable, A] => Unit) => Unit)(a: A): F[A] =
-    map(asyncCatch(k))(_.getOrElse(a))
+    map(asyncCatch(k))(_.right.getOrElse(a))
 
   def never[A]: F[A] = map(asyncCatch[A](_ => ()))(_.right.get)
 

--- a/core/shared/src/main/scala/cats/effect/UConcurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/UConcurrent.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import simulacrum._
+
+import scala.util.Either
+
+@typeclass
+trait UConcurrent[F[_]] extends UAsync[F] {
+  def cancelableCatch[A](k: (Either[Throwable, A] => Unit) => IO[Unit]): F[Either[Throwable, A]]
+
+  def uncancelable[A](fa: F[A]): F[A]
+
+  def start[A](fa: F[A]): F[Fiber[F, A]]
+
+  def racePair[A,B](fa: F[A], fb: F[B]): F[Either[(A, Fiber[F, B]), (Fiber[F, A], B)]]
+
+  def race[A, B](fa: F[A], fb: F[B]): F[Either[A, B]] =
+    flatMap(racePair(fa, fb)) {
+      case Left((a, fiberB)) => map(fiberB.cancel)(_ => Left(a))
+      case Right((fiberA, b)) => map(fiberA.cancel)(_ => Right(b))
+    }
+}

--- a/core/shared/src/main/scala/cats/effect/UConcurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/UConcurrent.scala
@@ -24,12 +24,119 @@ import scala.util.Either
 trait UConcurrent[F[_]] extends UAsync[F] {
   def cancelableCatch[A](k: (Either[Throwable, A] => Unit) => IO[Unit]): F[Either[Throwable, A]]
 
+  /**
+   * Returns a new `F` that mirrors the source, but that is uninterruptible.
+   *
+   * This means that the [[Fiber.cancel cancel]] signal has no effect on the
+   * result of [[Fiber.join join]] and that the cancelable token returned by
+   * [[ConcurrentEffect.runCancelable]] on evaluation will have no effect.
+   *
+   * This operation is undoing the cancelation mechanism of [[cancelable]],
+   * with this equivalence:
+   *
+   * {{{
+   *   F.uncancelable(F.cancelable { cb => f(cb); io }) <-> F.async(f)
+   * }}}
+   *
+   * Sample:
+   *
+   * {{{
+   *   val F = Concurrent[IO]
+   *   val timer = Timer[IO]
+   *
+   *   // Normally Timer#sleep yields cancelable tasks
+   *   val tick = F.uncancelable(timer.sleep(10.seconds))
+   *
+   *   // This prints "Tick!" after 10 seconds, even if we are
+   *   // cancelling the Fiber after start:
+   *   for {
+   *     fiber <- F.start(tick)
+   *     _ <- fiber.cancel
+   *     _ <- fiber.join
+   *   } yield {
+   *     println("Tick!")
+   *   }
+   * }}}
+   *
+   * Cancelable effects are great in race conditions, however sometimes
+   * this operation is necessary to ensure that the bind continuation
+   * of a task (the following `flatMap` operations) are also evaluated
+   * no matter what.
+   */
   def uncancelable[A](fa: F[A]): F[A]
 
+  /**
+   * Start concurrent execution of the source suspended in
+   * the `F` context.
+   *
+   * Returns a [[Fiber]] that can be used to either join or cancel
+   * the running computation, being similar in spirit (but not
+   * in implementation) to starting a thread.
+   */
   def start[A](fa: F[A]): F[Fiber[F, A]]
 
+  /**
+   * Run two tasks concurrently, creating a race between them and returns a
+   * pair containing both the winner's successful value and the loser
+   * represented as a still-unfinished fiber.
+   *
+   * If the first task completes in error, then the result will
+   * complete in error, the other task being cancelled.
+   *
+   * On usage the user has the option of cancelling the losing task,
+   * this being equivalent with plain [[race]]:
+   *
+   * {{{
+   *   val ioA: IO[A] = ???
+   *   val ioB: IO[B] = ???
+   *
+   *   Concurrent[IO].racePair(ioA, ioB).flatMap {
+   *     case Left((a, fiberB)) =>
+   *       fiberB.cancel.map(_ => a)
+   *     case Right((fiberA, b)) =>
+   *       fiberA.cancel.map(_ => b)
+   *   }
+   * }}}
+   *
+   * See [[race]] for a simpler version that cancels the loser
+   * immediately.
+   */
   def racePair[A,B](fa: F[A], fb: F[B]): F[Either[(A, Fiber[F, B]), (Fiber[F, A], B)]]
 
+  /**
+   * Run two tasks concurrently and return the first to finish,
+   * either in success or error. The loser of the race is cancelled.
+   *
+   * The two tasks are potentially executed in parallel, the winner
+   * being the first that signals a result.
+   *
+   * As an example, this would be the implementation of a "timeout"
+   * operation:
+   *
+   * {{{
+   *   import cats.effect._
+   *   import scala.concurrent.duration._
+   *
+   *   def timeoutTo[F[_], A](fa: F[A], after: FiniteDuration, fallback: F[A])
+   *     (implicit F: Concurrent[F], timer: Timer[F]): F[A] = {
+   *
+   *      F.race(fa, timer.sleep(after)).flatMap {
+   *        case Left((a, _)) => F.pure(a)
+   *        case Right((_, _)) => fallback
+   *      }
+   *   }
+   *
+   *   def timeout[F[_], A](fa: F[A], after: FiniteDuration)
+   *     (implicit F: Concurrent[F], timer: Timer[F]): F[A] = {
+   *
+   *      timeoutTo(fa, after,
+   *        F.raiseError(new TimeoutException(after.toString)))
+   *   }
+   * }}}
+   *
+   * Also see [[racePair]] for a version that does not cancel
+   * the loser automatically on successful results.
+   */
   def race[A, B](fa: F[A], fb: F[B]): F[Either[A, B]] =
     flatMap(racePair(fa, fb)) {
       case Left((a, fiberB)) => map(fiberB.cancel)(_ => Left(a))

--- a/core/shared/src/main/scala/cats/effect/UIO.scala
+++ b/core/shared/src/main/scala/cats/effect/UIO.scala
@@ -23,7 +23,8 @@ import scala.concurrent.duration.FiniteDuration
 import cats.effect.internals.IONewtype
 
 
-object UIOImpl extends UIOInstances with IONewtype {
+object UIOImpl extends UIOInstances {
+
   private[cats] def create[A](s: IO[A]): Type[A] =
     s.asInstanceOf[Type[A]]
 
@@ -95,7 +96,7 @@ object UIOImpl extends UIOInstances with IONewtype {
 
 }
 
-private[effect] abstract class UIOParallelNewtype {
+private[effect] abstract class UIOParallelNewtype extends IONewtype {
 
   type Par[A] = Par.Type[A]
 

--- a/core/shared/src/main/scala/cats/effect/UIO.scala
+++ b/core/shared/src/main/scala/cats/effect/UIO.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.{Applicative, Monad, MonadError, Monoid, Parallel, Semigroup, ~>}
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import cats.effect.internals.IONewtype
+
+
+object UIOImpl extends UIOInstances with IONewtype {
+  private[cats] def create[A](s: IO[A]): Type[A] =
+    s.asInstanceOf[Type[A]]
+
+  def fromIO[A](ioa: IO[A]): UIO[Either[Throwable, A]] =
+    create(ioa.attempt)
+
+  def runUIO[A](uioa: UIO[A]): IO[A] =
+    uioa.asInstanceOf[IO[A]]
+
+  def runEitherIO[A](uioa: UIO[Either[Throwable, A]]): IO[A] =
+    MonadError[IO, Throwable].rethrow(runUIO(uioa))
+
+  def unsafeFromIO[A](ioa: IO[A]): UIO[A] = create(ioa)
+
+  def pure[A](x: A): UIO[A] = create(IO.pure(x))
+
+  def apply[A](x: => A): UIO[Either[Throwable, A]] =
+    fromIO(IO(x))
+
+  def async[A](k: (Either[Throwable, A] => Unit) => Unit): UIO[Either[Throwable, A]] =
+    fromIO(IO.async(k))
+
+  def suspend[A](thunk: => UIO[A]): UIO[A] =
+    unsafeFromIO(IO.suspend(runUIO(thunk)))
+
+  val unit: UIO[Unit] =
+    pure(())
+
+  def race[A, B](lh: UIO[A], rh: UIO[B]): UIO[Either[A, B]] =
+    unsafeFromIO(IO.race(runUIO(lh), runUIO(rh)))
+
+
+  def cancelable[A](k: (Either[Throwable, A] => Unit) => IO[Unit]): UIO[Either[Throwable, A]] =
+    fromIO(IO.cancelable(k))
+
+
+  def start[A](uioa: UIO[A]): UIO[Fiber[UIO, A]] =
+    unsafeFromIO(runUIO(uioa).start.map(uioFiber))
+
+
+  def fromFuture[A](iof: UIO[Future[A]]): UIO[Either[Throwable, A]] =
+    fromIO(IO.fromFuture(runUIO(iof)))
+
+  def shift(implicit timer: Timer[UIO]): UIO[Unit] =
+    timer.shift
+
+  def sleep(duration: FiniteDuration)(implicit timer: Timer[UIO]): UIO[Unit] =
+    timer.sleep(duration)
+
+  val cancelBoundary: UIO[Unit] = unsafeFromIO(IO.cancelBoundary)
+
+  def racePair[A, B](lh: UIO[A], rh: UIO[B]): UIO[Either[(A, Fiber[UIO, B]), (Fiber[UIO, A], B)]] = {
+    import cats.syntax.bifunctor._
+    import cats.instances.either._
+
+    UIOImpl.unsafeFromIO(IO.racePair(runUIO(lh), runUIO(rh)).map { e =>
+      e.bimap({
+        case (a, fiber) => (a, uioFiber(fiber))
+      }, {
+        case (fiber, b) => (uioFiber(fiber), b)
+      })
+    })
+  }
+
+  private def uioFiber[A](f: Fiber[IO, A]): Fiber[UIO, A] =
+    Fiber(unsafeFromIO(f.join), unsafeFromIO(f.cancel))
+
+}
+
+private[effect] abstract class UIOParallelNewtype {
+
+  type Par[A] = Par.Type[A]
+
+  object Par extends IONewtype {
+
+    def fromUIO[A](s: UIO[A]): Type[A] =
+      s.asInstanceOf[Type[A]]
+
+    def toUIO[A](s: Type[A]): UIO[A] =
+      s.asInstanceOf[UIO[A]]
+
+  }
+}
+
+
+private[effect] sealed abstract class UIOInstances extends UIOParallelNewtype {
+  implicit val catsEffectUAsyncForUIO: UAsync[UIO] = new UAsync[UIO] {
+    def tailRecM[A, B](a: A)(f: A => UIO[Either[A, B]]): UIO[B] =
+      UIOImpl.create(Monad[IO].tailRecM(a)(f andThen UIOImpl.runUIO))
+
+    def flatMap[A, B](fa: UIO[A])(f: A => UIO[B]): UIO[B] =
+      UIOImpl.create(Monad[IO].flatMap(UIOImpl.runUIO(fa))(f andThen UIOImpl.runUIO))
+
+    def pure[A](x: A): UIO[A] =
+      UIOImpl.pure(x)
+
+    def delayCatch[A](thunk: => A): UIO[Either[Throwable, A]] =
+      UIO(thunk)
+
+    def asyncCatch[A](k: (Either[Throwable, A] => Unit) => Unit): UIO[Either[Throwable, A]] =
+      UIO.async(k)
+  }
+
+  implicit val catsEffectApplicativeForParUIO: Applicative[UIOImpl.Par] = new Applicative[UIOImpl.Par] {
+    def pure[A](x: A): UIOImpl.Par[A] = UIOImpl.Par.fromUIO(UIOImpl.pure(x))
+
+    def ap[A, B](ff: UIOImpl.Par[A => B])(fa: UIOImpl.Par[A]): UIOImpl.Par[B] =
+      UIOImpl.Par.fromUIO(UIOImpl.create(Parallel.parAp(UIOImpl.runUIO(UIOImpl.Par.toUIO(ff)))(UIOImpl.runUIO(UIOImpl.Par.toUIO(fa)))))
+  }
+
+  implicit val catsEffectParallelForUIO: Parallel[UIO, UIOImpl.Par] = new Parallel[UIO, UIOImpl.Par] {
+    def applicative: Applicative[UIOImpl.Par] = catsEffectApplicativeForParUIO
+
+    def monad: Monad[UIO] = catsEffectUAsyncForUIO
+
+    def sequential: ~>[UIOImpl.Par, UIO] =
+      new ~>[UIOImpl.Par, UIO] { def apply[A](fa: UIOImpl.Par[A]): UIO[A] = UIOImpl.Par.toUIO(fa) }
+
+    def parallel: ~>[UIO, UIOImpl.Par] =
+      new ~>[UIO, UIOImpl.Par] { def apply[A](fa: UIO[A]): UIOImpl.Par[A] = UIOImpl.Par.fromUIO(fa) }
+  }
+
+  implicit def catsEffectMonoidForUIO[A: Monoid]: Monoid[UIO[A]] = new Monoid[UIO[A]] {
+    def empty: UIO[A] = UIOImpl.pure(Monoid[A].empty)
+    def combine(x: UIO[A], y: UIO[A]): UIO[A] =
+      UIOImpl.create(UIOImpl.runUIO(x).flatMap(a1 => UIOImpl.runUIO(y).map(a2 => Semigroup[A].combine(a1, a2))))
+  }
+}

--- a/core/shared/src/main/scala/cats/effect/USync.scala
+++ b/core/shared/src/main/scala/cats/effect/USync.scala
@@ -24,10 +24,10 @@ trait USync[F[_]] extends Monad[F] {
   def delayCatch[A](thunk: => A): F[Either[Throwable, A]]
 
   def delayUnit(thunk: => Unit): F[Unit] =
-    map(delayCatch(thunk))(_.getOrElse(()))
+    map(delayCatch(thunk))(_.right.getOrElse(()))
 
   def delayDefault[A](thunk: => A)(a: A): F[A] =
-    map(delayCatch(thunk))(_.getOrElse(a))
+    map(delayCatch(thunk))(_.right.getOrElse(a))
 
   def bewareDelayNoCatch[A](thunk: => A): F[A] =
     map(delayCatch[A](thunk))(_.right.get)

--- a/core/shared/src/main/scala/cats/effect/USync.scala
+++ b/core/shared/src/main/scala/cats/effect/USync.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.Monad
+import simulacrum._
+
+@typeclass
+trait USync[F[_]] extends Monad[F] {
+  def delayCatch[A](thunk: => A): F[Either[Throwable, A]]
+
+  def delayUnit(thunk: => Unit): F[Unit] =
+    map(delayCatch(thunk))(_.getOrElse(()))
+
+  def delayDefault[A](thunk: => A)(a: A): F[A] =
+    map(delayCatch(thunk))(_.getOrElse(a))
+}
+
+object USync {
+  def bewareDelayNoCatch[F[_], A](thunk: => A)(implicit F: USync[F]): F[A] =
+    F.map(F.delayCatch[A](thunk))(_.right.get)
+}

--- a/core/shared/src/main/scala/cats/effect/internals/IONewtype.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IONewtype.scala
@@ -30,7 +30,7 @@ import cats.effect.IO
  * Inspired by
  * [[https://github.com/alexknvl/newtypes alexknvl/newtypes]].
  */
-private[effect] abstract class IONewtype { self =>
+private[effect] trait IONewtype { self =>
   type Base
   trait Tag extends Any
   type Type[+A] <: Base with Tag

--- a/core/shared/src/main/scala/cats/effect/internals/IONewtype.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IONewtype.scala
@@ -30,7 +30,7 @@ import cats.effect.IO
  * Inspired by
  * [[https://github.com/alexknvl/newtypes alexknvl/newtypes]].
  */
-private[effect] trait IONewtype { self =>
+private[effect] abstract class IONewtype { self =>
   type Base
   trait Tag extends Any
   type Type[+A] <: Base with Tag

--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+
+package object effect {
+  type UIO[+A] = UIOImpl.Type[A]
+  val UIO = UIOImpl
+}

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -21,7 +21,7 @@ package laws
 import cats.implicits._
 import cats.laws._
 
-trait AsyncLaws[F[_]] extends SyncLaws[F] {
+trait AsyncLaws[F[_]] extends SyncLaws[F] with UAsyncLaws[F] {
   implicit def F: Async[F]
 
   def asyncRightIsPure[A](a: A) =
@@ -41,19 +41,6 @@ trait AsyncLaws[F[_]] extends SyncLaws[F] {
     val read: F[A] = F.delay(cur)
 
     change *> change *> read <-> F.pure(f(f(a)))
-  }
-
-  def repeatedCallbackIgnored[A](a: A, f: A => A) = {
-    var cur = a
-    val change = F.delay { cur = f(cur) }
-    val readResult = F.delay { cur }
-
-    val double: F[Unit] = F.async { cb =>
-      cb(Right(()))
-      cb(Right(()))
-    }
-
-    double *> change *> readResult <-> F.delay(f(a))
   }
 
   def propagateErrorsThroughBindAsync[A](t: Throwable) = {

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
@@ -21,7 +21,7 @@ package laws
 import cats.implicits._
 import cats.laws._
 
-trait SyncLaws[F[_]] extends BracketLaws[F, Throwable] {
+trait SyncLaws[F[_]] extends BracketLaws[F, Throwable] with USyncLaws[F] {
   implicit def F: Sync[F]
 
   def bracketReleaseCalledForSuccess[A, B, C](fa: F[A], b: B, c: C, f: (A, C) => C) = {
@@ -88,40 +88,6 @@ trait SyncLaws[F[_]] extends BracketLaws[F, Throwable] {
     fa <-> F.raiseError(t)
   }
 
-  def bindSuspendsEvaluation[A](fa: F[A], a1: A, f: (A, A) => A) = {
-    var state = a1
-    val evolve = F.flatMap(fa) { a2 =>
-      state = f(a1, a2)
-      F.pure(state)
-    }
-    // Observing `state` before and after `evolve`
-    F.map2(F.pure(state), evolve)(f) <-> F.map(fa)(a2 => f(a1, f(a1, a2)))
-  }
-
-  def mapSuspendsEvaluation[A](fa: F[A], a1: A, f: (A, A) => A) = {
-    var state = a1
-    val evolve = F.map(fa) { a2 =>
-      state = f(a1, a2)
-      state
-    }
-    // Observing `state` before and after `evolve`
-    F.map2(F.pure(state), evolve)(f) <-> F.map(fa)(a2 => f(a1, f(a1, a2)))
-  }
-
-  def stackSafetyOnRepeatedLeftBinds(iterations: Int) = {
-    val result = (0 until iterations).foldLeft(F.delay(())) { (acc, _) =>
-      acc.flatMap(_ => F.delay(()))
-    }
-    result <-> F.pure(())
-  }
-
-  def stackSafetyOnRepeatedRightBinds(iterations: Int) = {
-    val result = (0 until iterations).foldRight(F.delay(())) { (_, acc) =>
-      F.delay(()).flatMap(_ => acc)
-    }
-    result <-> F.pure(())
-  }
-
   def stackSafetyOnRepeatedAttempts(iterations: Int) = {
     // Note this isn't enough to guarantee stack safety, unless 
     // coupled with `bindSuspendsEvaluation`
@@ -129,15 +95,6 @@ trait SyncLaws[F[_]] extends BracketLaws[F, Throwable] {
       F.attempt(acc).map(_ => ())
     }
     result <-> F.pure(())
-  }
-
-  def stackSafetyOnRepeatedMaps(iterations: Int) = {
-    // Note this isn't enough to guarantee stack safety, unless 
-    // coupled with `mapSuspendsEvaluation`
-    val result = (0 until iterations).foldLeft(F.delay(0)) { (acc, _) =>
-      F.map(acc)(_ + 1)
-    }
-    result <-> F.pure(iterations)
   }
 }
 

--- a/laws/shared/src/main/scala/cats/effect/laws/UAsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/UAsyncLaws.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package laws
+
+import cats.implicits._
+import cats.laws._
+
+
+trait UAsyncLaws[F[_]] extends USyncLaws[F] {
+  implicit def F: UAsync[F]
+
+  def asyncRightIsPureRight[A](a: A) =
+    F.asyncCatch[A](_(Right(a))) <-> F.pure(Right(a))
+
+  def asyncLeftIsPureRight[A](e: Throwable) =
+    F.asyncCatch[A](_(Left(e))) <-> F.pure(Left(e))
+
+  def repeatedAsyncEvaluationNotMemoized[A](a: A, f: A => A) = {
+    var cur = a
+
+    val change: F[Unit] = F asyncUnit { cb =>
+      cur = f(cur)
+      cb(Right(()))
+    }
+
+    val read: F[Either[Throwable, A]] = F.delayCatch(cur)
+
+    change *> change *> read <-> F.pure(Right(f(f(a))))
+  }
+
+  def repeatedCallbackIgnored[A](a: A, f: A => A) = {
+    var cur = a
+    val change = F.delayUnit { cur = f(cur) }
+    val readResult = F.delayCatch { cur }
+
+    val double: F[Unit] = F.asyncUnit { cb =>
+      cb(Right(()))
+      cb(Right(()))
+    }
+
+    double *> change *> readResult <-> F.delayCatch(f(a))
+  }
+}
+object UAsyncLaws {
+  def apply[F[_]](implicit F0: UAsync[F]): UAsyncLaws[F] = new UAsyncLaws[F] {
+    val F = F0
+  }
+}

--- a/laws/shared/src/main/scala/cats/effect/laws/UAsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/UAsyncLaws.scala
@@ -28,10 +28,10 @@ trait UAsyncLaws[F[_]] extends USyncLaws[F] {
   def asyncRightIsPureRight[A](a: A) =
     F.asyncCatch[A](_(Right(a))) <-> F.pure(Right(a))
 
-  def asyncLeftIsPureRight[A](e: Throwable) =
+  def asyncLeftIsPureLeft[A](e: Throwable) =
     F.asyncCatch[A](_(Left(e))) <-> F.pure(Left(e))
 
-  def repeatedAsyncEvaluationNotMemoized[A](a: A, f: A => A) = {
+  def repeatedAsyncCatchEvaluationNotMemoized[A](a: A, f: A => A) = {
     var cur = a
 
     val change: F[Unit] = F asyncUnit { cb =>

--- a/laws/shared/src/main/scala/cats/effect/laws/UConcurrentLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/UConcurrentLaws.scala
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package laws
+
+import cats.effect.laws.util.Pledge
+import cats.laws._
+import cats.implicits._
+import scala.Predef.{identity => id}
+
+
+trait UConcurrentLaws[F[_]] extends UAsyncLaws[F] {
+  implicit def F: UConcurrent[F]
+
+  def asyncCancelableCoherence[A](r: Either[Throwable, A]) = {
+    F.asyncCatch[A](cb => cb(r)) <-> F.cancelableCatch[A] { cb => cb(r); IO.unit }
+  }
+
+  def asyncCancelableReceivesCancelSignal[A](a: A) = {
+    val lh = Pledge[F, A].flatMap { effect =>
+      val async = F.cancelableCatch[Unit](_ => effect.complete[IO](a))
+      F.start(async).flatMap(_.cancel) *> effect.await
+    }
+    lh <-> F.pure(a)
+  }
+
+  def startJoinIsIdentity[A](fa: F[A]) =
+    F.start(fa).flatMap(_.join) <-> fa
+
+  def joinIsIdempotent[A](a: A) = {
+    val lh = Pledge[F, A].flatMap { p =>
+      // N.B. doing effect.complete twice triggers error
+      F.start(p.complete(a)).flatMap(t => t.join *> t.join) *> p.await
+    }
+    lh <-> F.pure(a)
+  }
+
+  def startCancelIsUnit[A](fa: F[A]) = {
+    F.start(fa).flatMap(_.cancel) <-> F.unit
+  }
+
+  def uncancelableMirrorsSource[A](fa: F[A]) = {
+    F.uncancelable(fa) <-> fa
+  }
+
+  def uncancelablePreventsCancelation[A](a: A) = {
+    val lh = Pledge[F, A].flatMap { p =>
+      val async = F.cancelableCatch[Unit](_ => p.complete[IO](a))
+      F.start(F.uncancelable(async)).flatMap(_.cancel) *> p.await
+    }
+    // Non-terminating
+    lh <-> F.never
+  }
+
+  def raceMirrorsLeftWinner[A](fa: F[A], default: A) = {
+    F.race(fa, F.never[A]).map(_.left.getOrElse(default)) <-> fa
+  }
+
+  def raceMirrorsRightWinner[A](fa: F[A], default: A) = {
+    F.race(F.never[A], fa).map(_.right.getOrElse(default)) <-> fa
+  }
+
+  def raceCancelsLoser[A, B](r: Either[Throwable, A], leftWinner: Boolean, b: B) = {
+    val received = Pledge[F, B].flatMap { effect =>
+      val winner = F.asyncCatch[A](_(r))
+      val loser = F.cancelableCatch[A](_ => effect.complete[IO](b))
+      val race =
+        if (leftWinner) F.race(winner, loser)
+        else F.race(loser, winner)
+
+      race *> effect.await
+    }
+    received <-> F.pure(b)
+  }
+
+  def raceCancelsBoth[A, B, C](a: A, b: B, f: (A, B) => C) = {
+    val fc = for {
+      pa <- Pledge[F, A]
+      loserA = F.cancelableCatch[A](_ => pa.complete[IO](a))
+      pb <- Pledge[F, B]
+      loserB = F.cancelableCatch[B](_ => pb.complete[IO](b))
+      race <- F.start(F.race(loserA, loserB))
+      _ <- race.cancel
+      a <- pa.await[F]
+      b <- pb.await[F]
+    } yield f(a, b)
+
+    fc <-> F.pure(f(a, b))
+  }
+
+  def racePairMirrorsLeftWinner[A](fa: F[A]) = {
+    val never = F.never[A]
+    val received =
+      F.racePair(fa, never).flatMap {
+        case Left((a, fiberB)) =>
+          fiberB.cancel.map(_ => a)
+        case Right(_) =>
+          throw new IllegalStateException("right")
+      }
+    received <-> F.race(fa, never).map(_.fold(id, id))
+  }
+
+  def racePairMirrorsRightWinner[B](fb: F[B]) = {
+    val never = F.never[B]
+    val received =
+      F.racePair(never, fb).flatMap {
+        case Right((fiberA, b)) =>
+          fiberA.cancel.map(_ => b)
+        case Left(_) =>
+          throw new IllegalStateException("left")
+      }
+    received <-> F.race(never, fb).map(_.fold(id, id))
+  }
+
+
+  def racePairCancelsLoser[A, B](r: Either[Throwable, A], leftWinner: Boolean, b: B) = {
+    val received: F[B] = Pledge[F, B].flatMap { effect =>
+      val winner = F.asyncCatch[A](_(r))
+      val loser = F.cancelableCatch[A](_ => effect.complete[IO](b))
+      val race =
+        if (leftWinner) F.racePair(winner, loser)
+        else F.racePair(loser, winner)
+
+      race.flatMap {
+        case Right(Left((_, fiber))) =>
+          fiber.cancel *> effect.await[F]
+        case Right(Right((fiber, _))) =>
+          fiber.cancel *> effect.await[F]
+        case Left(_) =>
+          effect.await[F]
+      }
+    }
+    received <-> F.pure(b)
+  }
+
+
+  def racePairCanJoinLeft[A](a: A) = {
+    val lh = Pledge[F, A].flatMap { fa =>
+      F.racePair(fa.await[F], F.unit).flatMap {
+        case Left((l, _)) => F.pure(l)
+        case Right((fiberL, _)) =>
+          fa.complete[F](a) *> fiberL.join
+      }
+    }
+    lh <-> F.pure(a)
+  }
+
+  def racePairCanJoinRight[A](a: A) = {
+    val lh = Pledge[F, A].flatMap { fa =>
+      F.racePair(F.unit, fa.await[F]).flatMap {
+        case Left((_, fiberR)) =>
+          fa.complete[F](a) *> fiberR.join
+        case Right((_, r)) =>
+          F.pure(r)
+      }
+    }
+    lh <-> F.pure(a)
+  }
+
+  def racePairCancelsBoth[A, B, C](a: A, b: B, f: (A, B) => C) = {
+    val fc = for {
+      pa <- Pledge[F, A]
+      loserA = F.cancelableCatch[A](_ => pa.complete[IO](a))
+      pb <- Pledge[F, B]
+      loserB = F.cancelableCatch[B](_ => pb.complete[IO](b))
+      race <- F.start(F.racePair(loserA, loserB))
+      _ <- race.cancel
+      a <- pa.await[F]
+      b <- pb.await[F]
+    } yield f(a, b)
+
+    fc <-> F.pure(f(a, b))
+  }
+}
+
+object UConcurrentLaws {
+  def apply[F[_]](implicit F0: UConcurrent[F]): UConcurrentLaws[F] = new UConcurrentLaws[F] {
+    val F = F0
+  }
+}

--- a/laws/shared/src/main/scala/cats/effect/laws/USyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/USyncLaws.scala
@@ -31,7 +31,7 @@ trait USyncLaws[F[_]] extends MonadLaws[F] {
   def delayCatchThrowIsPureLeft[A](e: Throwable) =
     F.delayCatch[A](throw e) <-> F.pure(Either.left(e))
 
-  def unsequencedDelayIsNoop[A](a: A, f: A => A) = {
+  def unsequencedDelayCatchIsNoop[A](a: A, f: A => A) = {
     var cur = a
     val change = F delayCatch { cur = f(cur) }
     val _ = change

--- a/laws/shared/src/main/scala/cats/effect/laws/USyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/USyncLaws.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package laws
+
+import cats.implicits._
+import cats.laws._
+
+
+trait USyncLaws[F[_]] extends MonadLaws[F] {
+  implicit def F: USync[F]
+
+  def delayCatchConstantIsPure[A](a: A) =
+    F.delayCatch(a) <-> F.pure(Either.right(a))
+
+  def delayCatchThrowIsPureLeft[A](e: Throwable) =
+    F.delayCatch[A](throw e) <-> F.pure(Either.left(e))
+
+  def unsequencedDelayIsNoop[A](a: A, f: A => A) = {
+    var cur = a
+    val change = F delayCatch { cur = f(cur) }
+    val _ = change
+
+    F.delayCatch(cur) <-> F.pure(Either.right(a))
+  }
+
+  def bindSuspendsEvaluation[A](fa: F[A], a1: A, f: (A, A) => A) = {
+    var state = a1
+    val evolve = F.flatMap(fa) { a2 =>
+      state = f(a1, a2)
+      F.pure(state)
+    }
+    // Observing `state` before and after `evolve`
+    F.map2(F.pure(state), evolve)(f) <-> F.map(fa)(a2 => f(a1, f(a1, a2)))
+  }
+
+  def mapSuspendsEvaluation[A](fa: F[A], a1: A, f: (A, A) => A) = {
+    var state = a1
+    val evolve = F.map(fa) { a2 =>
+      state = f(a1, a2)
+      state
+    }
+    // Observing `state` before and after `evolve`
+    F.map2(F.pure(state), evolve)(f) <-> F.map(fa)(a2 => f(a1, f(a1, a2)))
+  }
+
+  def stackSafetyOnRepeatedLeftBinds(iterations: Int) = {
+    val result = (0 until iterations).foldLeft(F.delayUnit(())) { (acc, _) =>
+      acc.flatMap(_ => F.delayUnit(()))
+    }
+    result <-> F.pure(())
+  }
+
+  def stackSafetyOnRepeatedRightBinds(iterations: Int) = {
+    val result = (0 until iterations).foldRight(F.delayUnit(())) { (_, acc) =>
+      F.delayUnit(()).flatMap(_ => acc)
+    }
+    result <-> F.pure(())
+  }
+
+  def stackSafetyOnRepeatedMaps(iterations: Int) = {
+    // Note this isn't enough to guarantee stack safety, unless
+    // coupled with `mapSuspendsEvaluation`
+    val result = (0 until iterations).foldLeft(F.delayDefault(0)(0)) { (acc, _) =>
+      F.map(acc)(_ + 1)
+    }
+    result <-> F.pure(iterations)
+  }
+}
+
+object USyncLaws {
+  def apply[F[_]](implicit F0: USync[F]): USyncLaws[F] = new USyncLaws[F] {
+    val F = F0
+  }
+}

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/Arbitrary.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/Arbitrary.scala
@@ -23,6 +23,7 @@ import cats.effect.IO.Par
 import cats.effect.internals.IORunLoop
 import org.scalacheck.Arbitrary.{arbitrary => getArbitrary}
 import org.scalacheck._
+
 import scala.util.Either
 
 object arbitrary {
@@ -31,6 +32,10 @@ object arbitrary {
 
   implicit def catsEffectLawsArbitraryForIOParallel[A: Arbitrary: Cogen]: Arbitrary[IO.Par[A]] =
     Arbitrary(catsEffectLawsArbitraryForIO[A].arbitrary.map(Par.apply))
+
+  implicit def arbitraryUIO[A: Arbitrary: Cogen]: Arbitrary[UIO[A]] =
+    Arbitrary(catsEffectLawsArbitraryForIO[A].arbitrary.map(io => UIO.create(io)))
+
 
   def genIO[A: Arbitrary: Cogen]: Gen[IO[A]] = {
     Gen.frequency(

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
@@ -24,7 +24,7 @@ import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import org.scalacheck._, Prop.forAll
 
-trait AsyncTests[F[_]] extends SyncTests[F] {
+trait AsyncTests[F[_]] extends SyncTests[F] with UAsyncTests[F] {
   def laws: AsyncLaws[F]
 
   def async[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](
@@ -56,7 +56,7 @@ trait AsyncTests[F[_]] extends SyncTests[F] {
     new RuleSet {
       val name = "async"
       val bases = Nil
-      val parents = Seq(sync[A, B, C])
+      val parents = Seq(sync[A, B, C], uasync[A, B, C])
       val props = {
         val safeTests = Seq(
           "async right is pure" -> forAll(laws.asyncRightIsPure[A] _),

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/SyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/SyncTests.scala
@@ -25,7 +25,7 @@ import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import org.scalacheck._, Prop.forAll
 
 
-trait SyncTests[F[_]] extends BracketTests[F, Throwable] {
+trait SyncTests[F[_]] extends BracketTests[F, Throwable] with USyncTests[F] {
 
   def laws: SyncLaws[F]
 
@@ -58,8 +58,7 @@ trait SyncTests[F[_]] extends BracketTests[F, Throwable] {
     new RuleSet {
       val name = "sync"
       val bases = Nil
-      val parents = Seq(bracket[A, B, C])
-
+      val parents = Seq(bracket[A, B, C], usync[A, B, C])
 
       val props = Seq(
         "bracket release is called for success" -> forAll(laws.bracketReleaseCalledForSuccess[A, B, C] _),
@@ -71,12 +70,7 @@ trait SyncTests[F[_]] extends BracketTests[F, Throwable] {
         "unsequenced delay is no-op" -> forAll(laws.unsequencedDelayIsNoop[A] _),
         "repeated sync evaluation not memoized" -> forAll(laws.repeatedSyncEvaluationNotMemoized[A] _),
         "propagate errors through bind (suspend)" -> forAll(laws.propagateErrorsThroughBindSuspend[A] _),
-        "bind suspends evaluation" -> forAll(laws.bindSuspendsEvaluation[A] _),
-        "map suspends evaluation" -> forAll(laws.mapSuspendsEvaluation[A] _),
-        "stack-safe on left-associated binds" -> Prop.lzy(laws.stackSafetyOnRepeatedLeftBinds(params.stackSafeIterationsCount)),
-        "stack-safe on right-associated binds" -> Prop.lzy(laws.stackSafetyOnRepeatedRightBinds(params.stackSafeIterationsCount)),
-        "stack-safe on repeated attempts" -> Prop.lzy(laws.stackSafetyOnRepeatedAttempts(params.stackSafeIterationsCount)),
-        "stack-safe on repeated maps" -> Prop.lzy(laws.stackSafetyOnRepeatedMaps(params.stackSafeIterationsCount)))
+        "stack-safe on repeated attempts" -> Prop.lzy(laws.stackSafetyOnRepeatedAttempts(params.stackSafeIterationsCount)))
     }
   }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/UConcurrentTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/UConcurrentTests.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package laws
+package discipline
+
+import cats.laws.discipline._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import org.scalacheck._, Prop.forAll
+
+trait UConcurrentTests[F[_]] extends UAsyncTests[F] {
+  def laws: UConcurrentLaws[F]
+
+  def uconcurrent[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](
+    implicit
+    ArbFA: Arbitrary[F[A]],
+    ArbFB: Arbitrary[F[B]],
+    ArbFC: Arbitrary[F[C]],
+    ArbFAtoB: Arbitrary[F[A => B]],
+    ArbFBtoC: Arbitrary[F[B => C]],
+    ArbT: Arbitrary[Throwable],
+    CogenA: Cogen[A],
+    CogenB: Cogen[B],
+    CogenC: Cogen[C],
+    EqFA: Eq[F[A]],
+    EqFB: Eq[F[B]],
+    EqFC: Eq[F[C]],
+    EqFU: Eq[F[Unit]],
+    EqFEitherTA: Eq[F[Either[Throwable, A]]],
+    EqFABC: Eq[F[(A, B, C)]],
+    EqFInt: Eq[F[Int]],
+    iso: Isomorphisms[F],
+    params: Parameters): RuleSet = {
+
+    new RuleSet {
+      val name = "uconcurrent"
+      val bases = Nil
+      val parents = Seq(uasync[A, B, C])
+      val props = Seq(
+        "asyncCatch cancelable coherence" -> forAll(laws.asyncCatchCancelableCatchCoherence[A] _),
+        "asyncCatch cancelable receives cancel signal" -> forAll(laws.asyncCatchCancelableReceivesCancelSignal[A] _),
+        "start then join is identity" -> forAll(laws.startJoinIsIdentity[A] _),
+        "join is idempotent" -> forAll(laws.joinIsIdempotent[A] _),
+        "start.flatMap(_.cancel) is unit" -> forAll(laws.startCancelIsUnit[A] _),
+        "uncancelable mirrors source" -> forAll(laws.uncancelableMirrorsSource[A] _),
+        "uncancelable prevents cancelation" -> forAll(laws.uncancelablePreventsCancelation[A] _),
+        "race mirrors left winner" -> forAll(laws.raceMirrorsLeftWinner[A] _),
+        "race mirrors right winner" -> forAll(laws.raceMirrorsRightWinner[A] _),
+        "race cancels loser" -> forAll(laws.raceCancelsLoser[A, B] _),
+        "race cancels both" -> forAll(laws.raceCancelsBoth[A, B, C] _),
+        "racePair mirrors left winner" -> forAll(laws.racePairMirrorsLeftWinner[A] _),
+        "racePair mirrors right winner" -> forAll(laws.racePairMirrorsRightWinner[B] _),
+        "racePair cancels both" -> forAll(laws.racePairCancelsBoth[A, B, C] _),
+        "racePair can join left" -> forAll(laws.racePairCanJoinLeft[A] _),
+        "racePair can join right" -> forAll(laws.racePairCanJoinRight[A] _))
+    }
+  }
+}
+
+object UConcurrentTests {
+  def apply[F[_]: UConcurrent]: UConcurrentTests[F] = new UConcurrentTests[F] {
+    def laws: UConcurrentLaws[F] = UConcurrentLaws[F]
+  }
+}

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestInstances.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestInstances.scala
@@ -16,8 +16,10 @@
 
 package cats.effect.laws.util
 
-import cats.effect.IO
-import cats.kernel.Eq
+import cats.Eq
+import cats.effect.{IO, UIO}
+import cats.instances.eq._
+import cats.syntax.contravariant._
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
@@ -49,6 +51,9 @@ trait TestInstances {
       def eqv(x: IO.Par[A], y: IO.Par[A]): Boolean =
         eqFuture[A].eqv(unwrap(x).unsafeToFuture(), unwrap(y).unsafeToFuture())
     }
+
+  implicit def eqUIO[A](implicit A: Eq[A], ec: TestContext): Eq[UIO[A]] =
+    eqIO[A].contramap(uio => UIO.runUIO(uio))
 
   /**
    * Defines equality for `Future` references that can

--- a/laws/shared/src/test/scala/cats/effect/UIOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/UIOTests.scala
@@ -16,19 +16,13 @@
 
 package cats.effect
 
-import cats.Monad
-import simulacrum._
+import cats.effect.laws.discipline.{UConcurrentTests}
+import cats.kernel.laws.discipline.MonoidTests
+import cats.implicits._
+import cats.effect.laws.discipline.arbitrary._
 
-@typeclass
-trait USync[F[_]] extends Monad[F] {
-  def delayCatch[A](thunk: => A): F[Either[Throwable, A]]
+class UIOTests extends BaseTestsSuite {
 
-  def delayUnit(thunk: => Unit): F[Unit] =
-    map(delayCatch(thunk))(_.getOrElse(()))
-
-  def delayDefault[A](thunk: => A)(a: A): F[A] =
-    map(delayCatch(thunk))(_.getOrElse(a))
-
-  def bewareDelayNoCatch[A](thunk: => A): F[A] =
-    map(delayCatch[A](thunk))(_.right.get)
+  checkAllAsync("UIO", implicit ec => MonoidTests[UIO[Int]].monoid)
+  checkAllAsync("UIO", implicit ec => UConcurrentTests[UIO].uconcurrent[Int, Int, Int])
 }


### PR DESCRIPTION
This is a WIP I started some time ago to address #176 as well as #67. It adds a newtype for `IO` called `UIO` that's taken from what I created in `cats-uio`.
I recognize there is no consensus on this issue at all, but I had this WIP on my computer for a while and wanted to maybe restart discussion around it. 
I still strongly believe this would be a valuable addition to this project, but also realize that we're adding a lot of stuff that makes the hierarchy a tad more complex.

I think this is a fully source compatible change, but it's probably not binary compatible, which is unfortunate.