### PR TITLE
Upgrade to Scala 2.12.7 and 2.13.0-M5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,20 @@ matrix:
       scala: 2.11.12
       env: COVERAGE=
     - jdk: oraclejdk8
-      scala: 2.12.6
+      scala: 2.12.7
       env: COVERAGE=
     - jdk: oraclejdk8
-      scala: 2.13.0-M4
+      scala: 2.13.0-M5
       env: COVERAGE=
     - jdk: openjdk11
-      scala: 2.12.6
+      scala: 2.12.7
       env: COVERAGE=
 
 script:
   - export SBT_PROFILE=$COVERAGE
   - sbt ++$TRAVIS_SCALA_VERSION $COVERAGE ci
   - |
-    if [ "$TRAVIS_SCALA_VERSION" = "2.12.6"]; then
+    if [ "$TRAVIS_SCALA_VERSION" = "2.12.7"]; then
       sbt ++$TRAVIS_SCALA_VERSION microsite/makeMicrosite
     fi
 

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ addCommandAlias("release", ";project root ;reload ;+publishSigned ;sonatypeRelea
 val commonSettings = Seq(
   scalaVersion := "2.12.6",
 
-  crossScalaVersions := Seq("2.11.12", "2.12.6", "2.13.0-M5"),
+  crossScalaVersions := Seq("2.11.12", "2.12.7", "2.13.0-M5"),
 
   //todo: re-enable disable scaladoc on 2.13 due to https://github.com/scala/bug/issues/11045
   sources in (Compile, doc) := (

--- a/build.sbt
+++ b/build.sbt
@@ -189,7 +189,10 @@ val commonSettings = Seq(
 
 val mimaSettings = Seq(
   mimaPreviousArtifacts := {
-    Set(organization.value %% name.value % "1.0.0")
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 13)) =>  Set(organization.value % (name.value + "_2.13.0-M4") % "1.0.0")
+      case _ => Set(organization.value %% name.value % "1.0.0")
+    }
   },
   mimaBinaryIssueFilters ++= {
     import com.typesafe.tools.mima.core._


### PR DESCRIPTION
closes #66 

I've got a few warnings when compiling with `scala-2.13.0-M5`. Most of them related to `Either` being now right-biased. Not sure whether it should be treated differently or not.

```
[info] Compiling 61 Scala sources to /workspace/oss/cats-effect/core/js/target/scala-2.13.0-M5/classes ...
[info]   Compilation completed in 10.16s.
[warn] /workspace/oss/cats-effect/core/shared/src/main/scala/cats/effect/syntax/BracketSyntax.scala:24:71: parameter value bracket in method catsEffectSyntaxBracket is never used
[warn]   implicit def catsEffectSyntaxBracket[F[_], A, E](fa: F[A])(implicit bracket: Bracket[F, E]): BracketOps[F, E, A] =
[warn]                                                                       ^
[warn] /workspace/oss/cats-effect/core/shared/src/main/scala/cats/effect/syntax/BracketSyntax.scala:24:71: parameter value bracket in method catsEffectSyntaxBracket is never used
[warn]   implicit def catsEffectSyntaxBracket[F[_], A, E](fa: F[A])(implicit bracket: Bracket[F, E]): BracketOps[F, E, A] =
[warn]                                                                       ^
[warn] /workspace/oss/cats-effect/core/shared/src/main/scala/cats/effect/ConcurrentEffect.scala:96:46: method right in class Either is deprecated (since 2.13.0): Either is now right-biased
[warn]       F.runCancelable(fa.value)(cb.compose(_.right.flatMap(x => x))).map(EitherT.liftF(_)(F))
[warn]                                              ^
[warn] /workspace/oss/cats-effect/core/shared/src/main/scala/cats/effect/ConcurrentEffect.scala:109:44: method right in class Either is deprecated (since 2.13.0): Either is now right-biased
[warn]       F.runCancelable(fa.run)(cb.compose(_.right.map(_._2))).map(WriterT.liftF(_)(L, F))
[warn]                                            ^
[warn] /workspace/oss/cats-effect/core/shared/src/main/scala/cats/effect/Effect.scala:95:41: method right in class Either is deprecated (since 2.13.0): Either is now right-biased
[warn]       F.runAsync(fa.value)(cb.compose(_.right.flatMap(x => x)))
[warn]                                         ^
[warn] /workspace/oss/cats-effect/core/shared/src/main/scala/cats/effect/Effect.scala:108:39: method right in class Either is deprecated (since 2.13.0): Either is now right-biased
[warn]       F.runAsync(fa.run)(cb.compose(_.right.map(_._2)))
[warn]                                       ^
[warn] /workspace/oss/cats-effect/core/shared/src/main/scala/cats/effect/ConcurrentEffect.scala:96:46: method right in class Either is deprecated (since 2.13.0): Either is now right-biased
[warn]       F.runCancelable(fa.value)(cb.compose(_.right.flatMap(x => x))).map(EitherT.liftF(_)(F))
[warn]                                              ^
[warn] /workspace/oss/cats-effect/core/shared/src/main/scala/cats/effect/ConcurrentEffect.scala:109:44: method right in class Either is deprecated (since 2.13.0): Either is now right-biased
[warn]       F.runCancelable(fa.run)(cb.compose(_.right.map(_._2))).map(WriterT.liftF(_)(L, F))
[warn]                                            ^
[warn] /workspace/oss/cats-effect/core/shared/src/main/scala/cats/effect/Effect.scala:95:41: method right in class Either is deprecated (since 2.13.0): Either is now right-biased
[warn]       F.runAsync(fa.value)(cb.compose(_.right.flatMap(x => x)))
[warn]                                         ^
[warn] /workspace/oss/cats-effect/core/shared/src/main/scala/cats/effect/Effect.scala:108:39: method right in class Either is deprecated (since 2.13.0): Either is now right-biased
[warn]       F.runAsync(fa.run)(cb.compose(_.right.map(_._2)))
[warn]                                       ^
[warn] 5 warnings found
```

```
[info] Compiling 16 Scala sources to /workspace/oss/cats-effect/laws/js/target/scala-2.13.0-M5/classes ...
[warn] /workspace/oss/cats-effect/laws/shared/src/main/scala/cats/effect/laws/discipline/EffectTests.scala:55:5: parameter value EqIOEitherFAA in method effect is never used
[warn]     EqIOEitherFAA: Eq[IO[Either[F[A], A]]],
[warn]     ^
[warn] /workspace/oss/cats-effect/laws/shared/src/main/scala/cats/effect/laws/ConcurrentLaws.scala:152:34: method left in class Either is deprecated (since 2.13.0): use swap instead
[warn]     F.race(fa, F.never[A]).map(_.left.getOrElse(default)) <-> fa
[warn]                                  ^
[warn] /workspace/oss/cats-effect/laws/shared/src/main/scala/cats/effect/laws/ConcurrentLaws.scala:156:34: method right in class Either is deprecated (since 2.13.0): Either is now right-biased
[warn]     F.race(F.never[A], fa).map(_.right.getOrElse(default)) <-> fa
[warn]                                  ^
[warn] /workspace/oss/cats-effect/laws/shared/src/main/scala/cats/effect/laws/discipline/EffectTests.scala:55:5: parameter value EqIOEitherFAA in method effect is never used
[warn]     EqIOEitherFAA: Eq[IO[Either[F[A], A]]],
[warn]     ^
[warn] three warnings found
[info] Done compiling.
[warn] /workspace/oss/cats-effect/laws/shared/src/main/scala/cats/effect/laws/ConcurrentLaws.scala:152:34: method left in class Either is deprecated (since 2.13.0): use swap instead
[warn]     F.race(fa, F.never[A]).map(_.left.getOrElse(default)) <-> fa
[warn]                                  ^
[warn] /workspace/oss/cats-effect/laws/shared/src/main/scala/cats/effect/laws/ConcurrentLaws.scala:156:34: method right in class Either is deprecated (since 2.13.0): Either is now right-biased
[warn]     F.race(F.never[A], fa).map(_.right.getOrElse(default)) <-> fa
[warn]                                  ^
[warn] three warnings found
```

/cc: @SethTisue