### PR TITLE
Add a `map` method directly onto `Resource`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -139,11 +139,10 @@ sealed abstract class Resource[F[_], A] {
     Bind(this, f)
 
   /**
-    * Direct implementation of the `map` operation which is otherwise
-    * available via the `cats.Monad` instance for `Resource[F, ?]`
+    *  Given a mapping function, transforms the resource provided by
+    *  this Resource.
     *
-    * This allows IDEs which have issues with Partial Unification to
-    * see `map`.
+    *  This is the standard `Functor.map`.
     */
   def map[B](f: A => B)(implicit F: Applicative[F]): Resource[F, B] =
     flatMap(a => Resource.pure[F, B](f(a)))

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -146,7 +146,7 @@ sealed abstract class Resource[F[_], A] {
     * see `map`.
     */
   def map[B](f: A => B)(implicit F: Monad[F]): Resource[F, B] =
-    flatMap(a => Resource.applyCase(F.pure((f(a), _ => F.unit))))
+    flatMap(a => Resource.pure[F, B](f(a)))
 
   /**
     * Given a `Resource`, possibly built by composing multiple

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -444,6 +444,9 @@ private[effect] abstract class ResourceMonadError[F[_], E] extends ResourceMonad
 private[effect] abstract class ResourceMonad[F[_]] extends Monad[Resource[F, ?]] {
   protected implicit def F: Monad[F]
 
+  override def map[A, B](fa: Resource[F, A])(f: A => B): Resource[F, B] =
+    fa.map(f)
+
   def pure[A](a: A): Resource[F, A] =
     Resource.applyCase(F.pure((a, _ => F.unit)))
 

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -139,6 +139,16 @@ sealed abstract class Resource[F[_], A] {
     Bind(this, f)
 
   /**
+    * Direct implementation of the `map` operation which is otherwise
+    * available via the `cats.Monad` instance for `Resource[F, ?]`
+    *
+    * This allows IDEs which have issues with Partial Unification to
+    * see `map`.
+    */
+  def map[B](f: A => B)(implicit F: Monad[F]): Resource[F, B] =
+    flatMap(a => Resource.applyCase(F.pure((f(a), _ => F.unit))))
+
+  /**
     * Given a `Resource`, possibly built by composing multiple
     * `Resource`s monadically, returns the acquired resource, as well
     * as an action that runs all the finalizers for releasing it.

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -145,7 +145,7 @@ sealed abstract class Resource[F[_], A] {
     * This allows IDEs which have issues with Partial Unification to
     * see `map`.
     */
-  def map[B](f: A => B)(implicit F: Monad[F]): Resource[F, B] =
+  def map[B](f: A => B)(implicit F: Applicative[F]): Resource[F, B] =
     flatMap(a => Resource.pure[F, B](f(a)))
 
   /**

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -87,13 +87,6 @@ class ResourceTests extends BaseTestsSuite {
       Resource.liftF(fa).use(IO.pure) <-> fa
     }
   }
-  testAsync("map should be the same as going via Monad") { implicit ec =>
-    val monad = implicitly[Monad[Resource[IO, ?]]]
-    check { fa: IO[String] =>
-      Resource.liftF(fa).map(_.toLowerCase).use(IO.pure) <->
-        monad.map(Resource.liftF(fa))(_.toLowerCase).use(IO.pure)
-    }
-  }
 
   testAsync("allocated produces the same value as the resource") { implicit ec =>
     check { resource: Resource[IO, Int] =>

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -124,5 +124,4 @@ class ResourceTests extends BaseTestsSuite {
     val suspend = Resource.suspend[IO, Int](IO.raiseError(exception))
     suspend.attempt.use(IO.pure).unsafeRunSync() shouldBe Left(exception)
   }
-
 }

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -87,6 +87,13 @@ class ResourceTests extends BaseTestsSuite {
       Resource.liftF(fa).use(IO.pure) <-> fa
     }
   }
+  testAsync("map should be the same as going via Monad") { implicit ec =>
+    val monad = implicitly[Monad[Resource[IO, ?]]]
+    check { fa: IO[String] =>
+      Resource.liftF(fa).map(_.toLowerCase).use(IO.pure) <->
+        monad.map(Resource.liftF(fa))(_.toLowerCase).use(IO.pure)
+    }
+  }
 
   testAsync("allocated produces the same value as the resource") { implicit ec =>
     check { resource: Resource[IO, Int] =>
@@ -117,4 +124,5 @@ class ResourceTests extends BaseTestsSuite {
     val suspend = Resource.suspend[IO, Int](IO.raiseError(exception))
     suspend.attempt.use(IO.pure).unsafeRunSync() shouldBe Left(exception)
   }
+
 }


### PR DESCRIPTION
This enables it to be found by IDEs which have issues with partial
unification and feels like it should be there since the class already
provides `flatMap`.