### PR TITLE
Platform specific IOApps with customizable runtimes

### DIFF
--- a/core/js/src/main/scala/cats/effect/internals/IOAppPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOAppPlatform.scala
@@ -20,44 +20,78 @@ package internals
 
 import cats.implicits._
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
 import scala.scalajs.js
 
-private[effect] object IOAppPlatform {
-  def main(args: Array[String], cs: Eval[ContextShift[IO]], timer: Eval[Timer[IO]])(run: List[String] => IO[ExitCode]): Unit = {
-    val io = mainFiber(args, cs, timer)(run).flatMap { fiber =>
-      installHandler(fiber) *> fiber.join
-    }
-    io.unsafeRunAsync {
+private[effect] trait IOAppPlatform { self: IOApp =>
+  /**
+   * The main method. Runs the `IO` returned by [[run]] and exits the
+   * JVM with the resulting code after shutting down the
+   * [[executionContextResource]] and the [[ScheduledExecutorService]]
+   * resource.
+   */
+  def main(args: Array[String]): Unit = {
+    IOAppPlatform.main(args, executionContext)(run(_, _)).unsafeRunAsync {
       case Left(t) =>
         Logger.reportFailure(t)
-        sys.exit(ExitCode.Error.code)
+        IOAppPlatform.exit(ExitCode.Error.code)
       case Right(0) =>
         ()
       case Right(code) =>
-        sys.exit(code)
+        IOAppPlatform.exit(code)
     }
   }
 
-  def mainFiber(args: Array[String], contextShift: Eval[ContextShift[IO]], timer: Eval[Timer[IO]])(run: List[String] => IO[ExitCode]): IO[Fiber[IO, Int]] = {
+  /**
+   * The execution context for the app. Defaults to the global execution
+   * context.
+   *
+   * Unlike [[IOApp]] on the JVM, this execution context is not a
+   * [[Resource]], as the standard execution on Scala.js runtime can't
+   * be shut down. However, the process does not terminate until the
+   * event queue is processed, which supports a similar graceful shutdown
+   * to the JVM equivalent.
+   */
+  protected def executionContext: ExecutionContext =
+    ExecutionContext.global
+}
+
+private[effect] object IOAppPlatform {
+  private def exit(code: Int) = {
+    // Try to exit gracefully using `process.exitCode = code`
+    try js.Dynamic.global.process.exitCode = code
+    catch {
+      // If that's not supported in our env, do it the aggressive way
+      case _: js.JavaScriptException => sys.exit(code)
+    }
+  }
+
+  def main(args: Array[String], executionContext: ExecutionContext)(
+    run: (IOApp.Runtime, List[String]) => IO[ExitCode]
+  ): IO[Int] = {
+    val runtime = IOApp.Runtime(executionContext)
+
     // An infinite heartbeat to keep main alive.  This is similar to
     // `IO.never`, except `IO.never` doesn't schedule any tasks and is
     // insufficient to keep main alive.  The tick is fast enough that
     // it isn't silently discarded, as longer ticks are, but slow
     // enough that we don't interrupt often.  1 hour was chosen
     // empirically.
-    def keepAlive: IO[Nothing] = timer.value.sleep(1.hour) >> keepAlive
+    def keepAlive: IO[Nothing] = runtime.timer.sleep(1.hour) >> keepAlive
 
-    val program = run(args.toList).handleErrorWith {
+    val program = run(runtime, args.toList).handleErrorWith {
       t => IO(Logger.reportFailure(t)) *> IO.pure(ExitCode.Error)
     }
 
-    IO.race(keepAlive, program)(contextShift.value).flatMap {
+    IO.race(keepAlive, program)(runtime.contextShift).flatMap {
       case Left(_) =>
         // This case is unreachable, but scalac won't let us omit it.
         IO.raiseError(new AssertionError("IOApp keep alive failed unexpectedly."))
       case Right(exitCode) =>
         IO.pure(exitCode.code)
-    }.start(contextShift.value)
+    }.start(runtime.contextShift).flatMap { fiber =>
+      installHandler(fiber) *> fiber.join
+    }
   }
 
   val defaultTimer: Timer[IO] = IOTimer.global
@@ -79,4 +113,6 @@ private[effect] object IOAppPlatform {
       }
     }
   }
+
+  trait RuntimePlatformCompanion
 }

--- a/core/jvm/src/main/scala/cats/effect/internals/IOAppPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOAppPlatform.scala
@@ -18,10 +18,19 @@ package cats
 package effect
 package internals
 
-private[effect] object IOAppPlatform {
+import cats.implicits._
+import java.util.concurrent.{ForkJoinPool, ForkJoinWorkerThread, ScheduledExecutorService, TimeUnit}
+import scala.concurrent.ExecutionContext
 
-  def main(args: Array[String], contextShift: Eval[ContextShift[IO]], timer: Eval[Timer[IO]])(run: List[String] => IO[ExitCode]): Unit = {
-    val code = mainFiber(args, contextShift, timer)(run).flatMap(_.join).unsafeRunSync()
+private[effect] trait IOAppPlatform { self: IOApp =>
+  /**
+   * The main method. Runs the `IO` returned by [[run]] and exits the
+   * JVM with the resulting code after shutting down the
+   * [[executionContextResource]] and the [[ScheduledExecutorService]]
+   * resource.
+   */
+  final def main(args: Array[String]): Unit = {
+    val code = IOAppPlatform.main(args, executionContextResource, scheduledExecutorResource)(run(_, _))
     if (code == 0) {
       // Return naturally from main. This allows any non-daemon
       // threads to gracefully complete their work, and managed
@@ -32,23 +41,92 @@ private[effect] object IOAppPlatform {
     }
   }
 
-  def mainFiber(args: Array[String], contextShift: Eval[ContextShift[IO]],  timer: Eval[Timer[IO]])(run: List[String] => IO[ExitCode]): IO[Fiber[IO, Int]] = {
-    val io = run(args.toList).redeem(
+  /**
+   * Provides a main execution context for the app. By default, this is a
+   * fork-join pool with the same number of threads as available
+   * processors. This is used instead of the
+   * `scala.concurrent.ExecutionContext.global` in order to support
+   * awaiting the graceful termination of any pending tasks.
+   *
+   * This same resource is used for the [[IOApp.Runtime]]'s execution
+   * context, [[ContextShift]], and [[Timer]].
+   */
+  protected def executionContextResource: Resource[SyncIO, ExecutionContext] =
+    Resource.make(SyncIO(
+      new ForkJoinPool(
+        Runtime.getRuntime.availableProcessors.max(2),
+        new ForkJoinPool.ForkJoinWorkerThreadFactory {
+          def newThread(pool: ForkJoinPool): ForkJoinWorkerThread = {
+            val th = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool)
+            th.setName(s"cats-effect-${th.getId}")
+            th
+          }
+        },
+        null,
+        true)
+    ))(pool => SyncIO {
+      pool.shutdown()
+      pool.awaitTermination(Long.MaxValue, TimeUnit.MILLISECONDS)
+    })
+      .map(ExecutionContext.fromExecutorService)
+
+  /**
+   * Provides a scheduler resource for the app. Defaults to a
+   * ScheduledExecutorService with two threads.  This resource is used
+   * to construct the runtime's [[Timer]].
+   */
+  protected def scheduledExecutorResource: Resource[SyncIO, ScheduledExecutorService] =
+    Resource.make(SyncIO(IOTimer.newScheduler(daemon = false)))(s => SyncIO {
+      s.shutdown()
+      s.awaitTermination(Long.MaxValue, TimeUnit.MILLISECONDS)
+    })
+}
+
+private[effect] object IOAppPlatform {
+  def main(args: Array[String],
+           executionContextResource: Resource[SyncIO, ExecutionContext],
+           scheduledExecutorResource: Resource[SyncIO, ScheduledExecutorService])(
+    run: (IOApp.Runtime, List[String]) => IO[ExitCode]
+  ): Int = {
+    def unsafeAcquire[A](resource: Resource[SyncIO, A]): (A, ExitCase[Throwable] => SyncIO[Unit]) =
+      resource match {
+        case Resource.Allocate(resource) =>
+          resource.unsafeRunSync()
+        case Resource.Bind(source, fs) =>
+          val (s, shutdownS) = unsafeAcquire(source)
+          val (a, shutdownA) = unsafeAcquire(fs(s))
+          (a, exitCase => shutdownA(exitCase).guaranteeCase(shutdownS))
+        case Resource.Suspend(resource) =>
+          unsafeAcquire(resource.unsafeRunSync())
+      }
+
+    val (scheduler, shutdownScheduler) = unsafeAcquire(scheduledExecutorResource)
+    val (ec, shutdownEc) = unsafeAcquire(executionContextResource)
+
+    val runtime = IOApp.Runtime(ec, scheduler)
+
+    val code = run(runtime, args.toList).redeem(
       e => {
         Logger.reportFailure(e)
         ExitCode.Error.code
       },
-      r => r.code)
-
-    io.start(contextShift.value).flatMap { fiber =>
+      r => r.code
+    ).start(runtime.contextShift).flatMap { fiber =>
       installHook(fiber).map(_ => fiber)
-    }
-  }
+    }.flatMap(_.join).unsafeRunSync()
 
-  // both lazily initiated on JVM platform to prevent
-  // warm-up of underlying default EC's for code that does not require concurrency
-  def defaultTimer: Timer[IO] = IOTimer.global
-  def defaultContextShift: ContextShift[IO] = IOContextShift.global
+    // Wait for graceful release of scheduler resource
+    shutdownScheduler(ExitCase.Completed)
+      .handleError(Logger.reportFailure)
+      .unsafeRunSync()
+
+    // Wait for graceful release of executor resource
+    shutdownEc(ExitCase.Completed)
+      .handleError(Logger.reportFailure)
+      .unsafeRunSync()
+
+    code
+  }
 
   private def installHook(fiber: Fiber[IO, Int]): IO[Unit] =
     IO {
@@ -57,4 +135,12 @@ private[effect] object IOAppPlatform {
         fiber.cancel.unsafeRunSync()
       }
     }
+
+  trait RuntimePlatformCompanion {
+    def apply(ec: ExecutionContext, ses: ScheduledExecutorService) = new Runtime {
+      implicit def executionContext: ExecutionContext = ec
+      implicit def contextShift: ContextShift[IO] = IO.contextShift(ec)
+      implicit def timer: Timer[IO] = IO.timer(ec, ses)
+    }
+  }
 }

--- a/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
@@ -63,15 +63,18 @@ private[internals] object IOTimer {
   lazy val global: Timer[IO] =
     apply(ExecutionContext.Implicits.global)
 
-  private lazy val scheduler: ScheduledExecutorService =
+  private[internals] def newScheduler(daemon: Boolean): ScheduledExecutorService =
     Executors.newScheduledThreadPool(2, new ThreadFactory {
       def newThread(r: Runnable): Thread = {
         val th = new Thread(r)
-        th.setName("cats-effect")
-        th.setDaemon(true)
+        th.setName(s"cats-effect-scheduler-${th.getId}")
+        th.setDaemon(daemon)
         th
       }
     })
+
+  private lazy val scheduler: ScheduledExecutorService =
+    newScheduler(daemon = true)
 
   private final class ShiftTick(
     conn: IOConnection,

--- a/core/jvm/src/test/scala/cats/effect/IOAppTests.scala
+++ b/core/jvm/src/test/scala/cats/effect/IOAppTests.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+
+import cats.effect.internals.{IOAppPlatform, TestUtils, TrampolineEC}
+import java.util.concurrent.{Executors, ScheduledExecutorService}
+import org.scalatest.{AsyncFunSuite, BeforeAndAfterAll, Matchers}
+import scala.concurrent.ExecutionContext
+
+class IOAppTests extends AsyncFunSuite with Matchers with BeforeAndAfterAll with TestUtils {
+  val trampoline: Resource[SyncIO, ExecutionContext] = Resource.pure(TrampolineEC.immediate)
+  val scheduler: Resource[SyncIO, ScheduledExecutorService] =
+    Resource.make(SyncIO(Executors.newScheduledThreadPool(2)))(e => SyncIO(e.shutdown()))
+
+  test("exits with specified code") {
+    IOAppPlatform.main(Array.empty, trampoline, scheduler) { (_, _) =>
+      IO.pure(ExitCode(42))
+    } shouldEqual 42
+  }
+
+  test("accepts arguments") {
+    IOAppPlatform.main(Array("1", "2", "3"), trampoline, scheduler) { (_, args) =>
+      IO.pure(ExitCode(args.mkString.toInt))
+    } shouldEqual 123
+  }
+
+  test("raised error exits with 1") {
+    silenceSystemErr {
+      IOAppPlatform.main(Array.empty, trampoline, scheduler) { (_, _) =>
+        IO.raiseError(new Exception())
+      } shouldEqual 1
+    }
+  }
+
+  test("synchronously brackets the executor resource") {
+    var closed = false
+    val resource = trampoline.flatMap { ec =>
+      Resource.make(SyncIO.pure(ec))(_ => SyncIO { closed = true })
+    }
+    IOAppPlatform.main(Array.empty, resource, scheduler) { (runtime, _) =>
+      IO(if (closed) ExitCode(0) else ExitCode(1))
+    } shouldEqual 1
+    closed shouldEqual true
+  }
+
+  test("synchronously brackets the scheduler resource") {
+    var closed = false
+    val resource = scheduler.flatMap { ec =>
+      Resource.make(SyncIO.pure(ec))(_ => SyncIO { closed = true })
+    }
+    IOAppPlatform.main(Array.empty, trampoline, resource) { (runtime, _) =>
+      IO(if (closed) ExitCode(0) else ExitCode(1))
+    } shouldEqual 1
+    closed shouldEqual true
+  }
+
+  test("throws if resource acquisition fails") {
+    class Boom extends Exception
+    silenceSystemErr {
+      val resource: Resource[SyncIO, ExecutionContext] =
+        Resource.liftF(SyncIO.raiseError(new Boom()))
+      a [Boom] should be thrownBy {
+        IOAppPlatform.main(Array.empty, resource, scheduler) { (_, _) =>
+          IO.pure(ExitCode(0))
+        }
+      }
+    }
+  }
+}

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1358,11 +1358,12 @@ object IO extends IOInstances {
    * Returns a [[ContextShift]] instance for [[IO]], built from a
    * Scala `ExecutionContext`.
    *
-   * NOTE: you don't need to build such instances when using [[IOApp]].
+   * NOTE: When using [[IOApp]], an appropriate implicit instance
+   * can be imported from `runtime`
    *
    * @param ec is the execution context used for the actual execution of
    *        tasks (e.g. bind continuations) and can be backed by the
-   *        user's own thread-pool
+   *        user's own thread pool
    */
   def contextShift(ec: ExecutionContext): ContextShift[IO] =
     IOContextShift(ec)

--- a/core/shared/src/main/scala/cats/effect/IOApp.scala
+++ b/core/shared/src/main/scala/cats/effect/IOApp.scala
@@ -18,6 +18,7 @@ package cats
 package effect
 
 import cats.effect.internals.IOAppPlatform
+import scala.concurrent.ExecutionContext
 
 /**
  * `App` type that runs a [[cats.effect.IO]].  Shutdown occurs after
@@ -41,7 +42,7 @@ import cats.effect.internals.IOAppPlatform
  * import cats.implicits._
  *
  * object MyApp extends IOApp {
- *   def run(args: List[String]): IO[ExitCode] =
+ *   def run(runtime: IOApp.Runtime, args: List[String]): IO[ExitCode] =
  *     args.headOption match {
  *       case Some(name) =>
  *         IO(println(s"Hello, \${name}.")).as(ExitCode.Success)
@@ -51,48 +52,52 @@ import cats.effect.internals.IOAppPlatform
  * }
  * }}}
  */
-trait IOApp {
+trait IOApp extends IOAppPlatform {
   /**
    * Produces the `IO` to be run as an app.
    *
-   * @return the [[cats.effect.ExitCode]] the JVM exits with
+   * @param runtime the [[Runtime]] for this app
+   *
+   * @param args the command line args passed to the application
+   *
+   * @return an [[cats.effect.ExitCode]] to exit the process with
+   * after the `ec` completes.
    */
-  def run(args: List[String]): IO[ExitCode]
+  def run(runtime: IOApp.Runtime, args: List[String]): IO[ExitCode]
+}
 
+object IOApp {
   /**
-   * The main method that runs the `IO` returned by [[run]] and exits
-   * the JVM with the resulting code on completion.
-   */
-  final def main(args: Array[String]): Unit =
-    IOAppPlatform.main(args, Eval.later(contextShift), Eval.later(timer))(run)
+   * A runtime for an [[IOApp]] in [[IO]]. Import from the runtime to get an
+   * implicit execution context, [[ContextShift]], and [[Timer]].
+   **/
+  trait Runtime {
+    /**
+     * The execution context for an [[IOApp]].  This is the main thread pool.
+     *
+     * Blocking on this thread pool is heavily discouraged.  Use
+     * [[ContextShift#evalOn]] with a separate pool for these cases.
+     */
+    implicit def executionContext: ExecutionContext
 
-  /**
-   * Provides an implicit [[ContextShift]] instance for the app.
-   *
-   * The default is lazily constructed from the global execution context
-   * (i.e. `scala.concurrent.ExecutionContext.Implicits.global`).
-   *
-   * Users can override this instance in order to customize the main
-   * thread-pool on top of the JVM, or to customize the run-loop on
-   * top of JavaScript.
-   */
-  protected implicit def contextShift: ContextShift[IO] =
-    IOAppPlatform.defaultContextShift
+    /**
+     * A [[ContextShift]] for the [[IOApp]] that shifts back to
+     * [[executionContext]].
+     */
+    implicit def contextShift: ContextShift[IO]
 
-  /**
-   * Provides an implicit [[Timer]] instance for the app.
-   *
-   * Users can override this instance in order to customize the
-   * underlying scheduler being used.
-   *
-   * The default on top of the JVM uses an internal scheduler built with Java's
-   * [[https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executors.html#newScheduledThreadPool-int- Executors.newScheduledThreadPool]]
-   * (configured with one or two threads) and that defers the execution of the
-   * scheduled ticks (the bind continuations get shifted) to Scala's `global`.
-   *
-   * On top of JavaScript the default timer will simply use the standard
-   * [[https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout setTimeout]].
-   */
-  protected implicit def timer: Timer[IO] =
-    IOAppPlatform.defaultTimer
+    /**
+     * A [[Timer]] for the [[IOApp]] that shifts back to
+     * [[executionContext]].
+     */
+    implicit def timer: Timer[IO]
+  }
+
+  object Runtime extends IOAppPlatform.RuntimePlatformCompanion {
+    def apply(ec: ExecutionContext) = new Runtime {
+      implicit def executionContext: ExecutionContext = ec
+      implicit def contextShift: ContextShift[IO] = IO.contextShift(ec)
+      implicit def timer: Timer[IO] = IO.timer(ec)
+    }
+  }
 }


### PR DESCRIPTION
A continuation of #337 and #339.

On the JVM:
* Provides a `Resource[SyncIO, ExecutionContext]` on `IOApp`, so we can properly await any pending work.  Without it, we can't have a graceful shutdown of the main pool.
* Provides a `Resource[SyncIO, ScheduledExecutorService]` on `IOApp`, so we can properly await any pending tasks.  Without it, we can't have a graceful shutdown of the scheduler that drives the `Timer`.
* `SyncIO` is chosen to ensure that the resources are not closed while a `ConcurrentEffect[IO]` may be in use to interpret the `IO`.

On Scala.js:
* Provides an `ExecutionContext`.  Unlike the JVM's thread pools, a JS `ExecutionContext` is not shutdown.  Furthermore, the process is kept alive until the event loop is processed, so we get a graceful shutdown.
* Tries to use Node.js's `process.exitCode` over `sys.exit` for a more graceful shutdown.

On both:
* Provide a `Runtime` to the `run` method.  This gives the entire implicit environment, which all use the same `ExecutionContext`:
  * The `ExecutionContext` itself, for interop with `Future`-based APIs
  * A `ContextShift[IO]` built on the execution context.
  * A `Timer[IO]`, built on the execution context shift and the `ScheduledExecutorService` (JVM) or `setTimeout` (JS)


