### PR TITLE
Fix: Semaphore.async -> Semaphore.uncancelable in docs

### DIFF
--- a/site/src/main/tut/concurrency/semaphore.md
+++ b/site/src/main/tut/concurrency/semaphore.md
@@ -20,7 +20,7 @@ abstract class Semaphore[F[_]] {
 ### On Blocking
 
 - Blocking acquires are cancelable if the semaphore is created with `Semaphore.apply` (and hence, with a `Concurrent[F]` instance).
-- Blocking acquires are non-cancelable if the semaphore is created with `Semaphore.async` (and hence, with an `Async[F]` instance).
+- Blocking acquires are non-cancelable if the semaphore is created with `Semaphore.uncancelable` (and hence, with an `Async[F]` instance).
 
 ### Shared Resource
 


### PR DESCRIPTION
A very small change to docs I missed in #222, when Semaphore.async builder was renamed to Semaphore.uncancelable.