### PR TITLE
Remove EffectLaws.runSyncStepAsyncNeverProducesLeftPureIO

### DIFF
--- a/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
@@ -53,10 +53,6 @@ trait EffectLaws[F[_]] extends AsyncLaws[F] {
     F.runSyncStep(F.async[A](k)) <-> IO.pure(Left(F.async[A](k)))
   }
 
-  def runSyncStepAsyncNeverProducesLeftPureIO[A] = {
-    F.runSyncStep(F.never[A]) <-> IO.pure(Left(F.never[A]))
-  }
-
   def runSyncStepCanBeAttemptedSynchronously[A](fa: F[A]) = {
     Either.catchNonFatal(F.runSyncStep(fa).attempt.unsafeRunSync()).isRight
   }

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/EffectTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/EffectTests.scala
@@ -67,7 +67,6 @@ trait EffectTests[F[_]] extends AsyncTests[F] {
         "runAsync ignores error in handler" -> forAll(laws.runAsyncIgnoresErrorInHandler[A] _),
         "runSyncStep suspend pure produces the same" -> forAll(laws.runSyncStepSuspendPureProducesTheSame[A] _),
         "runSyncStep async produces left pure IO" -> forAll(laws.runSyncStepAsyncProducesLeftPureIO[A] _),
-        "runSyncStep async never produces left pure IO" -> Prop.lzy(laws.runSyncStepAsyncNeverProducesLeftPureIO[A]),
         "runSyncStep can be attempted synchronously" -> forAll(laws.runSyncStepCanBeAttemptedSynchronously[A] _),
         "runSyncStep runAsync consistency" -> forAll(laws.runSyncStepRunAsyncConsistency[A] _),
         "repeated callback ignored" -> forAll(laws.repeatedCallbackIgnored[A] _),


### PR DESCRIPTION
Removing `runSyncStepAsyncNeverProducesLeftPureIO` because:

- it is redundant with `runSyncStepAsyncProducesLeftPureIO`
- it is expensive due to usage of `F.never`, also see recent #260 