### PR TITLE
Do not forcibly exit on ExitCode.Success

### DIFF
--- a/core/js/src/main/scala/cats/effect/internals/IOAppPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOAppPlatform.scala
@@ -27,6 +27,8 @@ private[effect] object IOAppPlatform {
       case Left(t) =>
         IO(Logger.reportFailure(t)) *>
         IO(sys.exit(ExitCode.Error.code))
+      case Right(0) =>
+        IO.unit
       case Right(code) =>
         IO(sys.exit(code))
     }.unsafeRunSync()

--- a/core/shared/src/main/scala/cats/effect/IOApp.scala
+++ b/core/shared/src/main/scala/cats/effect/IOApp.scala
@@ -20,13 +20,21 @@ package effect
 import cats.effect.internals.IOAppPlatform
 
 /**
- * `App` type that runs a [[cats.effect.IO]] and exits with the
- * returned code.  If the `IO` raises an error, then the stack trace
- * is printed to standard error and the JVM exits with code 1.
+ * `App` type that runs a [[cats.effect.IO]].  Shutdown occurs after
+ * the `IO` completes, as follows:
+ *
+ * - If completed with `ExitCode.Success`, the main method exits and
+ *   shutdown is handled by the platform.
+ *
+ * - If completed with any other [[ExitCode]], `sys.exit` is called
+ *   with the specified code.
+ *
+ * - If the `IO` raises an error, the stack trace is printed to
+ *   standard error and `sys.exit(1)` is called.
  *
  * When a shutdown is requested via a signal, the `IO` is canceled and
- * we wait for the `IO` to release any resources.  The JVM exits with
- * the numeric value of the signal plus 128.
+ * we wait for the `IO` to release any resources.  The process exits
+ * with the numeric value of the signal plus 128.
  *
  * {{{
  * import cats.effect.IO


### PR DESCRIPTION
Motivations:
- Spark cluster exits with code 16 when `sys.exit` is called.  This makes "successful" jobs fail.
- Returning main on success, rather than forcibly exiting, allows the natural shutdown for the platform to proceed.  For example, this gives any non-daemon threads a chance to finish their jobs on the JVM.