### PR TITLE
Add summoner for Timer

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Timer.scala
+++ b/core/shared/src/main/scala/cats/effect/Timer.scala
@@ -78,6 +78,8 @@ trait Timer[F[_]]  {
 }
 
 object Timer {
+  def apply[F[_]](implicit ev: Timer[F]): Timer[F] = ev
+
   /**
    * Derives a [[Timer]] instance for `cats.data.EitherT`,
    * given we have one for `F[_]`.


### PR DESCRIPTION
This PR brings back the summoner `apply` for Timer.
I think the decision of removing the default instance for Timer is solid, since you can't guarantee coherence (and you see it as soon as you try using `TextContext`).
I also think that the strategy of proving an instance via `IOApp` is solid, since it links `Timer` to an "environment", and it fits well with a general strategy for final tagless algebras that I like to call `implicit call sites`.
However, removing `apply` went a step too far, and I don't think it brings anything to the table apart from inconvenience, especially considering that `Timer` is being passed implicitly anyway in most of the ecosystem.