### PR TITLE
Ref.of builder

### DIFF
--- a/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
@@ -108,7 +108,7 @@ object Semaphore {
   /** Creates a new `Semaphore`, initialized with `n` available permits. */
   def apply[F[_]](n: Long)(implicit F: Concurrent[F]): F[Semaphore[F]] = {
     assertNonNegative[F](n) *>
-      Ref[F](Right(n): State[F]).map(stateRef => new ConcurrentSemaphore(stateRef))
+      Ref.of[F, State[F]](Right(n)).map(stateRef => new ConcurrentSemaphore(stateRef))
   }
 
   /**
@@ -117,7 +117,7 @@ object Semaphore {
    */
   def async[F[_]](n: Long)(implicit F: Async[F]): F[Semaphore[F]] = {
     assertNonNegative[F](n) *>
-      Ref[F](Right(n): State[F]).map(stateRef => new AsyncSemaphore(stateRef))
+      Ref.of[F, State[F]](Right(n)).map(stateRef => new AsyncSemaphore(stateRef))
   }
   
   private abstract class AbstractSemaphore[F[_]](state: Ref[F, State[F]])(implicit F: Async[F]) extends Semaphore[F] {

--- a/core/shared/src/test/scala/cats/effect/concurrent/DeferredTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/DeferredTests.scala
@@ -49,7 +49,7 @@ class DeferredTests extends AsyncFunSuite with Matchers with EitherValues {
 
     test(s"$label - get blocks until set") {
       val op = for {
-        state <- Ref[IO](0)
+        state <- Ref[IO].of(0)
         modifyGate <- pc[Unit]
         readGate <- pc[Unit]
         _ <- IO.shift *> (modifyGate.get *> state.update(_ * 2) *> readGate.complete(())).start
@@ -66,7 +66,7 @@ class DeferredTests extends AsyncFunSuite with Matchers with EitherValues {
 
   private def cancelBeforeForcing(pc: IO[Deferred[IO, Int]]): IO[Option[Int]] = 
     for {
-        r <- Ref[IO](Option.empty[Int])
+        r <- Ref[IO].of(Option.empty[Int])
         p <- pc
         fiber <- p.get.start
         _ <- fiber.cancel

--- a/core/shared/src/test/scala/cats/effect/concurrent/MVarTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/MVarTests.scala
@@ -371,8 +371,8 @@ abstract class BaseMVarTests extends AsyncFunSuite with Matchers {
     val count = if (Platform.isJvm) 10000 else 1000
     val task = for {
       mVar <- empty[Int]
-      ref <- Ref[IO, Int](0)
-      takes = (0 until count).map(_ => IO.shift *> mVar.read.map2(mVar.take)(_ + _).flatMap(x => ref.modify(_ + x))).toList.parSequence
+      ref <- Ref[IO].of(0)
+      takes = (0 until count).map(_ => IO.shift *> mVar.read.map2(mVar.take)(_ + _).flatMap(x => ref.update(_ + x))).toList.parSequence
       puts = (0 until count).map(_ => IO.shift *> mVar.put(1)).toList.parSequence
       fiber1 <- takes.start
       fiber2 <- puts.start

--- a/core/shared/src/test/scala/cats/effect/concurrent/RefTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/RefTests.scala
@@ -37,14 +37,14 @@ class RefTests extends AsyncFunSuite with Matchers {
 
   test("concurrent modifications") {
     val finalValue = 100
-    val r = Ref.unsafe[IO](0)
+    val r = Ref.unsafe[IO, Int](0)
     val modifies = List.fill(finalValue)(IO.shift *> r.update(_ + 1)).sequence
     run(IO.shift *> modifies.start *> awaitEqual(r.get, finalValue))
   }
 
   test("access - successful") {
     val op = for {
-      r <- Ref[IO](0)
+      r <- Ref[IO].of(0)
       valueAndSetter <- r.access
       (value, setter) = valueAndSetter
       success <- setter(value + 1)
@@ -55,7 +55,7 @@ class RefTests extends AsyncFunSuite with Matchers {
 
   test("access - setter should fail if value is modified before setter is called") {
     val op = for {
-      r <- Ref[IO](0)
+      r <- Ref[IO].of(0)
       valueAndSetter <- r.access
       (value, setter) = valueAndSetter
       _ <- r.set(5)
@@ -67,7 +67,7 @@ class RefTests extends AsyncFunSuite with Matchers {
 
   test("access - setter should fail if called twice") {
     val op = for {
-      r <- Ref[IO](0)
+      r <- Ref[IO].of(0)
       valueAndSetter <- r.access
       (value, setter) = valueAndSetter
       cond1 <- setter(value + 1)


### PR DESCRIPTION
- Ref.ApplyBuilders is introduced and made public, similar to #217
- Refs can be constructed as Ref[F, A].of(a) or Ref[F].of(a)
- Unsafe builder is only available as a version with all type parameters