### PR TITLE
Add "repeated asyncF evaluation not memoized" law

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -197,7 +197,11 @@ val mimaSettings = Seq(
       exclude[DirectMissingMethodProblem]("cats.effect.concurrent.Semaphore#AsyncSemaphore.awaitGate"),
       exclude[DirectMissingMethodProblem]("cats.effect.concurrent.Semaphore#ConcurrentSemaphore.awaitGate"),
       // All internals — https://github.com/typelevel/cats-effect/pull/424
-      exclude[MissingClassProblem]("cats.effect.concurrent.Deferred$UncancelabbleDeferred")
+      exclude[MissingClassProblem]("cats.effect.concurrent.Deferred$UncancelabbleDeferred"),
+      // Laws - https://github.com/typelevel/cats-effect/pull/473
+      exclude[ReversedMissingMethodProblem]("cats.effect.laws.AsyncLaws.repeatedAsyncFEvaluationNotMemoized"),
+      exclude[ReversedMissingMethodProblem]("cats.effect.laws.BracketLaws.bracketPropagatesTransformerEffects"),
+      exclude[ReversedMissingMethodProblem]("cats.effect.laws.discipline.BracketTests.bracketTrans")
     )
   })
 

--- a/build.sbt
+++ b/build.sbt
@@ -294,6 +294,7 @@ lazy val laws = crossProject(JSPlatform, JVMPlatform)
       "org.scalatest"  %%% "scalatest"  % ScalaTestVersion.value % "test"))
 
   .jvmConfigure(_.enablePlugins(AutomateHeaderPlugin))
+  .jvmConfigure(_.settings(mimaSettings))
   .jsConfigure(_.enablePlugins(AutomateHeaderPlugin))
   .jvmConfigure(profile)
   .jsConfigure(_.settings(scalaJSSettings))

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -37,9 +37,22 @@ trait AsyncLaws[F[_]] extends SyncLaws[F] {
   def repeatedAsyncEvaluationNotMemoized[A](a: A, f: A => A) = {
     var cur = a
 
-    val change: F[Unit] = F async { cb =>
+    val change: F[Unit] = F.async { cb =>
       cur = f(cur)
       cb(Right(()))
+    }
+
+    val read: F[A] = F.delay(cur)
+
+    change *> change *> read <-> F.pure(f(f(a)))
+  }
+
+  def repeatedAsyncFEvaluationNotMemoized[A](a: A, f: A => A) = {
+    var cur = a
+
+    val change: F[Unit] = F.asyncF { cb =>
+      cur = f(cur)
+      F.delay(cb(Right(())))
     }
 
     val read: F[A] = F.delay(cur)

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
@@ -62,6 +62,7 @@ trait AsyncTests[F[_]] extends SyncTests[F] {
           "async right is pure" -> forAll(laws.asyncRightIsPure[A] _),
           "async left is raiseError" -> forAll(laws.asyncLeftIsRaiseError[A] _),
           "repeated async evaluation not memoized" -> forAll(laws.repeatedAsyncEvaluationNotMemoized[A] _),
+          "repeated asyncF evaluation not memoized" -> forAll(laws.repeatedAsyncFEvaluationNotMemoized[A] _),
           "propagate errors through bind (async)" -> forAll(laws.propagateErrorsThroughBindAsync[A] _),
           "async can be derived from asyncF" -> forAll(laws.asyncCanBeDerivedFromAsyncF[A] _),
           "bracket release is called on Completed or Error" -> forAll(laws.bracketReleaseIsCalledOnCompletedOrError[A, B] _))


### PR DESCRIPTION
I thought it would be reasonable to check that.

It's easy to break this law, for example by removing the `suspend` call here: https://github.com/kubukoz/slick-effect/blob/3af6c4ab8950f42ebbcaaed0fc5621c503bb258a/src/main/scala/slickeffect/DBIOAsync.scala#L27. That would memoize the promise, and it would only be completed once.