### PR TITLE
Fix resource attempt on suspend

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -350,7 +350,10 @@ private[effect] abstract class ResourceMonadError[F[_], E] extends ResourceMonad
           })
         })
       case Suspend(resource) =>
-        Suspend(resource.map(_.attempt))
+        Suspend(resource.attempt.map {
+          case Left(error) => Resource.pure(Left(error))
+          case Right(fa: Resource[F, A]) => fa.attempt
+        })
     }
 
   def handleErrorWith[A](fa: Resource[F, A])(f: E => Resource[F, A]): Resource[F, A] =


### PR DESCRIPTION
I found some problem with Resource attempt, while testing http4s.

Minimal reproduce code:
```sh
import cats.effect._
import cats.implicits._

val suspend = Resource.suspend[IO, Int](IO.raiseError(new Exception("")))
suspend.attempt.use(_ => IO.unit).unsafeRunSync()
```
expected: successful code execution
actual:  java.io.IOException:

I think problematic code at `cats.effect.ResourceMonadError#attempt` on case `Suspend`, and this change fixes it

