### PR TITLE
Make IO.Par's applicative commutative

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -730,9 +730,29 @@ private[effect] abstract class IOParallelNewtype
    * for more details.
    */
   object Par extends IONewtype
+
+  private[effect] def ioParCommutativeApplicative(implicit cs: ContextShift[IO]): CommutativeApplicative[IO.Par] =
+    new CommutativeApplicative[IO.Par] {
+      import IO.Par.{unwrap, apply => par}
+
+      final override def pure[A](x: A): IO.Par[A] =
+        par(IO.pure(x))
+      final override def map2[A, B, Z](fa: IO.Par[A], fb: IO.Par[B])(f: (A, B) => Z): IO.Par[Z] =
+        par(IOParMap(cs, unwrap(fa), unwrap(fb))(f))
+      final override def ap[A, B](ff: IO.Par[A => B])(fa: IO.Par[A]): IO.Par[B] =
+        map2(ff, fa)(_(_))
+      final override def product[A, B](fa: IO.Par[A], fb: IO.Par[B]): IO.Par[(A, B)] =
+        map2(fa, fb)((_, _))
+      final override def map[A, B](fa: IO.Par[A])(f: A => B): IO.Par[B] =
+        par(unwrap(fa).map(f))
+      final override def unit: IO.Par[Unit] =
+        par(IO.unit)
+    }
 }
 
 private[effect] abstract class IOLowPriorityInstances extends IOParallelNewtype {
+  implicit def parApplicative(implicit cs: ContextShift[IO]): Applicative[IO.Par] = ioParCommutativeApplicative
+
   private[effect] class IOSemigroup[A: Semigroup] extends Semigroup[IO[A]] {
     def combine(ioa1: IO[A], ioa2: IO[A]) =
       ioa1.flatMap(a1 => ioa2.map(a2 => Semigroup[A].combine(a1, a2)))
@@ -796,23 +816,7 @@ private[effect] abstract class IOLowPriorityInstances extends IOParallelNewtype 
 }
 
 private[effect] abstract class IOInstances extends IOLowPriorityInstances {
-
-  implicit def parApplicative(implicit cs: ContextShift[IO]): CommutativeApplicative[IO.Par] = new CommutativeApplicative[IO.Par] {
-    import IO.Par.{unwrap, apply => par}
-
-    final override def pure[A](x: A): IO.Par[A] =
-      par(IO.pure(x))
-    final override def map2[A, B, Z](fa: IO.Par[A], fb: IO.Par[B])(f: (A, B) => Z): IO.Par[Z] =
-      par(IOParMap(cs, unwrap(fa), unwrap(fb))(f))
-    final override def ap[A, B](ff: IO.Par[A => B])(fa: IO.Par[A]): IO.Par[B] =
-      map2(ff, fa)(_(_))
-    final override def product[A, B](fa: IO.Par[A], fb: IO.Par[B]): IO.Par[(A, B)] =
-      map2(fa, fb)((_, _))
-    final override def map[A, B](fa: IO.Par[A])(f: A => B): IO.Par[B] =
-      par(unwrap(fa).map(f))
-    final override def unit: IO.Par[Unit] =
-      par(IO.unit)
-  }
+  implicit def parCommutativeApplicative(implicit cs: ContextShift[IO]): CommutativeApplicative[IO.Par] = ioParCommutativeApplicative
 
   implicit def ioConcurrentEffect(implicit cs: ContextShift[IO]): ConcurrentEffect[IO] =
     new IOEffect with ConcurrentEffect[IO] {

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -797,7 +797,7 @@ private[effect] abstract class IOLowPriorityInstances extends IOParallelNewtype 
 
 private[effect] abstract class IOInstances extends IOLowPriorityInstances {
 
-  implicit def parApplicative(implicit cs: ContextShift[IO]): Applicative[IO.Par] = new Applicative[IO.Par] {
+  implicit def parApplicative(implicit cs: ContextShift[IO]): CommutativeApplicative[IO.Par] = new CommutativeApplicative[IO.Par] {
     import IO.Par.{unwrap, apply => par}
 
     final override def pure[A](x: A): IO.Par[A] =

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -45,7 +45,7 @@ class IOTests extends BaseTestsSuite {
 
   checkAllAsync("IO.Par", implicit ec => {
     implicit val cs = ec.contextShift[IO]
-    ApplicativeTests[IO.Par].applicative[Int, Int, Int]
+    CommutativeApplicativeTests[IO.Par].commutativeApplicative[Int, Int, Int]
   })
 
   checkAllAsync("IO", implicit ec => {


### PR DESCRIPTION
Apparently MiMa claims this is binary incompatible, but maybe it's a false positive (the trait is `private[effect]` so maybe it only matters for implementations), so I submitted it anyway.

Please let me know what you think about making IO.Par's applicative commutative (I checked it before and it passed the laws... apparently)