### PR TITLE
Issue #380: Improve MVar by adding light async boundaries before put and take

### DIFF
--- a/core/shared/src/main/scala/cats/effect/internals/MVarConcurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/MVarConcurrent.scala
@@ -17,6 +17,7 @@
 package cats.effect
 package internals
 
+import cats.implicits._
 import java.util.concurrent.atomic.AtomicReference
 import cats.effect.concurrent.MVar
 import cats.effect.internals.Callback.rightUnit
@@ -35,16 +36,26 @@ private[effect] final class MVarConcurrent[F[_], A] private (
   private[this] val stateRef = new AtomicReference[State[A]](initial)
 
   def put(a: A): F[Unit] =
-    F.cancelable(unsafePut(a))
+    lightAsyncBoundary.flatMap { _ =>
+      if (unsafeTryPut(a))
+        F.unit
+      else
+        F.cancelable(unsafePut(a))
+    }
 
   def tryPut(a: A): F[Boolean] =
-    F.async(unsafePut1(a))
+    F.delay(unsafeTryPut(a))
 
   def take: F[A] =
-    F.cancelable(unsafeTake)
+    lightAsyncBoundary.flatMap { _ =>
+      unsafeTryTake() match {
+        case Some(a) => F.pure(a)
+        case None => F.cancelable(unsafeTake)
+      }
+    }
 
   def tryTake: F[Option[A]] =
-    F.async(unsafeTake1)
+    F.delay(unsafeTryTake())
 
   def read: F[A] =
     F.cancelable(unsafeRead)
@@ -57,11 +68,10 @@ private[effect] final class MVarConcurrent[F[_], A] private (
       }
     }
 
-
   @tailrec
-  private def unsafePut1(a: A)(onPut: Listener[Boolean]): Unit = {
+  private def unsafeTryPut(a: A): Boolean = {
     stateRef.get match {
-      case WaitForTake(_, _) => onPut(Right(false))
+      case WaitForTake(_, _) => false
 
       case current @ WaitForPut(reads, takes) =>
         var first: Listener[A] = null
@@ -74,7 +84,7 @@ private[effect] final class MVarConcurrent[F[_], A] private (
           }
 
         if (!stateRef.compareAndSet(current, update)) {
-          unsafePut1(a)(onPut) // retry
+          unsafeTryPut(a) // retry
         } else {
           val value = Right(a)
           // Satisfies all current `read` requests found
@@ -82,7 +92,7 @@ private[effect] final class MVarConcurrent[F[_], A] private (
           // Satisfies the first `take` request found
           if (first ne null) first(value)
           // Signals completion of `put`
-          onPut(Right(true))
+          true
         }
     }
   }
@@ -138,32 +148,30 @@ private[effect] final class MVarConcurrent[F[_], A] private (
     }
 
   @tailrec
-  private def unsafeTake1(onTake: Listener[Option[A]]): Unit = {
+  private def unsafeTryTake(): Option[A] = {
     val current: State[A] = stateRef.get
     current match {
       case WaitForTake(value, queue) =>
         if (queue.isEmpty) {
           if (stateRef.compareAndSet(current, State.empty))
-            // Signals completion of `take`
-            onTake(Right(Some(value)))
+            Some(value)
           else {
-            unsafeTake1(onTake) // retry
+            unsafeTryTake() // retry
           }
         } else {
           val ((ax, notify), xs) = queue.dequeue
           val update = WaitForTake(ax, xs)
           if (stateRef.compareAndSet(current, update)) {
-            // Signals completion of `take`
-            onTake(Right(Some(value)))
             // Complete the `put` request waiting on a notification
             notify(rightUnit)
+            Some(value)
           } else {
-            unsafeTake1(onTake) // retry
+            unsafeTryTake() // retry
           }
         }
 
       case WaitForPut(_, _) =>
-        onTake(Right(None))
+        None
     }
   }
 
@@ -250,6 +258,11 @@ private[effect] final class MVarConcurrent[F[_], A] private (
     val cursor = listeners.values.iterator
     while (cursor.hasNext)
       cursor.next().apply(value)
+  }
+
+  private[this] val lightAsyncBoundary = {
+    val k = (cb: Either[Throwable, Unit] => Unit) => cb(rightUnit)
+    F.async[Unit](k)
   }
 }
 

--- a/laws/jvm/src/test/scala/cats/effect/MVarJVMTests.scala
+++ b/laws/jvm/src/test/scala/cats/effect/MVarJVMTests.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import java.util.concurrent.atomic.AtomicBoolean
+import cats.implicits._
+import org.scalatest._
+import scala.concurrent.duration._
+import scala.concurrent.{CancellationException, ExecutionContext}
+
+class MVarJVMTests extends FunSuite with Matchers {
+  test("Issue typelevel/cats-effect#380") {
+    implicit val ec: ExecutionContext = ExecutionContext.global
+    implicit val cs = IO.contextShift(ec)
+    implicit val timer: Timer[IO] = IO.timer(ec)
+
+    for (_ <- 0 until 10) {
+      val cancelLoop = new AtomicBoolean(false)
+      val unit = IO {
+        if (cancelLoop.get()) throw new CancellationException
+      }
+
+      try {
+        val task = for {
+          mv <- cats.effect.concurrent.MVar[IO].empty[Unit]
+          _  <- (mv.take *> unit.foreverM).start
+          _  <- timer.sleep(100.millis)
+          _  <- mv.put(())
+        } yield ()
+
+        val dt = 10.seconds
+        assert(task.unsafeRunTimed(dt).nonEmpty, s"; timed-out after $dt")
+      } finally {
+        cancelLoop.set(true)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Related to issue #380.

Adding light async boundaries before put and take avoids a deadlock in a certain, common scenario.
See test.