### PR TITLE
Remove misleading information about Context shift from IO parallel tutorial

### DIFF
--- a/site/src/main/tut/datatypes/io.md
+++ b/site/src/main/tut/datatypes/io.md
@@ -1201,7 +1201,7 @@ Note: all parallel operations require an implicit `ContextShift[IO]` in scope
 (see [ContextShift](./contextshift.html)). You have a `ContextShift` in scope if:
 
 1. via usage of [IOApp](./ioapp.html) that gives you a `ContextShift` by default
-3. the user provides a custom `ContextShift`, which can be created using `IO.contextShift(executionContext)`
+2. the user provides a custom `ContextShift`, which can be created using `IO.contextShift(executionContext)`
 
 ### parMapN
 

--- a/site/src/main/tut/datatypes/io.md
+++ b/site/src/main/tut/datatypes/io.md
@@ -1200,9 +1200,8 @@ Since the introduction of the [Parallel](https://github.com/typelevel/cats/blob/
 Note: all parallel operations require an implicit `ContextShift[IO]` in scope
 (see [ContextShift](./contextshift.html)). You have a `ContextShift` in scope if:
 
-1. there's an implicit `ExecutionContext` in scope
-2. via usage of [IOApp](./ioapp.html) that gives you a `ContextShift` by default
-3. the user provides a custom `ContextShift`
+1. via usage of [IOApp](./ioapp.html) that gives you a `ContextShift` by default
+3. the user provides a custom `ContextShift`, which can be created using `IO.contextShift(executionContext)`
 
 ### parMapN
 


### PR DESCRIPTION
Since there is no longer implicit context shift carried with global
execution context I removed this part of docs. I added a quick example
how to setup context shift using method from IO. This was the part I was
missing when reading the documentation. This fixes #404