### PR TITLE
Exclude non-terminating law from the default tests

### DIFF
--- a/laws/shared/src/main/scala/cats/effect/laws/ConcurrentLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ConcurrentLaws.scala
@@ -101,7 +101,7 @@ trait ConcurrentLaws[F[_]] extends AsyncLaws[F] {
       F.start(F.uncancelable(async)).flatMap(_.cancel) *> F.liftIO(p.get)
     }
     // Non-terminating
-    lh <-> F.async(_ => ())
+    lh <-> F.never
   }
 
   def acquireIsNotCancelable[A](a1: A, a2: A) = {

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
@@ -58,7 +58,7 @@ trait AsyncTests[F[_]] extends SyncTests[F] {
       val bases = Nil
       val parents = Seq(sync[A, B, C])
       val props = {
-        val safeTests = Seq(
+        val default = Seq(
           "async right is pure" -> forAll(laws.asyncRightIsPure[A] _),
           "async left is raiseError" -> forAll(laws.asyncLeftIsRaiseError[A] _),
           "repeated async evaluation not memoized" -> forAll(laws.repeatedAsyncEvaluationNotMemoized[A] _),
@@ -68,11 +68,11 @@ trait AsyncTests[F[_]] extends SyncTests[F] {
         // Activating the tests that detect non-termination only if allowed by Params,
         // because such tests might not be reasonable depending on evaluation model
         if (params.allowNonTerminationLaws)
-          safeTests ++ Seq(
+          default ++ Seq(
             "never is derived from async" -> Prop.lzy(laws.neverIsDerivedFromAsync[A])
           )
         else
-          safeTests
+          default
       }
     }
   }

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/ConcurrentTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/ConcurrentTests.scala
@@ -57,28 +57,38 @@ trait ConcurrentTests[F[_]] extends AsyncTests[F] {
       val name = "concurrent"
       val bases = Nil
       val parents = Seq(async[A, B, C])
-      val props = Seq(
-        "async cancelable coherence" -> forAll(laws.asyncCancelableCoherence[A] _),
-        "async cancelable receives cancel signal" -> forAll(laws.asyncCancelableReceivesCancelSignal[A] _),
-        "asyncF registration can be cancelled" -> forAll(laws.asyncFRegisterCanBeCancelled[A] _),
-        "bracket release is called on cancel" -> forAll(laws.cancelOnBracketReleases[A, B] _),
-        "start then join is identity" -> forAll(laws.startJoinIsIdentity[A] _),
-        "join is idempotent" -> forAll(laws.joinIsIdempotent[A] _),
-        "start.flatMap(_.cancel) is unit" -> forAll(laws.startCancelIsUnit[A] _),
-        "uncancelable mirrors source" -> forAll(laws.uncancelableMirrorsSource[A] _),
-        "uncancelable prevents cancellation" -> forAll(laws.uncancelablePreventsCancelation[A] _),
-        "acquire of bracket is not cancelable" -> forAll(laws.acquireIsNotCancelable[A] _),
-        "release of bracket is not cancelable" -> forAll(laws.releaseIsNotCancelable[A] _),
-        "race mirrors left winner" -> forAll(laws.raceMirrorsLeftWinner[A] _),
-        "race mirrors right winner" -> forAll(laws.raceMirrorsRightWinner[A] _),
-        "race cancels loser" -> forAll(laws.raceCancelsLoser[A, B] _),
-        "race cancels both" -> forAll(laws.raceCancelsBoth[A, B, C] _),
-        "racePair mirrors left winner" -> forAll(laws.racePairMirrorsLeftWinner[A] _),
-        "racePair mirrors right winner" -> forAll(laws.racePairMirrorsRightWinner[B] _),
-        "racePair cancels loser" -> forAll(laws.racePairCancelsLoser[A, B] _),
-        "racePair cancels both" -> forAll(laws.racePairCancelsBoth[A, B, C] _),
-        "racePair can join left" -> forAll(laws.racePairCanJoinLeft[A] _),
-        "racePair can join right" -> forAll(laws.racePairCanJoinRight[A] _))
+      val props = {
+        val default = Seq(
+          "async cancelable coherence" -> forAll(laws.asyncCancelableCoherence[A] _),
+          "async cancelable receives cancel signal" -> forAll(laws.asyncCancelableReceivesCancelSignal[A] _),
+          "asyncF registration can be cancelled" -> forAll(laws.asyncFRegisterCanBeCancelled[A] _),
+          "bracket release is called on cancel" -> forAll(laws.cancelOnBracketReleases[A, B] _),
+          "start then join is identity" -> forAll(laws.startJoinIsIdentity[A] _),
+          "join is idempotent" -> forAll(laws.joinIsIdempotent[A] _),
+          "start.flatMap(_.cancel) is unit" -> forAll(laws.startCancelIsUnit[A] _),
+          "uncancelable mirrors source" -> forAll(laws.uncancelableMirrorsSource[A] _),
+          "acquire of bracket is not cancelable" -> forAll(laws.acquireIsNotCancelable[A] _),
+          "release of bracket is not cancelable" -> forAll(laws.releaseIsNotCancelable[A] _),
+          "race mirrors left winner" -> forAll(laws.raceMirrorsLeftWinner[A] _),
+          "race mirrors right winner" -> forAll(laws.raceMirrorsRightWinner[A] _),
+          "race cancels loser" -> forAll(laws.raceCancelsLoser[A, B] _),
+          "race cancels both" -> forAll(laws.raceCancelsBoth[A, B, C] _),
+          "racePair mirrors left winner" -> forAll(laws.racePairMirrorsLeftWinner[A] _),
+          "racePair mirrors right winner" -> forAll(laws.racePairMirrorsRightWinner[B] _),
+          "racePair cancels loser" -> forAll(laws.racePairCancelsLoser[A, B] _),
+          "racePair cancels both" -> forAll(laws.racePairCancelsBoth[A, B, C] _),
+          "racePair can join left" -> forAll(laws.racePairCanJoinLeft[A] _),
+          "racePair can join right" -> forAll(laws.racePairCanJoinRight[A] _))
+
+        // Activating the tests that detect non-termination only if allowed by Params,
+        // because such tests might not be reasonable depending on evaluation model
+        if (params.allowNonTerminationLaws)
+            default ++ Seq(
+              "uncancelable prevents cancellation" -> forAll(laws.uncancelablePreventsCancelation[A] _)
+            )
+        else
+          default
+      }
     }
   }
 }


### PR DESCRIPTION
Non-terminating laws (i.e. testing equivalence with `F.never`) cannot be tested in case the evaluation in `Eq` is done via blocking threads (e.g. usage of `unsafeRunSync`).

The `uncancelablePreventsCancelation` law is such a law that needs a comparison with `F.never` and thus needs to be excluded.