### PR TITLE
Fix #316: fix IO.bracket to be stack safe; add laws to SyncLaws

### DIFF
--- a/core/shared/src/main/scala/cats/effect/internals/IOBracket.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOBracket.scala
@@ -45,6 +45,9 @@ private[effect] object IOBracket {
     cb: Callback.T[B])
     extends (Either[Throwable, A] => Unit) with Runnable {
 
+    // This runnable is a dirty optimization to avoid some memory allocations;
+    // This class switches from being a Callback to a Runnable, but relies on
+    // the internal IO callback protocol to be respected (called at most once)
     private[this] var result: Either[Throwable, A] = _
 
     def apply(ea: Either[Throwable, A]): Unit = {

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/SyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/SyncTests.scala
@@ -73,7 +73,11 @@ trait SyncTests[F[_]] extends BracketTests[F, Throwable] {
         "stack-safe on left-associated binds" -> Prop.lzy(laws.stackSafetyOnRepeatedLeftBinds(params.stackSafeIterationsCount)),
         "stack-safe on right-associated binds" -> Prop.lzy(laws.stackSafetyOnRepeatedRightBinds(params.stackSafeIterationsCount)),
         "stack-safe on repeated attempts" -> Prop.lzy(laws.stackSafetyOnRepeatedAttempts(params.stackSafeIterationsCount)),
-        "stack-safe on repeated maps" -> Prop.lzy(laws.stackSafetyOnRepeatedMaps(params.stackSafeIterationsCount)))
+        "stack-safe on repeated maps" -> Prop.lzy(laws.stackSafetyOnRepeatedMaps(params.stackSafeIterationsCount)),
+        "stack-safe on bracket with left-associated binds" -> Prop.lzy(laws.stackSafetyOfBracketOnRepeatedLeftBinds(params.stackSafeIterationsCount)),
+        "stack-safe on bracket with right-associated binds" -> Prop.lzy(laws.stackSafetyOfBracketOnRepeatedRightBinds(params.stackSafeIterationsCount)),
+        "stack-safe on guarantee with left-associated binds" -> Prop.lzy(laws.stackSafetyOfGuaranteeOnRepeatedLeftBinds(params.stackSafeIterationsCount)),
+        "stack-safe on guarantee with right-associated binds" -> Prop.lzy(laws.stackSafetyOfGuaranteeOnRepeatedRightBinds(params.stackSafeIterationsCount)))
     }
   }
 }


### PR DESCRIPTION
Fixes #316 