### PR TITLE
Use parSequence rather than sequence in RefTests

### DIFF
--- a/core/shared/src/test/scala/cats/effect/concurrent/RefTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/RefTests.scala
@@ -41,7 +41,7 @@ class RefTests extends AsyncFunSuite with Matchers {
   test("concurrent modifications") {
     val finalValue = 100
     val r = Ref.unsafe[IO, Int](0)
-    val modifies = List.fill(finalValue)(IO.shift *> r.update(_ + 1)).sequence
+    val modifies = List.fill(finalValue)(IO.shift *> r.update(_ + 1)).parSequence
     run(IO.shift *> modifies.start *> awaitEqual(r.get, finalValue))
   }
 


### PR DESCRIPTION
Imho `sequence` will not catch bugs related to concurrent modifications, but `parSequence` will do.