### PR TITLE
Add Resource.evalTap

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -231,6 +231,13 @@ sealed abstract class Resource[F[_], A] {
     */
   def evalMap[B](f: A => F[B])(implicit F: Applicative[F]): Resource[F, B] =
     this.flatMap(a => Resource.liftF(f(a)))
+
+  /**
+    * Applies an effectful transformation to the allocated resource. Like a
+    * `flatTap` on `F[A]` while maintaining the resource context
+    */
+  def evalTap[B](f: A => F[B])(implicit F: Applicative[F]): Resource[F, A] =
+    this.evalMap(a => f(a).as(a))
 }
 
 object Resource extends ResourceInstances {


### PR DESCRIPTION
A cross between `flatTap` and `evalMap`. Use case - an action returning a temporary resource with custom setup. For me this pattern pops up all the time when writing logic that uses temporary files (create a temporary file, write some data to it, yield the file).