### PR TITLE
Fix #276: Change Bracket laws

### DIFF
--- a/laws/shared/src/main/scala/cats/effect/laws/BracketLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/BracketLaws.scala
@@ -33,9 +33,6 @@ trait BracketLaws[F[_], E] extends MonadErrorLaws[F, E] {
   def bracketCaseFailureInAcquisitionRemainsFailure[A, B](e: E, f: A => F[B], release: F[Unit]) =
     F.bracketCase(F.raiseError[A](e))(f)((_, _) => release) <-> F.raiseError(e)
 
-  def bracketCaseEmitsUseFailure[A](e: E, e2: E, fa: F[A]) =
-    F.bracketCase(fa)(_ => F.raiseError[A](e))((_, _) => F.raiseError(e2)) <-> fa *> F.raiseError(e)
-
   def bracketIsDerivedFromBracketCase[A, B](fa: F[A], use: A => F[B], release: A => F[Unit]) =
     F.bracket(fa)(use)(release) <-> F.bracketCase(fa)(use)((a, _) => release(a))
 

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
@@ -24,36 +24,6 @@ import cats.laws._
 trait SyncLaws[F[_]] extends BracketLaws[F, Throwable] {
   implicit def F: Sync[F]
 
-  def bracketReleaseCalledForSuccess[A, B, C](fa: F[A], b: B, c: C, f: (A, C) => C) = {
-    val lh = F.suspend {
-      var input = c
-      val br = F.bracketCase(fa) { _ =>
-        F.delay(b)
-      } { (a, _) =>
-        F.delay { input = f(a, c) }
-      }
-      br *> F.delay(input)
-    }
-
-    lh <-> fa.map(a => f(a, c))
-  }
-
-  def bracketReleaseCalledForError[A](a: A, f: A => A) = {
-    var input = a
-    val update = F.delay { input = f(input) }
-    val read = F.delay(input)
-    val ex = new Exception()
-    val fa = F.pure(a)
-
-    val bracketed = F.bracketCase(fa)(_ => F.raiseError[A](ex)) {
-      case (_, ExitCase.Error(_)) => update
-      case _ => F.unit
-    }
-
-    F.handleError(bracketed)(_ => a) *> read <-> F.pure(f(a))
-  }
-
-
   def delayConstantIsPure[A](a: A) =
     F.delay(a) <-> F.pure(a)
 

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
@@ -63,7 +63,8 @@ trait AsyncTests[F[_]] extends SyncTests[F] {
           "async left is raiseError" -> forAll(laws.asyncLeftIsRaiseError[A] _),
           "repeated async evaluation not memoized" -> forAll(laws.repeatedAsyncEvaluationNotMemoized[A] _),
           "propagate errors through bind (async)" -> forAll(laws.propagateErrorsThroughBindAsync[A] _),
-          "async can be derived from asyncF" -> forAll(laws.asyncCanBeDerivedFromAsyncF[A] _))
+          "async can be derived from asyncF" -> forAll(laws.asyncCanBeDerivedFromAsyncF[A] _),
+          "bracket release is called on Completed or Error" -> forAll(laws.bracketReleaseIsCalledOnCompletedOrError[A, B] _))
 
         // Activating the tests that detect non-termination only if allowed by Params,
         // because such tests might not be reasonable depending on evaluation model

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/BracketTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/BracketTests.scala
@@ -59,7 +59,6 @@ trait BracketTests[F[_], E] extends MonadErrorTests[F, E] {
 
       val props = Seq(
         "bracketCase with pure unit on release is eqv to map" -> forAll(laws.bracketCaseWithPureUnitIsEqvMap[A, B] _),
-        "bracketCase with failure in use and release is use" -> forAll(laws.bracketCaseEmitsUseFailure[A] _),
         "bracketCase with failure in acquisition remains failure" -> forAll(laws.bracketCaseFailureInAcquisitionRemainsFailure[A, B] _),
         "bracketCase with pure unit on release is eqv to uncancelable(..).flatMap" -> forAll(laws.bracketCaseWithPureUnitIsUncancelable[A, B] _),
         "bracket is derived from bracketCase" -> forAll(laws.bracketIsDerivedFromBracketCase[A, B] _),

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/SyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/SyncTests.scala
@@ -60,10 +60,7 @@ trait SyncTests[F[_]] extends BracketTests[F, Throwable] {
       val bases = Nil
       val parents = Seq(bracket[A, B, C])
 
-
       val props = Seq(
-        "bracket release is called for success" -> forAll(laws.bracketReleaseCalledForSuccess[A, B, C] _),
-        "bracket release is called for error" -> forAll(laws.bracketReleaseCalledForError[A] _),
         "delay constant is pure" -> forAll(laws.delayConstantIsPure[A] _),
         "suspend constant is pure join" -> forAll(laws.suspendConstantIsPureJoin[A] _),
         "throw in delay is raiseError" -> forAll(laws.delayThrowIsRaiseError[A] _),


### PR DESCRIPTION
Fixes #276 — We've got 3 problematic laws being published:

`Bracket.bracketCaseEmitsUseFailure` — this law tests that the error raised in `use` is the being emitted in case both `use` and `release` fails. That's very nice to do, however we left the behavior of `release` raising errors as undefined in the laws and this law breaks that agreement. Which is a problem — for example in Scalaz 8 errors thrown in `release` are not allowed via the type system.

`Sync.bracketReleaseCalledForSuccess` and `Sync.bracketReleaseCalledForError` — these laws are problematic because they rely on the behavior of `flatMap` to observe the side effect and by doing that we are introducing an unintended assumption about the behavior of `F[_]`. In particular streaming types get disallowed and that's IMO a shame.

Without relying on `flatMap` the problem is we cannot observe the side effect until `Async`, so in order to not completely remove these laws, I've replaced them with another in `AsyncLaws`:

```scala
  def bracketReleaseIsCalledOnCompletedOrError[A, B](fa: F[A], b: B) = {
    val lh = Deferred.uncancelable[F, B].flatMap { promise =>
      val br = F.bracketCase(F.delay(promise)) { _ =>
        fa
      } {
        case (r, Completed | Error(_)) => r.complete(b)
        case _ => F.unit
      }
      // Start and forget
      F.asyncF[Unit](cb => F.delay(cb(Right(()))) *> br.as(())) *> promise.get
    }
    lh <-> F.pure(b)
  }
```