### PR TITLE
Fix shell test to makeMicrosite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - export SBT_PROFILE=$COVERAGE
   - sbt ++$TRAVIS_SCALA_VERSION $COVERAGE ci
   - |
-    if [[ "$TRAVIS_SCALA_VERSION" =~ "2\.12\." ]]; then
+    if [[ "$TRAVIS_SCALA_VERSION" =~ ^2\.12\. ]]; then
       sbt ++$TRAVIS_SCALA_VERSION microsite/makeMicrosite
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,12 @@ matrix:
       scala: 2.12.8
       env: COVERAGE=
 
+install:
+  - rvm use 2.6.0 --install --fuzzy
+  - gem update --system
+  - gem install sass
+  - gem install jekyll -v 3.2.1
+
 script:
   - export SBT_PROFILE=$COVERAGE
   - sbt ++$TRAVIS_SCALA_VERSION $COVERAGE ci


### PR DESCRIPTION
https://api.travis-ci.org/v3/job/476841108/log.txt

```
/home/travis/.travis/job_stages: line 104: [: missing `]'
travis_time:end:01382cf6:start=1546954447220165630,finish=1546954447223387832,duration=3222202
[0K[32;1mThe command "if [ "$TRAVIS_SCALA_VERSION" = "2.12.7"]; then
  sbt ++$TRAVIS_SCALA_VERSION microsite/makeMicrosite
fi
" exited with 0.[0m
```

`makeMicrosite` is silently not running.  This is responsible for not detecting the errors mentioned in #460.