### PR TITLE
Add delay combinator for IO

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -779,7 +779,7 @@ private[effect] abstract class IOLowPriorityInstances extends IOParallelNewtype 
       fa.guaranteeCase(finalizer)
 
     final override def delay[A](thunk: => A): IO[A] =
-      IO(thunk)
+      IO.delay(thunk)
     final override def suspend[A](thunk: => IO[A]): IO[A] =
       IO.suspend(thunk)
     final override def async[A](k: (Either[Throwable, A] => Unit) => Unit): IO[A] =
@@ -955,12 +955,21 @@ private[effect] abstract class IOInstances extends IOLowPriorityInstances {
 object IO extends IOInstances {
 
   /**
+    * Suspends a synchronous side effect in `IO`.
+    *
+    * Alias for `IO.delay(body)`.
+    */
+  def apply[A](body: => A): IO[A] =
+    delay(body)
+
+  /**
    * Suspends a synchronous side effect in `IO`.
    *
    * Any exceptions thrown by the effect will be caught and sequenced
    * into the `IO`.
    */
-  def apply[A](body: => A): IO[A] = Delay(body _)
+  def delay[A](body: => A): IO[A] =
+    Delay(body _)
 
   /**
    * Suspends a synchronous side effect which produces an `IO` in `IO`.


### PR DESCRIPTION
I favor being explicit about what combinator I'm using. Also makes sense to have a named "smart constructor" for each IO constructor for consistency's sake. Historically, Monix `Task.apply` performed both a delay and inserted an asynchronous boundary, so was thrown off when I couldn't find a named `delay`.

