### PR TITLE
Add ContextShift#evalOnK

### DIFF
--- a/core/shared/src/main/scala/cats/effect/ContextShift.scala
+++ b/core/shared/src/main/scala/cats/effect/ContextShift.scala
@@ -65,7 +65,7 @@ trait ContextShift[F[_]] {
   /**
    * `evalOn` as a natural transformation.
    */
-  def evalOnK(ec: ExecutionContext): F ~> F = λ[F ~> F](evalOn(_))
+  def evalOnK(ec: ExecutionContext): F ~> F = λ[F ~> F](evalOn(ec)(_))
 }
 
 object ContextShift {

--- a/core/shared/src/main/scala/cats/effect/ContextShift.scala
+++ b/core/shared/src/main/scala/cats/effect/ContextShift.scala
@@ -16,7 +16,7 @@
 
 package cats.effect
 
-import cats.{Applicative, Functor, Monad, Monoid}
+import cats.{Applicative, Functor, Monad, Monoid, ~>}
 import cats.data._
 import scala.annotation.implicitNotFound
 import scala.concurrent.ExecutionContext

--- a/core/shared/src/main/scala/cats/effect/ContextShift.scala
+++ b/core/shared/src/main/scala/cats/effect/ContextShift.scala
@@ -61,6 +61,11 @@ trait ContextShift[F[_]] {
    * @param fa  Computation to evaluate using `ec`
    */
   def evalOn[A](ec: ExecutionContext)(fa: F[A]): F[A]
+  
+  /**
+   * `evalOn` as a natural transformation.
+   */
+  def evalOnK(ec: ExecutionContext): F ~> F = λ[F ~> F](evalOn)
 }
 
 object ContextShift {

--- a/core/shared/src/main/scala/cats/effect/ContextShift.scala
+++ b/core/shared/src/main/scala/cats/effect/ContextShift.scala
@@ -65,7 +65,7 @@ trait ContextShift[F[_]] {
   /**
    * `evalOn` as a natural transformation.
    */
-  def evalOnK(ec: ExecutionContext): F ~> F = λ[F ~> F](evalOn)
+  def evalOnK(ec: ExecutionContext): F ~> F = λ[F ~> F](evalOn(_))
 }
 
 object ContextShift {

--- a/core/shared/src/main/scala/cats/effect/ContextShift.scala
+++ b/core/shared/src/main/scala/cats/effect/ContextShift.scala
@@ -61,15 +61,15 @@ trait ContextShift[F[_]] {
    * @param fa  Computation to evaluate using `ec`
    */
   def evalOn[A](ec: ExecutionContext)(fa: F[A]): F[A]
-  
-  /**
-   * `evalOn` as a natural transformation.
-   */
-  def evalOnK(ec: ExecutionContext): F ~> F = λ[F ~> F](evalOn(ec)(_))
 }
 
 object ContextShift {
   def apply[F[_]](implicit ev: ContextShift[F]): ContextShift[F] = ev
+
+  /**
+    * `evalOn` as a natural transformation.
+    */
+  def evalOnK[F[_]](ec: ExecutionContext)(implicit cs: ContextShift[F]): F ~> F = λ[F ~> F](cs.evalOn(ec)(_))
 
   /**
    * Derives a [[ContextShift]] instance for `cats.data.EitherT`,

--- a/laws/shared/src/test/scala/cats/effect/ContextShiftTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ContextShiftTests.scala
@@ -55,6 +55,23 @@ class ContextShiftTests extends BaseTestsSuite {
     f.value shouldBe Some(Success(1))
   }
 
+  testAsync("ContextShift.evalOnK[IO]") { ec =>
+    implicit val cs = ec.contextShift[IO]
+    val ec2 = TestContext()
+
+    val funK = ContextShift.evalOnK[IO](ec2)
+    val f = funK(IO(1)).unsafeToFuture()
+    f.value shouldBe None
+
+    ec.tick()
+    f.value shouldBe None
+
+    ec2.tick()
+    f.value shouldBe None
+    ec.tick()
+    f.value shouldBe Some(Success(1))
+  }
+
   // -- EitherT
 
   testAsync("Timer[EitherT].shift") { ec =>


### PR DESCRIPTION
This adds a variant of `evalOn` that returns a natural transformation.

Can make it easier to "extend" a natural transformation like Doobie's interpreter:

```scala
implicit val F: ContextShift[F] = ...
type G[A] = Kleisli[F, Connection, A]
transactor.copy(interpret0 =
  transactor.interpret.andThen(λ[G ~> G](_.mapK(F.evalOn(blockingContext)))))
```

(would look even better if there was a FunctionK-returning equivalent of `Kleisli#mapK` (https://github.com/typelevel/cats/pull/2450), but it's a step forward)

I can follow up with some tests if needed (and if the feature is wanted), so feel free to let me know what you think.
