### PR TITLE
Fix #382: bracket should not have an uncancelable `acquire` by law

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -188,7 +188,14 @@ val mimaSettings = Seq(
     Seq(
       exclude[DirectMissingMethodProblem]("cats.effect.internals.IOBracket#EnsureReleaseFrame.this"),
       exclude[DirectMissingMethodProblem]("cats.effect.internals.IOBracket#BracketReleaseFrame.this"),
-      exclude[DirectMissingMethodProblem]("cats.effect.internals.IOBracket#BaseReleaseFrame.this")
+      exclude[DirectMissingMethodProblem]("cats.effect.internals.IOBracket#BaseReleaseFrame.this"),
+      // Related to: https://github.com/typelevel/cats-effect/issues/382
+      // All internal implementation details (fingers crossed)
+      exclude[IncompatibleTemplateDefProblem]("cats.effect.Concurrent$KleisliConcurrent"),
+      exclude[IncompatibleTemplateDefProblem]("cats.effect.Sync$KleisliSync"),
+      exclude[IncompatibleTemplateDefProblem]("cats.effect.Async$KleisliAsync"),
+      exclude[IncompatibleTemplateDefProblem]("cats.effect.Bracket$KleisliBracket")
+      // ...
     )
   })
 

--- a/core/shared/src/main/scala/cats/effect/Async.scala
+++ b/core/shared/src/main/scala/cats/effect/Async.scala
@@ -361,10 +361,10 @@ object Async {
     override implicit protected def F: Async[F]
     protected def FF = F
 
-    override def asyncF[A](k: (Either[Throwable, A] => Unit) => EitherT[F, L, Unit]): EitherT[F, L, A] =
+    final override def asyncF[A](k: (Either[Throwable, A] => Unit) => EitherT[F, L, Unit]): EitherT[F, L, A] =
       EitherT.liftF(F.asyncF(cb => F.as(k(cb).value, ())))
 
-    override def async[A](k: (Either[Throwable, A] => Unit) => Unit): EitherT[F, L, A] =
+    final override def async[A](k: (Either[Throwable, A] => Unit) => Unit): EitherT[F, L, A] =
       EitherT.liftF(F.async(k))
   }
 
@@ -375,10 +375,10 @@ object Async {
     override protected implicit def F: Async[F]
     protected def FF = F
 
-    override def asyncF[A](k: (Either[Throwable, A] => Unit) => OptionT[F, Unit]): OptionT[F, A] =
+    final override def asyncF[A](k: (Either[Throwable, A] => Unit) => OptionT[F, Unit]): OptionT[F, A] =
       OptionT.liftF(F.asyncF(cb => F.as(k(cb).value, ())))
 
-    override def async[A](k: (Either[Throwable, A] => Unit) => Unit): OptionT[F, A] =
+    final override def async[A](k: (Either[Throwable, A] => Unit) => Unit): OptionT[F, A] =
       OptionT.liftF(F.async(k))
   }
 
@@ -389,10 +389,10 @@ object Async {
     override protected implicit def F: Async[F]
     protected def FA = F
 
-    override def asyncF[A](k: (Either[Throwable, A] => Unit) => StateT[F, S, Unit]): StateT[F, S, A] =
+    final override def asyncF[A](k: (Either[Throwable, A] => Unit) => StateT[F, S, Unit]): StateT[F, S, A] =
       StateT(s => F.map(F.asyncF[A](cb => k(cb).runA(s)))(a => (s, a)))
 
-    override def async[A](k: (Either[Throwable, A] => Unit) => Unit): StateT[F, S, A] =
+    final override def async[A](k: (Either[Throwable, A] => Unit) => Unit): StateT[F, S, A] =
       StateT.liftF(F.async(k))
   }
 
@@ -403,23 +403,23 @@ object Async {
     override protected implicit def F: Async[F]
     protected def FA = F
 
-    override def asyncF[A](k: (Either[Throwable, A] => Unit) => WriterT[F, L, Unit]): WriterT[F, L, A] =
+    final override def asyncF[A](k: (Either[Throwable, A] => Unit) => WriterT[F, L, Unit]): WriterT[F, L, A] =
       WriterT.liftF(F.asyncF(cb => F.as(k(cb).run, ())))
 
-    override def async[A](k: (Either[Throwable, A] => Unit) => Unit): WriterT[F, L, A] =
+    final override def async[A](k: (Either[Throwable, A] => Unit) => Unit): WriterT[F, L, A] =
       WriterT.liftF(F.async(k))(L, FA)
   }
 
-  private[effect] abstract class KleisliAsync[F[_], R]
-    extends Sync.KleisliSync[F, R]
-    with Async[Kleisli[F, R, ?]] {
+  private[effect] trait KleisliAsync[F[_], R]
+    extends Async[Kleisli[F, R, ?]]
+    with Sync.KleisliSync[F, R] {
 
     override protected implicit def F: Async[F]
 
-    override def asyncF[A](k: (Either[Throwable, A] => Unit) => Kleisli[F, R, Unit]): Kleisli[F, R, A] =
+    final override def asyncF[A](k: (Either[Throwable, A] => Unit) => Kleisli[F, R, Unit]): Kleisli[F, R, A] =
       Kleisli(a => F.asyncF(cb => k(cb).run(a)))
 
-    override def async[A](k: (Either[Throwable, A] => Unit) => Unit): Kleisli[F, R, A] =
+    final override def async[A](k: (Either[Throwable, A] => Unit) => Unit): Kleisli[F, R, A] =
       Kleisli.liftF(F.async(k))
   }
 }

--- a/core/shared/src/main/scala/cats/effect/ConcurrentEffect.scala
+++ b/core/shared/src/main/scala/cats/effect/ConcurrentEffect.scala
@@ -91,7 +91,7 @@ object ConcurrentEffect {
 
     protected def F: ConcurrentEffect[F]
 
-    override def runCancelable[A](fa: EitherT[F, Throwable, A])
+    final override def runCancelable[A](fa: EitherT[F, Throwable, A])
       (cb: Either[Throwable, A] => IO[Unit]): SyncIO[CancelToken[EitherT[F, Throwable, ?]]] =
       F.runCancelable(fa.value)(cb.compose(_.right.flatMap(x => x))).map(EitherT.liftF(_)(F))
   }
@@ -104,7 +104,7 @@ object ConcurrentEffect {
     protected def F: ConcurrentEffect[F]
     protected def L: Monoid[L]
 
-    override def runCancelable[A](fa: WriterT[F, L, A])
+    final override def runCancelable[A](fa: WriterT[F, L, A])
       (cb: Either[Throwable, A] => IO[Unit]): SyncIO[CancelToken[WriterT[F, L, ?]]] =
       F.runCancelable(fa.run)(cb.compose(_.right.map(_._2))).map(WriterT.liftF(_)(L, F))
   }

--- a/core/shared/src/main/scala/cats/effect/Effect.scala
+++ b/core/shared/src/main/scala/cats/effect/Effect.scala
@@ -48,7 +48,7 @@ trait Effect[F[_]] extends Async[F] {
    *
    * {{{
    *   val io = F.runAsync(fa)(cb)
-   *   // Running io results in evaluation of `fa` starting 
+   *   // Running io results in evaluation of `fa` starting
    *   io.unsafeRunSync
    * }}}
    */
@@ -91,10 +91,10 @@ object Effect {
 
     protected def F: Effect[F]
 
-    def runAsync[A](fa: EitherT[F, Throwable, A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] =
+    final def runAsync[A](fa: EitherT[F, Throwable, A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] =
       F.runAsync(fa.value)(cb.compose(_.right.flatMap(x => x)))
 
-    override def toIO[A](fa: EitherT[F, Throwable, A]): IO[A] =
+    final override def toIO[A](fa: EitherT[F, Throwable, A]): IO[A] =
       F.toIO(F.rethrow(fa.value))
   }
 
@@ -104,10 +104,10 @@ object Effect {
     protected def F: Effect[F]
     protected def L: Monoid[L]
 
-    def runAsync[A](fa: WriterT[F, L, A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] =
+    final def runAsync[A](fa: WriterT[F, L, A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] =
       F.runAsync(fa.run)(cb.compose(_.right.map(_._2)))
 
-    override def toIO[A](fa: WriterT[F, L, A]): IO[A] =
+    final override def toIO[A](fa: WriterT[F, L, A]): IO[A] =
       F.toIO(fa.value(F))
   }
 }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -742,7 +742,8 @@ private[effect] abstract class IOLowPriorityInstances extends IOParallelNewtype 
 
   implicit val ioEffect: Effect[IO] = new IOEffect
 
-  private[effect] class IOEffect extends Effect[IO] with StackSafeMonad[IO] {
+  private[effect] class IOEffect extends IOEffectBase
+  private[effect] trait IOEffectBase extends Effect[IO] with StackSafeMonad[IO] {
     final override def pure[A](a: A): IO[A] =
       IO.pure(a)
     final override def unit: IO[Unit] =
@@ -815,7 +816,7 @@ private[effect] abstract class IOInstances extends IOLowPriorityInstances {
   }
 
   implicit def ioConcurrentEffect(implicit cs: ContextShift[IO]): ConcurrentEffect[IO] =
-    new IOEffect with ConcurrentEffect[IO] {
+    new ConcurrentEffect[IO] with IOEffectBase {
       final override def start[A](fa: IO[A]): IO[Fiber[IO, A]] =
         fa.start
       final override def race[A, B](fa: IO[A], fb: IO[B]): IO[Either[A, B]] =

--- a/core/shared/src/main/scala/cats/effect/Sync.scala
+++ b/core/shared/src/main/scala/cats/effect/Sync.scala
@@ -92,16 +92,16 @@ object Sync {
   private[effect] trait EitherTSync[F[_], L] extends Sync[EitherT[F, L, ?]] {
     protected implicit def F: Sync[F]
 
-    def pure[A](x: A): EitherT[F, L, A] =
+    final def pure[A](x: A): EitherT[F, L, A] =
       EitherT.pure(x)
 
-    def handleErrorWith[A](fa: EitherT[F, L, A])(f: Throwable => EitherT[F, L, A]): EitherT[F, L, A] =
+    final def handleErrorWith[A](fa: EitherT[F, L, A])(f: Throwable => EitherT[F, L, A]): EitherT[F, L, A] =
       EitherT(F.handleErrorWith(fa.value)(f.andThen(_.value)))
 
-    def raiseError[A](e: Throwable): EitherT[F, L, A] =
+    final def raiseError[A](e: Throwable): EitherT[F, L, A] =
       EitherT.liftF(F.raiseError(e))
 
-    def bracketCase[A, B](acquire: EitherT[F, L, A])
+    final def bracketCase[A, B](acquire: EitherT[F, L, A])
       (use: A => EitherT[F, L, B])
       (release: (A, ExitCase[Throwable]) => EitherT[F, L, Unit]): EitherT[F, L, B] = {
 
@@ -118,31 +118,31 @@ object Sync {
       })
     }
 
-    def flatMap[A, B](fa: EitherT[F, L, A])(f: A => EitherT[F, L, B]): EitherT[F, L, B] =
+    final def flatMap[A, B](fa: EitherT[F, L, A])(f: A => EitherT[F, L, B]): EitherT[F, L, B] =
       fa.flatMap(f)
 
-    def tailRecM[A, B](a: A)(f: A => EitherT[F, L, Either[A, B]]): EitherT[F, L, B] =
+    final def tailRecM[A, B](a: A)(f: A => EitherT[F, L, Either[A, B]]): EitherT[F, L, B] =
       EitherT.catsDataMonadErrorForEitherT[F, L].tailRecM(a)(f)
 
-    def suspend[A](thunk: => EitherT[F, L, A]): EitherT[F, L, A] =
+    final def suspend[A](thunk: => EitherT[F, L, A]): EitherT[F, L, A] =
       EitherT(F.suspend(thunk.value))
 
-    override def uncancelable[A](fa: EitherT[F, L, A]): EitherT[F, L, A] =
+    override final def uncancelable[A](fa: EitherT[F, L, A]): EitherT[F, L, A] =
       EitherT(F.uncancelable(fa.value))
   }
 
   private[effect] trait OptionTSync[F[_]] extends Sync[OptionT[F, ?]] {
     protected implicit def F: Sync[F]
 
-    def pure[A](x: A): OptionT[F, A] = OptionT.pure(x)
+    final def pure[A](x: A): OptionT[F, A] = OptionT.pure(x)
 
-    def handleErrorWith[A](fa: OptionT[F, A])(f: Throwable => OptionT[F, A]): OptionT[F, A] =
+    final def handleErrorWith[A](fa: OptionT[F, A])(f: Throwable => OptionT[F, A]): OptionT[F, A] =
       OptionT.catsDataMonadErrorForOptionT[F, Throwable].handleErrorWith(fa)(f)
 
-    def raiseError[A](e: Throwable): OptionT[F, A] =
+    final def raiseError[A](e: Throwable): OptionT[F, A] =
       OptionT.catsDataMonadErrorForOptionT[F, Throwable].raiseError(e)
 
-    def bracketCase[A, B](acquire: OptionT[F, A])
+    final def bracketCase[A, B](acquire: OptionT[F, A])
       (use: A => OptionT[F, B])
       (release: (A, ExitCase[Throwable]) => OptionT[F, Unit]): OptionT[F, B] = {
 
@@ -157,31 +157,31 @@ object Sync {
       })
     }
 
-    def flatMap[A, B](fa: OptionT[F, A])(f: A => OptionT[F, B]): OptionT[F, B] =
+    final def flatMap[A, B](fa: OptionT[F, A])(f: A => OptionT[F, B]): OptionT[F, B] =
       fa.flatMap(f)
 
-    def tailRecM[A, B](a: A)(f: A => OptionT[F, Either[A, B]]): OptionT[F, B] =
+    final def tailRecM[A, B](a: A)(f: A => OptionT[F, Either[A, B]]): OptionT[F, B] =
       OptionT.catsDataMonadErrorForOptionT[F, Throwable].tailRecM(a)(f)
 
-    def suspend[A](thunk: => OptionT[F, A]): OptionT[F, A] =
+    final def suspend[A](thunk: => OptionT[F, A]): OptionT[F, A] =
       OptionT(F.suspend(thunk.value))
 
-    override def uncancelable[A](fa: OptionT[F, A]): OptionT[F, A] =
+    override final def uncancelable[A](fa: OptionT[F, A]): OptionT[F, A] =
       OptionT(F.uncancelable(fa.value))
   }
 
   private[effect] trait StateTSync[F[_], S] extends Sync[StateT[F, S, ?]] {
     protected implicit def F: Sync[F]
 
-    def pure[A](x: A): StateT[F, S, A] = StateT.pure(x)
+    final def pure[A](x: A): StateT[F, S, A] = StateT.pure(x)
 
-    def handleErrorWith[A](fa: StateT[F, S, A])(f: Throwable => StateT[F, S, A]): StateT[F, S, A] =
+    final def handleErrorWith[A](fa: StateT[F, S, A])(f: Throwable => StateT[F, S, A]): StateT[F, S, A] =
       StateT(s => F.handleErrorWith(fa.run(s))(e => f(e).run(s)))
 
-    def raiseError[A](e: Throwable): StateT[F, S, A] =
+    final def raiseError[A](e: Throwable): StateT[F, S, A] =
       StateT.liftF(F.raiseError(e))
 
-    def bracketCase[A, B](acquire: StateT[F, S, A])
+    final def bracketCase[A, B](acquire: StateT[F, S, A])
       (use: A => StateT[F, S, B])
       (release: (A, ExitCase[Throwable]) => StateT[F, S, Unit]): StateT[F, S, B] = {
 
@@ -194,17 +194,17 @@ object Sync {
       }
     }
 
-    override def uncancelable[A](fa: StateT[F, S, A]): StateT[F, S, A] =
+    override final def uncancelable[A](fa: StateT[F, S, A]): StateT[F, S, A] =
       fa.transformF(F.uncancelable)
 
-    def flatMap[A, B](fa: StateT[F, S, A])(f: A => StateT[F, S, B]): StateT[F, S, B] =
+    final def flatMap[A, B](fa: StateT[F, S, A])(f: A => StateT[F, S, B]): StateT[F, S, B] =
       fa.flatMap(f)
 
     // overwriting the pre-existing one, since flatMap is guaranteed stack-safe
-    def tailRecM[A, B](a: A)(f: A => StateT[F, S, Either[A, B]]): StateT[F, S, B] =
+    final def tailRecM[A, B](a: A)(f: A => StateT[F, S, Either[A, B]]): StateT[F, S, B] =
       IndexedStateT.catsDataMonadForIndexedStateT[F, S].tailRecM(a)(f)
 
-    def suspend[A](thunk: => StateT[F, S, A]): StateT[F, S, A] =
+    final def suspend[A](thunk: => StateT[F, S, A]): StateT[F, S, A] =
       StateT.applyF(F.suspend(thunk.runF))
   }
 
@@ -212,15 +212,15 @@ object Sync {
     protected implicit def F: Sync[F]
     protected implicit def L: Monoid[L]
 
-    def pure[A](x: A): WriterT[F, L, A] = WriterT.value(x)
+    final def pure[A](x: A): WriterT[F, L, A] = WriterT.value(x)
 
-    def handleErrorWith[A](fa: WriterT[F, L, A])(f: Throwable => WriterT[F, L, A]): WriterT[F, L, A] =
+    final def handleErrorWith[A](fa: WriterT[F, L, A])(f: Throwable => WriterT[F, L, A]): WriterT[F, L, A] =
       WriterT.catsDataMonadErrorForWriterT[F, L, Throwable].handleErrorWith(fa)(f)
 
-    def raiseError[A](e: Throwable): WriterT[F, L, A] =
+    final def raiseError[A](e: Throwable): WriterT[F, L, A] =
       WriterT.catsDataMonadErrorForWriterT[F, L, Throwable].raiseError(e)
 
-    def bracketCase[A, B](acquire: WriterT[F, L, A])
+    final def bracketCase[A, B](acquire: WriterT[F, L, A])
       (use: A => WriterT[F, L, B])
       (release: (A, ExitCase[Throwable]) => WriterT[F, L, Unit]): WriterT[F, L, B] = {
 
@@ -233,35 +233,26 @@ object Sync {
       }
     }
 
-    override def uncancelable[A](fa: WriterT[F, L, A]): WriterT[F, L, A] =
+    override final def uncancelable[A](fa: WriterT[F, L, A]): WriterT[F, L, A] =
       WriterT(F.uncancelable(fa.run))
 
-    def flatMap[A, B](fa: WriterT[F, L, A])(f: A => WriterT[F, L, B]): WriterT[F, L, B] =
+    final def flatMap[A, B](fa: WriterT[F, L, A])(f: A => WriterT[F, L, B]): WriterT[F, L, B] =
       fa.flatMap(f)
 
-    def tailRecM[A, B](a: A)(f: A => WriterT[F, L, Either[A, B]]): WriterT[F, L, B] =
+    final def tailRecM[A, B](a: A)(f: A => WriterT[F, L, Either[A, B]]): WriterT[F, L, B] =
       WriterT.catsDataMonadForWriterT[F, L].tailRecM(a)(f)
 
-    def suspend[A](thunk: => WriterT[F, L, A]): WriterT[F, L, A] =
+    final def suspend[A](thunk: => WriterT[F, L, A]): WriterT[F, L, A] =
       WriterT(F.suspend(thunk.run))
   }
 
-  private[effect] abstract class KleisliSync[F[_], R]
-    extends Bracket.KleisliBracket[F, R, Throwable]
-    with Sync[Kleisli[F, R, ?]] {
+  private[effect] trait KleisliSync[F[_], R]
+    extends Sync[Kleisli[F, R, ?]]
+    with Bracket.KleisliBracket[F, R, Throwable] {
 
     protected implicit override def F: Sync[F]
 
-    override def handleErrorWith[A](fa: Kleisli[F, R, A])(f: Throwable => Kleisli[F, R, A]): Kleisli[F, R, A] =
-      Kleisli { r => F.suspend(F.handleErrorWith(fa.run(r))(e => f(e).run(r))) }
-
-    override def flatMap[A, B](fa: Kleisli[F, R, A])(f: A => Kleisli[F, R, B]): Kleisli[F, R, B] =
-      Kleisli { r => F.suspend(fa.run(r).flatMap(f.andThen(_.run(r)))) }
-
-    def suspend[A](thunk: => Kleisli[F, R, A]): Kleisli[F, R, A] =
+    final def suspend[A](thunk: => Kleisli[F, R, A]): Kleisli[F, R, A] =
       Kleisli(r => F.suspend(thunk.run(r)))
-
-    override def uncancelable[A](fa: Kleisli[F, R, A]): Kleisli[F, R, A] =
-      Kleisli { r => F.suspend(F.uncancelable(fa.run(r))) }
   }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/BracketTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/BracketTests.scala
@@ -60,10 +60,8 @@ trait BracketTests[F[_], E] extends MonadErrorTests[F, E] {
       val props = Seq(
         "bracketCase with pure unit on release is eqv to map" -> forAll(laws.bracketCaseWithPureUnitIsEqvMap[A, B] _),
         "bracketCase with failure in acquisition remains failure" -> forAll(laws.bracketCaseFailureInAcquisitionRemainsFailure[A, B] _),
-        "bracketCase with pure unit on release is eqv to uncancelable(..).flatMap" -> forAll(laws.bracketCaseWithPureUnitIsUncancelable[A, B] _),
         "bracket is derived from bracketCase" -> forAll(laws.bracketIsDerivedFromBracketCase[A, B] _),
         "uncancelable prevents Cancelled case" -> forAll(laws.uncancelablePreventsCanceledCase[A] _),
-        "acquire and release of bracket are uncancelable" -> forAll(laws.acquireAndReleaseAreUncancelable[A, B] _),
         "guarantee is derived from bracket" -> forAll(laws.guaranteeIsDerivedFromBracket[A] _),
         "guaranteeCase is derived from bracketCase" -> forAll(laws.guaranteeCaseIsDerivedFromBracketCase[A] _)
       )

--- a/laws/shared/src/test/scala/cats/effect/IOBracketUncancelableIssue382Suite.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOBracketUncancelableIssue382Suite.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.implicits._
+import scala.concurrent.Promise
+import scala.util.Success
+
+/** 
+ * This test suite is to make sure that `IO` overrides `uncancelable` in
+ * both `Effect` and `ConcurrentEffect`.
+ *
+ * See issue: https://github.com/typelevel/cats-effect/issues/382
+ *
+ * TODO: remove in Cats-Effect 2.0
+ */
+class IOBracketUncancelableIssue382Suite extends BaseTestsSuite {
+  testAsync("ConcurrentEffect[IO].uncancelable should not fork") { ec =>
+    implicit val contextShift = ec.contextShift[IO]
+    val F = ConcurrentEffect[IO]
+    val io = F.uncancelable(IO.cancelBoundary *> IO(1))
+    val p = Promise[Int]()
+
+    io.unsafeRunCancelable {
+      case Left(e) => p.failure(e)
+      case Right(a) => p.success(a)
+    }
+
+    p.future.value shouldBe Some(Success(1))
+  }
+
+  testAsync("Effect[IO].uncancelable should work") { ec =>
+    val F = Effect[IO]
+    val contextShift = ec.contextShift[IO]
+    val io = F.uncancelable(contextShift.shift *> IO(1))
+    val p = Promise[Int]()
+
+    val c = io.unsafeRunCancelable {
+      case Left(e) => p.failure(e)
+      case Right(a) => p.success(a)
+    }
+
+    c.unsafeRunAsyncAndForget
+    ec.tick()
+
+    p.future.value shouldBe Some(Success(1))
+    ec.state.tasks.isEmpty shouldBe true    
+  }
+
+  testAsync("ConcurrentEffect[IO].uncancelable should work") { ec =>
+    implicit val contextShift = ec.contextShift[IO]
+    val F = ConcurrentEffect[IO]
+    val io = F.uncancelable(contextShift.shift *> IO(1))
+    val p = Promise[Int]()
+
+    val c = io.unsafeRunCancelable {
+      case Left(e) => p.failure(e)
+      case Right(a) => p.success(a)
+    }
+
+    c.unsafeRunAsyncAndForget
+    ec.tickOne()
+
+    p.future.value shouldBe Some(Success(1))
+    ec.state.tasks.isEmpty shouldBe true    
+  }
+}


### PR DESCRIPTION
Fixes #382.

Changes:

- deprecate 2 laws from `BracketLaws`
- remove them from the execution plan of `BracketTests`
- replace the default implementation of `Bracket.uncancelable` with one equivalent with the identity function
- add old implementation of `uncancelable` to `Concurrent`
- change the internal implementation of the instances to protect against such overrides (an old Scala gotcha ... the right most trait being inherited has priority)