### PR TITLE
Add Resource#map

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -132,6 +132,13 @@ sealed abstract class Resource[F[_], A] {
   }
 
   /**
+    * Implementation for the `map` operation, as described via the
+    * `cats.Functor` type class.
+    * */
+  def map[B](f: A => B)(implicit F: Applicative[F]): Resource[F, B] =
+    Bind(this, (a: A) => Resource.pure[F, B](f(a)))
+
+  /**
    * Implementation for the `flatMap` operation, as described via the
    * `cats.Monad` type class.
    */

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -97,6 +97,24 @@ class ResourceTests extends BaseTestsSuite {
     }
   }
 
+  testAsync("map on lifted Resource") { implicit ec =>
+    check { fa: IO[Int] =>
+      Resource.liftF(fa).map(_ + 1).use(IO.pure) <-> fa.map(_ + 1)
+    }
+  }
+
+  testAsync("map on pure Resource") { implicit ec =>
+    check { a: Int =>
+      Resource.pure[IO, Int](a).map(_ + 1).use(IO.pure) <-> IO.pure(a + 1)
+    }
+  }
+
+  testAsync("map on lifted Resource is equivalent to flatMap with pure") { implicit ec =>
+    check { (resource: Resource[IO, Int], fb: Int => IO[String]) =>
+      resource.map(_ + 5).use(fb) <-> resource.flatMap(a => Resource.pure(a + 5)).use(fb)
+    }
+  }
+
   test("allocate does not release until close is invoked") {
     val released = new java.util.concurrent.atomic.AtomicBoolean(false)
     val release = Resource.make(IO.unit)(_ => IO(released.set(true)))


### PR DESCRIPTION
This will make it easier for IntelliJ users to work with resources (both in for comprehensions and in direct `map` calls), as well as people who don't want to import syntax just to use `map` :)