### PR TITLE
fix 441

### DIFF
--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -82,7 +82,7 @@ trait AsyncLaws[F[_]] extends SyncLaws[F] {
       // Start and forget
       // we attempt br because even if fa fails, we expect the release function
       // to run and set the promise.
-      F.asyncF[Unit](cb => F.delay(cb(Right(()))) *> br.attempt *> promise.get
+      F.asyncF[Unit](cb => F.delay(cb(Right(())))) *> br.attempt *> promise.get
     }
     lh <-> F.pure(b)
   }

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -82,7 +82,8 @@ trait AsyncLaws[F[_]] extends SyncLaws[F] {
       // Start and forget
       F.asyncF[Unit](cb => F.delay(cb(Right(()))) *> br.as(())) *> promise.get
     }
-    lh <-> F.pure(b)
+    // use as here so that if we are failed we get the same failure
+    lh <-> fa.as(b)
   }
 }
 

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -80,10 +80,11 @@ trait AsyncLaws[F[_]] extends SyncLaws[F] {
         case _ => F.unit
       }
       // Start and forget
-      F.asyncF[Unit](cb => F.delay(cb(Right(()))) *> br.as(())) *> promise.get
+      // we attempt br because even if fa fails, we expect the release function
+      // to run and set the promise.
+      F.asyncF[Unit](cb => F.delay(cb(Right(()))) *> br.attempt *> promise.get
     }
-    // use as here so that if we are failed we get the same failure
-    lh <-> fa.as(b)
+    lh <-> F.pure(b)
   }
 }
 

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -82,7 +82,7 @@ trait AsyncLaws[F[_]] extends SyncLaws[F] {
       // Start and forget
       // we attempt br because even if fa fails, we expect the release function
       // to run and set the promise.
-      F.asyncF[Unit](cb => F.delay(cb(Right(())))) *> br.attempt *> promise.get
+      F.asyncF[Unit](cb => F.delay(cb(Right(()))) *> br.attempt.as(())) *> promise.get
     }
     lh <-> F.pure(b)
   }


### PR DESCRIPTION
This should fix #441 

Although a better fix would actually generate failed IOs and show this change to the law is what we want.

I think this is a good fix, but an alternate approach would be to recover `F[A]` to `F[Unit]` before we start and write the law on that recovered `F[Unit]`