### PR TITLE
NonFatal changes - handling InterruptedException and being publicly available

### DIFF
--- a/core/js/src/main/scala/cats/effect/internals/TrampolineEC.scala
+++ b/core/js/src/main/scala/cats/effect/internals/TrampolineEC.scala
@@ -19,6 +19,8 @@ package cats.effect.internals
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 
+import cats.effect.misc.NonFatal
+
 /** INTERNAL API — a [[scala.concurrent.ExecutionContext]] implementation
   * that executes runnables immediately, on the current thread,
   * by means of a trampoline implementation.

--- a/core/jvm/src/main/scala/cats/effect/internals/TrampolineEC.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/TrampolineEC.scala
@@ -19,6 +19,8 @@ package cats.effect.internals
 import scala.annotation.tailrec
 import scala.concurrent.{BlockContext, CanAwait, ExecutionContext}
 
+import cats.effect.misc.NonFatal
+
 /** INTERNAL API — a [[scala.concurrent.ExecutionContext]] implementation
   * that executes runnables immediately, on the current thread,
   * by means of a trampoline implementation.

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -22,11 +22,12 @@ import cats.effect.internals.Callback.Extensions
 import cats.effect.internals._
 import cats.effect.internals.TrampolineEC.immediate
 import cats.effect.internals.IOPlatform.fusionMaxStackDepth
-
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, Promise, TimeoutException}
 import scala.util.{Failure, Left, Right, Success}
+
+import cats.effect.misc.NonFatal
 
 /**
  * A pure abstraction representing the intention to perform a

--- a/core/shared/src/main/scala/cats/effect/internals/Cancelable.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/Cancelable.scala
@@ -19,6 +19,8 @@ package cats.effect.internals
 import cats.effect.util.CompositeException
 import scala.collection.mutable.ListBuffer
 
+import cats.effect.misc.NonFatal
+
 /**
  * INTERNAL API - utilities for dealing with cancelable thunks.
  */

--- a/core/shared/src/main/scala/cats/effect/internals/IOParMap.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOParMap.scala
@@ -18,8 +18,11 @@ package cats.effect.internals
 
 import cats.effect.IO
 import cats.effect.internals.Callback.Extensions
+
 import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.ExecutionContext
+
+import cats.effect.misc.NonFatal
 
 private[effect] object IOParMap {
   import Callback.{Type => Callback}

--- a/core/shared/src/main/scala/cats/effect/internals/IORunLoop.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IORunLoop.scala
@@ -18,8 +18,9 @@ package cats.effect.internals
 
 import cats.effect.IO
 import cats.effect.IO.{Async, Bind, Delay, Map, Pure, RaiseError, Suspend}
-
 import scala.collection.mutable.ArrayStack
+
+import cats.effect.misc.NonFatal
 
 private[effect] object IORunLoop {
   private type Current = IO[Any]

--- a/core/shared/src/main/scala/cats/effect/misc/NonFatal.scala
+++ b/core/shared/src/main/scala/cats/effect/misc/NonFatal.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package cats.effect.internals
+package cats.effect.misc
 
 /**
  * Extractor of non-fatal `Throwable` instances.
@@ -22,11 +22,15 @@ package cats.effect.internals
  * Alternative to [[scala.util.control.NonFatal]] that only
  * considers `VirtualMachineError`s as fatal.
  *
- * Inspired by the FS2 implementation.
+ * Inspired by the FS2 implementation and adjustments to Monix implementation
+ * by Jakub Kozlowski (@kubukoz)
  */
-private[effect] object NonFatal {
+object NonFatal {
   def apply(t: Throwable): Boolean = t match {
     case _: VirtualMachineError => false
+    case _: InterruptedException =>
+      Thread.currentThread().interrupt()
+      true
     case _ => true
   }
 

--- a/core/shared/src/test/scala/cats/effect/internals/TestUtils.scala
+++ b/core/shared/src/test/scala/cats/effect/internals/TestUtils.scala
@@ -16,6 +16,8 @@
 
 package cats.effect.internals
 
+import cats.effect.misc.NonFatal
+
 import java.io.{ByteArrayOutputStream, PrintStream}
 
 /**

--- a/core/shared/src/test/scala/cats/effect/misc/NonFatalTests.scala
+++ b/core/shared/src/test/scala/cats/effect/misc/NonFatalTests.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package cats.effect.internals
+package cats.effect.misc
+
+import scala.util.control.ControlThrowable
 
 import org.scalatest.FunSuite
-import scala.util.control.ControlThrowable
 
 class NonFatalTests extends FunSuite {
   test("catches ThreadDeath") {
@@ -65,5 +66,16 @@ class NonFatalTests extends FunSuite {
           fail("Should not catch VirtualMachineError")
       }
     }
+  }
+
+  test("restores interrupted status on InterruptedException") {
+    try {
+       throw new InterruptedException
+     } catch {
+       case NonFatal(_) =>
+         assert(Thread.interrupted())
+       case _: Throwable =>
+         fail("Should catch InterruptedException")
+     }
   }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
@@ -17,13 +17,13 @@
 package cats.effect.laws.util
 
 import cats.effect.internals.Cancelable.{Type => Cancelable}
-import cats.effect.internals.NonFatal
 import cats.effect.{IO, LiftIO, Timer}
-
 import scala.collection.immutable.SortedSet
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.{Duration, FiniteDuration, TimeUnit}
 import scala.util.Random
+
+import cats.effect.misc.NonFatal
 
 /**
  * A `scala.concurrent.ExecutionContext` implementation and a provider


### PR DESCRIPTION
Fixes #181

- NonFatal restored interruption status when InterruptedException is caught
- NonFatal is moved to package cats.effect.misc and made public