### PR TITLE
Concurrent, version 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -257,6 +257,9 @@ val mimaSettings = Seq(
       exclude[DirectMissingMethodProblem]("cats.effect.Concurrent#StateTConcurrent.onCancelRaiseError"),
       exclude[DirectMissingMethodProblem]("cats.effect.Concurrent#Ops.onCancelRaiseError"),
 
+      // Issue #290: Concurrent/ConcurrentEffect changes
+      exclude[IncompatibleResultTypeProblem]("cats.effect.IO.unsafeRunCancelable"),
+
       //
       // Following are all internal implementation details:
       //

--- a/core/js/src/main/scala/cats/effect/internals/IOPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOPlatform.scala
@@ -38,7 +38,7 @@ private[effect] object IOPlatform {
       case null =>
         // Triggering cancellation first
         cb.isActive = false
-        cancel()
+        cancel.unsafeRunAsync(Callback.report)
         throw new UnsupportedOperationException(
           "cannot synchronously await result on JavaScript; " +
           "use runAsync or unsafeRunAsync")

--- a/core/shared/src/main/scala/cats/effect/Async.scala
+++ b/core/shared/src/main/scala/cats/effect/Async.scala
@@ -307,7 +307,7 @@ object Async {
    * When using [[Concurrent]], prefer to use [[Concurrent.cancelable]]
    * instead, because it can have `F[_]` specific optimizations.
    */
-  def cancelable[F[_], A](k: (Either[Throwable, A] => Unit) => CancelToken[IO])
+  def cancelable[F[_], A](k: (Either[Throwable, A] => Unit) => CancelToken[F])
     (implicit F: Async[F]): F[A] = {
 
     F.asyncF[A] { cb =>
@@ -321,10 +321,8 @@ object Async {
         cb(result)
       }
       F.bracketCase(F.pure(token))(_ => latchF) {
-        case (ref, Canceled) =>
-          F.liftIO(ref)
-        case _ =>
-          F.unit
+        case (cancel, Canceled) => cancel
+        case _ => F.unit
       }
     }
   }

--- a/core/shared/src/main/scala/cats/effect/Async.scala
+++ b/core/shared/src/main/scala/cats/effect/Async.scala
@@ -19,14 +19,11 @@ package effect
 
 import simulacrum._
 import cats.data._
-import cats.effect.ExitCase.Canceled
 import cats.effect.IO.{Delay, Pure, RaiseError}
 import cats.effect.internals.{Callback, IORunLoop}
-import cats.effect.internals.TrampolineEC.immediate
-import cats.effect.internals.Callback.{rightUnit, successUnit}
 
 import scala.annotation.implicitNotFound
-import scala.concurrent.{ExecutionContext, Promise}
+import scala.concurrent.ExecutionContext
 import scala.util.Either
 
 /**
@@ -295,37 +292,6 @@ object Async {
           }
         }
     }
-
-  /**
-   * Cancelable builder derived from [[Async.asyncF asyncF]] and
-   * [[Bracket.bracketCase bracketCase]].
-   *
-   * Note that this builder is at this point not lawful, because
-   * the cancellation ability of values built via `bracketCase`
-   * isn't established until [[Concurrent]].
-   *
-   * When using [[Concurrent]], prefer to use [[Concurrent.cancelable]]
-   * instead, because it can have `F[_]` specific optimizations.
-   */
-  def cancelable[F[_], A](k: (Either[Throwable, A] => Unit) => CancelToken[F])
-    (implicit F: Async[F]): F[A] = {
-
-    F.asyncF[A] { cb =>
-      // For back-pressuring bracketCase until the callback gets called.
-      // Need to work with `Promise` due to the callback being side-effecting.
-      val latch = Promise[Unit]()
-      val latchF = F.async[Unit](cb => latch.future.onComplete(_ => cb(rightUnit))(immediate))
-      // Side-effecting call; unfreezes latch in order to allow bracket to finish
-      val token = k { result =>
-        latch.complete(successUnit)
-        cb(result)
-      }
-      F.bracketCase(F.pure(token))(_ => latchF) {
-        case (cancel, Canceled) => cancel
-        case _ => F.unit
-      }
-    }
-  }
 
   /**
    * [[Async]] instance built for `cats.data.EitherT` values initialized

--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -259,8 +259,9 @@ trait Concurrent[F[_]] extends Async[F] {
    * when the asynchronous process is complete with a final result.
    *
    * The registration function is also supposed to return
-   * an `IO[Unit]` that captures the logic necessary for
-   * canceling the asynchronous process, for as long as it
+   * a [[CancelToken]], which is nothing more than an
+   * alias for `F[Unit]`, capturing the logic necessary for
+   * canceling the asynchronous process for as long as it
    * is still active.
    *
    * Example:
@@ -277,8 +278,8 @@ trait Concurrent[F[_]] extends Async[F] {
    *       val run = new Runnable { def run() = cb(Right(())) }
    *       val future = ec.schedule(run, d.length, d.unit)
    *
-   *       // Cancellation logic, suspended in IO
-   *       IO(future.cancel(true))
+   *       // Cancellation logic, suspended in F
+   *       F.delay(future.cancel(true))
    *     }
    *   }
    * }}}

--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -270,7 +270,7 @@ trait Concurrent[F[_]] extends Async[F] {
    *   }
    * }}}
    */
-  def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[IO]): F[A] =
+  def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[F]): F[A] =
     Async.cancelable(k)(this)
 
   /**
@@ -395,8 +395,8 @@ object Concurrent {
     // compiler will choke on type inference :-(
     type Fiber[A] = cats.effect.Fiber[EitherT[F, L, ?], A]
 
-    override def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[IO]): EitherT[F, L, A] =
-      EitherT.liftF(F.cancelable(k))(F)
+//    override def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[IO]): EitherT[F, L, A] =
+//      EitherT.liftF(F.cancelable(k))(F)
 
     override def start[A](fa: EitherT[F, L, A]) =
       EitherT.liftF(F.start(fa.value).map(fiberT))
@@ -433,8 +433,8 @@ object Concurrent {
     // compiler will choke on type inference :-(
     type Fiber[A] = cats.effect.Fiber[OptionT[F, ?], A]
 
-    override def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[IO]): OptionT[F, A] =
-      OptionT.liftF(F.cancelable(k))(F)
+//    override def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[IO]): OptionT[F, A] =
+//      OptionT.liftF(F.cancelable(k))(F)
 
     override def start[A](fa: OptionT[F, A]) =
       OptionT.liftF(F.start(fa.value).map(fiberT))
@@ -471,8 +471,8 @@ object Concurrent {
     // compiler will choke on type inference :-(
     type Fiber[A] = cats.effect.Fiber[StateT[F, S, ?], A]
 
-    override def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[IO]): StateT[F, S, A] =
-      StateT.liftF(F.cancelable(k))(F)
+//    override def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[IO]): StateT[F, S, A] =
+//      StateT.liftF(F.cancelable(k))(F)
 
     override def start[A](fa: StateT[F, S, A]): StateT[F, S, Fiber[A]] =
       StateT(s => F.start(fa.run(s)).map { fiber => (s, fiberT(fiber)) })
@@ -501,8 +501,8 @@ object Concurrent {
     // compiler will choke on type inference :-(
     type Fiber[A] = cats.effect.Fiber[WriterT[F, L, ?], A]
 
-    override def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[IO]): WriterT[F, L, A] =
-      WriterT.liftF(F.cancelable(k))(L, F)
+//    override def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[IO]): WriterT[F, L, A] =
+//      WriterT.liftF(F.cancelable(k))(L, F)
 
     override def start[A](fa: WriterT[F, L, A]) =
       WriterT(F.start(fa.run).map { fiber =>
@@ -530,8 +530,8 @@ object Concurrent {
     // compiler can choke on type inference :-(
     type Fiber[A] = cats.effect.Fiber[Kleisli[F, R, ?], A]
 
-    override def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[IO]): Kleisli[F, R, A] =
-      Kleisli.liftF(F.cancelable(k))
+//    override def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[IO]): Kleisli[F, R, A] =
+//      Kleisli.liftF(F.cancelable(k))
 
     override def start[A](fa: Kleisli[F, R, A]): Kleisli[F, R, Fiber[A]] =
       Kleisli(r => F.start(fa.run(r)).map(fiberT))

--- a/core/shared/src/main/scala/cats/effect/ConcurrentEffect.scala
+++ b/core/shared/src/main/scala/cats/effect/ConcurrentEffect.scala
@@ -59,7 +59,7 @@ trait ConcurrentEffect[F[_]] extends Concurrent[F] with Effect[F] {
    *   cancel.unsafeRunSync
    * }}}
    */
-  def runCancelable[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): IO[IO[Unit]]
+  def runCancelable[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): IO[CancelToken[IO]]
 
   override def toIO[A](fa: F[A]): IO[A] =
     ConcurrentEffect.toIOFromRunCancelable(fa)(this)

--- a/core/shared/src/main/scala/cats/effect/ConcurrentEffect.scala
+++ b/core/shared/src/main/scala/cats/effect/ConcurrentEffect.scala
@@ -42,22 +42,20 @@ trait ConcurrentEffect[F[_]] extends Concurrent[F] with Effect[F] {
   /**
    * Evaluates `F[_]` with the ability to cancel it.
    *
-   * The returned `IO[IO[Unit]]` is a suspended cancelable action that
-   * can be used to cancel the running computation.
+   * The returned `IO[CancelToken[F]]` is a suspended cancelable
+   * action that can be used to cancel the running computation.
    *
-   * Note that evaluating the returned `IO` value, along with
-   * the boxed cancelable action are guaranteed to have immediate
-   * (synchronous) execution so you can safely do this, even
-   * on top of JavaScript (which has no ability to block threads):
+   * [[CancelToken]] is nothing more than an alias for `F[Unit]`
+   * and needs to be evaluated in order for cancelation of the
+   * active process to occur.
    *
-   * {{{
-   *   val io = F.runCancelable(fa)(cb)
+   * Contract:
    *
-   *   // For triggering asynchronous execution
-   *   val cancel = io.unsafeRunSync
-   *   // For cancellation
-   *   cancel.unsafeRunSync
-   * }}}
+   *  - the evaluation of the returned `IO` value is guaranteed
+   *    to have synchronous execution, therefore it can be
+   *    evaluated via [[IO.unsafeRunSync]]
+   *  - the evaluation of the suspended [[CancelToken]] however
+   *    must be asynchronous
    */
   def runCancelable[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): IO[CancelToken[F]]
 

--- a/core/shared/src/main/scala/cats/effect/Fiber.scala
+++ b/core/shared/src/main/scala/cats/effect/Fiber.scala
@@ -58,7 +58,7 @@ trait Fiber[F[_], A] {
    * of the underlying fiber is already complete, then there's nothing
    * to cancel.
    */
-  def cancel: F[Unit]
+  def cancel: CancelToken[F]
 
   /**
    * Returns a new task that will await for the completion of the

--- a/core/shared/src/main/scala/cats/effect/concurrent/Deferred.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Deferred.scala
@@ -125,7 +125,7 @@ object Deferred {
                   if (ref.compareAndSet(s, updated)) ()
                   else unregister()
               }
-            IO(unregister())
+            F.delay(unregister())
           }
       }
 
@@ -142,8 +142,7 @@ object Deferred {
             else register()
         }
 
-      register.foreach(a => cb(Right(a)))
-
+      register().foreach(a => cb(Right(a)))
       id
     }
 

--- a/core/shared/src/main/scala/cats/effect/internals/Callback.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/Callback.scala
@@ -42,6 +42,8 @@ private[effect] object Callback {
 
   /** Reusable `Right(())` reference. */
   val rightUnit = Right(())
+  /** Reusable `Success(())` reference. */
+  val successUnit = Success(())
 
   /** Reusable no-op, side-effectful `Function1` reference. */
   val dummy1: Any => Unit = _ => ()

--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -25,7 +25,7 @@ package object effect {
    * For example seeing `CancelToken[IO]` instead of `IO[Unit]`
    * can be more readable.
    *
-   * Cancellation tokens usually have these properties:
+   * Cancelation tokens usually have these properties:
    *
    *  1. they suspend over side effectful actions on shared state
    *  1. they need to be idempotent

--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+
+package object effect {
+  /**
+   * A cancelation token is an effectful action that is
+   * able to cancel a running task.
+   *
+   * This is just an alias in order to clarify the API.
+   * For example seeing `CancelToken[IO]` instead of `IO[Unit]`
+   * can be more readable.
+   *
+   * Cancellation tokens usually have these properties:
+   *
+   *  1. they suspend over side effectful actions on shared state
+   *  1. they need to be idempotent
+   *
+   * Note that in the case of well behaved implementations like
+   * that of [[IO]] idempotency is taken care of by its internals
+   * whenever dealing with cancellation tokens, but idempotency
+   * is a useful property to keep in mind when building such values.
+   */
+  type CancelToken[F[_]] = F[Unit]
+}

--- a/core/shared/src/test/scala/cats/effect/SyntaxTests.scala
+++ b/core/shared/src/test/scala/cats/effect/SyntaxTests.scala
@@ -63,6 +63,6 @@ object SyntaxTests extends AllCatsEffectSyntax {
     val fa = mock[F[A]]
     val cb = mock[Either[Throwable, A] => IO[Unit]]
 
-    typed[IO[IO[Unit]]](fa.runCancelable(cb))
+    typed[IO[F[Unit]]](fa.runCancelable(cb))
   }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/ConcurrentEffectLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ConcurrentEffectLaws.scala
@@ -29,17 +29,8 @@ trait ConcurrentEffectLaws[F[_]] extends ConcurrentLaws[F] with EffectLaws[F] {
 
   def runAsyncRunCancelableCoherence[A](fa: F[A]) = {
     val fa1 = IO.async[A] { cb => F.runAsync(fa)(r => IO(cb(r))).unsafeRunSync() }
-    val fa2 = IO.cancelable[A] { cb => F.runCancelable(fa)(r => IO(cb(r))).unsafeRunSync() }
+    val fa2 = IO.cancelable[A] { cb => F.toIO(F.runCancelable(fa)(r => IO(cb(r))).unsafeRunSync()) }
     fa1 <-> fa2
-  }
-
-  def runCancelableIsSynchronous[A](fa: F[A]) = {
-    // Creating never ending tasks
-    def never[T] = IO.async[T](_ => {})
-    val ff = F.cancelable[A](_ => F.runAsync(fa)(_ => never))
-
-    val lh = IO(F.runCancelable(ff)(_ => never).unsafeRunSync().unsafeRunSync())
-    lh <-> IO.unit
   }
 
   def runCancelableStartCancelCoherence[A](a: A) = {
@@ -47,11 +38,11 @@ trait ConcurrentEffectLaws[F[_]] extends ConcurrentLaws[F] with EffectLaws[F] {
     val f1: F[A] = for {
       effect1 <- Deferred.uncancelable[F, A]
       latch    = Promise[Unit]()
-      never    = F.cancelable[A] { _ => latch.success(()); F.toIO(effect1.complete(a)) }
+      never    = F.cancelable[A] { _ => latch.success(()); effect1.complete(a) }
       cancel  <- F.liftIO(F.runCancelable(never)(_ => IO.unit))
       // Waiting for the task to start before cancelling it
       _       <- F.liftIO(IO.fromFuture(IO.pure(latch.future)))
-      _       <- F.liftIO(cancel)
+      _       <- cancel
       result  <- effect1.get
     } yield result
 

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/ConcurrentEffectTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/ConcurrentEffectTests.scala
@@ -62,7 +62,6 @@ trait ConcurrentEffectTests[F[_]] extends ConcurrentTests[F] with EffectTests[F]
       val parents = Seq(concurrent[A, B, C], effect[A, B, C])
       val props = Seq(
         "runAsync runCancelable coherence" -> forAll(laws.runAsyncRunCancelableCoherence[A] _),
-        "runCancelable is synchronous" -> forAll(laws.runCancelableIsSynchronous[A] _),
         "runCancelable start.flatMap(_.cancel) coherence" -> forAll(laws.runCancelableStartCancelCoherence[A] _),
         "toIO is consistent with runCancelable" -> forAll(laws.toIORunCancelableConsistency[A] _))
     }

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/ConcurrentEffectTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/ConcurrentEffectTests.scala
@@ -62,6 +62,7 @@ trait ConcurrentEffectTests[F[_]] extends ConcurrentTests[F] with EffectTests[F]
       val parents = Seq(concurrent[A, B, C], effect[A, B, C])
       val props = Seq(
         "runAsync runCancelable coherence" -> forAll(laws.runAsyncRunCancelableCoherence[A] _),
+        "runCancelable is synchronous" -> forAll(laws.runCancelableIsSynchronous[A] _),
         "runCancelable start.flatMap(_.cancel) coherence" -> forAll(laws.runCancelableStartCancelCoherence[A] _),
         "toIO is consistent with runCancelable" -> forAll(laws.toIORunCancelableConsistency[A] _))
     }

--- a/laws/shared/src/test/scala/cats/effect/IOCancelableTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOCancelableTests.scala
@@ -103,7 +103,7 @@ class IOCancelableTests extends BaseTestsSuite {
     val cancel = task.unsafeRunCancelable(Callback.promise(p))
     sc.state.tasks.isEmpty shouldBe false
 
-    cancel()
+    cancel.unsafeRunSync()
     sc.tick()
     sc.state.tasks.isEmpty shouldBe true
     p.future.value shouldBe None

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import cats.effect.concurrent.Deferred
 import cats.effect.internals.{Callback, IOPlatform}
-import cats.effect.laws.discipline.ConcurrentEffectTests
+import cats.effect.laws.discipline.{ConcurrentEffectTests, EffectTests}
 import cats.effect.laws.discipline.arbitrary._
 import cats.implicits._
 import cats.kernel.laws.discipline.MonoidTests
@@ -29,7 +29,7 @@ import cats.laws._
 import cats.laws.discipline._
 import org.scalacheck._
 
-import scala.concurrent.{Future, Promise, TimeoutException}
+import scala.concurrent.{ExecutionContext, Future, Promise, TimeoutException}
 import scala.util.{Failure, Success}
 import scala.concurrent.duration._
 
@@ -42,8 +42,13 @@ class IOTests extends BaseTestsSuite {
   checkAllAsync("IO.Par", implicit ec => ApplicativeTests[IO.Par].applicative[Int, Int, Int])
   checkAllAsync("IO", implicit ec => ParallelTests[IO, IO.Par].parallel[Int, Int])
 
-  checkAllAsync("IO(defaults)", implicit ec => {
+  checkAllAsync("IO(Effect defaults)", implicit ec => {
     implicit val ioEffect = IOTests.ioEffectDefaults
+    EffectTests[IO].effect[Int, Int, Int]
+  })
+
+  checkAllAsync("IO(ConcurrentEffect defaults)", implicit ec => {
+    implicit val ioConcurrent = IOTests.ioConcurrentEffectDefaults(ec)
     ConcurrentEffectTests[IO].concurrentEffect[Int, Int, Int]
   })
 
@@ -136,7 +141,6 @@ class IOTests extends BaseTestsSuite {
     ec.tick()
     expected.value shouldEqual Some(Success(1))
   }
-
 
   testAsync("shift works for failure (via Timer)") { implicit ec =>
     val dummy = new RuntimeException("dummy")
@@ -555,7 +559,7 @@ class IOTests extends BaseTestsSuite {
     val io1 = IO.shift *> IO.cancelable[Int](_ => IO { wasCanceled = true })
     val cancel = io1.unsafeRunCancelable(Callback.promise(p))
 
-    cancel()
+    cancel.unsafeRunSync()
     // Signal not observed yet due to IO.shift
     wasCanceled shouldBe false
 
@@ -872,7 +876,7 @@ class IOTests extends BaseTestsSuite {
     val f = p.future
 
     ec.tick()
-    cancel()
+    cancel.unsafeRunSync()
     ec.tick()
 
     assert(ec.state.tasks.isEmpty, "tasks.isEmpty")
@@ -929,8 +933,23 @@ class IOTests extends BaseTestsSuite {
 
 object IOTests {
   /** Implementation for testing default methods. */
-  val ioEffectDefaults = new Effect[IO] {
-    private val ref = implicitly[Effect[IO]]
+  val ioEffectDefaults = new IODefaults
+
+  /** Implementation for testing default methods. */
+  def ioConcurrentEffectDefaults(implicit ec: ExecutionContext) =
+    new IODefaults with ConcurrentEffect[IO] {
+      override protected val ref = implicitly[ConcurrentEffect[IO]]
+
+      def runCancelable[A](fa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): IO[CancelToken[IO]] =
+        fa.runCancelable(cb)
+      def start[A](fa: IO[A]): IO[Fiber[IO, A]] =
+        fa.start
+      def racePair[A, B](fa: IO[A], fb: IO[B]): IO[Either[(A, Fiber[IO, B]), (Fiber[IO, A], B)]] =
+        IO.racePair(fa, fb)
+    }
+
+  class IODefaults extends Effect[IO] {
+    protected val ref = implicitly[Effect[IO]]
 
     def async[A](k: ((Either[Throwable, A]) => Unit) => Unit): IO[A] =
       ref.async(k)
@@ -952,10 +971,6 @@ object IOTests {
       ref.runSyncStep(fa)
     def suspend[A](thunk: =>IO[A]): IO[A] =
       ref.suspend(thunk)
-    def runCancelable[A](fa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): IO[IO[Unit]] =
-      fa.runCancelable(cb)
-    def cancelable[A](k: (Either[Throwable, A] => Unit) => IO[Unit]): IO[A] =
-      IO.cancelable(k)
     def bracketCase[A, B](acquire: IO[A])
       (use: A => IO[B])
       (release: (A, ExitCase[Throwable]) => IO[Unit]): IO[B] =

--- a/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/InstancesTests.scala
@@ -62,5 +62,4 @@ class InstancesTests extends BaseTestsSuite {
 
   implicit def stateTEq[F[_]: FlatMap, S: Monoid, A](implicit FSA: Eq[F[(S, A)]]): Eq[StateT[F, S, A]] =
     Eq.by[StateT[F, S, A], F[(S, A)]](state => state.run(Monoid[S].empty))
-
 }

--- a/laws/shared/src/test/scala/cats/effect/TestContextTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/TestContextTests.scala
@@ -175,7 +175,7 @@ class TestContextTests extends BaseTestsSuite {
     assert(p2.future.value === None)
     assert(p3.future.value === None)
 
-    cancel()
+    cancel.unsafeRunSync()
     ec.tick()
     assert(p2.future.value === None)
 

--- a/site/src/main/tut/datatypes/io.md
+++ b/site/src/main/tut/datatypes/io.md
@@ -613,12 +613,12 @@ this kind of code is impure and should be used with care:
 // Delayed println
 val io: IO[Unit] = IO.sleep(10.seconds) *> IO(println("Hello!"))
 
-val cancel: () => Unit = 
+val cancel: IO[Unit] = 
   io.unsafeRunCancelable(r => println(s"Done: $r"))
 
 // ... if a race condition happens, we can cancel it,
 // thus canceling the scheduling of `IO.sleep`
-cancel()
+cancel.unsafeRunSync()
 ```
 
 The `runCancelable` alternative is the operation that's compliant with

--- a/site/src/main/tut/typeclasses/concurrent-effect.md
+++ b/site/src/main/tut/typeclasses/concurrent-effect.md
@@ -13,9 +13,24 @@ In addition to the algebras of `Concurrent` and `Effect`, instances must also im
 *Note this is the safe and generic version of `IO.unsafeRunCancelable`*.
 
 ```tut:silent
-import cats.effect.{Concurrent, Effect, IO}
+import cats.effect.{Concurrent, Effect, IO, CancelToken}
 
 trait ConcurrentEffect[F[_]] extends Concurrent[F] with Effect[F] {
-  def runCancelable[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): IO[IO[Unit]]
+  def runCancelable[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): IO[CancelToken[F]]
+}
+```
+
+This `runCancelable` operation actually mirrors the `cancelable` builder in [Concurrent](./concurrent.html). With the `runCancelable` and `cancelable` pair one is then able to convert between `ConcurrentEffect` data types:
+
+```tut:reset:silent
+import cats.effect._
+
+def convert[F[_], G[_], A](fa: F[A])
+  (implicit F: ConcurrentEffect[F], G: Concurrent[G]): G[A] = {
+ 
+  G.cancelable { cb =>
+    val token = F.runCancelable(fa)(r => IO(cb(r))).unsafeRunSync()
+    convert[F, G, Unit](token)
+  }
 }
 ```


### PR DESCRIPTION
This is a change proposal that breaks binary and source compatibility.

We can refrain from doing that and I'd like your opinion, but unfortunately we are breaking binary and source compatibility in the next release anyway, at least due to #278 and possibly #289.

NOTE this PR is needed as a precursor to the upcoming changes for fixing #267.

Changes:

1. demote `Concurrent#cancelable` from being a primitive operation by providing a default implementation; instances can override it
3. Make `cancelable` work with `F[Unit]` as the "cancel token" instead of `IO[Unit]`; thus we are making `Concurrent` independent of `IO`
4. Introduce a `type CancelToken[F[_]] = F[Unit]` alias to better document cancellation tokens used in the API, because working with `IO[IO[Unit]]` is damn confusing, versus `IO[CancelToken[IO]]`
5. drop a law because we cannot keep it: `ConcurrentLaws#runCancelableIsSynchronous` (TODO: maybe we need a variant of it)
6. also changed the signature of `ConcurrentEffect#runCancelable` and of `IO.unsafeRunCancelable`

/cc @SystemFw and @oleg-py will probably like this PR.

This is a follow-up on #247 by @oleg-py, however Oleg's implementation for `cancelable` wasn't working. For one because he was missing `asyncF` which in this case is essential.

## Backwards Incompatible Changes

In `IO` the signature of `unsafeRunCancelable` is now changed from:

```scala
def unsafeRunCancelable(cb: Either[Throwable, A] => Unit): () => Unit
```

After the PR:

```scala
def unsafeRunCancelable(cb: Either[Throwable, A] => Unit): CancelToken[IO]
```

(N.B. `CancelToken[IO]` is a plain type alias for `IO[Unit]`)

This is necessary for #267 because in order to sequence finalizers, from now on we have to consider that all cancellation tokens can be back-pressured.

In `Concurrent` the `cancelable` builder changes signature and gets demoted from being a primitive operation:

```scala
trait Concurrent[F[_]] {
  // ....
  def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[F]): F[A] =
    Concurrent.defaultCancelable(k)(this)
}
```

The `cancelable` builder is an FFI function that can be optimized by implementations. But implementations like that of Scalaz's ZIO can simply ignore it if they don't want to implement it, given it now has a default implementation.

Thus the `Concurrent` type class is defined by `start` and by `racePair`.

In `ConcurrentEffect` the `runCancelable` function has changed to mirror the `cancelable` builder:

```scala
def runCancelable[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): IO[CancelToken[F]]
```

Thus the cancellation token exposed changes from `IO[Unit]` to `F[Unit]`.