### PR TITLE
Add Sync.memoize to memoize SyncIO

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -375,6 +375,45 @@ object Concurrent {
     }
 
   /**
+    * Lazily memoizes `f`. For every time the returned `F[F[A]]` is
+    * bound, the effect `f` will be performed at most once (when the
+    * inner `F[A]` is bound the first time).
+    *
+    * This has to spin if there are two concurrent evaluations.
+    */
+  def memoizeSpin[F[_], A](f: F[A])(implicit F: Sync[F]): F[F[A]] = {
+    sealed trait SpinState
+    case object Unset extends SpinState
+    case class Error(throwable: Throwable) extends SpinState
+    case object Evaluating extends SpinState
+    case class Finished(result: A) extends SpinState
+
+    Ref.of[F, SpinState](Unset).map { ref =>
+      lazy val spin: F[A] =
+        ref.access.flatMap {
+          case (Unset, set) =>
+            set(Evaluating).flatMap {
+              case true =>
+                // we got the lock
+                f.attempt
+                  .flatTap {
+                    case Right(a) => ref.set(Finished(a))
+                    case Left(err) => ref.set(Error(err))
+                  }
+                  .rethrow
+              case false =>
+                spin
+            }
+          case (Finished(a), _) => F.pure(a)
+          case (Error(err), _) => F.raiseError(err)
+          case (Evaluating, _) => spin
+        }
+
+      spin
+    }
+  }
+
+  /**
    * Returns an effect that either completes with the result of the source within
    * the specified time `duration` or otherwise raises a `TimeoutException`.
    *

--- a/laws/shared/src/test/scala/cats/effect/MemoizeTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/MemoizeTests.scala
@@ -26,15 +26,20 @@ import cats.effect.laws.discipline.arbitrary._
 import cats.laws._
 import cats.laws.discipline._
 
-class MemoizeTests extends BaseTestsSuite {
-  testAsync("Concurrent.memoize does not evaluates the effect if the inner `F[A]`isn't bound") { implicit ec =>
+abstract class MemoizeTestsBase extends BaseTestsSuite {
+
+  def method: String
+
+  def memoize[A](fa: IO[A])(implicit F: Concurrent[IO]): IO[IO[A]]
+
+  testAsync(s"Concurrent.$method does not evaluates the effect if the inner `F[A]`isn't bound") { implicit ec =>
     implicit val cs = ec.contextShift[IO]
     val timer = ec.timer[IO]
 
     val prog = for {
       ref <- Ref.of[IO, Int](0)
       action = ref.update(_ + 1)
-      _ <- Concurrent.memoize(action)
+      _ <- memoize(action)
       _ <- timer.sleep(100.millis)
       v <- ref.get
     } yield v
@@ -44,7 +49,7 @@ class MemoizeTests extends BaseTestsSuite {
     result.value shouldBe Some(Success(0))
   }
 
-  testAsync("Concurrent.memoize evalutes effect once if inner `F[A]` is bound twice"){ implicit ec =>
+  testAsync(s"Concurrent.$method evalutes effect once if inner `F[A]` is bound twice"){ implicit ec =>
     implicit val cs = ec.contextShift[IO]
 
     val prog = for {
@@ -53,7 +58,7 @@ class MemoizeTests extends BaseTestsSuite {
         val ns = s + 1
         ns -> ns
       }
-      memoized <- Concurrent.memoize(action)
+      memoized <- memoize(action)
       x <- memoized
       y <- memoized
       v <- ref.get
@@ -64,7 +69,7 @@ class MemoizeTests extends BaseTestsSuite {
     result.value shouldBe Some(Success((1, 1, 1)))
   }
 
-  testAsync("Concurrent.memoize effect evaluates effect once if the inner `F[A]` is bound twice (race)" ){ implicit ec =>
+  testAsync(s"Concurrent.$method effect evaluates effect once if the inner `F[A]` is bound twice (race)" ){ implicit ec =>
     implicit val cs = ec.contextShift[IO]
     val timer = ec.timer[IO]
 
@@ -74,7 +79,7 @@ class MemoizeTests extends BaseTestsSuite {
         val ns = s + 1
         ns -> ns
       }
-      memoized <- Concurrent.memoize(action)
+      memoized <- memoize(action)
       _ <- memoized.start
       x <- memoized
       _ <- timer.sleep(100.millis)
@@ -86,10 +91,22 @@ class MemoizeTests extends BaseTestsSuite {
     result.value shouldBe Some(Success((1, 1)))
   }
 
-  testAsync("Concurrent.memoize and then flatten is identity") { implicit ec =>
+  testAsync(s"Concurrent.$method and then flatten is identity") { implicit ec =>
     implicit val cs = ec.contextShift[IO]
     check { fa: IO[Int] =>
-      Concurrent.memoize(fa).flatten <-> fa
+      memoize(fa).flatten <-> fa
     }
   }
+}
+
+class MemoizeTests extends MemoizeTestsBase {
+  lazy val method = "memoize"
+  def memoize[A](fa: IO[A])(implicit F: Concurrent[IO]): IO[IO[A]] =
+    Concurrent.memoize(fa)
+}
+
+class MemoizeSpinTests extends MemoizeTestsBase {
+  lazy val method = "memoizeSpin"
+  def memoize[A](fa: IO[A])(implicit F: Concurrent[IO]): IO[IO[A]] =
+    Concurrent.memoizeSpin(fa)
 }


### PR DESCRIPTION
This can be useful to replace `Eval` with `SyncIO` since `Eval` has an impure memoize and we want to have a pure replacement.