### PR TITLE
dual effect concurrent data constructors

### DIFF
--- a/core/shared/src/main/scala/cats/effect/concurrent/Deferred.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Deferred.scala
@@ -101,6 +101,14 @@ object Deferred {
   def uncancelable[F[_], A](implicit F: Async[F]): F[Deferred[F, A]] =
     F.delay(unsafeUncancelable[F, A])
 
+  /** Like [[apply]] but initializes state using another effect constructor */
+  def in[F[_], G[_], A](implicit F: Sync[F], G: Concurrent[G]): F[Deferred[G, A]] =
+    F.delay(unsafe[G, A])
+
+  /** Like [[uncancelable]] but initializes state using another effect constructor */
+  def uncancelableIn[F[_], G[_], A](implicit F: Sync[F], G: Async[G]): F[Deferred[G, A]] =
+    F.delay(unsafeUncancelable[G, A])
+
   /**
    * Like [[uncancelable]] but returns the newly allocated promise directly
    * instead of wrapping it in `F.delay`. This method is considered

--- a/core/shared/src/main/scala/cats/effect/concurrent/MVar.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/MVar.scala
@@ -189,6 +189,30 @@ object MVar {
     F.delay(MVarAsync(initial))
 
   /**
+   * Like [[of]] but initializes state using another effect constructor
+   */
+  def in[F[_], G[_], A](initial: A)(implicit F: Sync[F], G: Concurrent[G]): F[MVar[G, A]] =
+    F.delay(MVarConcurrent(initial))
+
+  /**
+   * Like [[empty]] but initializes state using another effect constructor
+   */
+  def emptyIn[F[_], G[_], A](implicit F: Sync[F], G: Concurrent[G]): F[MVar[G, A]] =
+    F.delay(MVarConcurrent.empty)
+
+  /**
+   * Like [[uncancelableOf]] but initializes state using another effect constructor
+   */
+  def uncancelableIn[F[_], G[_], A](initial: A)(implicit F: Sync[F], G: Async[G]): F[MVar[G, A]] =
+    F.delay(MVarAsync(initial))
+
+  /**
+   * Like [[uncancelableEmpty]] but initializes state using another effect constructor
+   */
+  def uncancelableEmptyIn[F[_], G[_], A](implicit F: Sync[F], G: Async[G]): F[MVar[G, A]] =
+    F.delay(MVarAsync.empty)
+
+  /**
    * Returned by the [[apply]] builder.
    */
   final class ApplyBuilders[F[_]](val F: Concurrent[F]) extends AnyVal {

--- a/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
@@ -149,6 +149,12 @@ object Ref {
   def of[F[_], A](a: A)(implicit F: Sync[F]): F[Ref[F, A]] = F.delay(unsafe(a))
 
   /**
+   *  Builds a `Ref` value for data types that are [[Sync]]
+   *  Like [[of]] but initializes state using another effect constructor
+   */
+  def in[F[_], G[_], A](a: A)(implicit F: Sync[F], G: Sync[G]): F[Ref[G, A]] = F.delay(unsafe(a))
+
+  /**
    * Like `apply` but returns the newly allocated ref directly instead of wrapping it in `F.delay`.
    * This method is considered unsafe because it is not referentially transparent -- it allocates
    * mutable state.

--- a/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
@@ -119,6 +119,24 @@ object Semaphore {
       Ref.of[F, State[F]](Right(n)).map(stateRef => new AsyncSemaphore(stateRef))
   }
 
+  /**
+   * Creates a new `Semaphore`, initialized with `n` available permits.
+   * like `apply` but initializes state using another effect constructor
+   */
+  def in[F[_], G[_]](n: Long)(implicit F: Sync[F], G: Concurrent[G]): F[Semaphore[G]] =
+    assertNonNegative[F](n) *>
+      Ref.in[F, G, State[G]](Right(n)).map(stateRef => new ConcurrentSemaphore(stateRef))
+
+  /**
+   * Creates a new `Semaphore`, initialized with `n` available permits.
+   * Like [[apply]] but only requires an `Async` constraint in exchange for the various
+   * acquire effects being uncancelable
+   * and initializes state using another effect constructor
+   */
+  def uncancelableIn[F[_], G[_]](n: Long)(implicit F: Sync[F], G: Async[G]): F[Semaphore[G]] =
+    assertNonNegative[F](n) *>
+      Ref.in[F, G, State[G]](Right(n)).map(stateRef => new AsyncSemaphore(stateRef))
+
   private def assertNonNegative[F[_]](n: Long)(implicit F: ApplicativeError[F, Throwable]): F[Unit] =
     if (n < 0) F.raiseError(new IllegalArgumentException(s"n must be nonnegative, was: $n")) else F.unit
 


### PR DESCRIPTION
Add dual effect constructors, using another `Sync` instance for delay state creation as discussed in #373