### PR TITLE
Updated oraclejdk10 to openjdk11 in travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - jdk: oraclejdk8
       scala: 2.11.12
       env: COVERAGE=coverage
-    - jdk: oraclejdk10
+    - jdk: oraclejdk11
       scala: 2.11.12
       env: COVERAGE=
     - jdk: oraclejdk8
@@ -15,7 +15,7 @@ matrix:
     - jdk: oraclejdk8
       scala: 2.13.0-M4
       env: COVERAGE=
-    - jdk: oraclejdk10
+    - jdk: oraclejdk11
       scala: 2.12.6
       env: COVERAGE=
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - jdk: oraclejdk8
       scala: 2.11.12
       env: COVERAGE=coverage
-    - jdk: oraclejdk11
+    - jdk: openjdk11
       scala: 2.11.12
       env: COVERAGE=
     - jdk: oraclejdk8
@@ -15,7 +15,7 @@ matrix:
     - jdk: oraclejdk8
       scala: 2.13.0-M4
       env: COVERAGE=
-    - jdk: oraclejdk11
+    - jdk: openjdk11
       scala: 2.12.6
       env: COVERAGE=
 


### PR DESCRIPTION
Hello guys!

In my other pull request I saw that the build is failing due to oracle java 10 being deprecated https://travis-ci.org/typelevel/cats-effect/jobs/444783719 . Since w have java 11 ready and released I decided that it is wise to change java 10 to java 11 in build.