### PR TITLE
Add IO.fromTry

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -25,7 +25,7 @@ import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, Promise, TimeoutException}
 import scala.util.control.NonFatal
-import scala.util.{Left, Right}
+import scala.util.{Failure, Left, Right, Success, Try}
 
 /**
  * A pure abstraction representing the intention to perform a
@@ -1204,6 +1204,16 @@ object IO extends IOInstances {
     e match {
       case Right(a) => pure(a)
       case Left(err) => raiseError(err)
+    }
+
+  /**
+   * Lifts an `Try[A]` into the `IO[A]` context, raising the throwable if it
+   * exists.
+   */
+  def fromTry[A](t: Try[A]): IO[A] =
+    t match {
+      case Success(a) => pure(a)
+      case Failure(err) => raiseError(err)
     }
 
   /**

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -30,7 +30,7 @@ import cats.laws.discipline._
 import org.scalacheck._
 
 import scala.concurrent.{ExecutionContext, Future, Promise, TimeoutException}
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 import scala.concurrent.duration._
 
 
@@ -135,6 +135,24 @@ class IOTests extends BaseTestsSuite {
     val e : Either[Throwable, Foo] = Right(Foo(1))
 
     IO.fromEither(e).attempt.unsafeRunSync() should matchPattern {
+      case Right(Foo(_)) => ()
+    }
+  }
+
+  test("fromTry handles Failure") {
+    case object Foo extends Exception
+    val t : Try[Nothing] = Failure(Foo)
+
+    IO.fromTry(t).attempt.unsafeRunSync() should matchPattern {
+      case Left(Foo) => ()
+    }
+  }
+
+  test("fromTry handles Success") {
+    case class Foo(x: Int)
+    val t : Try[Foo] = Success(Foo(1))
+
+    IO.fromTry(t).attempt.unsafeRunSync() should matchPattern {
       case Right(Foo(_)) => ()
     }
   }


### PR DESCRIPTION
This adds `fromTry` to the `IO` companion object. It is available on the `ApplicativeError[IO, Throwable]` instance, but this can be a bit tedious to type every time you want to use it (and is non-obvious to folks who are new to FP).