### PR TITLE
Update reference to evalOn's fa parameter

### DIFF
--- a/core/shared/src/main/scala/cats/effect/ContextShift.scala
+++ b/core/shared/src/main/scala/cats/effect/ContextShift.scala
@@ -50,8 +50,8 @@ trait ContextShift[F[_]] {
   def shift: F[Unit]
 
   /**
-   * Evaluates `f` on the supplied execution context and shifts evaluation
-   * back to the default execution environment of `F` at the completion of `f`,
+   * Evaluates `fa` on the supplied execution context and shifts evaluation
+   * back to the default execution environment of `F` at the completion of `fa`,
    * regardless of success or failure.
    *
    * The primary use case for this method is executing blocking code on a


### PR DESCRIPTION
`f` was renamed to `fa` in e8301908d7628d572ba37d44cfa6cd2dcf43c584 but not in the first Scaladoc paragraph.