### PR TITLE
Remove unnecessary Parallel instance in semaphore docs.

### DIFF
--- a/site/src/main/tut/concurrency/semaphore.md
+++ b/site/src/main/tut/concurrency/semaphore.md
@@ -86,8 +86,6 @@ class PreciousResource[F[_]](name: String, s: Semaphore[F])(implicit F: Concurre
     } yield ()
 }
 
-implicit val par: Parallel[IO, IO] = Parallel[IO, IO.Par].asInstanceOf[Parallel[IO, IO]]
-
 val program: IO[Unit] =
   for {
     s  <- Semaphore[IO](1)


### PR DESCRIPTION
Remove unnecessary instance of `Parallel[IO, IO]` from Semaphore documentation as ` Parallel[IO, IO.Par]` works just fine there.
