### PR TITLE
Uniquely name cats-effect-scheduler threads

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
@@ -67,7 +67,7 @@ private[internals] object IOTimer {
     Executors.newScheduledThreadPool(2, new ThreadFactory {
       def newThread(r: Runnable): Thread = {
         val th = new Thread(r)
-        th.setName("cats-effect")
+        th.setName(s"cats-effect-scheduler-${th.getId}")
         th.setDaemon(true)
         th
       }


### PR DESCRIPTION
1. Make clear that these are scheduler threads
2. Give them a unique name, in the same spirit as the global execution context