### PR TITLE
Resource — new encoding

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -434,7 +434,7 @@ lazy val siteSettings = Seq(
     "-Ywarn-unused:imports",
     "-Ywarn-unused:locals",
     "-Ywarn-unused:patvars",
-    "-Ywarn-unused:privates",    
+    "-Ywarn-unused:privates",
     "-Ywarn-numeric-widen",
     "-Ywarn-dead-code",
     "-Xlint:-missing-interpolator,_").contains),
@@ -501,7 +501,8 @@ scalacOptions in ThisBuild ++= Seq(
   "-unchecked",
   "-Xfatal-warnings",
   "-Yno-adapted-args",
-  "-Ywarn-dead-code"
+  "-Ywarn-dead-code",
+  "-Ypartial-unification"
 )
 
 scalacOptions in ThisBuild ++= {
@@ -514,7 +515,7 @@ scalacOptions in ThisBuild ++= {
       "-Ywarn-unused:privates",
       "-Xlint:-missing-interpolator,-unused,_"
     )
-    case _ => 
+    case _ =>
       Seq("-Xlint:-missing-interpolator,_")
   }
 }

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -161,10 +161,10 @@ object Resource extends ResourceInstances {
    * @tparam F the effect type in which the resource is acquired and released
    * @tparam A the type of the resource
    * @param allocate an effect that returns a tuple of a resource and
-   * an effect to release it
+   *        an effectful function to release it
    */
-  def applyCase[F[_], A](resource: F[(A, ExitCase[_] => F[Unit])]): Resource[F, A] =
-    Allocate(resource)
+  def applyCase[F[_], A](allocate: F[(A, ExitCase[_] => F[Unit])]): Resource[F, A] =
+    Allocate(allocate)
 
   /**
    * Given a `Resource` suspended in `F[_]`, lifts it in the `Resource` context.

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestInstances.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestInstances.scala
@@ -94,7 +94,7 @@ trait TestInstances {
    * equivalent if they allocate an equivalent resource.  Cleanup,
    * which is run purely for effect, is not considered.
    */
-  implicit def eqResource[F[_], A, E](implicit E: Eq[F[A]], F: Bracket[F, E]): Eq[Resource[F, A]] =
+  implicit def eqResource[F[_], A](implicit E: Eq[F[A]], F: Bracket[F, Throwable]): Eq[Resource[F, A]] =
     new Eq[Resource[F, A]] {
       def eqv(x: Resource[F, A], y: Resource[F, A]): Boolean =
         E.eqv(x.use(F.pure), y.use(F.pure))

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestInstances.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestInstances.scala
@@ -16,8 +16,7 @@
 
 package cats.effect.laws.util
 
-import cats.Functor
-import cats.effect.{IO, Resource}
+import cats.effect.{Bracket, IO, Resource}
 import cats.kernel.Eq
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
@@ -95,10 +94,10 @@ trait TestInstances {
    * equivalent if they allocate an equivalent resource.  Cleanup,
    * which is run purely for effect, is not considered.
    */
-  implicit def eqResource[F[_], A](implicit E: Eq[F[A]], F: Functor[F]): Eq[Resource[F, A]] =
+  implicit def eqResource[F[_], A, E](implicit E: Eq[F[A]], F: Bracket[F, E]): Eq[Resource[F, A]] =
     new Eq[Resource[F, A]] {
       def eqv(x: Resource[F, A], y: Resource[F, A]): Boolean =
-        E.eqv(F.map(x.allocate)(_._1), F.map(y.allocate)(_._1))
+        E.eqv(x.use(F.pure), y.use(F.pure))
     }
 }
 

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -23,7 +23,7 @@ import cats.laws._
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.implicits._
-import org.scalacheck._
+//import org.scalacheck._
 
 class ResourceTests extends BaseTestsSuite {
   checkAllAsync("Resource[IO, ?]", implicit ec => MonadErrorTests[Resource[IO, ?], Throwable].monadError[Int, Int, Int])
@@ -31,48 +31,48 @@ class ResourceTests extends BaseTestsSuite {
   checkAllAsync("Resource[IO, ?]", implicit ec => SemigroupKTests[Resource[IO, ?]].semigroupK[Int])
 
   testAsync("Resource.make is equivalent to a partially applied bracket") { implicit ec =>
-    Prop.forAll { (acquire: IO[String], release: String => IO[Unit], f: String => IO[String]) =>
+    check { (acquire: IO[String], release: String => IO[Unit], f: String => IO[String]) =>
       acquire.bracket(f)(release) <-> Resource.make(acquire)(release).use(f)
     }
   }
 
   test("releases resources in reverse order of acquisition") {
-    Prop.forAll { as: List[(String, Either[Throwable, Unit])] =>
-      var released: List[String] = Nil
+    check { as: List[(Int, Either[Throwable, Unit])] =>
+      var released: List[Int] = Nil
       val r = as.traverse { case (a, e) =>
         Resource.make(IO(a))(a => IO { released = a :: released } *> IO.fromEither(e))
       }
-      r.use(IO.pure).unsafeRunSync()
+      r.use(IO.pure).attempt.unsafeRunSync()
       released <-> as.map(_._1)
     }
   }
 
   test("releases both resources on combine") {
-    Prop.forAll { (rx: Resource[IO, String], ry: Resource[IO, String]) =>
-      var acquired: Set[String] = Set.empty
-      var released: Set[String] = Set.empty
-      def observe(r: Resource[IO, String]) = r.flatMap { a =>
-        Resource.make(IO { acquired += a } *> IO.pure(a))(a => IO { released += a }).map(Set(_))
+    check { (rx: Resource[IO, Int], ry: Resource[IO, Int]) =>
+      var acquired: Set[Int] = Set.empty
+      var released: Set[Int] = Set.empty
+      def observe(r: Resource[IO, Int]) = r.flatMap { a =>
+        Resource.make(IO { acquired += a } *> IO.pure(a))(a => IO { released += a }).as(())
       }
-      (observe(rx) combine observe(ry)).use(_ => IO.unit).unsafeRunSync()
+      (observe(rx) combine observe(ry)).use(_ => IO.unit).attempt.unsafeRunSync()
       released <-> acquired
     }
   }
 
   test("releases both resources on combineK") {
-    Prop.forAll { (rx: Resource[IO, String], ry: Resource[IO, String]) =>
-      var acquired: Set[String] = Set.empty
-      var released: Set[String] = Set.empty
-      def observe(r: Resource[IO, String]) = r.flatMap { a =>
-        Resource.make(IO { acquired += a } *> IO.pure(a))(a => IO { released += a }).map(Set(_))
+    check { (rx: Resource[IO, Int], ry: Resource[IO, Int]) =>
+      var acquired: Set[Int] = Set.empty
+      var released: Set[Int] = Set.empty
+      def observe(r: Resource[IO, Int]) = r.flatMap { a =>
+        Resource.make(IO { acquired += a } *> IO.pure(a))(a => IO { released += a }).as(())
       }
-      (observe(rx) combineK observe(ry)).use(_ => IO.unit).unsafeRunSync()
+      (observe(rx) combineK observe(ry)).use(_ => IO.unit).attempt.unsafeRunSync()
       released <-> acquired
     }
   }
 
   testAsync("liftF") { implicit ec =>
-    Prop.forAll { fa: IO[String] =>
+    check { fa: IO[String] =>
       Resource.liftF(fa).use(IO.pure) <-> fa
     }
   }

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -23,7 +23,6 @@ import cats.laws._
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.implicits._
-//import org.scalacheck._
 
 class ResourceTests extends BaseTestsSuite {
   checkAllAsync("Resource[IO, ?]", implicit ec => MonadErrorTests[Resource[IO, ?], Throwable].monadError[Int, Int, Int])


### PR DESCRIPTION
As mentioned in PR #270 (see [my comment](https://github.com/typelevel/cats-effect/pull/270#pullrequestreview-133517991)), I believe the current `Resource` encoding isn't sufficient, the current implementation assuming the behavior of `IO`, yet `F[_] : Bracket` assumes no such thing.

In particular if `F[_]` is a stream, then both the current and the proposed `flatMap` implementations are broken.

This PR proposes  a new encoding for `Resource`.

With this new encoding, `Resource` now works much like streaming abstractions do (i.e. it has the ability to interpret `flatMap` calls in a safe way), whereas previous implementations had to rely on `flatMap` for specifying acquisition of combined resources, which is unsafe in the presence of cancellation.

```scala
case class Allocate[F[_], A](
  resource: F[(A, ExitCase[_] => F[Unit])])
  extends Resource[F, A]

case class Bind[F[_], S, A](
  source: Resource[F, S],
  f: S => Resource[F, A])
  extends Resource[F, A]

case class Suspend[F[_], A](
  resource: F[Resource[F, A]])
  extends Resource[F, A]
```

NOTES:

- the new `flatMap` operation just returns a `Bind` value
- we can no longer represent `def allocate: F[(A, F[Unit])]`, this signature being actually the source of the problem
- `use` is stack safe only if `F.bracket` is
- I also relaxed the requirements for `MonadError[Resource]` — no `F: Bracket` needed
- also introduced a lighter `Monad[Resource]` too, depending only on `F: Applicative`
- fixed tests

N.B. data constructors  are left public because in absence of a `def allocate` it's nice to leave the door open for converting `Resource` into something else, like a `Stream`. So to convert `Resource` into a `Stream` the user can just write its own interpreter.

This change does break backwards compatibility unfortunately. However I think the current `Resource` is broken and we can't release it if it is.