### PR TITLE
WIP: Create Bracket instances

### DIFF
--- a/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
@@ -25,11 +25,15 @@ import cats.laws.discipline.arbitrary._
 
 class InstancesTests extends BaseTestsSuite {
 
-  checkAllAsync("StateT[IO, S, ?]",
+  checkAllAsync("StateT[IO, Int, ?]",
     implicit ec => ConcurrentEffectTests[StateT[IO, Int, ?]].concurrentEffect[Int, Int, Int])
+  checkAllAsync("StateT[IO, Int, ?]",
+    implicit ec => BracketTests[StateT[IO, Int, ?], Throwable].bracket[Int, Int, Int])
 
   checkAllAsync("OptionT[IO, ?]",
     implicit ec => ConcurrentTests[OptionT[IO, ?]].concurrent[Int, Int, Int])
+  checkAllAsync("OptionT[IO, ?]",
+    implicit ec => BracketTests[OptionT[IO, ?], Throwable].bracket[Int, Int, Int])
 
   checkAllAsync("Kleisli[IO, ?]",
     implicit ec => ConcurrentTests[Kleisli[IO, Int, ?]].concurrent[Int, Int, Int])


### PR DESCRIPTION
Created Bracket instance for both `StateT` and `OptionT` and mix-in `Bracket` instances to `Sync` instances

Use Bracket instances for `StateT` and `Option`T on `Sync` instances and
removed Bracket-specific implementations on `Sync` instances

Test if Bracket Law holds for the instances

Partially solves issue #216 