### PR TITLE
Update documentation

### DIFF
--- a/site/src/main/tut/datatypes/io.md
+++ b/site/src/main/tut/datatypes/io.md
@@ -1178,7 +1178,7 @@ lazy val repeat: IO[Unit] =
 } yield ()
 ```
 
-In this example, `repeat` is a very long running `IO` (infinite, in fact!) which will just hog the underlying thread resource for as long as it continues running.  This can be a bit of a problem, and so we inject the `IO.shift` which yields control back to the underlying thread pool, giving it a chance to reschedule things and provide better fairness. This shifting also "bounces" the thread stack, popping all the way back to the thread pool and effectively trampolining the remainder of the computation. Although the thread-shifting is not completely necessary, it might help in some cases to aliviate the use of the main thread pool.
+In this example, `repeat` is a very long running `IO` (infinite, in fact!) which will just hog the underlying thread resource for as long as it continues running.  This can be a bit of a problem, and so we inject the `IO.shift` which yields control back to the underlying thread pool, giving it a chance to reschedule things and provide better fairness. This shifting also "bounces" the thread stack, popping all the way back to the thread pool and effectively trampolining the remainder of the computation. Although the thread-shifting is not completely necessary, it might help in some cases to alleviate the use of the main thread pool.
 
 Thus, this function has four important use cases:
 - Shifting blocking actions off of the main compute pool.

--- a/site/src/main/tut/datatypes/io.md
+++ b/site/src/main/tut/datatypes/io.md
@@ -1184,6 +1184,7 @@ Thus, this function has four important use cases:
 - Shifting blocking actions off of the main compute pool.
 - Defensively re-shifting asynchronous continuations back to the main compute pool.
 - Yielding control to some underlying pool for fairness reasons.
+- Preventing an overflow of the call stack in the case of improperly constructed `async` actions.
 
 `IO` is trampolined for all `synchronous` and `asynchronous` joins. This means that you can safely call `flatMap` in a recursive function of arbitrary depth, without fear of blowing the stack. So you can do this for example:
 


### PR DESCRIPTION
1) Fixes a typo (`aliviate` -> `alleviate`)
2) Adds the fourth important use case for `IO.shift` as mentioned [here](https://github.com/djspiewak/cats-effect/blob/dadacf0d071d6251f525bdaff5350cbbe0bc5c10/core/shared/src/main/scala/cats/effect/IO.scala#L582-L588)