### PR TITLE
Add the Continual type class

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Continual.scala
+++ b/core/shared/src/main/scala/cats/effect/Continual.scala
@@ -16,7 +16,8 @@
 
 package cats.effect
 
-import cats.syntax.all._
+import cats.Monoid
+import cats.data._
 import cats.effect.ExitCase.Canceled
 import simulacrum.typeclass
 
@@ -201,46 +202,103 @@ import simulacrum.typeclass
       case Canceled => sync.raiseError(e)
       case _ => sync.unit
     }
-
-  /**
-   * Creates a "cancel boundary", a node in the bind chain that can
-   * check the internal cancelation flag and stop processing in case
-   * cancelation has occurred.
-   *
-   * In the "continual" model, due to not relying on auto-cancelable
-   * bind chains, describing long, CPU-bound, run-loops can lead to
-   * tasks that are uncancelable, which can be fixed if needed via
-   * `cancelBoundary`. Example:
-   *
-   * {{{
-   *   def fib[F[_]](n: Int, a: Long, b: Long)
-   *     (implicit F: Concurrent[F], C: Continual[F]): F[Long] = {
-   *
-   *     if (n == 0) F.pure(a) else F.suspend {
-   *       val next = fib(n - 1, b, a + b)
-   *
-   *       if (n % 100 == 0)
-   *         C.cancelBoundary *> next
-   *       else
-   *         next
-   *     }
-   *   }
-   * }}}
-   *
-   * This function can only work if the `F` data type also implements
-   * [[Concurrent]].
-   */
-  def cancelBoundary(implicit F: Concurrent[F]): F[Unit] =
-    onCancelRaiseError(sync.unit, Continual.boundary)
-      .recoverWith {
-        case Continual.boundary => F.never
-      }
 }
 
 object Continual {
   /**
-   * Internal, reusable reference.
+   * [[Continual]] instance built for `cats.data.EitherT` values initialized
+   * with any `F` data type that also implements `Continual`.
    */
-  private val boundary: RuntimeException =
-    new RuntimeException("cancel boundary")
+  implicit def catsEitherTContinual[F[_]: Continual, L]: Continual[EitherT[F, L, ?]] =
+    new EitherTContinual[F, L] { def F = Continual[F] }
+
+  /**
+   * [[Continual]] instance built for `cats.data.OptionT` values initialized
+   * with any `F` data type that also implements `Continual`.
+   */
+  implicit def catsOptionTContinual[F[_]: Continual]: Continual[OptionT[F, ?]] =
+    new OptionTContinual[F] { def F = Continual[F] }
+
+  /**
+   * [[Continual]] instance built for `cats.data.StateT` values initialized
+   * with any `F` data type that also implements `Continual`.
+   */
+  implicit def catsStateTContinual[F[_]: Continual, S]: Continual[StateT[F, S, ?]] =
+    new StateTContinual[F, S] { def F = Continual[F] }
+
+  /**
+   * [[Continual]] instance built for `cats.data.WriterT` values initialized
+   * with any `F` data type that also implements `Continual`.
+   */
+  implicit def catsWriterTContinual[F[_]: Continual, L: Monoid]: Continual[WriterT[F, L, ?]] =
+    new WriterTContinual[F, L] { def F = Continual[F]; def L = Monoid[L] }
+
+  /**
+   * [[Continual]] instance built for `cats.data.Kleisli` values initialized
+   * with any `F` data type that also implements `Continual`.
+   */
+  implicit def catsKleisliContinual[F[_]: Continual, R]: Continual[Kleisli[F, R, ?]] =
+    new KleisliContinual[F, R] { def F = Continual[F] }
+
+  private[effect] trait EitherTContinual[F[_], L] extends Continual[EitherT[F, L, ?]] {
+    protected implicit def F: Continual[F]
+
+    val sync: Sync[EitherT[F, L, ?]] = Sync.catsEitherTSync(F.sync)
+
+    override def continual[A](fa: EitherT[F, L, A]): EitherT[F, L, A] =
+      EitherT(F.continual(fa.value))
+
+    override def onCancelRaiseError[A](fa: EitherT[F, L, A], e: Throwable): EitherT[F, L, A] =
+      EitherT(F.onCancelRaiseError(fa.value, e))
+  }
+
+  private[effect] trait OptionTContinual[F[_]] extends Continual[OptionT[F, ?]] {
+    protected implicit def F: Continual[F]
+
+    val sync: Sync[OptionT[F, ?]] = Sync.catsOptionTSync(F.sync)
+
+    override def continual[A](fa: OptionT[F, A]): OptionT[F, A] =
+      OptionT(F.continual(fa.value))
+
+    override def onCancelRaiseError[A](fa: OptionT[F, A], e: Throwable): OptionT[F, A] =
+      OptionT(F.onCancelRaiseError(fa.value, e))
+  }
+
+  private[effect] trait StateTContinual[F[_], S] extends Continual[StateT[F, S, ?]] {
+    protected implicit def F: Continual[F]
+    private implicit def FF: Sync[F] = F.sync
+
+    val sync: Sync[StateT[F, S, ?]] = Sync.catsStateTSync(F.sync)
+
+    override def continual[A](fa: StateT[F, S, A]): StateT[F, S, A] =
+      StateT.applyF(F.continual(fa.runF))
+
+    override def onCancelRaiseError[A](fa: StateT[F, S, A], e: Throwable): StateT[F, S, A] =
+      fa.transformF(F.onCancelRaiseError(_, e))
+  }
+
+  private[effect] trait WriterTContinual[F[_], L] extends Continual[WriterT[F, L, ?]] {
+    protected implicit def F: Continual[F]
+    protected implicit def L: Monoid[L]
+
+    val sync: Sync[WriterT[F, L, ?]] = Sync.catsWriterTSync(F.sync, L)
+
+    override def continual[A](fa: WriterT[F, L, A]): WriterT[F, L, A] =
+      WriterT(F.continual(fa.run))
+
+    override def onCancelRaiseError[A](fa: WriterT[F, L, A], e: Throwable): WriterT[F, L, A] =
+      WriterT(F.onCancelRaiseError(fa.run, e))
+  }
+
+  private[effect] abstract class KleisliContinual[F[_], R] extends Continual[Kleisli[F, R, ?]] {
+    protected implicit def F: Continual[F]
+
+    val sync: Sync[Kleisli[F, R, ?]] = Sync.catsKleisliSync(F.sync)
+
+    override def continual[A](fa: Kleisli[F, R, A]): Kleisli[F, R, A] =
+      Kleisli(a => F.sync.suspend(F.continual(fa.run(a))))
+
+    override def onCancelRaiseError[A](fa: Kleisli[F, R, A], e: Throwable): Kleisli[F, R, A] =
+      Kleisli(a => F.sync.suspend(F.onCancelRaiseError(fa.run(a), e)))
+  }
 }

--- a/core/shared/src/main/scala/cats/effect/Continual.scala
+++ b/core/shared/src/main/scala/cats/effect/Continual.scala
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.syntax.all._
+import cats.effect.ExitCase.Canceled
+import simulacrum.typeclass
+
+/**
+ * Describes [[Sync]] data types capable of the "continual"
+ * evaluation model.
+ *
+ * In the continual evaluation model `flatMap` chains are not
+ * auto-cancelable, the underlying run-loop relying solely on user
+ * supplied cancelation logic (e.g. [[Concurrent.cancelable]]).
+ *
+ * Describes [[cats.effect.Continual!.continual continual]],
+ * see its description for the contract.
+ */
+@typeclass trait Continual[F[_]] extends Serializable {
+  /**
+   * [[Sync]] restriction for types that can implement `Continual`.
+   *
+   * Using composition instead of inheritance, because the
+   * `Continual` type class is an add-on to the type class hierarchy.
+   *
+   * Note that using inheritance instead of composition would make it
+   * difficult to work with `Continual` in combination with other
+   * sub-types of `Sync`, such as `Async` or `Concurrent`.
+   */
+  implicit val sync: Sync[F]
+
+  /**
+   * Returns an `F[A]` value that on evaluation ensures the source
+   * will be evaluated using the "continual" model.
+   *
+   * In the continual evaluation model `flatMap` chains are not
+   * auto-cancelable, the underlying run-loop relying solely on
+   * user supplied cancelation logic (e.g. [[Concurrent.cancelable]]).
+   *
+   * Example:
+   *
+   * {{{
+   *   val F: Continual[F] = ???
+   *   val C: Continual[F] = ???
+   *   val timer: Timer[F] = Timer.derive[F]
+   *
+   *   val task = F.cancelable[Int] { _ =>
+   *     // N.B. this is a task that will never terminate
+   *     // (callback never gets invoked), but that has a
+   *     // cancelation handler installed:
+   *     IO(println("Cancelled task"))
+   *   }
+   *
+   *   C.continual {
+   *     timer.shift.flatMap(_ => task)
+   *   }
+   * }}}
+   *
+   * In this sample we are guaranteed that the cancelation handler
+   * of the described `task` gets evaluated, printing "cancelled task1",
+   * because `timer.shift` is not cancelable and the `flatMap` that
+   * binds them is not cancelable.
+   *
+   * Another example:
+   *
+   * {{{
+   *   C.continual {
+   *     timer.sleep(1.second).flatMap(_ => task)
+   *   }
+   * }}}
+   *
+   * This time `timer.sleep(1.second)` is cancelable and in case
+   * the cancel signal is received by the run-loop within that one
+   * second, then it will get cancelled. However, if
+   * `timer.sleep(1.second)` finishes, emitting its tick, then it's
+   * guaranteed that the cancelation handler of `task` gets executed.
+   *
+   * In other words if you have:
+   *
+   * {{{
+   *   for (t1 <- task1; t2 <- task2) yield ()
+   * }}}
+   *
+   * In the "continual" evaluation model you can have either "task1"
+   * cancelled (and its cancelation handler triggered), or "task2",
+   * but the implementation can no longer interrupt the processing
+   * in between.
+   *
+   * In other words the contract is that:
+   *
+   *  - if `task1` finishes, `task2` is guaranteed to at least start
+   *  - cancelation of a bind chain can still happen, but is managed
+   *    solely by user supplied logic (e.g. [[Concurrent.cancelable]])
+   *
+   * For [[cats.effect.IO]] this function would be the identity
+   * function, since Cats-Effect's `IO` is already using the
+   * "continual" model in its implementation.
+   */
+  def continual[A](fa: F[A]): F[A]
+
+  /**
+   * Returns a new `F` value that mirrors the source for normal
+   * termination, but that triggers the given error on cancelation.
+   *
+   * This `onCancelRaiseError` operator transforms any task into one
+   * that on cancelation will terminate with the given error, thus
+   * transforming potentially non-terminating tasks into ones that
+   * yield a certain error.
+   *
+   * {{{
+   *   import scala.concurrent.CancellationException
+   *
+   *   val F = Continual[IO]
+   *   val timer = Timer[IO]
+   *
+   *   val error = new CancellationException("Boo!")
+   *   val fa = F.onCancelRaiseError(timer.sleep(5.seconds), error)
+   *
+   *   fa.start.flatMap { fiber =>
+   *     fiber.cancel *> fiber.join
+   *   }
+   * }}}
+   *
+   * Without "onCancelRaiseError" the [[Timer.sleep sleep]] operation
+   * yields a non-terminating task on cancellation. But by applying
+   * "onCancelRaiseError", the yielded task above will terminate with
+   * the indicated "CancellationException" reference, which we can
+   * then also distinguish from other errors thrown in the `F` context.
+   *
+   * Depending on the implementation, tasks that are canceled can
+   * become non-terminating. This operation ensures that when
+   * cancelation happens, the resulting task is terminated with an
+   * error, such that logic can be scheduled to happen after
+   * cancelation:
+   *
+   * {{{
+   *   import scala.concurrent.CancellationException
+   *   val wasCanceled = new CancellationException()
+   *
+   *   F.onCancelRaiseError(fa, wasCanceled).attempt.flatMap {
+   *     case Right(a) =>
+   *       F.delay(println(s"Success: \$a"))
+   *     case Left(`wasCanceled`) =>
+   *       F.delay(println("Was canceled!"))
+   *     case Left(error) =>
+   *       F.delay(println(s"Terminated in error: \$error"))
+   *   }
+   * }}}
+   *
+   * This technique is how a "bracket" operation can be implemented
+   * in the "continual" model.
+   *
+   * Besides sending the cancelation signal, this operation also cuts
+   * the connection between the producer and the consumer. Example:
+   *
+   * {{{
+   *   val F = Concurrent[IO]
+   *   val timer = Timer[IO]
+   *
+   *   // This task is uninterruptible ;-)
+   *   val tick = F.uncancelable(
+   *     for {
+   *       _ <- timer.sleep(5.seconds)
+   *       _ <- IO(println("Tick!"))
+   *     } yield ())
+   *
+   *   // Builds an value that triggers an exception on cancellation
+   *   val loud = F.onCancelRaiseError(tick, new CancellationException)
+   * }}}
+   *
+   * In this example the `loud` reference will be completed with a
+   * "CancellationException", as indicated via "onCancelRaiseError".
+   * The logic of the source won't get cancelled, because we've
+   * embedded it all in [[Bracket.uncancelable uncancelable]]. But
+   * its bind continuation is not allowed to continue after that, its
+   * final result not being allowed to be signaled.
+   *
+   * Therefore this also transforms `uncancelable` values into ones
+   * that can be canceled. The logic of the source, its run-loop
+   * might not be interruptible, however `cancel` on a value on which
+   * `onCancelRaiseError` was applied will cut the connection from
+   * the producer, the consumer receiving the indicated error instead.
+   */
+  def onCancelRaiseError[A](fa: F[A], e: Throwable): F[A] =
+    sync.guaranteeCase(fa) {
+      case Canceled => sync.raiseError(e)
+      case _ => sync.unit
+    }
+
+  /**
+   * Creates a "cancel boundary", a node in the bind chain that can
+   * check the internal cancelation flag and stop processing in case
+   * cancelation has occurred.
+   *
+   * In the "continual" model, due to not relying on auto-cancelable
+   * bind chains, describing long, CPU-bound, run-loops can lead to
+   * tasks that are uncancelable, which can be fixed if needed via
+   * `cancelBoundary`. Example:
+   *
+   * {{{
+   *   def fib[F[_]](n: Int, a: Long, b: Long)
+   *     (implicit F: Concurrent[F], C: Continual[F]): F[Long] = {
+   *
+   *     if (n == 0) F.pure(a) else F.suspend {
+   *       val next = fib(n - 1, b, a + b)
+   *
+   *       if (n % 100 == 0)
+   *         C.cancelBoundary *> next
+   *       else
+   *         next
+   *     }
+   *   }
+   * }}}
+   *
+   * This function can only work if the `F` data type also implements
+   * [[Concurrent]].
+   */
+  def cancelBoundary(implicit F: Concurrent[F]): F[Unit] =
+    onCancelRaiseError(sync.unit, Continual.boundary)
+      .recoverWith {
+        case Continual.boundary => F.never
+      }
+}
+
+object Continual {
+  /**
+   * Internal, reusable reference.
+   */
+  private val boundary: RuntimeException =
+    new RuntimeException("cancel boundary")
+}

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -785,6 +785,24 @@ private[effect] abstract class IOLowPriorityInstances extends IOParallelNewtype 
     final override def runSyncStep[A](ioa: IO[A]): IO[Either[IO[A], A]] =
       ioa.runSyncStep
   }
+
+  /** [[Continual]] instance for [[IO]].
+    *
+    * NOTE the implementation of `cats.effect.IO` is already following
+    * this evaluation model in its implementation, therefore
+    * [[Continual.continual]] is equivalent to the identity function.
+    */
+  implicit val continual: Continual[IO] =
+    new Continual[IO] {
+      implicit val sync: Sync[IO] =
+        ioEffect
+      override def continual[A](fa: IO[A]): IO[A] =
+        fa
+      override def onCancelRaiseError[A](fa: IO[A], e: Throwable): IO[A] =
+        fa.onCancelRaiseError(e)
+      override def cancelBoundary(implicit ev: Concurrent[IO]): IO[Unit] =
+        IO.cancelBoundary
+    }
 }
 
 private[effect] abstract class IOInstances extends IOLowPriorityInstances {

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -800,8 +800,6 @@ private[effect] abstract class IOLowPriorityInstances extends IOParallelNewtype 
         fa
       override def onCancelRaiseError[A](fa: IO[A], e: Throwable): IO[A] =
         fa.onCancelRaiseError(e)
-      override def cancelBoundary(implicit ev: Concurrent[IO]): IO[Unit] =
-        IO.cancelBoundary
     }
 }
 

--- a/laws/shared/src/main/scala/cats/effect/laws/ContinualLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ContinualLaws.scala
@@ -86,17 +86,6 @@ trait ContinualLaws[F[_]] {
     F.continual(lh) <-> C.liftIO(IO(a))
   }
 
-  def cancelBoundaryInterrupts[A](a: A)
-    (implicit C: Concurrent[F]) = {
-
-    val lh = Deferred[F, Unit].flatMap { latch =>
-      val task = latch.get >> F.cancelBoundary >> C.pure(a)
-      C.start(task).flatMap(f => f.cancel >> latch.complete(()) >> f.join)
-    }
-    // We want to guarantee this only in the continual model
-    F.continual(lh) <-> C.never[A]
-  }
-
   def guaranteeCaseTerminatesOnCancel[A](e: Throwable)
     (implicit C: Concurrent[F]) = {
 

--- a/laws/shared/src/main/scala/cats/effect/laws/ContinualLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ContinualLaws.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package laws
+
+import cats.effect.ExitCase.Canceled
+import cats.effect.concurrent.Deferred
+import cats.implicits._
+import cats.laws._
+
+trait ContinualLaws[F[_]] {
+  implicit def F: Continual[F]
+
+  def continualMirrorsSource[A](fa: F[A]) =
+    F.continual(fa) <-> fa
+
+  def continualCancelationModel[A](a: A)
+    (implicit C: Concurrent[F]) = {
+
+    val lh = for {
+      start <- Deferred.uncancelable[F, Unit]
+      wasCanceled <- C.liftIO(Deferred.uncancelable[IO, A])
+      task = start.get >> C.cancelable[A](_ => wasCanceled.complete(a))
+      fiber <- C.start(task)
+      _ <- fiber.cancel
+      _ <- start.complete(())
+      r <- C.liftIO(wasCanceled.get)
+    } yield r
+
+    F.continual(lh) <-> C.pure(a)
+  }
+
+  def onCancelRaiseErrorMirrorsSource[A](fa: F[A], e: Throwable) =
+    F.onCancelRaiseError(fa, e) <-> fa
+
+  def onCancelRaiseErrorTerminatesOnCancel[A](e: Throwable)
+    (implicit C: Concurrent[F]) = {
+
+    val never = F.onCancelRaiseError(C.never[A], e)
+    val received =
+      for {
+        fiber <- C.start(never)
+        _ <- fiber.cancel
+        r <- fiber.join
+      } yield r
+    // We want to guarantee this only in the continual model
+    F.continual(received) <-> C.raiseError(e)
+  }
+
+  def onCancelRaiseErrorCanCancelSource[A](a: A, e: Throwable)
+    (implicit C: Concurrent[F])= {
+
+    val lh = C.liftIO(Deferred.uncancelable[IO, A]).flatMap { effect =>
+      val async = C.cancelable[Unit](_ => effect.complete(a))
+      C.start(F.onCancelRaiseError(async, e))
+        .flatMap(_.cancel) *> C.liftIO(effect.get)
+    }
+    // We want to guarantee this only in the continual model
+    F.continual(lh) <-> C.pure(a)
+  }
+
+  def onCancelRaiseErrorResetsCancellationFlag[A](a: A, e: Throwable)
+    (implicit C: Concurrent[F]) = {
+
+    val task = F.onCancelRaiseError(C.never[A], e)
+    val recovered = task.recoverWith {
+      case `e` => C.liftIO(IO.cancelBoundary *> IO(a))
+    }
+    val lh = C.start(recovered).flatMap(f => f.cancel *> f.join)
+    // We want to guarantee this only in the continual model
+    F.continual(lh) <-> C.liftIO(IO(a))
+  }
+
+  def cancelBoundaryInterrupts[A](a: A)
+    (implicit C: Concurrent[F]) = {
+
+    val lh = Deferred[F, Unit].flatMap { latch =>
+      val task = latch.get >> F.cancelBoundary >> C.pure(a)
+      C.start(task).flatMap(f => f.cancel >> latch.complete(()) >> f.join)
+    }
+    // We want to guarantee this only in the continual model
+    F.continual(lh) <-> C.never[A]
+  }
+
+  def guaranteeCaseTerminatesOnCancel[A](e: Throwable)
+    (implicit C: Concurrent[F]) = {
+
+    val never = C.guaranteeCase(C.never[A]) {
+      case Canceled => C.raiseError(e)
+      case _ => C.unit
+    }
+
+    val received =
+      for {
+        fiber <- C.start(never)
+        _ <- fiber.cancel
+        r <- fiber.join
+      } yield r
+
+    // We want to guarantee this only in the continual model
+    F.continual(received) <-> C.raiseError(e)
+  }
+
+  def guaranteeCaseCanCancelSource[A](a: A, e: Throwable)
+    (implicit C: Concurrent[F])= {
+
+    val lh = C.liftIO(Deferred.uncancelable[IO, A]).flatMap { effect =>
+      val async = C.cancelable[Unit](_ => effect.complete(a))
+      val task = C.start(C.guaranteeCase(async) {
+        case Canceled => C.raiseError(e)
+        case _ => C.unit
+      })
+      task.flatMap(_.cancel) *> C.liftIO(effect.get)
+    }
+    // We want to guarantee this only in the continual model
+    F.continual(lh) <-> C.pure(a)
+  }
+
+  def guaranteeCaseResetsCancellationFlag[A](a: A, e: Throwable)
+    (implicit C: Concurrent[F]) = {
+
+    val task = C.guaranteeCase(C.never[A]) {
+      case Canceled => C.raiseError(e)
+      case _ => C.unit
+    }
+    val recovered = task.recoverWith {
+      case `e` => C.liftIO(IO.cancelBoundary *> IO(a))
+    }
+    val lh = C.start(recovered).flatMap(f => f.cancel *> f.join)
+    // We want to guarantee this only in the continual model
+    F.continual(lh) <-> C.liftIO(IO(a))
+  }
+}
+
+object ContinualLaws {
+  def apply[F[_]](implicit F0: Continual[F]): ContinualLaws[F] = new ContinualLaws[F] {
+    val F = F0
+  }
+}

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/ContinualTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/ContinualTests.scala
@@ -55,24 +55,15 @@ trait ContinualTests[F[_]] extends Laws {
       val name = "continual.concurrent"
       val bases = Nil
       val parents = Seq(sync[A])
-      val props = {
-        val default = Seq(
-          "continual cancelation model" -> forAll(laws.continualCancelationModel[A] _),
-          "onCancelRaiseError terminates on cancel" -> forAll(laws.onCancelRaiseErrorTerminatesOnCancel[A] _),
-          "onCancelRaiseError can cancel source" -> forAll(laws.onCancelRaiseErrorCanCancelSource[A] _),
-          "onCancelRaiseError resets cancelation flag" -> forAll(laws.onCancelRaiseErrorResetsCancellationFlag[A] _),
-          "guaranteeCase terminates on cancel" -> forAll(laws.guaranteeCaseTerminatesOnCancel[A] _),
-          "guaranteeCase can cancel source" -> forAll(laws.guaranteeCaseCanCancelSource[A] _),
-          "guaranteeCase resets cancelation flag" -> forAll(laws.guaranteeCaseResetsCancellationFlag[A] _)
-        )
-
-        if (params.allowNonTerminationLaws)
-          default ++ Seq(
-            "cancelBoundary interrupts" -> forAll(laws.cancelBoundaryInterrupts[A] _)
-          )
-        else
-          default
-      }
+      val props = Seq(
+        "continual cancelation model" -> forAll(laws.continualCancelationModel[A] _),
+        "onCancelRaiseError terminates on cancel" -> forAll(laws.onCancelRaiseErrorTerminatesOnCancel[A] _),
+        "onCancelRaiseError can cancel source" -> forAll(laws.onCancelRaiseErrorCanCancelSource[A] _),
+        "onCancelRaiseError resets cancelation flag" -> forAll(laws.onCancelRaiseErrorResetsCancellationFlag[A] _),
+        "guaranteeCase terminates on cancel" -> forAll(laws.guaranteeCaseTerminatesOnCancel[A] _),
+        "guaranteeCase can cancel source" -> forAll(laws.guaranteeCaseCanCancelSource[A] _),
+        "guaranteeCase resets cancelation flag" -> forAll(laws.guaranteeCaseResetsCancellationFlag[A] _)
+      )
     }
   }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/ContinualTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/ContinualTests.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package laws
+package discipline
+
+import cats.Eq
+import cats.laws.discipline._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop.forAll
+import org.typelevel.discipline.Laws
+
+trait ContinualTests[F[_]] extends Laws {
+  def laws: ContinualLaws[F]
+
+  def sync[A: Arbitrary: Eq](
+    implicit
+    ArbFA: Arbitrary[F[A]],
+    EqFA: Eq[F[A]],
+    params: Parameters): RuleSet = {
+
+    new RuleSet {
+      val name = "continual.sync"
+      val bases = Nil
+      val parents = Nil
+      val props = Seq(
+        "continual mirrors source" -> forAll(laws.continualMirrorsSource[A] _),
+        "onCancelRaiseError mirrors source" -> forAll(laws.onCancelRaiseErrorMirrorsSource[A] _)
+      )
+    }
+  }
+
+  def concurrent[A: Arbitrary: Eq](
+    implicit
+    ArbFA: Arbitrary[F[A]],
+    EqFA: Eq[F[A]],
+    F: Concurrent[F],
+    params: Parameters): RuleSet = {
+
+    new RuleSet {
+      val name = "continual.concurrent"
+      val bases = Nil
+      val parents = Seq(sync[A])
+      val props = {
+        val default = Seq(
+          "continual cancelation model" -> forAll(laws.continualCancelationModel[A] _),
+          "onCancelRaiseError terminates on cancel" -> forAll(laws.onCancelRaiseErrorTerminatesOnCancel[A] _),
+          "onCancelRaiseError can cancel source" -> forAll(laws.onCancelRaiseErrorCanCancelSource[A] _),
+          "onCancelRaiseError resets cancelation flag" -> forAll(laws.onCancelRaiseErrorResetsCancellationFlag[A] _),
+          "guaranteeCase terminates on cancel" -> forAll(laws.guaranteeCaseTerminatesOnCancel[A] _),
+          "guaranteeCase can cancel source" -> forAll(laws.guaranteeCaseCanCancelSource[A] _),
+          "guaranteeCase resets cancelation flag" -> forAll(laws.guaranteeCaseResetsCancellationFlag[A] _)
+        )
+
+        if (params.allowNonTerminationLaws)
+          default ++ Seq(
+            "cancelBoundary interrupts" -> forAll(laws.cancelBoundaryInterrupts[A] _)
+          )
+        else
+          default
+      }
+    }
+  }
+}
+
+object ContinualTests {
+  def apply[F[_]: Continual]: ContinualTests[F] = new ContinualTests[F] {
+    def laws = ContinualLaws[F]
+  }
+}

--- a/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
@@ -25,11 +25,20 @@ import cats.laws.discipline.arbitrary._
 
 class InstancesTests extends BaseTestsSuite {
 
+  // StateT -----------------------
+
   checkAllAsync("StateT[IO, S, ?]",
     implicit ec => {
       implicit val timer: Timer[StateT[IO, Int, ?]] = Timer.derive
       ConcurrentEffectTests[StateT[IO, Int, ?]].concurrentEffect[Int, Int, Int]
     })
+
+  checkAllAsync("StateT[IO, S, ?]",
+    implicit ec => {
+      ContinualTests[StateT[IO, Int, ?]].concurrent[Int]
+    })
+
+  // OptionT -----------------------
 
   checkAllAsync("OptionT[IO, ?]",
     implicit ec => {
@@ -37,13 +46,28 @@ class InstancesTests extends BaseTestsSuite {
       ConcurrentTests[OptionT[IO, ?]].concurrent[Int, Int, Int]
     })
 
+  checkAllAsync("OptionT[IO, ?]",
+    implicit ec => {
+      ContinualTests[OptionT[IO, ?]].concurrent[Int]
+    })
+
+  // Kleisli -----------------------
+
   checkAllAsync("Kleisli[IO, ?]",
     implicit ec => {
       implicit val timer: Timer[Kleisli[IO, Int, ?]] = Timer.derive
       ConcurrentTests[Kleisli[IO, Int, ?]].concurrent[Int, Int, Int]
     })
+
   checkAllAsync("Kleisli[IO, ?]",
     implicit ec => BracketTests[Kleisli[IO, Int, ?], Throwable].bracket[Int, Int, Int])
+
+  checkAllAsync("Kleisli[IO, ?]",
+    implicit ec => {
+      ContinualTests[Kleisli[IO, Int, ?]].concurrent[Int]
+    })
+
+  // EitherT -----------------------
 
   checkAllAsync("EitherT[IO, Throwable, ?]",
     implicit ec => {
@@ -51,10 +75,22 @@ class InstancesTests extends BaseTestsSuite {
       ConcurrentEffectTests[EitherT[IO, Throwable, ?]].concurrentEffect[Int, Int, Int]
     })
 
+  checkAllAsync("EitherT[IO, Throwable, ?]",
+    implicit ec => {
+      ContinualTests[EitherT[IO, Throwable, ?]].concurrent[Int]
+    })
+
+  // WriterT -----------------------
+
   checkAllAsync("WriterT[IO, Int, ?]",
     implicit ec => {
       implicit val timer: Timer[WriterT[IO, Int, ?]] = Timer.derive
       ConcurrentEffectTests[WriterT[IO, Int, ?]].concurrentEffect[Int, Int, Int]
+    })
+
+  checkAllAsync("WriterT[IO, Int, ?]",
+    implicit ec => {
+      ContinualTests[WriterT[IO, Int, ?]].concurrent[Int]
     })
 
   implicit def keisliEq[F[_], R: Monoid, A](implicit FA: Eq[F[A]]): Eq[Kleisli[F, R, A]] =
@@ -62,5 +98,4 @@ class InstancesTests extends BaseTestsSuite {
 
   implicit def stateTEq[F[_]: FlatMap, S: Monoid, A](implicit FSA: Eq[F[(S, A)]]): Eq[StateT[F, S, A]] =
     Eq.by[StateT[F, S, A], F[(S, A)]](state => state.run(Monoid[S].empty))
-
 }


### PR DESCRIPTION
Fixes #242 — adds a `Continual` type class.

This proposal isn't necessarily for 1.0. Being an add-on, we can release it afterwards, although you know where my heart is at this point 🙂 If there's consensus (hopefully), we could schedule it for a 1.1

```scala
trait Continual[F[_]] {
  // Restriction via composition instead of inheritance
  implicit val sync: Sync[F]

  def continual[A](fa: F[A]): F[A]

  def onCancelRaiseError[A](fa: F[A], e: Throwable): F[A] =
    sync.guaranteeCase(fa) {
      case Canceled => sync.raiseError(e)
      case _ => sync.unit
    }
}
```

Via `continual`, the run-loop of implementing data types are forced to uphold this law, if `Concurrent`:

```scala
  def continualCancelationModel[A](a: A)
    (implicit C: Concurrent[F]) = {

    val lh = for {
      start <- Deferred.uncancelable[F, Unit]
      wasCanceled <- C.liftIO(Deferred.uncancelable[IO, A])
      // Relevant bit here:
      task = start.get >> C.cancelable[A](_ => wasCanceled.complete(a))
      fiber <- C.start(task)
      _ <- fiber.cancel
      _ <- start.complete(())
      r <- C.liftIO(wasCanceled.get)
    } yield r

    F.continual(lh) <-> C.pure(a)
  }
```

Or in other words, whenever you have:

```scala
for (t1 <- task1; t2 <- task2) yield ()
```

If `task1` does not get cancelled or finish in error, then `task2` is guaranteed to at least start.

The second requirement for the type class is for a `onCancelRaiseError` to be described as being equivalent to a `guaranteeCase` invocation, which adds restrictions on what `bracket` can do with errors thrown in `release` — `bracket` (and `guaranteeCase`) are now forced to re-throw errors thrown in  `release` and to reset the "internal cancelation flag".

So in summary:

1. the "*continual*" model is specifying that the underlying task should evaluate without cancelable `flatMaps`
2. specifies an `onCancelRaiseError` operation derived from `bracket`, that places restrictions on how `bracket` deals with errors in `release`

Important to note — this type class is an add-on to the type class hierarchy, which is why it is using composition instead of inheritance.

## Raison D'être

Reasons:

1. the cancelation model of `cats.effect.IO` is very explicit and predictable, users can and do form a good mental model about it after leaving their accrued baggage behind; however it is no longer exposed in the type classes due to #237, which means that users can no longer make use of it in polymorphic code
2. in the new model encodings like that of the current Monix `Iterant` are no longer possible and I don't find that acceptable, because it means that code in the wild can no longer be easily converted to polymorphic code making use of `F[_]` easily; now such code has to check whether it is compatible with the auto-cancelable model
3. `cats.effect.IO` is not auto-cancelable and because we are no longer exposing its capabilities in type classes, it means that by not being auto-cancelable it is less optimal then the implementations that are capable of such a feat
4. Scalaz 8's `IO` cannot do it and that's a good thing

I believe in this "continual" model and when I designed it, I did so with sympathy for the mental model people are going to have, with inspiration from books like:

<a href="https://en.wikipedia.org/wiki/The_Design_of_Everyday_Things" title="The Design of Everyday Things"><img src="https://user-images.githubusercontent.com/11753/40883882-f15b7ff0-670f-11e8-919b-e41a14f26636.png" label="The Design of Everyday Things" /></a>

It is important to note that this evaluation model, this type class, does not take anything away from you — if you believe in the model exposed by the current type classes, then you can keep using it. But users get a choice and Cats-Effect is exposing these fine grained type classes due to our belief that choice is good.

And unfortunately I find myself dropping an ad-hominem — lately the discourse is being monopolized by John De Goes's opinions and I find that to be unfortunate, because he does not have the best interest of the Cats-Effect project at heart, as he has stated his goals repeatedly.

Samples:

1. [recent tweets](https://twitter.com/jdegoes/status/1001847030128373767)
2. [There Can Be Only One...IO Monad](http://degoes.net/articles/only-one-io)

This is why I find that reason number 4 is a good thing — that Scalaz 8's `IO` cannot do it is perfect, because our type classes are meant to be generic and not describe any one particular `IO` flavor to the detriment of others, which as of `1.0.0-RC2` we just started doing 😉

## Going Forward

In the interest of having a good signal to noise ration, please refrain from restating arguments already said in #242 or #237.

If you want to do so, add links to previous comments instead of repeating the same things and I must insist on doing so, because the noise in those issues is not that great and throws people off.