### PR TITLE
Make Resource.liftF interruptible

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -315,7 +315,7 @@ object Resource extends ResourceInstances {
    * @param fa the value to lift into a resource
    */
   def liftF[F[_], A](fa: F[A])(implicit F: Applicative[F]): Resource[F, A] =
-    make(fa)(_ => F.unit)
+    Resource.suspend(fa.map(a => Resource.pure(a)))
 
   /**
     * Creates a [[Resource]] by wrapping a Java

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -122,21 +122,6 @@ class ResourceTests extends BaseTestsSuite {
     }
   }
 
-  testAsync("evalMap with cancellation <-> IO.never") { implicit ec =>
-    implicit val cs = ec.contextShift[IO]
-
-    check { (g: Int => IO[Int]) =>
-      val effect: Int => IO[Int] = a =>
-        for {
-          f <- (g(a) <* IO.cancelBoundary).start
-          _ <- f.cancel
-          r <- f.join
-        } yield r
-
-      Resource.liftF(IO(0)).evalMap(effect).use(IO.pure) <-> IO.never
-    }
-  }
-
   testAsync("(evalMap with error <-> IO.raiseError") { implicit ec =>
     case object Foo extends Exception
     implicit val cs = ec.contextShift[IO]

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -94,7 +94,6 @@ class ResourceTests extends BaseTestsSuite {
   }
 
   testAsync("liftF - interruption") { implicit ec =>
-    pending
     implicit val timer = ec.timer[IO]
     implicit val ctx = ec.contextShift[IO]
 

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -17,15 +17,17 @@
 package cats
 package effect
 
-import java.util.concurrent.atomic.AtomicBoolean
-
 import cats.data.Kleisli
+import cats.effect.concurrent.Deferred
 import cats.effect.laws.discipline.arbitrary._
+import cats.implicits._
 import cats.kernel.laws.discipline.MonoidTests
 import cats.laws._
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
-import cats.implicits._
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.duration._
+import scala.util.Success
 
 class ResourceTests extends BaseTestsSuite {
   checkAllAsync("Resource[IO, ?]", implicit ec => MonadErrorTests[Resource[IO, ?], Throwable].monadError[Int, Int, Int])
@@ -89,6 +91,29 @@ class ResourceTests extends BaseTestsSuite {
     check { fa: IO[String] =>
       Resource.liftF(fa).use(IO.pure) <-> fa
     }
+  }
+
+  testAsync("liftF - interruption") { implicit ec =>
+    pending
+    implicit val timer = ec.timer[IO]
+    implicit val ctx = ec.contextShift[IO]
+
+    def p = Deferred[IO, ExitCase[Throwable]].flatMap { stop =>
+      val r = Resource
+        .liftF(IO.never: IO[Int])
+        .use(IO.pure)
+        .guaranteeCase(stop.complete)
+
+      r.start.flatMap { fiber =>
+        timer.sleep(200.millis) >> fiber.cancel >> stop.get
+      }
+    }.timeout(2.seconds)
+
+    val res = p.unsafeToFuture
+
+    ec.tick(3.seconds)
+
+    res.value shouldBe Some(Success(ExitCase.Canceled))
   }
 
   testAsync("evalMap") { implicit ec =>


### PR DESCRIPTION
Currently `liftF` on `Resource` is implemented as an `Allocated` node with a no-op release, so 
`Resource.liftF(fa)` produces `Resource.Allocated(fa, _ => F.unit)`. 
During interpretation, `Allocated` nodes get translated into `bracket` calls, so `liftF` ends up producing `bracket(fa)(...)(_ => F.unit)`, which is no longer a no-op because `fa` is made uninterruptible by the fact that it's being passed as a `bracket.acquire` action.

----------

As a consequence, the following law is broken:
```
Resource.liftF(fa).use(IO.pure) <-> fa
```

and what ends up holding is
```
Resource.liftF(fa).use(IO.pure) <-> fa.uncancelable
```
 (This wasn't caught by our existing property tests for this law)

----------

On a practical level, this caused a bug in fs2 where compiling a Stream down to a  Resource made the Stream uninterruptible

```
 Resource
     .makeCase(CompileScope.newRoot[F])((scope, ec) => scope.close(ec).rethrow)
     .flatMap { scope =>
          Resource.liftF {
              // the main stream loop is now uninterruptible because it's in liftF
                F.delay(init())
                  .flatMap(i => Algebra.compile(s.get, scope, i)(foldChunk))
                  .map(finalize)
            }
        }
```

This PR fixes this issue by implementing `liftF` as a `Suspend` node instead
