### PR TITLE
Add a semiflatMap method to Resource

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -201,6 +201,13 @@ sealed abstract class Resource[F[_], A] {
         (a.asInstanceOf[A], release)
     }
   }
+
+  /**
+    * Applies an effectful transformation to the allocated resource. Like a
+    * `flatMap` on `F[A]` while maintaining the resource context
+    */
+  def semiflatMap[B](f: A => F[B])(implicit F: Applicative[F]): Resource[F, B] =
+    this.flatMap(a => Resource.liftF(f(a)))
 }
 
 object Resource extends ResourceInstances {

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -88,6 +88,12 @@ class ResourceTests extends BaseTestsSuite {
     }
   }
 
+  testAsync("semiflatMap") { implicit ec =>
+    check { fa: IO[String] =>
+      Resource.liftF(fa).semiflatMap(IO.pure).use(IO.pure) <-> fa
+    }
+  }
+
   testAsync("allocated produces the same value as the resource") { implicit ec =>
     check { resource: Resource[IO, Int] =>
       val a0 = Resource(resource.allocated).use(IO.pure).attempt
@@ -111,7 +117,7 @@ class ResourceTests extends BaseTestsSuite {
 
     prog.unsafeRunSync
   }
-  
+
   test("safe attempt suspended resource") {
     val exception = new Exception("boom!")
     val suspend = Resource.suspend[IO, Int](IO.raiseError(exception))


### PR DESCRIPTION
This adds `semiflatMap` (name taken from a similar method on [`EitherT`](https://github.com/typelevel/cats/blob/e1a7cfcddce0fd48403669a5744df50e4a08631c/core/src/main/scala/cats/data/EitherT.scala#L112)) to `Resource` to directly apply effectful transformations to the allocated resource.

Closes #391