### PR TITLE
Add IOApp.WithContext for custom executors and schedulers

### DIFF
--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/ECBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/ECBenchmark.scala
@@ -1,0 +1,37 @@
+package cats.effect.benchmarks
+
+import java.util.concurrent._
+import java.util.concurrent.atomic._
+import cats.effect.{ExitCode, IO, IOApp}
+import cats.implicits._
+import org.openjdk.jmh.annotations._
+import scala.concurrent.ExecutionContext
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class ECBenchmark {
+  trait Run { self: IOApp =>
+    val size = 100000
+    def run(args: List[String]) = {
+      def loop(i: Int): IO[Int] =
+        if (i < size) IO.shift.flatMap(_ => IO.pure(i + 1)).flatMap(loop)
+        else IO.shift.flatMap(_ => IO.pure(i))
+
+      IO(0).flatMap(loop).as(ExitCode.Success)
+    }
+  }
+
+  private val ioApp = new IOApp with Run
+  private val ioAppCtx = new IOApp.WithContext with Run
+
+  @Benchmark
+  def app(): Unit = {
+    val _ = ioApp.main(Array.empty)
+  }
+
+  @Benchmark
+  def appWithCtx(): Unit = {
+    val _ = ioAppCtx.main(Array.empty)
+  }
+}

--- a/core/js/src/main/scala/cats/effect/internals/IOAppCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOAppCompanionPlatform.scala
@@ -18,4 +18,4 @@ package cats
 package effect
 package internals
 
-trait IOAppCompanionPlatform
+private[effect] trait IOAppCompanionPlatform

--- a/core/js/src/main/scala/cats/effect/internals/IOAppCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOAppCompanionPlatform.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package internals
+
+trait IOAppCompanionPlatform

--- a/core/jvm/src/main/scala/cats/effect/internals/IOAppCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOAppCompanionPlatform.scala
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package internals
+
+import java.util.{Collection, Collections, List}
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.{Callable, Future, RejectedExecutionException, ScheduledFuture, TimeUnit, ScheduledExecutorService}
+import scala.concurrent.ExecutionContext
+
+private[effect] trait IOAppCompanionPlatform {
+  /**
+   * Supports customization of the execution context and scheduler
+   * used by an [[IOApp]]
+   */
+  trait WithContext extends IOApp {
+    /**
+     * Provides an execution context for this app to use as its main
+     * thread pool.  This execution context is used by the implicit
+     * [[contextShift]] and [[timer]] instances.
+     *
+     * [[main]] will block until this resource is released.  To
+     * implement a graceful shutdown where all pending work is
+     * complete, call `awaitTermination` in the release:
+     *
+     * {{{
+     * Resource.make(SyncIO(Executors.newFixedThreadPool(8)))(pool => SyncIO{
+     *   pool.shutdown()
+     *   pool.awaitTermination(10, TimeUnit.SECONDS)
+     * }).map(ExecutionContext.fromExecutorService)
+     * }}}
+     *
+     * The default implementation uses `ExecutionContext.global`,
+     * which can't be shut down or awaited.  In this default implementation,
+     * any pending tasks are dropped when `run` completes.
+     */
+    protected def executionContextResource: Resource[SyncIO, ExecutionContext] =
+      defaultExecutionContext
+
+    /**
+     * Provides a scheduler for this app to use.  This scheduler is
+     * used by the implicit [[timer]] instance.
+     *
+     * [[main]] will block until this resource is released.  To
+     * implement a graceful shutdown where all pending scheduled
+     * actions are triggered, call `awaitTermination` in the release:
+     *
+     * {{{
+     * Resource.make(SyncIO(Executors.newScheduledThreadPool(2)))(pool => SyncIO{
+     *   pool.shutdown
+     *   pool.awaitTermination(10, TimeUnit.SECONDS)
+     * })
+     * }}}
+     *
+     * The default implementation uses an internal scheduler built on
+     * two daemon threads, which can't be shut down or awaited.  In
+     * this default implementation, any pending actions are dropped
+     * when `run` completes.
+     */
+    protected def schedulerResource: Resource[SyncIO, ScheduledExecutorService] =
+      defaultScheduler
+
+    /**
+     * The main execution context for this app, provided by
+     * [[executionContextResoruce]].  Outside `run`, this context will
+     * reject all tasks.
+     */
+    protected def executionContext: ExecutionContext =
+      currentContext.get().executionContext
+
+    /**
+     * The main scheduler for this app, provided by
+     * [[schedulerResource]].  Outside `run`, this scheduler will
+     * reject all tasks.
+     */
+    protected def scheduler: ScheduledExecutorService =
+      currentContext.get().scheduler
+
+    /**
+     * The default [[ContextShift]] for this app.  Based on
+     * [[executionContext]].
+     */
+    override protected implicit def contextShift: ContextShift[IO] =
+      currentContext.get().contextShift
+
+    /**
+     * The default [[Timer]] for this app.  Based on [[executionContext]]
+     * and [[scheduler]].
+     */
+    override protected implicit def timer: Timer[IO] =
+      currentContext.get().timer
+
+    /**
+     * Uses [[executionContextResource]] and [[schedulerResource]] to
+     * execute `run` and exit with its result.  The main thread is
+     * blocked until both resources are fully released, permitting a
+     * graceful shutdown of the application.
+     */
+    override def main(args: Array[String]): Unit = {
+      val mainIO = executionContextResource.use { ec =>
+        schedulerResource.use { sc =>
+          val init = SyncIO {
+            if (!currentContext.compareAndSet(ClosedContext, new Context(ec, sc))) {
+              throw new IllegalStateException("IOApp already in use!")
+            }
+          }
+          val shutdown = SyncIO(currentContext.set(ClosedContext))
+          init.bracket(_ => SyncIO(super.main(args)))(_ => shutdown)
+        }
+      }
+      mainIO.unsafeRunSync()
+    }
+  }
+
+  private[this] val defaultExecutionContext: Resource[SyncIO, ExecutionContext] =
+    Resource.liftF(SyncIO(ExecutionContext.global))
+
+  private[this] val defaultScheduler: Resource[SyncIO, ScheduledExecutorService] =
+    Resource.liftF(SyncIO(IOTimer.scheduler))
+
+  private class Context(val executionContext: ExecutionContext, val scheduler: ScheduledExecutorService) {
+    val timer: Timer[IO] = IO.timer(executionContext, scheduler)
+    val contextShift: ContextShift[IO] = IO.contextShift(executionContext)
+  }
+
+  private[this] val ClosedExecutionContext: ExecutionContext = new ExecutionContext {
+    def execute(runnable: Runnable): Unit =
+      reject()
+
+    def reportFailure(cause: Throwable): Unit =
+      Logger.reportFailure(cause)
+  }
+
+  private[this] val ClosedScheduler: ScheduledExecutorService = new ScheduledExecutorService {
+    def schedule(command: Runnable, delay: Long, unit: TimeUnit): ScheduledFuture[_] =
+      reject()
+
+    def schedule[V](callable: Callable[V], delay: Long, unit: TimeUnit): ScheduledFuture[V] =
+      reject()
+
+    def scheduleAtFixedRate(command: Runnable, initialDelay: Long, period: Long, unit: TimeUnit): ScheduledFuture[_] =
+      reject()
+
+    def scheduleWithFixedDelay(command: Runnable, initialDelay: Long, delay: Long, unit: TimeUnit): ScheduledFuture[_] =
+      reject()
+
+    def shutdown(): Unit =
+      ()
+
+    def shutdownNow(): List[Runnable] =
+      Collections.emptyList[Runnable]
+
+    def isShutdown: Boolean =
+      true
+
+    def isTerminated: Boolean =
+      true
+
+    def awaitTermination(timeout: Long, unit: TimeUnit): Boolean =
+      true
+
+    def submit[T](task: Callable[T]): Future[T] =
+      reject()
+
+    def submit[T](task: Runnable, result: T): Future[T] =
+      reject()
+
+    def submit(task: Runnable): Future[_] =
+      reject()
+
+    def invokeAll[T](tasks: Collection[_ <: Callable[T]]): List[Future[T]] =
+      reject()
+
+    def invokeAll[T](tasks: Collection[_ <: Callable[T]], timeout: Long, unit: TimeUnit): List[Future[T]] =
+      reject()
+
+    def invokeAny[T](tasks: Collection[_ <: Callable[T]]): T =
+      reject()
+
+    def invokeAny[T](tasks: Collection[_ <: Callable[T]], timeout: Long, unit: TimeUnit): T =
+      reject()
+
+    def execute(command: Runnable): Unit =
+      reject()
+  }
+
+  private[this] val ClosedContext = new Context(ClosedExecutionContext, ClosedScheduler)
+
+  private[this] val currentContext = new AtomicReference(ClosedContext)
+
+  private def reject(): Nothing = {
+    throw new RejectedExecutionException("IOApp and its thread pools are shutdown")
+  }
+}

--- a/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
@@ -63,7 +63,7 @@ private[internals] object IOTimer {
   lazy val global: Timer[IO] =
     apply(ExecutionContext.Implicits.global)
 
-  private lazy val scheduler: ScheduledExecutorService =
+  private[internals] lazy val scheduler: ScheduledExecutorService =
     Executors.newScheduledThreadPool(2, new ThreadFactory {
       def newThread(r: Runnable): Thread = {
         val th = new Thread(r)

--- a/core/shared/src/main/scala/cats/effect/IOApp.scala
+++ b/core/shared/src/main/scala/cats/effect/IOApp.scala
@@ -17,7 +17,7 @@
 package cats
 package effect
 
-import cats.effect.internals.IOAppPlatform
+import cats.effect.internals.{IOAppCompanionPlatform, IOAppPlatform}
 
 /**
  * `App` type that runs a [[cats.effect.IO]].  Shutdown occurs after
@@ -63,7 +63,7 @@ trait IOApp {
    * The main method that runs the `IO` returned by [[run]] and exits
    * the JVM with the resulting code on completion.
    */
-  final def main(args: Array[String]): Unit =
+  def main(args: Array[String]): Unit =
     IOAppPlatform.main(args, Eval.later(contextShift), Eval.later(timer))(run)
 
   /**
@@ -96,3 +96,5 @@ trait IOApp {
   protected implicit def timer: Timer[IO] =
     IOAppPlatform.defaultTimer
 }
+
+object IOApp extends IOAppCompanionPlatform

--- a/core/shared/src/main/scala/cats/effect/IOApp.scala
+++ b/core/shared/src/main/scala/cats/effect/IOApp.scala
@@ -61,18 +61,18 @@ trait IOApp {
 
   /**
    * The main method that runs the `IO` returned by [[run]] and exits
-   * the JVM with the resulting code on completion.
+   * the app with the resulting code on completion.
    */
   def main(args: Array[String]): Unit =
     IOAppPlatform.main(args, Eval.later(contextShift), Eval.later(timer))(run)
 
   /**
-   * Provides an implicit [[ContextShift]] instance for the app.
+   * Provides an implicit [[ContextShift]] for the app.
    *
    * The default is lazily constructed from the global execution context
    * (i.e. `scala.concurrent.ExecutionContext.Implicits.global`).
    *
-   * Users can override this instance in order to customize the main
+   * Users can override this value in order to customize the main
    * thread-pool on top of the JVM, or to customize the run-loop on
    * top of JavaScript.
    */
@@ -80,9 +80,9 @@ trait IOApp {
     IOAppPlatform.defaultContextShift
 
   /**
-   * Provides an implicit [[Timer]] instance for the app.
+   * Provides an implicit [[Timer]] for the app.
    *
-   * Users can override this instance in order to customize the
+   * Users can override this value in order to customize the
    * underlying scheduler being used.
    *
    * The default on top of the JVM uses an internal scheduler built with Java's


### PR DESCRIPTION
Introduces `IOApp.WithContext` on the JVM to support customization of the execution context and scheduler that underlie the implicit `ContextShift` and `Timer`. We await the termination of both to support a safe, customizable shutdown with pending tasks.

Benchmark shows no significant performance difference.

Fixes #337.  Based on @alexandru's gist of #337, and previous attempts at #339 and #341.
