### PR TITLE
apply was added to ContextShift

### DIFF
--- a/core/shared/src/main/scala/cats/effect/ContextShift.scala
+++ b/core/shared/src/main/scala/cats/effect/ContextShift.scala
@@ -64,6 +64,8 @@ trait ContextShift[F[_]] {
 }
 
 object ContextShift {
+  def apply[F[_]](implicit ev: ContextShift[F]): ContextShift[F] = ev
+
   /**
    * Derives a [[ContextShift]] instance for `cats.data.EitherT`,
    * given we have one for `F[_]`.


### PR DESCRIPTION
Just for convenience, so that something like `ContextShift[F].shift *> someOp()` is possible