### PR TITLE
Documentation fusionMaxStackDepth system property referred to as env var

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/internals/IOPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOPlatform.scala
@@ -86,7 +86,7 @@ private[effect] object IOPlatform {
    *    about 4 KB of stack space
    *
    * If this parameter becomes a problem, it can be tuned by setting
-   * the `cats.effect.fusionMaxStackDepth` environment variable when
+   * the `cats.effect.fusionMaxStackDepth` system property when
    * executing the Java VM:
    *
    * <pre>


### PR DESCRIPTION
Really tiny pedantic PR!

`cats.effect.fusionMaxStackDepth` is a system property not an environment variable

See:
* https://docs.oracle.com/javase/tutorial/essential/environment/properties.html
* https://en.wikipedia.org/wiki/Environment_variable