### PR TITLE
Documentation for Resource, Deferred, Ref & Semaphore

### DIFF
--- a/site/src/main/resources/microsite/data/menu.yml
+++ b/site/src/main/resources/microsite/data/menu.yml
@@ -12,13 +12,34 @@ options:
         url: datatypes/fiber.html
         menu_section: fiber
 
+      - title: Resource
+        url: datatypes/resource.html
+        menu_section: resource
+
       - title: Timer
         url: datatypes/timer.html
         menu_section: timer
 
+  - title: Concurrency
+    url: concurrency/
+    menu_section: concurrency
+
+    nested_options:
+      - title: Deferred
+        url: concurrency/deferred.html
+        menu_section: deferred
+
       - title: MVar
-        url: datatypes/mvar.html
+        url: concurrency/mvar.html
         menu_section: mvar
+
+      - title: Ref
+        url: concurrency/ref.html
+        menu_section: ref
+
+      - title: Semaphore
+        url: concurrency/semaphore.html
+        menu_section: semaphore
 
   - title: Type Classes
     url: typeclasses/

--- a/site/src/main/tut/concurrency/deferred.md
+++ b/site/src/main/tut/concurrency/deferred.md
@@ -1,0 +1,66 @@
+---
+layout: docsplus
+title:  "Deferred"
+number: 12
+source: "shared/src/main/scala/cats/effect/concurrent/Deferred.scala"
+scaladoc: "#cats.effect.concurrent.Deferred"
+---
+
+A purely functional synchronization primitive which represents a single value which may not yet be available.
+
+When created, a `Deferred` is empty. It can then be completed exactly once, and never be made empty again.
+
+```tut:book:silent
+abstract class Deferred[F[_], A] {
+  def get: F[A]
+  def complete(a: A): F[Unit]
+}
+```
+
+### Expected behavior of `get`
+
+- `get` on an empty `Deferred` will block until the `Deferred` is completed.
+- `get` on a completed `Deferred` will always immediately return its content.
+
+### Expected behavior of `complete`
+
+- `complete(a)` on an empty `Deferred` will set it to `a`, and notify any and all readers currently blocked on a call to `get`.
+- `complete(a)` on a `Deferred` that has already been completed will not modify its content, and result in a failed `F`.
+
+### Notes
+
+Albeit simple, `Deferred` can be used in conjunction with `Ref` to build complex concurrent behaviour and data structures like queues and semaphores.
+
+Finally, the blocking mentioned above is semantic only, no actual threads are blocked by the implementation.
+
+### Only Once
+
+Whenever you are in a scenario when many processes can modify the same value but you only care about the first one in doing so and stop processing, then this is a great use case of `Deferred[F, A]`.
+
+Two processes will try to complete at the same time but only one will succeed, completing the deferred primitive exactly once. The loser one will raise an error when trying to complete a deferred already completed and automatically be canceled by the `IO.race` mechanism, that’s why we call attempt on the evaluation.
+
+```tut:book
+import cats.Parallel
+import cats.effect.{Concurrent, IO}
+import cats.effect.concurrent.Deferred
+import cats.implicits._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+implicit val par: Parallel[IO, IO] = Parallel[IO, IO.Par].asInstanceOf[Parallel[IO, IO]]
+
+def start(d: Deferred[IO, Int]): IO[Unit] = {
+  val attemptCompletion: Int => IO[Unit] = n => d.complete(n).attempt.void
+
+  List(
+    IO.race(attemptCompletion(1), attemptCompletion(2)),
+    d.get.flatMap { n => IO(println(s"Result: $n")) }
+  ).parSequence.void
+}
+
+val program: IO[Unit] =
+  for {
+    d <- Deferred[IO, Int]
+    _ <- start(d)
+  } yield ()
+```

--- a/site/src/main/tut/concurrency/index.md
+++ b/site/src/main/tut/concurrency/index.md
@@ -1,0 +1,12 @@
+---
+layout: docs
+title:  "Concurrency"
+position: 2
+---
+
+# Concurrency
+
+- **[Deferred](./deferred.html)**: pure concurrency primitive built on top of `scala.concurrent.Promise`.
+- **[MVar](./mvar.html)**: a purely functional concurrency primitive that works like a concurrent queue
+- **[Ref](./ref.html)**: pure concurrency primitive built on top of `java.util.concurrent.atomic.AtomicReference`.
+- **[Semaphore](./semaphore.html)**: a pure functional semaphore.

--- a/site/src/main/tut/concurrency/mvar.md
+++ b/site/src/main/tut/concurrency/mvar.md
@@ -1,6 +1,6 @@
 ---
 layout: docsplus
-title:  "IO"
+title:  "MVar"
 number: 12
 source: "shared/src/main/scala/cats/effect/concurrent/MVar.scala"
 scaladoc: "#cats.effect.concurrent.MVar"
@@ -8,6 +8,14 @@ scaladoc: "#cats.effect.concurrent.MVar"
 
 An `MVar` is a mutable location that can be empty or contains a value,
 asynchronously blocking reads when empty and blocking writes when full.
+
+```tut:book:silent
+abstract class MVar[F[_], A] {
+  def put(a: A): F[Unit]
+  def take: F[A]
+  def read: F[A]
+}
+```
 
 ## Introduction
 
@@ -27,7 +35,7 @@ It has two fundamental (atomic) operations:
   to a `take` followed by a `put`
 - `read`: which reads the current value without modifying the `MVar`,
   assuming there is a value available, or otherwise it waits until a value
-  is made available via `put` 
+  is made available via `put`
 
 <p class="extra" markdown='1'>
 In this context "<i>asynchronous blocking</i>" means that we are not blocking
@@ -60,7 +68,7 @@ import cats.effect._
 import cats.effect.concurrent._
 import cats.syntax.all._
 
-def sum(state: MVar[IO,Int], list: List[Int]): IO[Int] =
+def sum(state: MVar[IO, Int], list: List[Int]): IO[Int] =
   list match {
     case Nil => state.take
     case x :: xs =>
@@ -69,7 +77,7 @@ def sum(state: MVar[IO,Int], list: List[Int]): IO[Int] =
       }
   }
 
-MVar[IO].init(0).flatMap(sum(_, (0 until 100).toList))
+MVar.of[IO, Int](0).flatMap(sum(_, (0 until 100).toList))
 ```
 
 This sample isn't very useful, except to show how `MVar` can be used

--- a/site/src/main/tut/concurrency/ref.md
+++ b/site/src/main/tut/concurrency/ref.md
@@ -1,0 +1,80 @@
+---
+layout: docsplus
+title:  "Ref"
+number: 13
+source: "shared/src/main/scala/cats/effect/concurrent/Ref.scala"
+scaladoc: "#cats.effect.concurrent.Ref"
+---
+
+An asynchronous, concurrent mutable reference.
+
+```tut:book:silent
+import cats.data.State
+
+abstract class Ref[F[_], A] {
+  def get: F[A]
+  def set(a: A): F[Unit]
+  def modify[B](f: A => (A, B)): F[B]
+  // ... and much more
+}
+```
+
+Provides safe concurrent access and modification of its content, but no functionality for synchronisation, which is instead handled by `Deferred`.
+
+For this reason, a `Ref` is always initialised to a value.
+
+The default implementation is nonblocking and lightweight, consisting essentially of a purely functional wrapper over an `AtomicReference`.
+
+### Concurrent Counter
+
+This is probably one of the most common uses of this concurrency primitive.
+
+The workers will concurrently run and modify the value of the Ref so this is one possible outcome showing “#worker » currentCount”:
+
+```
+#1 >> 0
+#3 >> 0
+#2 >> 0
+#1 >> 2
+#2 >> 3
+#3 >> 3
+```
+
+```tut:book
+import cats.Parallel
+import cats.effect.{IO, Sync}
+import cats.effect.concurrent.Ref
+import cats.implicits._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class Worker[F[_]](number: Int, ref: Ref[F, Int])(implicit F: Sync[F]) {
+
+  private def putStrLn(value: String): F[Unit] = F.delay(println(value))
+
+  def start: F[Unit] =
+    for {
+      c1 <- ref.get
+      _  <- putStrLn("#$number >> $c1")
+      _  <- ref.modify(x => (x, x + 1))
+      c2 <- ref.get
+      _  <- putStrLn("#$number >> $c2")
+    } yield ()
+
+}
+
+implicit val par: Parallel[IO, IO] = Parallel[IO, IO.Par].asInstanceOf[Parallel[IO, IO]]
+
+val program: IO[Unit] =
+  for {
+    ref <- Ref.of[IO, Int](0)
+    w1  = new Worker[IO](1, ref)
+    w2  = new Worker[IO](2, ref)
+    w3  = new Worker[IO](3, ref)
+    _   <- List(
+             IO.shift *> w1.start,
+             IO.shift *> w2.start,
+             IO.shift *> w3.start
+           ).parSequence.void
+  } yield ()
+```

--- a/site/src/main/tut/concurrency/semaphore.md
+++ b/site/src/main/tut/concurrency/semaphore.md
@@ -1,0 +1,88 @@
+---
+layout: docsplus
+title:  "Semaphore"
+number: 15
+source: "shared/src/main/scala/cats/effect/concurrent/Semaphore.scala"
+scaladoc: "#cats.effect.concurrent.Semaphore"
+---
+
+A semaphore has a non-negative number of permits available. Acquiring a permit decrements the current number of permits and releasing a permit increases the current number of permits. An acquire that occurs when there are no permits available results in semantic blocking until a permit becomes available.
+
+```tut:book:silent
+abstract class Semaphore[F[_]] {
+  def available: F[Long]
+  def acquire: F[Unit]
+  def release: F[Unit]
+  // ... and much more
+}
+```
+
+### On Blocking
+
+- Blocking acquires are cancelable if the semaphore is created with `Semaphore.apply` (and hence, with a `Concurrent[F]` instance).
+- Blocking acquires are non-cancelable if the semaphore is created with `Semaphore.async` (and hence, with an `Async[F]` instance).
+
+### Shared Resource
+
+When multiple processes try to access a precious resource you might want to constraint the number of accesses. Here is where `Semaphore[F]` is useful.
+
+Three processes are trying to access a shared resource at the same time but only one at a time will be granted access and the next process have to wait until the resource gets available again (availability is one as indicated by the semaphore counter).
+
+`R1`, `R2` & `R3` will request access of the precious resource concurrently so this could be one possible outcome:
+
+```
+R1 >> Availability: 1
+R2 >> Availability: 1
+R2 >> Started | Availability: 0
+R3 >> Availability: 0
+--------------------------------
+R1 >> Started | Availability: 0
+R2 >> Done | Availability: 0
+--------------------------------
+R3 >> Started | Availability: 0
+R1 >> Done | Availability: 0
+--------------------------------
+R3 >> Done | Availability: 1
+```
+
+This means when `R1` and `R2` requested the availability it was one and `R2` was faster in getting access to the resource so it started processing. `R3` was the slowest and saw that there was no availability from the beginning.
+
+Once `R2` was done `R1` started processing immediately showing no availability. Once `R1` was done `R3` started processing immediately showing no availability. Finally, `R3` was done showing an availability of one once again.
+
+```tut:book
+import cats.Parallel
+import cats.effect.{Concurrent, IO, Timer}
+import cats.effect.concurrent.Semaphore
+import cats.implicits._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+class PreciousResource[F[_]](name: String, s: Semaphore[F])(implicit F: Concurrent[F], T: Timer[F]) {
+
+  def use: F[Unit] =
+    for {
+      x <- s.available
+      _ <- F.delay(println(s"$name >> Availability: $x"))
+      _ <- s.acquire
+      y <- s.available
+      _ <- F.delay(println(s"$name >> Started | Availability: $y"))
+      _ <- T.sleep(3.seconds)
+      _ <- s.release
+      z <- s.available
+      _ <- F.delay(println(s"$name >> Done | Availability: $z"))
+    } yield ()
+
+}
+
+implicit val par: Parallel[IO, IO] = Parallel[IO, IO.Par].asInstanceOf[Parallel[IO, IO]]
+
+val program: IO[Unit] =
+  for {
+    s  <- Semaphore[IO](1)
+    r1 = new PreciousResource[IO]("R1", s)
+    r2 = new PreciousResource[IO]("R2", s)
+    r3 = new PreciousResource[IO]("R3", s)
+    _  <- List(IO.shift *> r1.use, IO.shift *> r2.use, IO.shift *> r3.use).parSequence.void
+  } yield ()
+```

--- a/site/src/main/tut/datatypes/index.md
+++ b/site/src/main/tut/datatypes/index.md
@@ -6,10 +6,7 @@ position: 1
 
 # Data Types
 
-- **[IO](./io.html)**: data type for encoding side effects as pure values
-- **[Fiber](./fiber.html)**: the pure result of a [Concurrent](../typeclasses/concurrent.html) data type being started concurrently and that can be either joined or canceled
-- **[Timer](./timer.html)**: a pure scheduler exposing operations for measuring time and for delaying execution
-
-## Concurrent
-
-- **[MVar](./mvar.html)**: a purely functional concurrency primitive that works like a concurrent queue
+- **[IO](./io.html)**: data type for encoding side effects as pure values.
+- **[Fiber](./fiber.html)**: the pure result of a [Concurrent](../typeclasses/concurrent.html) data type being started concurrently and that can be either joined or canceled.
+- **[Resource](./resource.html)**: resource management data type that complements the `Bracket` typeclass.
+- **[Timer](./timer.html)**: a pure scheduler exposing operations for measuring time and for delaying execution.


### PR DESCRIPTION
Adding the microsite documentation for the types introduced by #188 and #196 .

Examples for `Deferred` and `Ref` were taken from [fs2 concurrency primitives](https://functional-streams-for-scala.github.io/fs2/concurrency-primitives.html) (which I was the author) and adapted to `Cats Effect`. Note that this is still not compiled through `tut` because the source is yet not merged, I will update this PR once it's done.

Example for `Resource` was taken from the Scala doc and adapted to compile with `tut`.

EDIT: Added docs for `Semaphore` with examples taken from the `fs2` guide as well.

~The typeclasses diagram is now missing the `Resource` typeclass, call for~ @Zelenya :smiley: 