### PR TITLE
Fix IOPlatform.composeErrors

### DIFF
--- a/core/js/src/main/scala/cats/effect/internals/IOPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOPlatform.scala
@@ -87,7 +87,11 @@ private[effect] object IOPlatform {
    * available since Java 7. On top of JavaScript the function would return
    * a `CompositeException`.
    */
-  def composeErrors(first: Throwable, rest: Throwable*): Throwable =
-    if (rest.isEmpty) first
-    else new CompositeException(first, NonEmptyList.fromListUnsafe(rest.toList))
+  def composeErrors(first: Throwable, rest: Throwable*): Throwable = {
+    rest.filter(_ != first).toList match {
+      case Nil => first
+      case nonEmpty =>
+        new CompositeException(first, NonEmptyList.fromListUnsafe(nonEmpty))
+    }
+  }
 }

--- a/core/jvm/src/main/scala/cats/effect/internals/IOPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOPlatform.scala
@@ -118,7 +118,7 @@ private[effect] object IOPlatform {
    * a `CompositeException`.
    */
   def composeErrors(first: Throwable, rest: Throwable*): Throwable = {
-    for (e <- rest) first.addSuppressed(e)
+    for (e <- rest; if e != first) first.addSuppressed(e)
     first
   }
 }


### PR DESCRIPTION
Fixes `IOPlatform.composeErrors` to ignore duplicate references, or otherwise `addSuppressed` throws exception.