### PR TITLE
Rename MVar.init to of and async suffix to uncancelable

### DIFF
--- a/core/shared/src/main/scala/cats/effect/concurrent/Deferred.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Deferred.scala
@@ -89,15 +89,15 @@ object Deferred {
     new ConcurrentDeferred[F, A](new AtomicReference(Deferred.State.Unset(LinkedMap.empty)))
 
   /** Creates an unset promise that only requires an `Async[F]` and does not support cancelation of `get`. **/
-  def async[F[_], A](implicit F: Async[F]): F[Deferred[F, A]] =
-    F.delay(unsafeAsync[F, A])
+  def uncancelable[F[_], A](implicit F: Async[F]): F[Deferred[F, A]] =
+    F.delay(unsafeUncancelable[F, A])
 
   /**
     * Like `async` but returns the newly allocated promise directly instead of wrapping it in `F.delay`.
     * This method is considered unsafe because it is not referentially transparent -- it allocates
     * mutable state.
     */
-  def unsafeAsync[F[_]: Async, A]: Deferred[F, A] =
+  def unsafeUncancelable[F[_]: Async, A]: Deferred[F, A] =
     new AsyncDeferred[F, A](Promise[A]())
 
   private final class Id

--- a/core/shared/src/main/scala/cats/effect/concurrent/MVar.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/MVar.scala
@@ -107,7 +107,7 @@ object MVar {
    *   MVar[IO].init("hello") <-> MVar.init[IO, String]("hello")
    * }}}
    *
-   * @see [[init]], [[initF]] and [[empty]]
+   * @see [[of]], [[ofF]] and [[empty]]
    */
   def apply[F[_]](implicit F: Concurrent[F]): ApplyBuilders[F] =
     new ApplyBuilders[F](F)
@@ -115,7 +115,7 @@ object MVar {
   /**
    * Creates a cancelable `MVar` that starts as empty.
    *
-   * @see [[emptyAsync]] for non-cancelable MVars
+   * @see [[uncancelableEmpty]] for non-cancelable MVars
    *
    * @param F is a [[Concurrent]] constraint, needed in order to
    *        describe cancelable operations
@@ -130,14 +130,14 @@ object MVar {
    *
    * @see [[empty]] for creating cancelable MVars
    */
-  def emptyAsync[F[_], A](implicit F: Async[F]): F[MVar[F, A]] =
+  def uncancelableEmpty[F[_], A](implicit F: Async[F]): F[MVar[F, A]] =
     F.delay(MVarAsync.empty)
 
   /**
    * Creates a cancelable `MVar` that's initialized to an `initial`
    * value.
    *
-   * @see [[initAsync]] for non-cancelable MVars
+   * @see [[uncancelableOf]] for non-cancelable MVars
    *
    * @param initial is a value that will be immediately available
    *        for the first `read` or `take` operation
@@ -145,7 +145,7 @@ object MVar {
    * @param F is a [[Concurrent]] constraint, needed in order to
    *        describe cancelable operations
    */
-  def init[F[_], A](initial: A)(implicit F: Concurrent[F]): F[MVar[F, A]] =
+  def of[F[_], A](initial: A)(implicit F: Concurrent[F]): F[MVar[F, A]] =
     F.delay(MVarConcurrent(initial))
 
   /**
@@ -154,35 +154,37 @@ object MVar {
    *
    * The resulting `MVar` has non-cancelable operations.
    *
-   * @see [[init]] for creating cancelable MVars
+   * @see [[of]] for creating cancelable MVars
    */
-  def initAsync[F[_], A](initial: A)(implicit F: Async[F]): F[MVar[F, A]] =
+  def uncancelableOf[F[_], A](initial: A)(implicit F: Async[F]): F[MVar[F, A]] =
     F.delay(MVarAsync(initial))
 
   /**
    * Creates a cancelable `MVar` initialized with a value given
    * in the `F[A]` context, thus the initial value being lazily evaluated.
    *
-   * @see [[init]] for creating MVars initialized with strict values
-   * @see [[initAsyncF]] for building non-cancelable MVars
+   * @see [[of]] for creating MVars initialized with strict values
+   * @see [[uncancelableOfF]] for building non-cancelable MVars
+ *
    * @param fa is the value that's going to be used as this MVar's
    *        initial value, available then for the first `take` or `read`
    * @param F is a [[Concurrent]] constraint, needed in order to
    *        describe cancelable operations
    */
-  def initF[F[_], A](fa: F[A])(implicit F: Concurrent[F]): F[MVar[F, A]] =
+  def ofF[F[_], A](fa: F[A])(implicit F: Concurrent[F]): F[MVar[F, A]] =
     F.map(fa)(MVarConcurrent.apply(_))
 
   /**
    * Creates a non-cancelable `MVar` initialized with a value given
    * in the `F[A]` context, thus the initial value being lazily evaluated.
    *
-   * @see [[initAsync]] for creating MVars initialized with strict values
-   * @see [[initF]] for building cancelable MVars
+   * @see [[uncancelableOf]] for creating MVars initialized with strict values
+   * @see [[ofF]] for building cancelable MVars
+ *
    * @param fa is the value that's going to be used as this MVar's
    *        initial value, available then for the first `take` or `read`
    */
-  def initAsyncF[F[_], A](fa: F[A])(implicit F: Async[F]): F[MVar[F, A]] =
+  def uncancelableOfF[F[_], A](fa: F[A])(implicit F: Async[F]): F[MVar[F, A]] =
     F.map(fa)(MVarAsync.apply(_))
 
   /**
@@ -192,18 +194,18 @@ object MVar {
     /**
      * Builds an `MVar` with an initial value.
      *
-     * @see documentation for [[MVar.init]]
+     * @see documentation for [[MVar.of]]
      */
-    def init[A](a: A): F[MVar[F, A]] =
-      MVar.init(a)(F)
+    def of[A](a: A): F[MVar[F, A]] =
+      MVar.of(a)(F)
 
     /**
      * Builds an `MVar` with an initial value that's lazily evaluated.
      *
-     * @see documentation for [[MVar.initF]]
+     * @see documentation for [[MVar.ofF]]
      */
-    def initF[A](fa: F[A]): F[MVar[F, A]] =
-      MVar.initF(fa)(F)
+    def ofF[A](fa: F[A]): F[MVar[F, A]] =
+      MVar.ofF(fa)(F)
 
     /**
      * Builds an empty `MVar`. 

--- a/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
@@ -115,7 +115,7 @@ object Semaphore {
    * Like [[apply]] but only requires an `Async` constraint in exchange for the various
    * acquire effects being uncancelable.
    */
-  def async[F[_]](n: Long)(implicit F: Async[F]): F[Semaphore[F]] = {
+  def uncancelable[F[_]](n: Long)(implicit F: Async[F]): F[Semaphore[F]] = {
     assertNonNegative[F](n) *>
       Ref.of[F, State[F]](Right(n)).map(stateRef => new AsyncSemaphore(stateRef))
   }
@@ -251,7 +251,7 @@ object Semaphore {
   }
 
   private final class AsyncSemaphore[F[_]](state: Ref[F, State[F]])(implicit F: Async[F]) extends AbstractSemaphore(state) {
-    protected def mkGate: F[Deferred[F, Unit]] = Deferred.async[F, Unit]
+    protected def mkGate: F[Deferred[F, Unit]] = Deferred.uncancelable[F, Unit]
     protected def awaitGate(entry: (Long, Deferred[F, Unit])): F[Unit] = entry._2.get
   }
 }

--- a/core/shared/src/test/scala/cats/effect/concurrent/DeferredTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/DeferredTests.scala
@@ -62,7 +62,7 @@ class DeferredTests extends AsyncFunSuite with Matchers with EitherValues {
   }
 
   tests("concurrent", new DeferredConstructor { def apply[A] = Deferred[IO, A] })
-  tests("async", new DeferredConstructor { def apply[A] = Deferred.async[IO, A] })
+  tests("async", new DeferredConstructor { def apply[A] = Deferred.uncancelable[IO, A] })
 
   private def cancelBeforeForcing(pc: IO[Deferred[IO, Int]]): IO[Option[Int]] = 
     for {
@@ -82,6 +82,6 @@ class DeferredTests extends AsyncFunSuite with Matchers with EitherValues {
   }
 
   test("async - get - cancel before forcing") {
-    cancelBeforeForcing(Deferred.async).unsafeToFuture.map(_ shouldBe Some(42))
+    cancelBeforeForcing(Deferred.uncancelable).unsafeToFuture.map(_ shouldBe Some(42))
   }
 }

--- a/core/shared/src/test/scala/cats/effect/concurrent/MVarTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/MVarTests.scala
@@ -25,10 +25,10 @@ import scala.concurrent.duration._
 
 class MVarConcurrentTests extends BaseMVarTests {
   def init[A](a: A): IO[MVar[IO, A]] =
-    MVar[IO].init(a)
+    MVar[IO].of(a)
 
   def initF[A](fa: IO[A]): IO[MVar[IO, A]] =
-    MVar[IO].initF(fa)
+    MVar[IO].ofF(fa)
 
   def empty[A]: IO[MVar[IO, A]] =
     MVar[IO].empty[A]
@@ -71,7 +71,7 @@ class MVarConcurrentTests extends BaseMVarTests {
   test("read is cancelable") {
     val task = for {
       mVar <- MVar[IO].empty[Int]
-      finished <- Deferred.async[IO, Int]
+      finished <- Deferred.uncancelable[IO, Int]
       fiber <- mVar.read.flatMap(finished.complete).start
       _ <- fiber.cancel
       _ <- mVar.put(10)
@@ -87,13 +87,13 @@ class MVarConcurrentTests extends BaseMVarTests {
 
 class MVarAsyncTests extends BaseMVarTests {
   def init[A](a: A): IO[MVar[IO, A]] =
-    MVar.initAsync(a)
+    MVar.uncancelableOf(a)
 
   def initF[A](fa: IO[A]): IO[MVar[IO, A]] =
-    MVar.initAsyncF(fa)
+    MVar.uncancelableOfF(fa)
 
   def empty[A]: IO[MVar[IO, A]] =
-    MVar.emptyAsync
+    MVar.uncancelableEmpty
 }
 
 abstract class BaseMVarTests extends AsyncFunSuite with Matchers {

--- a/core/shared/src/test/scala/cats/effect/concurrent/SemaphoreTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/SemaphoreTests.scala
@@ -61,5 +61,5 @@ class SemaphoreTests extends AsyncFunSuite with Matchers with EitherValues {
   }
 
   tests("concurrent", n => Semaphore[IO](n))
-  tests("async", n => Semaphore.async[IO](n))
+  tests("async", n => Semaphore.uncancelable[IO](n))
 }


### PR DESCRIPTION
A thing discussed on gitter, a follow-up to now-closed #220.

* `MVar.init` to `MVar.of`.
* `async` suffixes in factory methods are renamed to `uncancelable`. I think this is more intuitive, as word *async* is typically used to indicate something non-blocking, not something non-cancelable. Also, having `MVar.ofAsync(a)` would be quite misleading :)