### PR TITLE
Undeprecate WriterT instance

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Effect.scala
+++ b/core/shared/src/main/scala/cats/effect/Effect.scala
@@ -83,7 +83,6 @@ object Effect {
    * [[Effect]] instance built for `cats.data.WriterT` values initialized
    * with any `F` data type that also implements `Effect`.
    */
-  @deprecated("WARNING: currently the Effect[WriterT[F, L, ?]] instance is broken!", "1.1.0")
   implicit def catsWriterTEffect[F[_]: Effect, L: Monoid]: Effect[WriterT[F, L, ?]] =
     new WriterTEffect[F, L] { def F = Effect[F]; def L = Monoid[L] }
 


### PR DESCRIPTION
The bracket for WriterT was fixed in #374 but the deprecation warning was not removed from the Effect instance.