### PR TITLE
Note that MVar#take empties the variable

### DIFF
--- a/site/src/main/tut/concurrency/mvar.md
+++ b/site/src/main/tut/concurrency/mvar.md
@@ -34,7 +34,7 @@ It has these fundamental (atomic) operations:
 - `put`: fills the `MVar` if it is empty, or blocks (asynchronously)
   if the `MVar` is full, until the given value is next in line to be
   consumed on `take`
-- `take`: tries reading the current value, or blocks (asynchronously)
+- `take`: tries reading the current value (also emptying it), or blocks (asynchronously)
   until there is a value available, at which point the operation resorts
   to a `take` followed by a `put`
 - `read`: which reads the current value without modifying the `MVar`,


### PR DESCRIPTION
When I was reading the docs, I didn't understand how an MVar could be emptied, and the difference between `take` and `read` wasn't so clear (`read` is said to not modify, but `take` isn't explicitly said to empty the variable)