### PR TITLE
Use Throwable#addSupressed when IO.bracket fails in both use and release

### DIFF
--- a/core/js/src/main/scala/cats/effect/internals/IOPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOPlatform.scala
@@ -16,7 +16,10 @@
 
 package cats.effect.internals
 
+import cats.data.NonEmptyList
 import cats.effect.IO
+import cats.effect.util.CompositeException
+
 import scala.concurrent.duration.Duration
 
 private[effect] object IOPlatform {
@@ -44,7 +47,7 @@ private[effect] object IOPlatform {
 
   /**
    * Establishes the maximum stack depth for `IO#map` operations
-   * for JavaScript. 
+   * for JavaScript.
    *
    * The default for JavaScript is 32, from which we substract 1
    * as an optimization.
@@ -74,4 +77,17 @@ private[effect] object IOPlatform {
       }
     }
   }
+
+  /**
+   * Composes multiple errors together, meant for those cases in which
+   * error suppression, due to a second error being triggered, is not
+   * acceptable.
+   *
+   * On top of the JVM this function uses `Throwable#addSuppressed`,
+   * available since Java 7. On top of JavaScript the function would return
+   * a `CompositeException`.
+   */
+  def composeErrors(first: Throwable, rest: Throwable*): Throwable =
+    if (rest.isEmpty) first
+    else new CompositeException(first, NonEmptyList.fromListUnsafe(rest.toList))
 }

--- a/core/jvm/src/main/scala/cats/effect/internals/IOPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOPlatform.scala
@@ -23,7 +23,7 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.{Either, Try}
 
 private[effect] object IOPlatform {
-  /** 
+  /**
    * JVM-specific function that blocks for the result of an IO task.
    *
    * Uses the [[scala.concurrent.BlockContext]], instructing the
@@ -74,7 +74,7 @@ private[effect] object IOPlatform {
   /**
    * Establishes the maximum stack depth for `IO#map` operations.
    *
-   * The default is `128`, from which we substract one as an 
+   * The default is `128`, from which we substract one as an
    * optimization. This default has been reached like this:
    *
    *  - according to official docs, the default stack size on 32-bits
@@ -102,7 +102,29 @@ private[effect] object IOPlatform {
       .map(_ - 1)
       .getOrElse(127)
 
-  /** Returns `true` if the underlying platform is the JVM,
-    * `false` if it's JavaScript. */
+  /**
+   * Returns `true` if the underlying platform is the JVM,
+   * `false` if it's JavaScript.
+   */
   final val isJVM = true
+
+  /**
+   * Composes multiple errors together, meant for those cases in which
+   * error suppression, due to a second error being triggered, is not
+   * acceptable.
+   *
+   * On top of the JVM this function uses `Throwable#addSuppressed`,
+   * available since Java 7. On top of JavaScript the function would return
+   * a `CompositeException`.
+   */
+  def composeErrors(first: Throwable, rest: Throwable*): Throwable =
+    if (rest.isEmpty) first else {
+      val cursor = rest.iterator
+      while (cursor.hasNext) {
+        val next = cursor.next()
+        if (first ne next)
+          first.addSuppressed(next)
+      }
+      first
+    }
 }

--- a/core/jvm/src/main/scala/cats/effect/internals/IOPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOPlatform.scala
@@ -117,14 +117,8 @@ private[effect] object IOPlatform {
    * available since Java 7. On top of JavaScript the function would return
    * a `CompositeException`.
    */
-  def composeErrors(first: Throwable, rest: Throwable*): Throwable =
-    if (rest.isEmpty) first else {
-      val cursor = rest.iterator
-      while (cursor.hasNext) {
-        val next = cursor.next()
-        if (first ne next)
-          first.addSuppressed(next)
-      }
-      first
-    }
+  def composeErrors(first: Throwable, rest: Throwable*): Throwable = {
+    for (e <- rest) first.addSuppressed(e)
+    first
+  }
 }

--- a/core/shared/src/main/scala/cats/effect/internals/IOBracket.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOBracket.scala
@@ -58,12 +58,8 @@ private[effect] object IOBracket {
   private final class ReleaseRecover(e: Throwable)
     extends IOFrame[Unit, IO[Nothing]] {
 
-    def recover(e2: Throwable): IO[Nothing] = {
-      // Logging the error somewhere, because exceptions
-      // should never be silent
-      Logger.reportFailure(e2)
-      IO.raiseError(e)
-    }
+    def recover(e2: Throwable): IO[Nothing] =
+      IO.raiseError(IOPlatform.composeErrors(e, e2))
 
     def apply(a: Unit): IO[Nothing] =
       IO.raiseError(e)

--- a/laws/js/src/test/scala/cats/effect/IOJSTests.scala
+++ b/laws/js/src/test/scala/cats/effect/IOJSTests.scala
@@ -59,6 +59,11 @@ class IOJSTests extends AsyncFunSuite with Matchers {
       .attempt
       .unsafeRunSync()
 
-    r shouldEqual Left(CompositeException(e1, e2))
+    r.isLeft shouldBe true
+    r.left.get shouldBe a[CompositeException]
+
+    val err = r.left.get.asInstanceOf[CompositeException]
+    err.head shouldBe e1
+    err.tail.toList shouldBe List(e2)
   }
 }

--- a/laws/js/src/test/scala/cats/effect/IOJSTests.scala
+++ b/laws/js/src/test/scala/cats/effect/IOJSTests.scala
@@ -16,6 +16,7 @@
 
 package cats.effect
 
+import cats.effect.util.CompositeException
 import org.scalatest.{AsyncFunSuite, Matchers}
 
 import scala.concurrent.duration.{FiniteDuration, _}
@@ -48,5 +49,16 @@ class IOJSTests extends AsyncFunSuite with Matchers {
           succeed
       }
     }
+  }
+
+  test("bracket signals errors from both use and release via CompositeException") {
+    val e1 = new RuntimeException("e1")
+    val e2 = new RuntimeException("e2")
+
+    val r = IO.unit.bracket(_ => IO.raiseError(e1))(_ => IO.raiseError(e2))
+      .attempt
+      .unsafeRunSync()
+
+    r shouldEqual Left(CompositeException(e1, e2))
   }
 }


### PR DESCRIPTION
For `IO.bracket` we are logging the error in `release` in case `use` fails.

This PR changes the implementation such that:

1. on top of the JVM we are using `Throwable#addSupressed`, signaling the error in `use`, but with the error in `release` added as being suppressed
2. on top of JS we are bundling them together with `CompositeException`

```scala
IO.unit.bracket(_ => IO.raiseError(err1))(_ => IO.raiseError(err2))
```

On top of the JVM this piece of code should be equivalent with `IO.raiseError(err1)`, but `err2` is added as a "suppressed" error of `err1`. This is the standard way the JVM now deals with suppressed errors in its try-with-resources construct.