### PR TITLE
documentation - add one contextShift example out of three provided options

### DIFF
--- a/site/src/main/tut/datatypes/io.md
+++ b/site/src/main/tut/datatypes/io.md
@@ -1210,11 +1210,14 @@ It has the potential to run an arbitrary number of `IO`s in parallel, and it all
 
 ```tut:silent
 import cats.syntax.all._
+import scala.concurrent.ExecutionContext
+import cats.effect.ContextShift
 
 val ioA = IO(println("Running ioA"))
 val ioB = IO(println("Running ioB"))
 val ioC = IO(println("Running ioC"))
 
+implicit val ctxShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 val program = (ioA, ioB, ioC).parMapN { (_, _, _) => () }
 
 program.unsafeRunSync()


### PR DESCRIPTION
fixes following error in [cats-effect parallemsim example](https://typelevel.org/cats-effect/datatypes/io.html#parmapn) after adding `implcit ContextShift[IO]`

```scala
could not find implicit value for parameter p: cats.NonEmptyParallel[cats.effect.IO,F]
```

as the definition for `parMapN` is looking for `NonEmptyParallel`

```scala
  def parMapN[F[_], Z](f: (A0, A1, A2) => Z)(implicit p: NonEmptyParallel[M, F]): M[Z] = Parallel.parMap3(t3._1, t3._2, t3._3)(f)
```