### PR TITLE
Provides effect type agnostic Console

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Console.scala
+++ b/core/shared/src/main/scala/cats/effect/Console.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+
+import cats.Show
+import cats.instances.string._
+import cats.syntax.show._
+
+/**
+ * Effect type agnostic `Console` with common methods to write and read from the standard console.
+ */
+trait Console[F[_]] {
+  /**
+   * Prints a message of type A to the standard console followed by a new line if an instance `Show[A]` is found.
+   */
+  def putStrLn[A: Show](a: A): F[Unit]
+
+  /**
+   * Prints a message to the standard console followed by a new line.
+   */
+  def putStrLn(str: String): F[Unit] = putStrLn[String](str)
+
+  /**
+   * Prints a message of type A to the standard console if an instance `Show[A]` is found.
+   */
+  def putStr[A: Show](a: A): F[Unit]
+
+  /**
+   * Prints a message to the standard console.
+   */
+  def putStr(str: String): F[Unit] = putStr[String](str)
+
+  /**
+   * Prints a message of type A to the standard error output stream if an instance `Show[A]` is found.
+   */
+  def error[A: Show](a: A): F[Unit]
+
+  /**
+   * Prints a message to the standard error output stream.
+   */
+  def error(str: String): F[Unit] = error[String](str)
+
+  /**
+   * Reads line from the standard console.
+   *
+   * @return a value representing the user's input or raise an error in the F context.
+   */
+  def readLine: F[String]
+}
+
+object Console {
+  /**
+   * Default instance for `Console[IO]`
+   */
+  object io extends SyncConsole[IO]
+}
+
+/**
+ * A default instance for any `F[_]` with a `Sync` instance.
+ *
+ * Use it either in a DSL style:
+ *
+ * {{{
+ *   import cats.effect._
+ *
+ *   object io extends SyncConsole[IO]
+ *
+ *   import io._
+ *
+ *   val program: IO[Unit] =
+ *     for {
+ *       _ <- putStrLn("Please enter your name: ")
+ *       n <- readLine
+ *       _ <- if (n.nonEmpty) putStrLn(s"Hello $$n!")
+ *            else error("Name is empty!")
+ *     }
+ * }}}
+ *
+ * Or in tagless final style:
+ *
+ * {{{
+ *   import cats.effect._
+ *
+ *   def myProgram[F[_]](implicit C: Console[F]): F[Unit] =
+ *     for {
+ *       _ <- C.putStrLn("Please enter your name: ")
+ *       n <- C.readLine
+ *       _ <- if (n.nonEmpty) C.putStrLn(s"Hello $$n!")
+ *            else C.error("Name is empty!")
+ *     }
+ * }}}
+ *
+ */
+class SyncConsole[F[_]](implicit F: Sync[F]) extends Console[F] {
+  def putStrLn[A: Show](a: A): F[Unit] =
+    F.delay(println(a.show))
+  def putStr[A: Show](a: A): F[Unit] =
+    F.delay(print(a.show))
+  def error[A: Show](a: A): F[Unit] =
+    F.delay(System.err.println(a.show))
+  def readLine: F[String] =
+    F.delay(scala.io.StdIn.readLine)
+}

--- a/core/shared/src/main/scala/cats/effect/Console.scala
+++ b/core/shared/src/main/scala/cats/effect/Console.scala
@@ -33,7 +33,7 @@ trait Console[F[_]] {
   /**
    * Prints a message to the standard console followed by a new line.
    */
-  def putStrLn(str: String): F[Unit] = putStrLn[String](str)
+  final def putStrLn(str: String): F[Unit] = putStrLn[String](str)
 
   /**
    * Prints a message of type A to the standard console if an instance `Show[A]` is found.
@@ -43,7 +43,7 @@ trait Console[F[_]] {
   /**
    * Prints a message to the standard console.
    */
-  def putStr(str: String): F[Unit] = putStr[String](str)
+  final def putStr(str: String): F[Unit] = putStr[String](str)
 
   /**
    * Prints a message of type A to the standard error output stream if an instance `Show[A]` is found.
@@ -53,7 +53,7 @@ trait Console[F[_]] {
   /**
    * Prints a message to the standard error output stream.
    */
-  def error(str: String): F[Unit] = error[String](str)
+  final def error(str: String): F[Unit] = error[String](str)
 
   /**
    * Reads line from the standard console.

--- a/site/src/main/resources/microsite/data/menu.yml
+++ b/site/src/main/resources/microsite/data/menu.yml
@@ -22,7 +22,11 @@ options:
 
       - title: IOApp
         url: datatypes/ioapp.html
-        menu_section: ioapp    
+        menu_section: ioapp
+
+      - title: Console
+        url: datatypes/console.html
+        menu_section: console
 
   - title: Concurrency
     url: concurrency/

--- a/site/src/main/tut/datatypes/console.md
+++ b/site/src/main/tut/datatypes/console.md
@@ -1,0 +1,55 @@
+---
+layout: docsplus
+title:  "Console"
+number: 16
+source: "core/shared/src/main/scala/cats/effect/Console.scala"
+scaladoc: "#cats.effect.Console"
+---
+
+`Console` is a convenient addon that provides common methods to read/write from/to the standard input/output stream.
+
+```tut:silent
+trait Console[F[_]] {
+trait Console[F[_]] {
+  def putStrLn(str: String): F[Unit]
+  def error(str: String): F[Unit]
+  def readLine: F[String]
+  // and some more...
+}
+```
+
+## Integration with `IO`
+
+All you need to have is the `import cats.effect.Console.io._` in scope. Eg:
+
+```tut:silent
+import cats.effect.IO
+import cats.effect.Console.io._
+
+val program: IO[Unit] =
+  for {
+    _ <- putStrLn("Enter your name: ")
+    n <- readLine
+    _ <- putStrLn(s"Welcome $n!")
+  } yield ()
+```
+
+## Integration with a polymorphic `F[_]`
+
+You can either implement your own instance of `Console[F[_]]` by extending it or use the default instance defined for `Sync[F]`. Here's an example with the latter as an implicit instance:
+
+```tut:reset:silent
+import cats.effect.{Console, Sync, SyncConsole}
+import cats.syntax.all._
+
+implicit def console[F[_]: Sync]: Console[F] = new SyncConsole[F]
+
+def program[F[_]: Sync](implicit C: Console[F]): F[Unit] =
+  for {
+    _ <- C.putStrLn("Enter your name: ")
+    n <- C.readLine
+    _ <- C.putStrLn(s"Welcome $n!")
+  } yield ()
+```
+
+**NOTE:** All the writing methods (`putStrln`, `error`, etc) accept any parameter of type `A` that define a `Show[A]` instance.

--- a/site/src/main/tut/datatypes/index.md
+++ b/site/src/main/tut/datatypes/index.md
@@ -10,3 +10,5 @@ position: 1
 - **[Fiber](./fiber.html)**: the pure result of a [Concurrent](../typeclasses/concurrent.html) data type being started concurrently and that can be either joined or canceled.
 - **[Resource](./resource.html)**: resource management data type that complements the `Bracket` typeclass.
 - **[Timer](./timer.html)**: a pure scheduler exposing operations for measuring time and for delaying execution.
+- **[IOApp](./ioapp.html)**: a safe application type that describes a main which executes a `cats.effect.IO`, as an entry point to a pure FP program.
+- **[Console](./console.html)**: data type for read and write from/to the standard input/output stream.


### PR DESCRIPTION
I think many of us were interested in at least having a `putStrLn(str: String): IO[Unit]` when `IOApp` was defined but it didn't happen and I missed that merge.

In this PR a `Console[F[_]]` datatype provides some common methods to write an read from the standard console. Don't know whether you guys think it's best to `IOApp extends Console[IO]` or pushing the decision to the user. I went for the first option but I'm open to suggestions. 

Also, I used `putStrLn`, `error` and `readLine` as names matching the standard in Haskell except for `readLine` that it's `getLine`, I like it better :) Open to suggestions here as well.