### PR TITLE
Remove MVar.ofF (previous initF)

### DIFF
--- a/core/shared/src/main/scala/cats/effect/concurrent/MVar.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/MVar.scala
@@ -107,7 +107,7 @@ object MVar {
    *   MVar[IO].init("hello") <-> MVar.init[IO, String]("hello")
    * }}}
    *
-   * @see [[of]], [[ofF]] and [[empty]]
+   * @see [[of]]and [[empty]]
    */
   def apply[F[_]](implicit F: Concurrent[F]): ApplyBuilders[F] =
     new ApplyBuilders[F](F)
@@ -160,34 +160,6 @@ object MVar {
     F.delay(MVarAsync(initial))
 
   /**
-   * Creates a cancelable `MVar` initialized with a value given
-   * in the `F[A]` context, thus the initial value being lazily evaluated.
-   *
-   * @see [[of]] for creating MVars initialized with strict values
-   * @see [[uncancelableOfF]] for building non-cancelable MVars
- *
-   * @param fa is the value that's going to be used as this MVar's
-   *        initial value, available then for the first `take` or `read`
-   * @param F is a [[Concurrent]] constraint, needed in order to
-   *        describe cancelable operations
-   */
-  def ofF[F[_], A](fa: F[A])(implicit F: Concurrent[F]): F[MVar[F, A]] =
-    F.map(fa)(MVarConcurrent.apply(_))
-
-  /**
-   * Creates a non-cancelable `MVar` initialized with a value given
-   * in the `F[A]` context, thus the initial value being lazily evaluated.
-   *
-   * @see [[uncancelableOf]] for creating MVars initialized with strict values
-   * @see [[ofF]] for building cancelable MVars
- *
-   * @param fa is the value that's going to be used as this MVar's
-   *        initial value, available then for the first `take` or `read`
-   */
-  def uncancelableOfF[F[_], A](fa: F[A])(implicit F: Async[F]): F[MVar[F, A]] =
-    F.map(fa)(MVarAsync.apply(_))
-
-  /**
    * Returned by the [[apply]] builder.
    */
   final class ApplyBuilders[F[_]](val F: Concurrent[F]) extends AnyVal {
@@ -198,14 +170,6 @@ object MVar {
      */
     def of[A](a: A): F[MVar[F, A]] =
       MVar.of(a)(F)
-
-    /**
-     * Builds an `MVar` with an initial value that's lazily evaluated.
-     *
-     * @see documentation for [[MVar.ofF]]
-     */
-    def ofF[A](fa: F[A]): F[MVar[F, A]] =
-      MVar.ofF(fa)(F)
 
     /**
      * Builds an empty `MVar`. 

--- a/core/shared/src/test/scala/cats/effect/concurrent/MVarTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/MVarTests.scala
@@ -27,9 +27,6 @@ class MVarConcurrentTests extends BaseMVarTests {
   def init[A](a: A): IO[MVar[IO, A]] =
     MVar[IO].of(a)
 
-  def initF[A](fa: IO[A]): IO[MVar[IO, A]] =
-    MVar[IO].ofF(fa)
-
   def empty[A]: IO[MVar[IO, A]] =
     MVar[IO].empty[A]
 
@@ -89,9 +86,6 @@ class MVarAsyncTests extends BaseMVarTests {
   def init[A](a: A): IO[MVar[IO, A]] =
     MVar.uncancelableOf(a)
 
-  def initF[A](fa: IO[A]): IO[MVar[IO, A]] =
-    MVar.uncancelableOfF(fa)
-
   def empty[A]: IO[MVar[IO, A]] =
     MVar.uncancelableEmpty
 }
@@ -101,7 +95,6 @@ abstract class BaseMVarTests extends AsyncFunSuite with Matchers {
     ExecutionContext.Implicits.global
   
   def init[A](a: A): IO[MVar[IO, A]]
-  def initF[A](fa: IO[A]): IO[MVar[IO, A]]
   def empty[A]: IO[MVar[IO, A]]
 
   test("empty; put; take; put; take") {
@@ -351,19 +344,6 @@ abstract class BaseMVarTests extends AsyncFunSuite with Matchers {
 
     for (r <- task.unsafeToFuture()) yield {
       r shouldBe true
-    }
-  }
-
-  test("initF works") {
-    val task = for {
-      channel <- initF(IO(10))
-      r1 <- channel.read
-      r2 <- channel.read
-      r3 <- channel.take
-    } yield List(r1, r2, r3)
-
-    for (r <- task.unsafeToFuture()) yield {
-      r shouldBe List(10, 10, 10)
     }
   }
 


### PR DESCRIPTION
Removing `MVar.ofF` and `MVar.uncancelableOfF`, because they are just mapping `F[_]` and I'm not sure if it helps with anything.

In cats-effect it's better if the API surface is smaller. We can reconsider afterwards.