### PR TITLE
Avoid Throwable#addSuppressed, use CompositeException

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -190,22 +190,8 @@ val mimaSettings = Seq(
     import com.typesafe.tools.mima.core._
     import com.typesafe.tools.mima.core.ProblemFilters._
     Seq(
-      // All internals — https://github.com/typelevel/cats-effect/pull/376
-      exclude[DirectMissingMethodProblem]("cats.effect.internals.IOBracket#BracketStart.this"),
-      exclude[MissingClassProblem]("cats.effect.internals.ForwardCancelable$State$IsEmptyCanceled"),
-      exclude[MissingClassProblem]("cats.effect.internals.ForwardCancelable$State$IsEmptyCanceled$"),
-      exclude[MissingClassProblem]("cats.effect.internals.ForwardCancelable$State$Reference"),
-      exclude[MissingClassProblem]("cats.effect.internals.ForwardCancelable$State$IsEmpty$"),
-      exclude[DirectMissingMethodProblem]("cats.effect.internals.ForwardCancelable.:="),
-      exclude[DirectMissingMethodProblem]("cats.effect.internals.ForwardCancelable.this"),
-      exclude[DirectMissingMethodProblem]("cats.effect.internals.ForwardCancelable.plusOne"),
-      exclude[MissingClassProblem]("cats.effect.internals.ForwardCancelable$State$"),
-      exclude[MissingClassProblem]("cats.effect.internals.ForwardCancelable$State$Reference$"),
-      exclude[MissingClassProblem]("cats.effect.internals.ForwardCancelable$State$IsCanceled$"),
-      // https://github.com/typelevel/cats-effect/pull/377
-      exclude[DirectMissingMethodProblem]("cats.effect.internals.IOBracket#EnsureReleaseFrame.this"),
-      exclude[DirectMissingMethodProblem]("cats.effect.internals.IOBracket#BracketReleaseFrame.this"),
-      exclude[DirectMissingMethodProblem]("cats.effect.internals.IOBracket#BaseReleaseFrame.this"),
+      // Ignore any binary compatibility issues/problems that match the internals package
+      exclude[Problem]("cats.effect.internals.*"),
       // All internals - https://github.com/typelevel/cats-effect/pull/403
       exclude[DirectMissingMethodProblem]("cats.effect.concurrent.Semaphore#AbstractSemaphore.awaitGate"),
       exclude[DirectMissingMethodProblem]("cats.effect.concurrent.Semaphore#AsyncSemaphore.awaitGate"),

--- a/core/js/src/main/scala/cats/effect/internals/IOPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOPlatform.scala
@@ -16,9 +16,7 @@
 
 package cats.effect.internals
 
-import cats.data.NonEmptyList
 import cats.effect.IO
-import cats.effect.util.CompositeException
 
 import scala.concurrent.duration.Duration
 
@@ -75,23 +73,6 @@ private[effect] object IOPlatform {
         case Left(e) => Logger.reportFailure(e)
         case _ => ()
       }
-    }
-  }
-
-  /**
-   * Composes multiple errors together, meant for those cases in which
-   * error suppression, due to a second error being triggered, is not
-   * acceptable.
-   *
-   * On top of the JVM this function uses `Throwable#addSuppressed`,
-   * available since Java 7. On top of JavaScript the function would return
-   * a `CompositeException`.
-   */
-  def composeErrors(first: Throwable, rest: Throwable*): Throwable = {
-    rest.filter(_ != first).toList match {
-      case Nil => first
-      case nonEmpty =>
-        new CompositeException(first, NonEmptyList.fromListUnsafe(nonEmpty))
     }
   }
 }

--- a/core/jvm/src/main/scala/cats/effect/internals/IOPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOPlatform.scala
@@ -107,18 +107,4 @@ private[effect] object IOPlatform {
    * `false` if it's JavaScript.
    */
   final val isJVM = true
-
-  /**
-   * Composes multiple errors together, meant for those cases in which
-   * error suppression, due to a second error being triggered, is not
-   * acceptable.
-   *
-   * On top of the JVM this function uses `Throwable#addSuppressed`,
-   * available since Java 7. On top of JavaScript the function would return
-   * a `CompositeException`.
-   */
-  def composeErrors(first: Throwable, rest: Throwable*): Throwable = {
-    for (e <- rest; if e != first) first.addSuppressed(e)
-    first
-  }
 }

--- a/core/shared/src/main/scala/cats/effect/internals/CancelUtils.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/CancelUtils.scala
@@ -57,7 +57,7 @@ private[effect] object CancelUtils {
           case Nil =>
             IO.unit
           case first :: rest =>
-            IO.raiseError(IOPlatform.composeErrors(first, rest: _*))
+            IO.raiseError(IOFrame.composeErrors(first, rest: _*))
         }
       }
     }

--- a/core/shared/src/main/scala/cats/effect/internals/IOBracket.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOBracket.scala
@@ -170,7 +170,7 @@ private[effect] object IOBracket {
     extends IOFrame[Unit, IO[Nothing]] {
 
     def recover(e2: Throwable): IO[Nothing] =
-      IO.raiseError(IOPlatform.composeErrors(e, e2))
+      IO.raiseError(IOFrame.composeErrors(e, e2))
 
     def apply(a: Unit): IO[Nothing] =
       IO.raiseError(e)

--- a/core/shared/src/main/scala/cats/effect/internals/IOParMap.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOParMap.scala
@@ -110,7 +110,7 @@ private[effect] object IOParMap {
           other.cancel.unsafeRunAsync { r =>
             conn.pop()
             cb.async(Left(r match {
-              case Left(e2) => IOPlatform.composeErrors(e, e2)
+              case Left(e2) => IOFrame.composeErrors(e, e2)
               case _ => e
             }))
           }

--- a/core/shared/src/main/scala/cats/effect/internals/IORace.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IORace.scala
@@ -158,7 +158,7 @@ private[effect] object IORace {
 
   private[this] def composeErrors(e: Throwable, e2: Either[Throwable, _]): Throwable =
     e2 match {
-      case Left(e2) => IOPlatform.composeErrors(e, e2)
+      case Left(e2) => IOFrame.composeErrors(e, e2)
       case _ => e
     }
 

--- a/laws/js/src/test/scala/cats/effect/IOJSTests.scala
+++ b/laws/js/src/test/scala/cats/effect/IOJSTests.scala
@@ -16,7 +16,6 @@
 
 package cats.effect
 
-import cats.effect.util.CompositeException
 import org.scalatest.{AsyncFunSuite, Matchers}
 
 import scala.concurrent.duration.{FiniteDuration, _}
@@ -49,21 +48,5 @@ class IOJSTests extends AsyncFunSuite with Matchers {
           succeed
       }
     }
-  }
-
-  test("bracket signals errors from both use and release via CompositeException") {
-    val e1 = new RuntimeException("e1")
-    val e2 = new RuntimeException("e2")
-
-    val r = IO.unit.bracket(_ => IO.raiseError(e1))(_ => IO.raiseError(e2))
-      .attempt
-      .unsafeRunSync()
-
-    r.isLeft shouldBe true
-    r.left.get shouldBe a[CompositeException]
-
-    val err = r.left.get.asInstanceOf[CompositeException]
-    err.head shouldBe e1
-    err.tail.toList shouldBe List(e2)
   }
 }

--- a/laws/jvm/src/test/scala/cats/effect/IOJVMTests.scala
+++ b/laws/jvm/src/test/scala/cats/effect/IOJVMTests.scala
@@ -102,18 +102,6 @@ class IOJVMTests extends FunSuite with Matchers {
     }
   }
 
-  test("bracket signals errors from both use and release via Throwable#addSupressed") {
-    val e1 = new RuntimeException("e1")
-    val e2 = new RuntimeException("e2")
-
-    val r = IO.unit.bracket(_ => IO.raiseError(e1))(_ => IO.raiseError(e2))
-      .attempt
-      .unsafeRunSync()
-
-    r shouldEqual Left(e1)
-    r.left.get.getSuppressed.toList shouldBe List(e2)
-  }
-
   test("long synchronous loops that are forked are cancelable") {
     implicit val ec = new ExecutionContext {
       val thread = new AtomicReference[Thread](null)


### PR DESCRIPTION
I would say (without backing data) that it's fairly common in the
ecosystem to sometimes use 'case object' when defining a throwable.
This makes addSuppressed a memory leak risk.  There is the option to
disable suppressed exceptions, which makes addSuppressed a noop, but
that just makes it swallow errors then...

So for now I think it might be safest to just use CompositeException
(like we were already on JS).  Though I do share Ross' concern about
root causes...

Thoughts welcome.  There's also a bunch of thoughts by a handful of
people over in https://twitter.com/dwijnand/status/1073600688058458112.

/cc @rossabaker @alexandru
This undoes #255