### PR TITLE
Modify @implicitNotFound messages for Clock, ContextShift, Timer

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Clock.scala
+++ b/core/shared/src/main/scala/cats/effect/Clock.scala
@@ -38,9 +38,9 @@ import scala.concurrent.duration.{MILLISECONDS, NANOSECONDS, TimeUnit}
  * This is NOT a type class, as it does not have the coherence
  * requirement.
  */
-@implicitNotFound("""Cannot find an implicit value for Clock[${F}].
-Either import an implicit Timer[${F}] in scope or
-create a Clock[${F}] instance with Clock.create
+@implicitNotFound("""Cannot find an implicit value for Clock[${F}]:
+* import an implicit Timer[${F}] in scope or
+* create a Clock[${F}] instance with Clock.create
 """)
 trait Clock[F[_]] {
   /**

--- a/core/shared/src/main/scala/cats/effect/ContextShift.scala
+++ b/core/shared/src/main/scala/cats/effect/ContextShift.scala
@@ -18,7 +18,7 @@ package cats.effect
 
 import cats.{Applicative, Functor, Monad, Monoid}
 import cats.data._
-
+import scala.annotation.implicitNotFound
 import scala.concurrent.ExecutionContext
 
 /**
@@ -33,6 +33,10 @@ import scala.concurrent.ExecutionContext
  * This is NOT a type class, as it does not have the coherence
  * requirement.
  */
+@implicitNotFound("""Cannot find an implicit value for ContextShift[${F}]:
+* import ContextShift[${F}] from your effects library
+* if using IO, use cats.effect.IOApp or build one with cats.effect.IO.contextShift
+""")
 trait ContextShift[F[_]] {
   /**
    * Asynchronous boundary described as an effectful `F[_]` that

--- a/core/shared/src/main/scala/cats/effect/Timer.scala
+++ b/core/shared/src/main/scala/cats/effect/Timer.scala
@@ -43,11 +43,9 @@ import scala.concurrent.duration.FiniteDuration
  * This is NOT a type class, as it does not have the coherence
  * requirement.
  */
-@implicitNotFound("""Cannot find an implicit value for Timer[${F}]. 
-Either:
+@implicitNotFound("""Cannot find an implicit value for Timer[${F}]:
 * import Timer[${F}] from your effects library
-* use cats.effect.IOApp
-* build one with cats.effect.IO.timer
+* if using IO, use cats.effect.IOApp or build one with cats.effect.IO.timer
 """)
 trait Timer[F[_]]  {
   /**


### PR DESCRIPTION
In #289 we forgot to add an `@implicitNotFound` message for `ContextShift`.

Also modifies the message for `Clock` and `Timer` to be consistent.