### PR TITLE
Add timeout for IO and generic F

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -24,6 +24,8 @@ import cats.effect.internals.IORunLoop
 import cats.syntax.all._
 
 import scala.annotation.implicitNotFound
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration.FiniteDuration
 import scala.util.Either
 
 /**
@@ -423,6 +425,24 @@ object Concurrent {
           }
         }
     }
+
+  /**
+   * Returns an effect that either completes with the result of `fa` within the specified `FiniteDuration`
+   * or evaluates the `fallback`.
+   */
+
+  def timeoutTo[F[_], A](fa: F[A], after: FiniteDuration, fallback: F[A])(implicit F: Concurrent[F], timer: Timer[F]): F[A] =
+    F.race(fa, timer.sleep(after)) flatMap {
+      case Left((a, _)) => F.pure(a)
+      case Right(_) => fallback
+    }
+
+  /**
+   * Returns an effect that either completes with a result of `F[A]` or raises a `TimeoutException`.
+   */
+
+  def timeout[F[_], A](fa: F[A], after: FiniteDuration)(implicit F: Concurrent[F], timer: Timer[F]): F[A] =
+    timeoutTo(fa, after, F.raiseError(new TimeoutException(after.toString)))
 
   /**
    * [[Concurrent]] instance built for `cats.data.EitherT` values initialized

--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -433,7 +433,7 @@ object Concurrent {
 
   def timeoutTo[F[_], A](fa: F[A], after: FiniteDuration, fallback: F[A])(implicit F: Concurrent[F], timer: Timer[F]): F[A] =
     F.race(fa, timer.sleep(after)) flatMap {
-      case Left((a, _)) => F.pure(a)
+      case Left(a) => F.pure(a)
       case Right(_) => fallback
     }
 

--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -351,29 +351,7 @@ trait Concurrent[F[_]] extends Async[F] {
    * The two tasks are potentially executed in parallel, the winner
    * being the first that signals a result.
    *
-   * As an example, this would be the implementation of a "timeout"
-   * operation:
-   *
-   * {{{
-   *   import cats.effect._
-   *   import scala.concurrent.duration._
-   *
-   *   def timeoutTo[F[_], A](fa: F[A], after: FiniteDuration, fallback: F[A])
-   *     (implicit F: Concurrent[F], timer: Timer[F]): F[A] = {
-   *
-   *      F.race(fa, timer.sleep(after)).flatMap {
-   *        case Left((a, _)) => F.pure(a)
-   *        case Right((_, _)) => fallback
-   *      }
-   *   }
-   *
-   *   def timeout[F[_], A](fa: F[A], after: FiniteDuration)
-   *     (implicit F: Concurrent[F], timer: Timer[F]): F[A] = {
-   *
-   *      timeoutTo(fa, after,
-   *        F.raiseError(new TimeoutException(after.toString)))
-   *   }
-   * }}}
+   * As an example see [[Concurrent.timeoutTo]]
    *
    * Also see [[racePair]] for a version that does not cancel
    * the loser automatically on successful results.
@@ -429,6 +407,10 @@ object Concurrent {
   /**
    * Returns an effect that either completes with the result of `fa` within the specified `FiniteDuration`
    * or evaluates the `fallback`.
+   *
+   * The `fa` is cancelled in the event that it takes longer than the `FiniteDuration`
+   * to complete. Cancellation of an `fa` does not equate to immediate interruption of the `fa`.
+   * A completed cancel simply means that it has been asked to cancel.
    */
 
   def timeoutTo[F[_], A](fa: F[A], after: FiniteDuration, fallback: F[A])(implicit F: Concurrent[F], timer: Timer[F]): F[A] =
@@ -439,6 +421,10 @@ object Concurrent {
 
   /**
    * Returns an effect that either completes with a result of `F[A]` or raises a `TimeoutException`.
+   *
+   * The `fa` is cancelled in the event that it takes longer than the `FiniteDuration`
+   * to complete. Cancellation of an `fa` does not equate to immediate interruption of the `fa`.
+   * A completed cancel simply means that it has been asked to cancel.
    */
 
   def timeout[F[_], A](fa: F[A], after: FiniteDuration)(implicit F: Concurrent[F], timer: Timer[F]): F[A] =

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -402,7 +402,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * Returns this IO that either completes with the result of this IO within the specified `FiniteDuration`
    * or evaluates the `fallback`.
    */
-  final def timeoutTo[A](after: FiniteDuration, fallback: IO[A])(implicit timer: Timer[IO]): IO[A] =
+  final def timeoutTo(after: FiniteDuration, fallback: IO[A @uncheckedVariance])(implicit timer: Timer[IO]): IO[A] =
     IO.race(this, timer.sleep(after)) flatMap {
       case Left(a) => IO.pure(a)
       case Right(_) => fallback
@@ -412,7 +412,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * Returns this IO that either completes with the result of this IO within the specified `FiniteDuration`
    * or raises a `TimeoutException`.
    */
-  final def timeout[A](after: FiniteDuration)(implicit timer: Timer[IO]): IO[A] =
+  final def timeout(after: FiniteDuration)(implicit timer: Timer[IO]): IO[A] =
     timeoutTo(after, IO.raiseError(new TimeoutException(after.toString)))
 
   /**

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -402,7 +402,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * Returns this IO that either completes with the result of this IO within the specified `FiniteDuration`
    * or evaluates the `fallback`.
    */
-  final def timeoutTo(after: FiniteDuration, fallback: IO[A @uncheckedVariance])(implicit timer: Timer[IO]): IO[A] =
+  final def timeoutTo[A2 >: A](after: FiniteDuration, fallback: IO[A2])(implicit timer: Timer[IO]): IO[A2] =
     IO.race(this, timer.sleep(after)) flatMap {
       case Left(a) => IO.pure(a)
       case Right(_) => fallback
@@ -413,7 +413,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * or raises a `TimeoutException`.
    */
   final def timeout(after: FiniteDuration)(implicit timer: Timer[IO]): IO[A] =
-    timeoutTo(after, IO.raiseError(new TimeoutException(after.toString)))
+    timeoutTo(after, IO.raiseError(new TimeoutException(after.toString)))(timer)
 
   /**
    * Returns an `IO` action that treats the source task as the

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -404,7 +404,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    */
   final def timeoutTo[A](after: FiniteDuration, fallback: IO[A])(implicit timer: Timer[IO]): IO[A] =
     IO.race(this, timer.sleep(after)) flatMap {
-      case Left((a, _)) => IO.pure(a)
+      case Left(a) => IO.pure(a)
       case Right(_) => fallback
     }
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -408,7 +408,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * A completed cancel simply means that it has been asked to cancel.
    */
   final def timeoutTo[A2 >: A](after: FiniteDuration, fallback: IO[A2])(implicit timer: Timer[IO]): IO[A2] =
-    Concurrent.timeoutTo(this, after, fallback)
+    Concurrent.timeoutTo(this, after, fallback)(ioConcurrentEffect, timer)
 
   /**
    * Returns this IO that either completes with the result of this IO within the specified `FiniteDuration`

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -403,10 +403,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * or evaluates the `fallback`.
    */
   final def timeoutTo[A2 >: A](after: FiniteDuration, fallback: IO[A2])(implicit timer: Timer[IO]): IO[A2] =
-    IO.race(this, timer.sleep(after)) flatMap {
-      case Left(a) => IO.pure(a)
-      case Right(_) => fallback
-    }
+    Concurrent.timeoutTo(this, after, fallback)
 
   /**
    * Returns this IO that either completes with the result of this IO within the specified `FiniteDuration`


### PR DESCRIPTION
Adds timeoutTo and timeout to enable timeouts for IO and F

per https://github.com/typelevel/cats-effect/issues/209