### PR TITLE
Minimal proof of concept of SyncIO

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -175,15 +175,15 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * @see [[runCancelable]] for the version that gives you a cancelable
    *      token that can be used to send a cancel signal
    */
-  final def runAsync(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] = IO {
+  final def runAsync(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] = SyncIO {
     unsafeRunAsync(cb.andThen(_.unsafeRunAsync(Callback.report)))
   }
 
-  final def runSyncStep: IO[Either[IO[A], A]] = IO.suspend {
+  final def runSyncStep: SyncIO[Either[IO[A], A]] = SyncIO.suspend {
     IORunLoop.step(this) match {
-      case Pure(a) => Pure(Right(a))
-      case r @ RaiseError(_) => r
-      case async => Pure(Left(async))
+      case Pure(a) => SyncIO.pure(Right(a))
+      case RaiseError(e) => SyncIO.raiseError(e)
+      case async => SyncIO.pure(Left(async))
     }
   }
 
@@ -223,8 +223,8 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    *
    * @see [[runAsync]] for the simple, uninterruptible version
    */
-  final def runCancelable(cb: Either[Throwable, A] => IO[Unit]): IO[CancelToken[IO]] =
-    IO(unsafeRunCancelable(cb.andThen(_.unsafeRunAsync(_ => ()))))
+  final def runCancelable(cb: Either[Throwable, A] => IO[Unit]): SyncIO[CancelToken[IO]] =
+    SyncIO(unsafeRunCancelable(cb.andThen(_.unsafeRunAsync(_ => ()))))
 
   /**
    * Produces the result by running the encapsulated effects as impure
@@ -778,9 +778,9 @@ private[effect] abstract class IOLowPriorityInstances extends IOParallelNewtype 
       ioa
     override def toIO[A](fa: IO[A]): IO[A] =
       fa
-    final override def runAsync[A](ioa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] =
+    final override def runAsync[A](ioa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] =
       ioa.runAsync(cb)
-    final override def runSyncStep[A](ioa: IO[A]): IO[Either[IO[A], A]] =
+    final override def runSyncStep[A](ioa: IO[A]): SyncIO[Either[IO[A], A]] =
       ioa.runSyncStep
   }
 }
@@ -815,7 +815,7 @@ private[effect] abstract class IOInstances extends IOLowPriorityInstances {
 
     final override def cancelable[A](k: (Either[Throwable, A] => Unit) => IO[Unit]): IO[A] =
       IO.cancelable(k)
-    final override def runCancelable[A](fa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): IO[CancelToken[IO]] =
+    final override def runCancelable[A](fa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[CancelToken[IO]] =
       fa.runCancelable(cb)
 
     final override def toIO[A](fa: IO[A]): IO[A] = fa

--- a/core/shared/src/main/scala/cats/effect/SyncIO.scala
+++ b/core/shared/src/main/scala/cats/effect/SyncIO.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+
+final class SyncIO[+A] private (val toIO: IO[A]) {
+  def unsafeRunSync(): A = toIO.unsafeRunSync
+
+  def attempt: SyncIO[Either[Throwable, A]] = new SyncIO(toIO.attempt)
+  def map[B](f: A => B): SyncIO[B] = new SyncIO(toIO.map(f))
+  def flatMap[B](f: A => SyncIO[B]): SyncIO[B] = new SyncIO(toIO.flatMap(a => f(a).toIO))
+}
+
+object SyncIO {
+  def pure[A](a: A): SyncIO[A] = new SyncIO(IO.pure(a))
+  def apply[A](thunk: => A): SyncIO[A] = new SyncIO(IO(thunk))
+  def suspend[A](thunk: => SyncIO[A]): SyncIO[A] = new SyncIO(IO.suspend(thunk.toIO))
+  val unit: SyncIO[Unit] = pure(())
+  def eval[A](fa: Eval[A]): SyncIO[A] = fa match {
+    case Now(a) => pure(a)
+    case notNow => apply(notNow.value)
+  }
+  def raiseError[A](e: Throwable): SyncIO[A] = new SyncIO(IO.raiseError(e))
+  def fromEither[A](e: Either[Throwable, A]): SyncIO[A] = new SyncIO(IO.fromEither(e))
+}

--- a/core/shared/src/test/scala/cats/effect/SyntaxTests.scala
+++ b/core/shared/src/test/scala/cats/effect/SyntaxTests.scala
@@ -55,14 +55,14 @@ object SyntaxTests extends AllCatsEffectSyntax {
     val cb = mock[Either[Throwable, A] => IO[Unit]]
 
     typed[IO[A]](fa.toIO)
-    typed[IO[Unit]](fa.runAsync(cb))
-    typed[IO[Either[F[A], A]]](fa.runSyncStep)
+    typed[SyncIO[Unit]](fa.runAsync(cb))
+    typed[SyncIO[Either[F[A], A]]](fa.runSyncStep)
   }
 
   def concurrentEffectSyntax[F[_]: ConcurrentEffect, A] = {
     val fa = mock[F[A]]
     val cb = mock[Either[Throwable, A] => IO[Unit]]
 
-    typed[IO[F[Unit]]](fa.runCancelable(cb))
+    typed[SyncIO[F[Unit]]](fa.runCancelable(cb))
   }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/ConcurrentEffectLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ConcurrentEffectLaws.scala
@@ -50,7 +50,7 @@ trait ConcurrentEffectLaws[F[_]] extends ConcurrentLaws[F] with EffectLaws[F] {
       effect1 <- Deferred.uncancelable[F, A]
       latch    = Promise[Unit]()
       never    = F.cancelable[A] { _ => latch.success(()); effect1.complete(a) }
-      cancel  <- F.liftIO(F.runCancelable(never)(_ => IO.unit))
+      cancel  <- F.liftIO(F.runCancelable(never)(_ => IO.unit).toIO)
       // Waiting for the task to start before cancelling it
       _       <- F.liftIO(IO.fromFuture(IO.pure(latch.future)))
       _       <- cancel

--- a/laws/shared/src/main/scala/cats/effect/laws/ConcurrentEffectLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ConcurrentEffectLaws.scala
@@ -39,7 +39,7 @@ trait ConcurrentEffectLaws[F[_]] extends ConcurrentLaws[F] with EffectLaws[F] {
       val ff = F.cancelable[A](_ => latch.complete(()))
       // Execute, then cancel
       val token = F.suspend(F.runCancelable(ff)(_ => IO.unit).unsafeRunSync())
-      F.liftIO(F.runAsync(token)(_ => IO.unit)) *> latch.get
+      F.liftIO(F.runAsync(token)(_ => IO.unit).toIO) *> latch.get
     }
     lh <-> F.unit
   }

--- a/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
@@ -42,15 +42,15 @@ trait EffectLaws[F[_]] extends AsyncLaws[F] {
 
   def runAsyncIgnoresErrorInHandler[A](e: Throwable) = {
     val fa = F.pure(())
-    F.runAsync(fa)(_ => IO.raiseError(e)) <-> IO.pure(())
+    F.runAsync(fa)(_ => IO.raiseError(e)).toIO <-> SyncIO.pure(()).toIO
   }
 
   def runSyncStepSuspendPureProducesTheSame[A](fa: F[A]) = {
-    F.runSyncStep(F.suspend(fa)) <-> F.runSyncStep(fa)
+    F.runSyncStep(F.suspend(fa)).toIO <-> F.runSyncStep(fa).toIO
   }
 
   def runSyncStepAsyncProducesLeftPureIO[A](k: (Either[Throwable, A] => Unit) => Unit) = {
-    F.runSyncStep(F.async[A](k)) <-> IO.pure(Left(F.async[A](k)))
+    F.runSyncStep(F.async[A](k)).toIO <-> IO.pure(Left(F.async[A](k)))
   }
 
   def runSyncStepCanBeAttemptedSynchronously[A](fa: F[A]) = {
@@ -61,7 +61,7 @@ trait EffectLaws[F[_]] extends AsyncLaws[F] {
     def runToIO(fa: F[A]): IO[A] = IO.async { cb =>
       F.runAsync(fa)(eta => IO { cb(eta) }).unsafeRunSync()
     }
-    F.runSyncStep(fa).flatMap(_.fold(runToIO, IO.pure)) <-> runToIO(fa)
+    F.runSyncStep(fa).toIO.flatMap(_.fold(runToIO, IO.pure)) <-> runToIO(fa)
   }
 
   def toIOinverseOfLiftIO[A](ioa: IO[A]) =

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestInstances.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestInstances.scala
@@ -16,7 +16,7 @@
 
 package cats.effect.laws.util
 
-import cats.effect.{Bracket, IO, Resource}
+import cats.effect.{Bracket, IO, Resource, SyncIO}
 import cats.kernel.Eq
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
@@ -98,6 +98,13 @@ trait TestInstances {
     new Eq[Resource[F, A]] {
       def eqv(x: Resource[F, A], y: Resource[F, A]): Boolean =
         E.eqv(x.use(F.pure), y.use(F.pure))
+    }
+
+  /** Defines equality for `SyncIO` references. */
+  implicit def eqSyncIO[A](implicit A: Eq[A]): Eq[SyncIO[A]] =
+    new Eq[SyncIO[A]] {
+      def eqv(x: SyncIO[A], y: SyncIO[A]): Boolean =
+        A.eqv(x.unsafeRunSync(), y.unsafeRunSync())
     }
 }
 

--- a/laws/shared/src/test/scala/cats/effect/IOAsyncTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOAsyncTests.scala
@@ -42,7 +42,7 @@ class IOAsyncTests extends AsyncFunSuite with Matchers {
       case Left(e) => IO(effect.failure(e))
     }
 
-    for (_ <- io.unsafeToFuture(); v <- attempt.future) yield {
+    for (_ <- io.toIO.unsafeToFuture(); v <- attempt.future) yield {
       v shouldEqual expected
     }
   }

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -940,7 +940,7 @@ object IOTests {
     new IODefaults with ConcurrentEffect[IO] {
       override protected val ref = implicitly[ConcurrentEffect[IO]]
 
-      def runCancelable[A](fa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): IO[CancelToken[IO]] =
+      def runCancelable[A](fa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[CancelToken[IO]] =
         fa.runCancelable(cb)
       def start[A](fa: IO[A]): IO[Fiber[IO, A]] =
         fa.start

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -965,9 +965,9 @@ object IOTests {
       ref.flatMap(fa)(f)
     def tailRecM[A, B](a: A)(f: (A) => IO[Either[A, B]]): IO[B] =
       ref.tailRecM(a)(f)
-    def runAsync[A](fa: IO[A])(cb: (Either[Throwable, A]) => IO[Unit]): IO[Unit] =
+    def runAsync[A](fa: IO[A])(cb: (Either[Throwable, A]) => IO[Unit]): SyncIO[Unit] =
       ref.runAsync(fa)(cb)
-    def runSyncStep[A](fa: IO[A]): IO[Either[IO[A], A]] =
+    def runSyncStep[A](fa: IO[A]): SyncIO[Either[IO[A], A]] =
       ref.runSyncStep(fa)
     def suspend[A](thunk: =>IO[A]): IO[A] =
       ref.suspend(thunk)

--- a/laws/shared/src/test/scala/cats/effect/LTask.scala
+++ b/laws/shared/src/test/scala/cats/effect/LTask.scala
@@ -75,13 +75,13 @@ object LTask {
           p.future
         }
 
-      def runAsync[A](fa: LTask[A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] =
-        IO(fa.run(ec).onComplete { r =>
+      def runAsync[A](fa: LTask[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] =
+        SyncIO(fa.run(ec).onComplete { r =>
           cb(Conversions.toEither(r)).unsafeRunAsync(Callback.report)
         })
 
-      def runSyncStep[A](fa: LTask[A]): IO[Either[LTask[A], A]] =
-        IO.pure(Left(fa))
+      def runSyncStep[A](fa: LTask[A]): SyncIO[Either[LTask[A], A]] =
+        SyncIO.pure(Left(fa))
 
       def flatMap[A, B](fa: LTask[A])(f: A => LTask[B]): LTask[B] =
         LTask { implicit ec =>


### PR DESCRIPTION
Not for merge, just for discussion purposes.

This PR introduces `SyncIO` as a new type around `IO` which guarantees synchronous execution. It also updates the `Effect` and `ConcurrentEffect` type classes to use `SyncIO` in place of `IO` as the return from the `runAsync`, `runStepSync`, and `runCancelable` methods.

I left the callback passed to `runAsync` and `runCancelable` returning `IO` but perhaps that should be `SyncIO` too.

What do you think? If this strategy is amenable, I can create a real PR with updated documentation, more methods and constructors, and so on.