### PR TITLE
Fixed resource leak in Semaphore#withPermit and acquire(N)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -201,7 +201,11 @@ val mimaSettings = Seq(
       // https://github.com/typelevel/cats-effect/pull/377
       exclude[DirectMissingMethodProblem]("cats.effect.internals.IOBracket#EnsureReleaseFrame.this"),
       exclude[DirectMissingMethodProblem]("cats.effect.internals.IOBracket#BracketReleaseFrame.this"),
-      exclude[DirectMissingMethodProblem]("cats.effect.internals.IOBracket#BaseReleaseFrame.this")
+      exclude[DirectMissingMethodProblem]("cats.effect.internals.IOBracket#BaseReleaseFrame.this"),
+      // All internals - https://github.com/typelevel/cats-effect/pull/403
+      exclude[DirectMissingMethodProblem]("cats.effect.concurrent.Semaphore#AbstractSemaphore.awaitGate"),
+      exclude[DirectMissingMethodProblem]("cats.effect.concurrent.Semaphore#AsyncSemaphore.awaitGate"),
+      exclude[DirectMissingMethodProblem]("cats.effect.concurrent.Semaphore#ConcurrentSemaphore.awaitGate")
     )
   })
 

--- a/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
@@ -18,7 +18,6 @@ package cats
 package effect
 package concurrent
 
-import cats.effect.ExitCase
 import cats.implicits._
 import scala.collection.immutable.Queue
 
@@ -128,7 +127,6 @@ object Semaphore {
 
   private abstract class AbstractSemaphore[F[_]](state: Ref[F, State[F]])(implicit F: Async[F]) extends Semaphore[F] {
     protected def mkGate: F[Deferred[F, Unit]]
-    protected def awaitGate(entry: (Long, Deferred[F, Unit])): F[Unit]
 
     private def open(gate: Deferred[F, Unit]): F[Unit] = gate.complete(())
 
@@ -139,9 +137,14 @@ object Semaphore {
       case Right(available) => available
     }
 
-    def acquireN(n: Long) = {
+    def acquireN(n: Long) = F.bracketCase(acquireNInternal(n)) { case (g, _) => g } {
+      case ((_, c), ExitCase.Canceled) => c
+      case _ => F.unit
+    }
+
+    def acquireNInternal(n: Long) = {
       assertNonNegative[F](n) *> {
-        if (n == 0) F.unit
+        if (n == 0) F.pure((F.unit, F.unit))
         else mkGate.flatMap { gate =>
           state
             .modify { old =>
@@ -153,12 +156,20 @@ object Semaphore {
               }
               (u, u)
             }
-            .flatMap {
+            .map {
               case Left(waiting) =>
+                val cleanup = state.modify {
+                  case Left(waiting) =>
+                    waiting.find(_._2 eq gate).map(_._1) match {
+                      case None => (Left(waiting), releaseN(n))
+                      case Some(m) => (Left(waiting.filterNot(_._2 eq gate)), releaseN(n - m))
+                    }
+                  case Right(m) => (Right(m + n), F.unit)
+                }.flatten
                 val entry = waiting.lastOption.getOrElse(sys.error("Semaphore has empty waiting queue rather than 0 count"))
-                awaitGate(entry)
+                entry._2.get -> cleanup
 
-              case Right(_) => F.unit
+              case Right(_) => F.unit -> releaseN(n)
             }
         }
       }
@@ -241,25 +252,14 @@ object Semaphore {
     }
 
     def withPermit[A](t: F[A]): F[A] =
-      F.bracket(acquire)(_ => t)(_ => release)
+      F.bracket(acquireNInternal(1)) { case (g, _) => g *> t } { case (_, c) => c }
   }
 
   private final class ConcurrentSemaphore[F[_]](state: Ref[F, State[F]])(implicit F: Concurrent[F]) extends AbstractSemaphore(state) {
     protected def mkGate: F[Deferred[F, Unit]] = Deferred[F, Unit]
-    protected def awaitGate(entry: (Long, Deferred[F, Unit])): F[Unit] =
-      F.guaranteeCase(entry._2.get) {
-        case ExitCase.Canceled =>
-          state.update {
-            case Left(waiting) => Left(waiting.filter(_ != entry))
-            case Right(m)      => Right(m)
-          }
-        case _ =>
-          F.unit
-      }
   }
 
   private final class AsyncSemaphore[F[_]](state: Ref[F, State[F]])(implicit F: Async[F]) extends AbstractSemaphore(state) {
     protected def mkGate: F[Deferred[F, Unit]] = Deferred.uncancelable[F, Unit]
-    protected def awaitGate(entry: (Long, Deferred[F, Unit])): F[Unit] = entry._2.get
   }
 }


### PR DESCRIPTION
Addresses a leak in `withPermit` discussed in #382. Also addresses a leak of permits when `acquire(N)` is cancelled after receiving some but not all of its permits.