### PR TITLE
Added SyncIO data type for describing synchronous effectful computations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -219,14 +219,6 @@ val mimaSettings = Seq(
       exclude[ReversedMissingMethodProblem]("cats.effect.Effect#EitherTEffect.toIO"),
       exclude[ReversedMissingMethodProblem]("cats.effect.Effect.toIO"),
       exclude[ReversedMissingMethodProblem]("cats.effect.ConcurrentEffect.toIO"),
-      exclude[IncompatibleResultTypeProblem]("cats.effect.ConcurrentEffect#StateTConcurrentEffect.runCancelable"),
-      exclude[IncompatibleResultTypeProblem]("cats.effect.ConcurrentEffect#WriterTConcurrentEffect.runCancelable"),
-      exclude[IncompatibleResultTypeProblem]("cats.effect.ConcurrentEffect#Ops.runCancelable"),
-      exclude[IncompatibleResultTypeProblem]("cats.effect.Effect#StateTEffect.runAsync"),
-      exclude[IncompatibleResultTypeProblem]("cats.effect.Effect#WriterTEffect.runAsync"),
-      exclude[IncompatibleResultTypeProblem]("cats.effect.Effect#Ops.runAsync"),
-      exclude[IncompatibleResultTypeProblem]("cats.effect.ConcurrentEffect#EitherTConcurrentEffect.runCancelable"),
-      exclude[IncompatibleResultTypeProblem]("cats.effect.Effect#EitherTEffect.runAsync"),
 
       // Uncancelable moved down to Bracket
       exclude[DirectMissingMethodProblem]("cats.effect.Concurrent#Ops.uncancelable"),
@@ -337,6 +329,14 @@ val mimaSettings = Seq(
       exclude[ReversedMissingMethodProblem]("cats.effect.Effect#EitherTEffect.runAsync"),
       exclude[IncompatibleResultTypeProblem]("cats.effect.Effect.runAsync"),
       exclude[ReversedMissingMethodProblem]("cats.effect.Effect.runAsync"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.ConcurrentEffect#StateTConcurrentEffect.runCancelable"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.ConcurrentEffect#WriterTConcurrentEffect.runCancelable"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.ConcurrentEffect#Ops.runCancelable"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.Effect#StateTEffect.runAsync"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.Effect#WriterTEffect.runAsync"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.Effect#Ops.runAsync"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.ConcurrentEffect#EitherTConcurrentEffect.runCancelable"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.Effect#EitherTEffect.runAsync"),
 
       //
       // Following are all internal implementation details:

--- a/build.sbt
+++ b/build.sbt
@@ -219,6 +219,14 @@ val mimaSettings = Seq(
       exclude[ReversedMissingMethodProblem]("cats.effect.Effect#EitherTEffect.toIO"),
       exclude[ReversedMissingMethodProblem]("cats.effect.Effect.toIO"),
       exclude[ReversedMissingMethodProblem]("cats.effect.ConcurrentEffect.toIO"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.ConcurrentEffect#StateTConcurrentEffect.runCancelable"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.ConcurrentEffect#WriterTConcurrentEffect.runCancelable"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.ConcurrentEffect#Ops.runCancelable"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.Effect#StateTEffect.runAsync"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.Effect#WriterTEffect.runAsync"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.Effect#Ops.runAsync"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.ConcurrentEffect#EitherTConcurrentEffect.runCancelable"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.Effect#EitherTEffect.runAsync"),
 
       // Uncancelable moved down to Bracket
       exclude[DirectMissingMethodProblem]("cats.effect.Concurrent#Ops.uncancelable"),
@@ -305,6 +313,30 @@ val mimaSettings = Seq(
 
       // Issue #290: Concurrent/ConcurrentEffect changes
       exclude[IncompatibleResultTypeProblem]("cats.effect.IO.unsafeRunCancelable"),
+
+      // Issue #298: SyncIO changes
+      exclude[DirectMissingMethodProblem]("cats.effect.ConcurrentEffect#StateTConcurrentEffect.runCancelable"),
+      exclude[ReversedMissingMethodProblem]("cats.effect.ConcurrentEffect#StateTConcurrentEffect.runCancelable"),
+      exclude[DirectMissingMethodProblem]("cats.effect.ConcurrentEffect#WriterTConcurrentEffect.runCancelable"),
+      exclude[ReversedMissingMethodProblem]("cats.effect.ConcurrentEffect#WriterTConcurrentEffect.runCancelable"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.IO.runAsync"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.IO.runCancelable"),
+      exclude[DirectMissingMethodProblem]("cats.effect.ConcurrentEffect#Ops.runCancelable"),
+      exclude[ReversedMissingMethodProblem]("cats.effect.ConcurrentEffect#Ops.runCancelable"),
+      exclude[DirectMissingMethodProblem]("cats.effect.Effect#StateTEffect.runAsync"),
+      exclude[ReversedMissingMethodProblem]("cats.effect.Effect#StateTEffect.runAsync"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.ConcurrentEffect.runCancelable"),
+      exclude[ReversedMissingMethodProblem]("cats.effect.ConcurrentEffect.runCancelable"),
+      exclude[DirectMissingMethodProblem]("cats.effect.Effect#WriterTEffect.runAsync"),
+      exclude[ReversedMissingMethodProblem]("cats.effect.Effect#WriterTEffect.runAsync"),
+      exclude[DirectMissingMethodProblem]("cats.effect.Effect#Ops.runAsync"),
+      exclude[ReversedMissingMethodProblem]("cats.effect.Effect#Ops.runAsync"),
+      exclude[DirectMissingMethodProblem]("cats.effect.ConcurrentEffect#EitherTConcurrentEffect.runCancelable"),
+      exclude[ReversedMissingMethodProblem]("cats.effect.ConcurrentEffect#EitherTConcurrentEffect.runCancelable"),
+      exclude[DirectMissingMethodProblem]("cats.effect.Effect#EitherTEffect.runAsync"),
+      exclude[ReversedMissingMethodProblem]("cats.effect.Effect#EitherTEffect.runAsync"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.Effect.runAsync"),
+      exclude[ReversedMissingMethodProblem]("cats.effect.Effect.runAsync"),
 
       //
       // Following are all internal implementation details:

--- a/core/shared/src/main/scala/cats/effect/ConcurrentEffect.scala
+++ b/core/shared/src/main/scala/cats/effect/ConcurrentEffect.scala
@@ -42,7 +42,7 @@ trait ConcurrentEffect[F[_]] extends Concurrent[F] with Effect[F] {
   /**
    * Evaluates `F[_]` with the ability to cancel it.
    *
-   * The returned `IO[CancelToken[F]]` is a suspended cancelable
+   * The returned `SyncIO[CancelToken[F]]` is a suspended cancelable
    * action that can be used to cancel the running computation.
    *
    * [[CancelToken]] is nothing more than an alias for `F[Unit]`
@@ -51,13 +51,9 @@ trait ConcurrentEffect[F[_]] extends Concurrent[F] with Effect[F] {
    *
    * Contract:
    *
-   *  - the evaluation of the returned `IO` value is guaranteed
-   *    to have synchronous execution, therefore it can be
-   *    evaluated via [[IO.unsafeRunSync]]
-   *  - the evaluation of the suspended [[CancelToken]] however
-   *    must be asynchronous
+   *  - the evaluation of the suspended [[CancelToken]] must be asynchronous
    */
-  def runCancelable[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): IO[CancelToken[F]]
+  def runCancelable[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[CancelToken[F]]
 
   override def toIO[A](fa: F[A]): IO[A] =
     ConcurrentEffect.toIOFromRunCancelable(fa)(this)
@@ -102,7 +98,7 @@ object ConcurrentEffect {
     protected def F: ConcurrentEffect[F]
 
     override def runCancelable[A](fa: EitherT[F, Throwable, A])
-      (cb: Either[Throwable, A] => IO[Unit]): IO[CancelToken[EitherT[F, Throwable, ?]]] =
+      (cb: Either[Throwable, A] => IO[Unit]): SyncIO[CancelToken[EitherT[F, Throwable, ?]]] =
       F.runCancelable(fa.value)(cb.compose(_.right.flatMap(x => x))).map(EitherT.liftF(_)(F))
   }
 
@@ -115,7 +111,7 @@ object ConcurrentEffect {
     protected def S: Monoid[S]
 
     override def runCancelable[A](fa: StateT[F, S, A])
-      (cb: Either[Throwable, A] => IO[Unit]): IO[CancelToken[StateT[F, S, ?]]] =
+      (cb: Either[Throwable, A] => IO[Unit]): SyncIO[CancelToken[StateT[F, S, ?]]] =
       F.runCancelable(fa.runA(S.empty)(F))(cb).map(StateT.liftF(_)(F))
   }
 
@@ -128,7 +124,7 @@ object ConcurrentEffect {
     protected def L: Monoid[L]
 
     override def runCancelable[A](fa: WriterT[F, L, A])
-      (cb: Either[Throwable, A] => IO[Unit]): IO[CancelToken[WriterT[F, L, ?]]] =
+      (cb: Either[Throwable, A] => IO[Unit]): SyncIO[CancelToken[WriterT[F, L, ?]]] =
       F.runCancelable(fa.run)(cb.compose(_.right.map(_._2))).map(WriterT.liftF(_)(L, F))
   }
 }

--- a/core/shared/src/main/scala/cats/effect/Effect.scala
+++ b/core/shared/src/main/scala/cats/effect/Effect.scala
@@ -46,32 +46,25 @@ trait Effect[F[_]] extends Async[F] {
 
   /**
    * Evaluates `F[_]`, with the effect of starting the run-loop
-   * being suspended in the `IO` context.
+   * being suspended in the `SyncIO` context.
    *
-   * Note that evaluating the returned `IO[Unit]` is guaranteed
-   * to execute immediately:
    * {{{
    *   val io = F.runAsync(fa)(cb)
-   *
-   *   // For triggering actual execution, guaranteed to be
-   *   // immediate because it doesn't wait for the result
+   *   // Running io results in evaluation of `fa` starting 
    *   io.unsafeRunSync
    * }}}
    */
-  def runAsync[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit]
+  def runAsync[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit]
 
   /**
-   * Returns an `IO` which runs `fa` until it reaches an asynchronous
+   * Returns a `SyncIO` which runs `fa` until it reaches an asynchronous
    * boundary.
    *
    * If it is possible to run the entirety of `fa` synchronously, its
    * result is returned wrapped in a `Right`. Otherwise, the
    * continuation (asynchronous) effect is returned in a `Left`.
-   *
-   * Note that evaluating the returned `IO` is guaranteed
-   * to execute immediately.
    */
-  def runSyncStep[A](fa: F[A]): IO[Either[F[A], A]]
+  def runSyncStep[A](fa: F[A]): SyncIO[Either[F[A], A]]
 
   /**
    * Convert to an IO[A].
@@ -117,13 +110,13 @@ object Effect {
 
     protected def F: Effect[F]
 
-    def runAsync[A](fa: EitherT[F, Throwable, A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] =
+    def runAsync[A](fa: EitherT[F, Throwable, A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] =
       F.runAsync(fa.value)(cb.compose(_.right.flatMap(x => x)))
 
-    def runSyncStep[A](fa: EitherT[F, Throwable, A]): IO[Either[EitherT[F, Throwable, A], A]] = {
+    def runSyncStep[A](fa: EitherT[F, Throwable, A]): SyncIO[Either[EitherT[F, Throwable, A], A]] = {
       F.runSyncStep(fa.value).flatMap {
-        case Left(feta) => IO.pure(Left(EitherT(feta)))
-        case Right(eta) => IO.fromEither(eta).map(Right(_))
+        case Left(feta) => SyncIO.pure(Left(EitherT(feta)))
+        case Right(eta) => SyncIO.fromEither(eta).map(Right(_))
       }
     }
 
@@ -137,10 +130,10 @@ object Effect {
     protected def F: Effect[F]
     protected def S: Monoid[S]
 
-    def runAsync[A](fa: StateT[F, S, A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] =
+    def runAsync[A](fa: StateT[F, S, A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] =
       F.runAsync(fa.runA(S.empty)(F))(cb)
 
-    def runSyncStep[A](fa: StateT[F, S, A]): IO[Either[StateT[F, S, A], A]] =
+    def runSyncStep[A](fa: StateT[F, S, A]): SyncIO[Either[StateT[F, S, A], A]] =
       F.runSyncStep(fa.runA(S.empty)(F)).map(_.leftMap(fa => StateT.liftF(fa)(F)))
 
     override def toIO[A](fa: StateT[F, S, A]): IO[A] =
@@ -153,10 +146,10 @@ object Effect {
     protected def F: Effect[F]
     protected def L: Monoid[L]
 
-    def runAsync[A](fa: WriterT[F, L, A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] =
+    def runAsync[A](fa: WriterT[F, L, A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] =
       F.runAsync(fa.run)(cb.compose(_.right.map(_._2)))
 
-    def runSyncStep[A](fa: WriterT[F, L, A]): IO[Either[WriterT[F, L, A], A]] = {
+    def runSyncStep[A](fa: WriterT[F, L, A]): SyncIO[Either[WriterT[F, L, A], A]] = {
       F.runSyncStep(fa.run).map {
         case Left(fla) => Left(WriterT(fla))
         case Right(la) => Right(la._2)

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -86,7 +86,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
   import IO._
 
   /**
-   * Functor map on `IO`. Given a mapping functions, it transforms the
+   * Functor map on `IO`. Given a mapping function, it transforms the
    * value produced by the source, while keeping the `IO` context.
    *
    * Any exceptions thrown within the function will be caught and
@@ -175,15 +175,15 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * @see [[runCancelable]] for the version that gives you a cancelable
    *      token that can be used to send a cancel signal
    */
-  final def runAsync(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] = IO {
+  final def runAsync(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] = SyncIO {
     unsafeRunAsync(cb.andThen(_.unsafeRunAsync(Callback.report)))
   }
 
-  final def runSyncStep: IO[Either[IO[A], A]] = IO.suspend {
+  final def runSyncStep: SyncIO[Either[IO[A], A]] = SyncIO.suspend {
     IORunLoop.step(this) match {
-      case Pure(a) => Pure(Right(a))
-      case r @ RaiseError(_) => r
-      case async => Pure(Left(async))
+      case Pure(a) => SyncIO.pure(Right(a))
+      case RaiseError(e) => SyncIO.raiseError(e)
+      case async => SyncIO.pure(Left(async))
     }
   }
 
@@ -223,8 +223,8 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    *
    * @see [[runAsync]] for the simple, uninterruptible version
    */
-  final def runCancelable(cb: Either[Throwable, A] => IO[Unit]): IO[CancelToken[IO]] =
-    IO(unsafeRunCancelable(cb.andThen(_.unsafeRunAsync(_ => ()))))
+  final def runCancelable(cb: Either[Throwable, A] => IO[Unit]): SyncIO[CancelToken[IO]] =
+    SyncIO(unsafeRunCancelable(cb.andThen(_.unsafeRunAsync(_ => ()))))
 
   /**
    * Produces the result by running the encapsulated effects as impure
@@ -778,9 +778,9 @@ private[effect] abstract class IOLowPriorityInstances extends IOParallelNewtype 
       ioa
     override def toIO[A](fa: IO[A]): IO[A] =
       fa
-    final override def runAsync[A](ioa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] =
+    final override def runAsync[A](ioa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] =
       ioa.runAsync(cb)
-    final override def runSyncStep[A](ioa: IO[A]): IO[Either[IO[A], A]] =
+    final override def runSyncStep[A](ioa: IO[A]): SyncIO[Either[IO[A], A]] =
       ioa.runSyncStep
   }
 }
@@ -815,7 +815,7 @@ private[effect] abstract class IOInstances extends IOLowPriorityInstances {
 
     final override def cancelable[A](k: (Either[Throwable, A] => Unit) => IO[Unit]): IO[A] =
       IO.cancelable(k)
-    final override def runCancelable[A](fa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): IO[CancelToken[IO]] =
+    final override def runCancelable[A](fa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[CancelToken[IO]] =
       fa.runCancelable(cb)
 
     final override def toIO[A](fa: IO[A]): IO[A] = fa
@@ -1181,8 +1181,8 @@ object IO extends IOInstances {
     }
 
   /**
-   * Lifts an Either[Throwable, A] into the IO[A] context raising the throwable
-   * if it exists.
+   * Lifts an `Either[Throwable, A]` into the `IO[A]` context, raising
+   * the throwable if it exists.
    */
   def fromEither[A](e: Either[Throwable, A]): IO[A] =
     e match {

--- a/core/shared/src/main/scala/cats/effect/SyncIO.scala
+++ b/core/shared/src/main/scala/cats/effect/SyncIO.scala
@@ -1,0 +1,437 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+
+import scala.annotation.unchecked.uncheckedVariance
+
+/**
+ * A pure abstraction representing the intention to perform a
+ * side effect, where the result of that side effect is obtained
+ * synchronously.
+ *
+ * `SyncIO` is similar to [[IO]], but does not support asynchronous
+ * computations. Consequently, a `SyncIO` can be run synchronously
+ * to obtain a result via `unsafeRunSync`. This is unlike
+ * `IO#unsafeRunSync`, which cannot be safely called in general --
+ * doing so on the JVM blocks the calling thread while the
+ * async part of the computation is run and doing so on Scala.JS
+ * throws an exception upon encountering an async boundary.
+ */
+final class SyncIO[+A] private (val toIO: IO[A]) {
+
+  /**
+   * Produces the result by running the encapsulated effects as impure
+   * side effects.
+   *
+   * Any exceptions raised within the effect will be re-thrown during
+   * evaluation.
+   *
+   * As the name says, this is an UNSAFE function as it is impure and
+   * performs side effects and throws exceptions. You should ideally
+   * only call this function *once*, at the very end of your program.
+   */
+  def unsafeRunSync(): A = toIO.unsafeRunSync
+
+  /**
+   * Functor map on `SyncIO`. Given a mapping function, it transforms the
+   * value produced by the source, while keeping the `SyncIO` context.
+   *
+   * Any exceptions thrown within the function will be caught and
+   * sequenced in to the result `SyncIO[B]`.
+   */
+  def map[B](f: A => B): SyncIO[B] = new SyncIO(toIO.map(f))
+
+  /**
+   * Monadic bind on `SyncIO`, used for sequentially composing two `SyncIO`
+   * actions, where the value produced by the first `SyncIO` is passed as
+   * input to a function producing the second `SyncIO` action.
+   *
+   * Due to this operation's signature, `flatMap` forces a data
+   * dependency between two `SyncIO` actions, thus ensuring sequencing
+   * (e.g. one action to be executed before another one).
+   *
+   * Any exceptions thrown within the function will be caught and
+   * sequenced in to the result `SyncIO[B].
+   */
+  def flatMap[B](f: A => SyncIO[B]): SyncIO[B] = new SyncIO(toIO.flatMap(a => f(a).toIO))
+
+  /**
+   * Materializes any sequenced exceptions into value space, where
+   * they may be handled.
+   *
+   * This is analogous to the `catch` clause in `try`/`catch`, being
+   * the inverse of `SyncIO.raiseError`. Thus:
+   *
+   * {{{
+   * SyncIO.raiseError(ex).attempt.unsafeRunSync === Left(ex)
+   * }}}
+   *
+   * @see [[SyncIO.raiseError]]
+   */
+  def attempt: SyncIO[Either[Throwable, A]] = new SyncIO(toIO.attempt)
+
+  /**
+   * Converts the source `IO` into any `F` type that implements
+   * the [[LiftIO]] type class.
+   */
+  def to[F[_]](implicit F: LiftIO[F]): F[A @uncheckedVariance] =
+    F.liftIO(toIO)
+
+  /**
+   * Returns a `SyncIO` action that treats the source task as the
+   * acquisition of a resource, which is then exploited by the `use`
+   * function and then `released`.
+   *
+   * The `bracket` operation is the equivalent of the
+   * `try {} catch {} finally {}` statements from mainstream languages.
+   *
+   * The `bracket` operation installs the necessary exception handler
+   * to release the resource in the event of an exception being raised
+   * during the computation.
+   *
+   * If an exception is raised, then `bracket` will re-raise the
+   * exception ''after'' performing the `release`.
+   *
+   * '''NOTE on error handling''': one big difference versus
+   * `try/finally` statements is that, in case both the `release`
+   * function and the `use` function throws, the error raised by `use`
+   * gets signaled.
+   *
+   * For example:
+   *
+   * {{{
+   *   SyncIO("resource").bracket { _ =>
+   *     // use
+   *     SyncIO.raiseError(new RuntimeException("Foo"))
+   *   } { _ =>
+   *     // release
+   *     SyncIO.raiseError(new RuntimeException("Bar"))
+   *   }
+   * }}}
+   *
+   * In this case the error signaled downstream is `"Foo"`, while the
+   * `"Bar"` error gets reported. This is consistent with the behavior
+   * of Haskell's `bracket` operation and NOT with `try {} finally {}`
+   * from Scala, Java or JavaScript.
+   *
+   * @see [[bracketCase]]
+   *
+   * @param use is a function that evaluates the resource yielded by
+   *        the source, yielding a result that will get generated by
+   *        the task returned by this `bracket` function
+   *
+   * @param release is a function that gets called after `use`
+   *        terminates, either normally or in error, or if it gets
+   *        canceled, receiving as input the resource that needs to
+   *        be released
+   */
+  def bracket[B](use: A => SyncIO[B])(release: A => SyncIO[Unit]): SyncIO[B] =
+    bracketCase(use)((a, _) => release(a))
+
+  /**
+   * Returns a new `SyncIO` task that treats the source task as the
+   * acquisition of a resource, which is then exploited by the `use`
+   * function and then `released`, with the possibility of
+   * distinguishing between normal termination and failure, such
+   * that an appropriate release of resources can be executed.
+   *
+   * The `bracketCase` operation is the equivalent of
+   * `try {} catch {} finally {}` statements from mainstream languages
+   * when used for the acquisition and release of resources.
+   *
+   * The `bracketCase` operation installs the necessary exception handler
+   * to release the resource in the event of an exception being raised
+   * during the computation.
+   *
+   * In comparison with the simpler [[bracket]] version, this one
+   * allows the caller to differentiate between normal termination and
+   * termination in error. Note `SyncIO` does not support cancelation
+   * so that exit case should be ignored.
+   *
+   * @see [[bracket]]
+   *
+   * @param use is a function that evaluates the resource yielded by
+   *        the source, yielding a result that will get generated by
+   *        this function on evaluation
+   *
+   * @param release is a function that gets called after `use`
+   *        terminates, either normally or in error, receiving
+   *        as input the resource that needs that needs release,
+   *        along with the result of `use` (error or successful result)
+   */
+  def bracketCase[B](use: A => SyncIO[B])(release: (A, ExitCase[Throwable]) => SyncIO[Unit]): SyncIO[B] =
+    new SyncIO(toIO.bracketCase(a => use(a).toIO)((a, ec) => release(a, ec).toIO))
+
+  /**
+   * Executes the given `finalizer` when the source is finished,
+   * either in success or in error.
+   *
+   * This variant of [[guaranteeCase]] evaluates the given `finalizer`
+   * regardless of how the source gets terminated:
+   *
+   *  - normal completion
+   *  - completion in error
+   *
+   * This equivalence always holds:
+   *
+   * {{{
+   *   io.guarantee(f) <-> IO.unit.bracket(_ => io)(_ => f)
+   * }}}
+   *
+   * As best practice, it's not a good idea to release resources
+   * via `guaranteeCase` in polymorphic code. Prefer [[bracket]]
+   * for the acquisition and release of resources.
+   *
+   * @see [[guaranteeCase]] for the version that can discriminate
+   *      between termination conditions
+   *
+   * @see [[bracket]] for the more general operation
+   */
+  def guarantee(finalizer: SyncIO[Unit]): SyncIO[A] =
+    guaranteeCase(_ => finalizer)
+
+  /**
+   * Executes the given `finalizer` when the source is finished,
+   * either in success or in error, allowing
+   * for differentiating between exit conditions.
+   *
+   * This variant of [[guarantee]] injects an [[ExitCase]] in
+   * the provided function, allowing one to make a difference
+   * between:
+   *
+   *  - normal completion
+   *  - completion in error
+   *
+   * This equivalence always holds:
+   *
+   * {{{
+   *   io.guaranteeCase(f) <-> IO.unit.bracketCase(_ => io)((_, e) => f(e))
+   * }}}
+   *
+   * As best practice, it's not a good idea to release resources
+   * via `guaranteeCase` in polymorphic code. Prefer [[bracketCase]]
+   * for the acquisition and release of resources.
+   *
+   * @see [[guarantee]] for the simpler version
+   *
+   * @see [[bracketCase]] for the more general operation
+   */
+  def guaranteeCase(finalizer: ExitCase[Throwable] => SyncIO[Unit]): SyncIO[A] =
+    new SyncIO(toIO.guaranteeCase(ec => finalizer(ec).toIO))
+
+  /**
+   * Handle any error, potentially recovering from it, by mapping it to another
+   * `SyncIO` value.
+   *
+   * Implements `ApplicativeError.handleErrorWith`.
+   */
+  def handleErrorWith[AA >: A](f: Throwable => SyncIO[AA]): SyncIO[AA] =
+    new SyncIO(toIO.handleErrorWith(t => f(t).toIO))
+
+  /**
+   * Returns a new value that transforms the result of the source,
+   * given the `recover` or `map` functions, which get executed depending
+   * on whether the result is successful or if it ends in error.
+   *
+   * This is an optimization on usage of [[attempt]] and [[map]],
+   * this equivalence being true:
+   *
+   * {{{
+   *   io.redeem(recover, map) <-> io.attempt.map(_.fold(recover, map))
+   * }}}
+   *
+   * Usage of `redeem` subsumes `handleError` because:
+   *
+   * {{{
+   *   io.redeem(fe, id) <-> io.handleError(fe)
+   * }}}
+   *
+   * @param recover is a function used for error recover in case the
+   *        source ends in error
+   * @param map is a function used for mapping the result of the source
+   *        in case it ends in success
+   */
+  def redeem[B](recover: Throwable => B, map: A => B): SyncIO[B] =
+    new SyncIO(toIO.redeem(recover, map))
+
+  /**
+   * Returns a new value that transforms the result of the source,
+   * given the `recover` or `bind` functions, which get executed depending
+   * on whether the result is successful or if it ends in error.
+   *
+   * This is an optimization on usage of [[attempt]] and [[flatMap]],
+   * this equivalence being available:
+   *
+   * {{{
+   *   io.redeemWith(recover, bind) <-> io.attempt.flatMap(_.fold(recover, bind))
+   * }}}
+   *
+   * Usage of `redeemWith` subsumes `handleErrorWith` because:
+   *
+   * {{{
+   *   io.redeemWith(fe, F.pure) <-> io.handleErrorWith(fe)
+   * }}}
+   *
+   * Usage of `redeemWith` also subsumes [[flatMap]] because:
+   *
+   * {{{
+   *   io.redeemWith(F.raiseError, fs) <-> io.flatMap(fs)
+   * }}}
+   *
+   * @param recover is the function that gets called to recover the source
+   *        in case of error
+   * @param bind is the function that gets to transform the source
+   *        in case of success
+   */
+  def redeemWith[B](recover: Throwable => SyncIO[B], bind: A => SyncIO[B]): SyncIO[B] =
+    new SyncIO(toIO.redeemWith(t => recover(t).toIO, a => bind(a).toIO))
+
+  override def toString: String = toIO match {
+    case IO.Pure(a) => s"SyncIO($a)"
+    case IO.RaiseError(e) => s"SyncIO(throw $e)"
+    case _ => "SyncIO$" + System.identityHashCode(this)
+  }
+}
+
+object SyncIO extends SyncIOInstances {
+
+  /**
+   * Suspends a synchronous side effect in `SyncIO`.
+   *
+   * Any exceptions thrown by the effect will be caught and sequenced
+   * into the `SyncIO`.
+   */
+  def apply[A](thunk: => A): SyncIO[A] = new SyncIO(IO(thunk))
+
+  /**
+   * Suspends a synchronous side effect which produces a `SyncIO` in `SyncIO`.
+   *
+   * This is useful for trampolining (i.e. when the side effect is
+   * conceptually the allocation of a stack frame).  Any exceptions
+   * thrown by the side effect will be caught and sequenced into the
+   * `SyncIO`.
+   */
+  def suspend[A](thunk: => SyncIO[A]): SyncIO[A] = new SyncIO(IO.suspend(thunk.toIO))
+
+  /**
+   * Suspends a pure value in `SyncIO`.
+   *
+   * This should ''only'' be used if the value in question has
+   * "already" been computed!  In other words, something like
+   * `SyncIO.pure(readLine)` is most definitely not the right thing to do!
+   * However, `SyncIO.pure(42)` is correct and will be more efficient
+   * (when evaluated) than `SyncIO(42)`, due to avoiding the allocation of
+   * extra thunks.
+   */
+  def pure[A](a: A): SyncIO[A] = new SyncIO(IO.pure(a))
+
+  /** Alias for `SyncIO.pure(())`. */
+  val unit: SyncIO[Unit] = pure(())
+
+  /**
+   * Lifts an `Eval` into `SyncIO`.
+   *
+   * This function will preserve the evaluation semantics of any
+   * actions that are lifted into the pure `SyncIO`.  Eager `Eval`
+   * instances will be converted into thunk-less `SyncIO` (i.e. eager
+   * `SyncIO`), while lazy eval and memoized will be executed as such.
+   */
+  def eval[A](fa: Eval[A]): SyncIO[A] = fa match {
+    case Now(a) => pure(a)
+    case notNow => apply(notNow.value)
+  }
+
+  /**
+   * Constructs a `SyncIO` which sequences the specified exception.
+   *
+   * If this `SyncIO` is run using `unsafeRunSync` the exception will
+   * be thrown.  This exception can be "caught" (or rather, materialized
+   * into value-space) using the `attempt` method.
+   *
+   * @see [[SyncIO#attempt]]
+   */
+  def raiseError[A](e: Throwable): SyncIO[A] = new SyncIO(IO.raiseError(e))
+
+  /**
+   * Lifts an `Either[Throwable, A]` into the `SyncIO[A]` context, raising
+   * the throwable if it exists.
+   */
+  def fromEither[A](e: Either[Throwable, A]): SyncIO[A] = new SyncIO(IO.fromEither(e))
+}
+
+private[effect] abstract class SyncIOInstances extends SyncIOLowPriorityInstances {
+  implicit val syncIoSync: Sync[SyncIO] = new Sync[SyncIO] with StackSafeMonad[SyncIO] {
+    final override def pure[A](a: A): SyncIO[A] =
+      SyncIO.pure(a)
+    final override def unit: SyncIO[Unit] =
+      SyncIO.unit
+
+    final override def map[A, B](fa: SyncIO[A])(f: A => B): SyncIO[B] =
+      fa.map(f)
+    final override def flatMap[A, B](ioa: SyncIO[A])(f: A => SyncIO[B]): SyncIO[B] =
+      ioa.flatMap(f)
+
+    final override def attempt[A](ioa: SyncIO[A]): SyncIO[Either[Throwable, A]] =
+      ioa.attempt
+    final override def handleErrorWith[A](ioa: SyncIO[A])(f: Throwable => SyncIO[A]): SyncIO[A] =
+      ioa.handleErrorWith(f)
+    final override def raiseError[A](e: Throwable): SyncIO[A] =
+      SyncIO.raiseError(e)
+
+    final override def bracket[A, B](acquire: SyncIO[A])
+      (use: A => SyncIO[B])
+      (release: A => SyncIO[Unit]): SyncIO[B] =
+      acquire.bracket(use)(release)
+
+    final override def uncancelable[A](task: SyncIO[A]): SyncIO[A] =
+      task
+
+    final override def bracketCase[A, B](acquire: SyncIO[A])
+      (use: A => SyncIO[B])
+      (release: (A, ExitCase[Throwable]) => SyncIO[Unit]): SyncIO[B] =
+      acquire.bracketCase(use)(release)
+
+    final override def guarantee[A](fa: SyncIO[A])(finalizer: SyncIO[Unit]): SyncIO[A] =
+      fa.guarantee(finalizer)
+    final override def guaranteeCase[A](fa: SyncIO[A])(finalizer: ExitCase[Throwable] => SyncIO[Unit]): SyncIO[A] =
+      fa.guaranteeCase(finalizer)
+
+    final override def delay[A](thunk: => A): SyncIO[A] =
+      SyncIO(thunk)
+    final override def suspend[A](thunk: => SyncIO[A]): SyncIO[A] =
+      SyncIO.suspend(thunk)
+  }
+
+  implicit def syncIoMonoid[A: Monoid]: Monoid[SyncIO[A]] = new SyncIOSemigroup[A] with Monoid[SyncIO[A]] {
+    def empty: SyncIO[A] = SyncIO.pure(Monoid[A].empty)
+  }
+
+  implicit val syncIoSemigroupK: SemigroupK[SyncIO] = new SemigroupK[SyncIO] {
+    final override def combineK[A](a: SyncIO[A], b: SyncIO[A]): SyncIO[A] =
+      a.handleErrorWith(_ => b)
+  }
+}
+
+private[effect] abstract class SyncIOLowPriorityInstances {
+  private[effect] class SyncIOSemigroup[A: Semigroup] extends Semigroup[SyncIO[A]] {
+    def combine(sioa1: SyncIO[A], sioa2: SyncIO[A]) =
+      sioa1.flatMap(a1 => sioa2.map(a2 => Semigroup[A].combine(a1, a2)))
+  }
+
+  implicit def syncIoSemigroup[A: Semigroup]: Semigroup[SyncIO[A]] = new SyncIOSemigroup[A]
+}

--- a/core/shared/src/test/scala/cats/effect/SyntaxTests.scala
+++ b/core/shared/src/test/scala/cats/effect/SyntaxTests.scala
@@ -55,14 +55,14 @@ object SyntaxTests extends AllCatsEffectSyntax {
     val cb = mock[Either[Throwable, A] => IO[Unit]]
 
     typed[IO[A]](fa.toIO)
-    typed[IO[Unit]](fa.runAsync(cb))
-    typed[IO[Either[F[A], A]]](fa.runSyncStep)
+    typed[SyncIO[Unit]](fa.runAsync(cb))
+    typed[SyncIO[Either[F[A], A]]](fa.runSyncStep)
   }
 
   def concurrentEffectSyntax[F[_]: ConcurrentEffect, A] = {
     val fa = mock[F[A]]
     val cb = mock[Either[Throwable, A] => IO[Unit]]
 
-    typed[IO[F[Unit]]](fa.runCancelable(cb))
+    typed[SyncIO[F[Unit]]](fa.runCancelable(cb))
   }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestInstances.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestInstances.scala
@@ -16,7 +16,7 @@
 
 package cats.effect.laws.util
 
-import cats.effect.{Bracket, IO, Resource}
+import cats.effect.{Bracket, IO, Resource, SyncIO}
 import cats.kernel.Eq
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
@@ -98,6 +98,15 @@ trait TestInstances {
     new Eq[Resource[F, A]] {
       def eqv(x: Resource[F, A], y: Resource[F, A]): Boolean =
         E.eqv(x.use(F.pure), y.use(F.pure))
+    }
+
+  /** Defines equality for `SyncIO` references. */
+  implicit def eqSyncIO[A](implicit A: Eq[A]): Eq[SyncIO[A]] =
+    new Eq[SyncIO[A]] {
+      def eqv(x: SyncIO[A], y: SyncIO[A]): Boolean = {
+        val eqETA = cats.kernel.instances.either.catsStdEqForEither(eqThrowable, A)
+        eqETA.eqv(x.attempt.unsafeRunSync(), y.attempt.unsafeRunSync())
+      }
     }
 }
 

--- a/laws/shared/src/test/scala/cats/effect/IOAsyncTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOAsyncTests.scala
@@ -42,7 +42,7 @@ class IOAsyncTests extends AsyncFunSuite with Matchers {
       case Left(e) => IO(effect.failure(e))
     }
 
-    for (_ <- io.unsafeToFuture(); v <- attempt.future) yield {
+    for (_ <- io.toIO.unsafeToFuture(); v <- attempt.future) yield {
       v shouldEqual expected
     }
   }

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -392,7 +392,7 @@ class IOTests extends BaseTestsSuite {
   testAsync("sync.to[IO] is stack-safe") { implicit ec =>
     // Override default generator to only generate
     // synchronous instances that are stack-safe
-    implicit val arbIO = Arbitrary(genSyncIO[Int])
+    implicit val arbIO = Arbitrary(genSyncIO[Int].map(_.toIO))
 
     check { (io: IO[Int]) =>
       repeatedTransformLoop(10000, io) <-> io
@@ -940,7 +940,7 @@ object IOTests {
     new IODefaults with ConcurrentEffect[IO] {
       override protected val ref = implicitly[ConcurrentEffect[IO]]
 
-      def runCancelable[A](fa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): IO[CancelToken[IO]] =
+      def runCancelable[A](fa: IO[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[CancelToken[IO]] =
         fa.runCancelable(cb)
       def start[A](fa: IO[A]): IO[Fiber[IO, A]] =
         fa.start
@@ -965,9 +965,9 @@ object IOTests {
       ref.flatMap(fa)(f)
     def tailRecM[A, B](a: A)(f: (A) => IO[Either[A, B]]): IO[B] =
       ref.tailRecM(a)(f)
-    def runAsync[A](fa: IO[A])(cb: (Either[Throwable, A]) => IO[Unit]): IO[Unit] =
+    def runAsync[A](fa: IO[A])(cb: (Either[Throwable, A]) => IO[Unit]): SyncIO[Unit] =
       ref.runAsync(fa)(cb)
-    def runSyncStep[A](fa: IO[A]): IO[Either[IO[A], A]] =
+    def runSyncStep[A](fa: IO[A]): SyncIO[Either[IO[A], A]] =
       ref.runSyncStep(fa)
     def suspend[A](thunk: =>IO[A]): IO[A] =
       ref.suspend(thunk)

--- a/laws/shared/src/test/scala/cats/effect/LTask.scala
+++ b/laws/shared/src/test/scala/cats/effect/LTask.scala
@@ -75,13 +75,13 @@ object LTask {
           p.future
         }
 
-      def runAsync[A](fa: LTask[A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] =
-        IO(fa.run(ec).onComplete { r =>
+      def runAsync[A](fa: LTask[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] =
+        SyncIO(fa.run(ec).onComplete { r =>
           cb(Conversions.toEither(r)).unsafeRunAsync(Callback.report)
         })
 
-      def runSyncStep[A](fa: LTask[A]): IO[Either[LTask[A], A]] =
-        IO.pure(Left(fa))
+      def runSyncStep[A](fa: LTask[A]): SyncIO[Either[LTask[A], A]] =
+        SyncIO.pure(Left(fa))
 
       def flatMap[A, B](fa: LTask[A])(f: A => LTask[B]): LTask[B] =
         LTask { implicit ec =>

--- a/laws/shared/src/test/scala/cats/effect/SyncIOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/SyncIOTests.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+
+import cats.effect.internals.IOPlatform
+import cats.effect.laws.discipline.SyncTests
+import cats.effect.laws.discipline.arbitrary._
+import cats.implicits._
+import cats.kernel.laws.discipline.MonoidTests
+import cats.laws._
+import cats.laws.discipline._
+
+
+class SyncIOTests extends BaseTestsSuite {
+  checkAllAsync("SyncIO", implicit ec => SyncTests[SyncIO].sync[Int, Int, Int])
+  checkAllAsync("SyncIO", implicit ec => MonoidTests[SyncIO[Int]].monoid)
+  checkAllAsync("SyncIO", implicit ec => SemigroupKTests[SyncIO].semigroupK[Int])
+
+  test("defer evaluation until run") {
+    var run = false
+    val ioa = SyncIO { run = true }
+    run shouldEqual false
+    ioa.unsafeRunSync()
+    run shouldEqual true
+  }
+
+  test("catch exceptions within main block") {
+    case object Foo extends Exception
+
+    val ioa = SyncIO { throw Foo }
+
+    ioa.attempt.unsafeRunSync() should matchPattern {
+      case Left(Foo) => ()
+    }
+  }
+
+  test("fromEither handles Throwable in Left Projection") {
+    case object Foo extends Exception
+    val e : Either[Throwable, Nothing] = Left(Foo)
+
+    SyncIO.fromEither(e).attempt.unsafeRunSync() should matchPattern {
+      case Left(Foo) => ()
+    }
+  }
+
+  test("fromEither handles a Value in Right Projection") {
+    case class Foo(x: Int)
+    val e : Either[Throwable, Foo] = Right(Foo(1))
+
+    SyncIO.fromEither(e).attempt.unsafeRunSync() should matchPattern {
+      case Right(Foo(_)) => ()
+    }
+  }
+
+  test("attempt flatMap loop") {
+    def loop[A](source: SyncIO[A], n: Int): SyncIO[A] =
+      source.attempt.flatMap {
+        case Right(l) =>
+          if (n <= 0) SyncIO.pure(l)
+          else loop(source, n - 1)
+        case Left(e) =>
+          SyncIO.raiseError(e)
+      }
+
+    val value = loop(SyncIO("value"), 10000).unsafeRunSync()
+    value shouldEqual "value"
+  }
+
+  test("attempt foldLeft sequence") {
+    val count = 10000
+    val loop = (0 until count).foldLeft(SyncIO(0)) { (acc, _) =>
+      acc.attempt.flatMap {
+        case Right(x) => SyncIO.pure(x + 1)
+        case Left(e) => SyncIO.raiseError(e)
+      }
+    }
+
+    val value = loop.unsafeRunSync
+    value shouldEqual count
+  }
+
+  test("SyncIO(throw ex).attempt.map") {
+    val dummy = new RuntimeException("dummy")
+    val io = SyncIO[Int](throw dummy).attempt.map {
+      case Left(`dummy`) => 100
+      case _ => 0
+    }
+
+    val value = io.unsafeRunSync()
+    value shouldEqual 100
+  }
+
+  test("SyncIO(throw ex).flatMap.attempt.map") {
+    val dummy = new RuntimeException("dummy")
+    val io = SyncIO[Int](throw dummy).flatMap(SyncIO.pure).attempt.map {
+      case Left(`dummy`) => 100
+      case _ => 0
+    }
+
+    val value = io.unsafeRunSync()
+    value shouldEqual 100
+  }
+
+  test("SyncIO(throw ex).map.attempt.map") {
+    val dummy = new RuntimeException("dummy")
+    val io = SyncIO[Int](throw dummy).map(x => x).attempt.map {
+      case Left(`dummy`) => 100
+      case _ => 0
+    }
+
+    val value = io.unsafeRunSync()
+    value shouldEqual 100
+  }
+
+  testAsync("io.to[IO] <-> io.toIO") { implicit ec =>
+    check { (io: SyncIO[Int]) => io.to[IO] <-> io.toIO }
+  }
+
+  testAsync("io.attempt.to[IO] <-> io.toIO.attempt") { implicit ec =>
+    check { (io: SyncIO[Int]) =>
+      io.attempt.to[IO] <-> io.toIO.attempt
+    }
+  }
+
+  testAsync("io.handleError(f).to[IO] <-> io.handleError(f)") { implicit ec =>
+    val F = implicitly[Sync[IO]]
+
+    check { (io: IO[Int], f: Throwable => IO[Int]) =>
+      val fa = F.handleErrorWith(io)(f)
+      fa.to[IO] <-> fa
+    }
+  }
+
+  test("suspend with unsafeRunSync") {
+    val io = SyncIO.suspend(SyncIO(1)).map(_ + 1)
+    io.unsafeRunSync() shouldEqual 2
+  }
+
+  test("map is stack-safe for unsafeRunSync") {
+    import IOPlatform.{fusionMaxStackDepth => max}
+    val f = (x: Int) => x + 1
+    val io = (0 until (max * 10000)).foldLeft(SyncIO(0))((acc, _) => acc.map(f))
+
+    io.unsafeRunSync() shouldEqual max * 10000
+  }
+
+  testAsync("IO#redeem(throw, f) <-> IO#map") { implicit ec =>
+    check { (io: IO[Int], f: Int => Int) =>
+      io.redeem(e => throw e, f) <-> io.map(f)
+    }
+  }
+
+  testAsync("IO#redeem(f, identity) <-> IO#handleError") { implicit ec =>
+    check { (io: IO[Int], f: Throwable => Int) =>
+      io.redeem(f, identity) <-> io.handleError(f)
+    }
+  }
+
+  testAsync("IO#redeemWith(raiseError, f) <-> IO#flatMap") { implicit ec =>
+    check { (io: IO[Int], f: Int => IO[Int]) =>
+      io.redeemWith(IO.raiseError, f) <-> io.flatMap(f)
+    }
+  }
+
+  testAsync("IO#redeemWith(f, pure) <-> IO#handleErrorWith") { implicit ec =>
+    check { (io: IO[Int], f: Throwable => IO[Int]) =>
+      io.redeemWith(f, IO.pure) <-> io.handleErrorWith(f)
+    }
+  }
+
+  test("unsafeRunSync works for bracket") {
+    var effect = 0
+    val io = SyncIO(1).bracket(x => SyncIO(x + 1))(_ => SyncIO { effect += 1 })
+    io.unsafeRunSync() shouldBe 2
+    effect shouldBe 1
+  }
+}

--- a/site/src/main/tut/datatypes/io.md
+++ b/site/src/main/tut/datatypes/io.md
@@ -623,16 +623,18 @@ cancel.unsafeRunSync()
 
 The `runCancelable` alternative is the operation that's compliant with
 the laws of [ConcurrentEffect](../typeclasses/concurrent-effect.html).
-Same idea, only the actual execution is suspended in `IO`:
+Same idea, only the actual execution is suspended in `SyncIO`:
 
 ```tut:silent
-val pureResult: IO[IO[Unit]] = io.runCancelable { r => 
+import cats.effect.SyncIO
+
+val pureResult: SyncIO[IO[Unit]] = io.runCancelable { r => 
   IO(println(s"Done: $r"))
 }
 
 // On evaluation, this will first execute the source, then it 
 // will cancel it, because it makes perfect sense :-)
-val cancel = pureResult.flatten
+val cancel = pureResult.toIO.flatten
 ```
 
 ### uncancelable marker

--- a/site/src/main/tut/typeclasses/concurrent-effect.md
+++ b/site/src/main/tut/typeclasses/concurrent-effect.md
@@ -8,15 +8,15 @@ scaladoc: "#cats.effect.ConcurrentEffect"
 
 Type class describing effect data types that are cancelable and can be evaluated concurrently.
 
-In addition to the algebras of `Concurrent` and `Effect`, instances must also implement the `ConcurrentEffect.runCancelable` operation that triggers the evaluation, suspended in the `IO` context, but that also returns a token that can be used for canceling the running computation.
+In addition to the algebras of `Concurrent` and `Effect`, instances must also implement the `ConcurrentEffect.runCancelable` operation that triggers the evaluation, suspended in the `SyncIO` context, but that also returns a token that can be used for canceling the running computation.
 
 *Note this is the safe and generic version of `IO.unsafeRunCancelable`*.
 
 ```tut:silent
-import cats.effect.{Concurrent, Effect, IO, CancelToken}
+import cats.effect.{Concurrent, Effect, IO, CancelToken, SyncIO}
 
 trait ConcurrentEffect[F[_]] extends Concurrent[F] with Effect[F] {
-  def runCancelable[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): IO[CancelToken[F]]
+  def runCancelable[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[CancelToken[F]]
 }
 ```
 

--- a/site/src/main/tut/typeclasses/effect.md
+++ b/site/src/main/tut/typeclasses/effect.md
@@ -9,29 +9,29 @@ scaladoc: "#cats.effect.Effect"
 A `Monad` that can suspend side effects into the `F[_]` context and supports lazy and potentially asynchronous evaluation.
 
 ```tut:silent
-import cats.effect.{Async, IO}
+import cats.effect.{Async, IO, SyncIO}
 
 trait Effect[F[_]] extends Async[F] {
-  def runAsync[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit]
+  def runAsync[A](fa: F[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit]
 }
 ```
 
 This type class is describing data types that:
 - Implement the `Async` algebra.
-- Implement a lawful `Effect.runAsync` operation that triggers the evaluation (in the context of `IO`).
+- Implement a lawful `Effect.runAsync` operation that triggers the evaluation (in the context of `SyncIO`).
 
 Note: this is the safe and generic version of `IO.unsafeRunAsync` (aka Haskell's `unsafePerformIO`).
 
 ### runAsync
 
-It represents the intention to evaluate a given effect in the context of `F[_]` asynchronously giving you back an `IO[A]`. Eg.:
+It represents the intention to evaluate a given effect in the context of `F[_]` asynchronously giving you back a `SyncIO[A]`. Eg.:
 
 ```tut:silent
 import cats.effect.Effect
 
 val task = IO("Hello World!")
 
-val ioa: IO[Unit] =
+val ioa: SyncIO[Unit] =
   Effect[IO].runAsync(task) {
     case Right(value) => IO(println(value))
     case Left(error)  => IO.raiseError(error)


### PR DESCRIPTION
This is the polished version of #297.

Added the `SyncIO` type as a newtype over `IO`, exposing only synchronous constructors. This is an easy way to achieve parity with `IO` w.r.t. things like performance, stack safety, exception handling, etc. There's instances for `Sync[SyncIO]`, `Monoid[SyncIO[A]]` given `Monoid[A]`, `Semigroup[SyncIO[A]]` given `Semigroup[A]`, and `SemigroupK[SyncIO]`.

Signatures of `runAsync` and `runStepSync` on `Effect` and `runCancelable` on `ConcurrentEffect` were modified to return a `SyncIO` instead of an `IO`.

ScalaDoc and tests were lifted from IO and edited appropriately due to lack of cancelation support in IO. The duplication bothers me but users will be happier with the docs.

This is a joint PR between me and @dscleaver. I squashed everything in to one commit but history is available here: https://github.com/Comcast/cats-effect/tree/topic/syncio