### PR TITLE
Do some doc fixing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - export SBT_PROFILE=$COVERAGE
   - sbt ++$TRAVIS_SCALA_VERSION $COVERAGE ci
   - |
-    if [ "$TRAVIS_SCALA_VERSION" = "2.12.7"]; then
+    if [[ "$TRAVIS_SCALA_VERSION" =~ "2\.12\." ]]; then
       sbt ++$TRAVIS_SCALA_VERSION microsite/makeMicrosite
     fi
 

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ addCommandAlias("ci", ";test ;mimaReportBinaryIssues; doc")
 addCommandAlias("release", ";project root ;reload ;+publishSigned ;sonatypeReleaseAll ;microsite/publishMicrosite")
 
 val commonSettings = Seq(
-  scalaVersion := "2.12.6",
+  scalaVersion := "2.12.7",
 
   crossScalaVersions := Seq("2.11.12", "2.12.7", "2.13.0-M5"),
 

--- a/site/src/main/tut/datatypes/io.md
+++ b/site/src/main/tut/datatypes/io.md
@@ -577,7 +577,7 @@ Example:
 import scala.concurrent.ExecutionContext
 
 // Needed for IO.start to do a logical thread fork
-implicit val cs = IO.contextShift(ExecutionContext.global)
+implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
 val launchMissiles = IO.raiseError(new Exception("boom!"))
 val runToBunker = IO(println("To the bunker!!!"))
@@ -1208,7 +1208,7 @@ Note: all parallel operations require an implicit `ContextShift[IO]` in scope
 It has the potential to run an arbitrary number of `IO`s in parallel, and it allows you to apply a function to the result (as in `map`). It finishes processing when all the `IO`s are completed, either successfully or with a failure. For example:
 
 ```tut:silent
-import cats.syntax.all._
+import cats.implicits._
 import scala.concurrent.ExecutionContext
 import cats.effect.ContextShift
 
@@ -1216,7 +1216,7 @@ val ioA = IO(println("Running ioA"))
 val ioB = IO(println("Running ioB"))
 val ioC = IO(println("Running ioC"))
 
-implicit val ctxShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+// make sure that you have an implicit ContextShift[IO] in scope. We created one earlier in this document.
 val program = (ioA, ioB, ioC).parMapN { (_, _, _) => () }
 
 program.unsafeRunSync()

--- a/site/src/main/tut/datatypes/resource.md
+++ b/site/src/main/tut/datatypes/resource.md
@@ -8,6 +8,8 @@ scaladoc: "#cats.effect.Resource"
 
 Effectfully allocates and releases a resource. Forms a `MonadError` on the resource type when the effect type has a `Bracket` instance.
 
+The [Acquiring and releasing `Resource`s](../tutorial/tutorial.html#acquiring-and-releasing-resources) section of the tutorial provides some additional context and examples regarding `Resource`.
+
 ```tut:silent
 import cats.effect.Bracket
 

--- a/site/src/main/tut/typeclasses/sync.md
+++ b/site/src/main/tut/typeclasses/sync.md
@@ -9,7 +9,8 @@ scaladoc: "#cats.effect.Sync"
 A `Monad` that can suspend the execution of side effects in the `F[_]` context.
 
 ```tut:silent
-import cats.MonadError
+import cats.{Defer, MonadError}
+import cats.effect.Bracket
 
 trait Sync[F[_]] extends Bracket[F, Throwable] with Defer[F] {
   def suspend[A](thunk: => F[A]): F[A]


### PR DESCRIPTION
This started out as me just attempting to provide a link to the
"Acquiring and releasing `Resource`s" section of the tutorial from with
tin the `Resource` data type doc. But then I went down a bit of a rabbit
hole...

There was a Scala 2.12.6 vs 2.12.7 mismatch between `build.sbt` and
`.travis.yml`. This meant that the build hasn't actually been compiling
the docs recently. So I fixed a few spots that weren't compiling in the
docs (though I'm not sure whether I fixed them in the preferred way). I
went ahead and attempted to make the scala version check for the docs
build a bit more lenient to hopefully avoid a similar issue in the
future. Admittedly my bash skills are lacking, so we should probably
check that it works as expected in the Travis build.