### PR TITLE
Bracket instance for Kleisli

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -211,7 +211,10 @@ val mimaSettings = Seq(
       exclude[DirectMissingMethodProblem]("cats.effect.internals.IOFrame.errorHandler"),
       // New stuff
       exclude[ReversedMissingMethodProblem]("cats.effect.internals.IOConnection.tryReactivate"),
-      exclude[DirectMissingMethodProblem]("cats.effect.internals.IOCancel#RaiseCancelable.this")
+      exclude[DirectMissingMethodProblem]("cats.effect.internals.IOCancel#RaiseCancelable.this"),
+      exclude[IncompatibleTemplateDefProblem]("cats.effect.Concurrent$KleisliConcurrent"),
+      exclude[IncompatibleTemplateDefProblem]("cats.effect.Sync$KleisliSync"),
+      exclude[IncompatibleTemplateDefProblem]("cats.effect.Async$KleisliAsync")
     )
   })
 

--- a/core/shared/src/main/scala/cats/effect/Async.scala
+++ b/core/shared/src/main/scala/cats/effect/Async.scala
@@ -270,8 +270,9 @@ object Async {
       WriterT.liftF(F.async(k))(L, FA)
   }
 
-  private[effect] trait KleisliAsync[F[_], R] extends Async[Kleisli[F, R, ?]]
-    with Sync.KleisliSync[F, R] {
+  private[effect] abstract class KleisliAsync[F[_], R]
+    extends Sync.KleisliSync[F, R]
+    with Async[Kleisli[F, R, ?]] {
 
     override protected implicit def F: Async[F]
 

--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -551,7 +551,7 @@ object Concurrent {
               F.pure(Some(Right((fiberT[A](fiberA), r))))
           }
       })
-      
+
     def uncancelable[A](fa: OptionT[F, A]): OptionT[F, A] =
       OptionT(F.uncancelable(fa.value))
 
@@ -634,8 +634,9 @@ object Concurrent {
       Fiber(WriterT(fiber.join), WriterT.liftF(fiber.cancel))
   }
 
-  private[effect] trait KleisliConcurrent[F[_], R] extends Concurrent[Kleisli[F, R, ?]]
-    with Async.KleisliAsync[F, R] {
+  private[effect] abstract class KleisliConcurrent[F[_], R]
+    extends Async.KleisliAsync[F, R]
+    with Concurrent[Kleisli[F, R, ?]] {
 
     override protected implicit def F: Concurrent[F]
     // Needed to drive static checks, otherwise the

--- a/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
@@ -33,6 +33,8 @@ class InstancesTests extends BaseTestsSuite {
 
   checkAllAsync("Kleisli[IO, ?]",
     implicit ec => ConcurrentTests[Kleisli[IO, Int, ?]].concurrent[Int, Int, Int])
+  checkAllAsync("Kleisli[IO, ?]",
+    implicit ec => BracketTests[Kleisli[IO, Int, ?], Throwable].bracket[Int, Int, Int])
 
   checkAllAsync("EitherT[IO, Throwable, ?]",
     implicit ec => ConcurrentEffectTests[EitherT[IO, Throwable, ?]].concurrentEffect[Int, Int, Int])


### PR DESCRIPTION
This is a first step towards fixing #216: adds a `Bracket` instance for `Kleisli`.