### PR TITLE
Fix IO.asyncF

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -204,10 +204,8 @@ trait Concurrent[F[_]] extends Async[F] {
    *     (implicit F: Concurrent[F], ec: ScheduledExecutorService): F[Unit] = {
    *
    *     F.cancelable { cb =>
-   *       // Note the callback is pure, so we need to trigger evaluation
-   *       val run = new Runnable { def run() = cb(Right(())) }
-   *
    *       // Schedules task to run after delay
+   *       val run = new Runnable { def run() = cb(Right(())) }
    *       val future = ec.schedule(run, d.length, d.unit)
    *
    *       // Cancellation logic, suspended in IO


### PR DESCRIPTION
I have to push a fix for `asyncF` — it has the quality of hooking into the underlying cancellation mechanism, however the underlying connection used is current used by both:

- the bind continuation of the generated `asyncF`
- the task generated by the registration function and the `runCancelable` that we are doing

This can create a race condition. It's not easy to reproduce, because we'd need to schedule tasks for execution *after* executing the callback. So a sample like this can screw with the run-loop:

```scala
IO.asyncF { cb =>
  IO(cb(Right(())) *> IO.sleep(1.second) *> IO(println("Fire and forget!"))
}
```

