### PR TITLE
Fix fib in cats-effect/datatypes documentation.

### DIFF
--- a/site/src/main/tut/datatypes/io.md
+++ b/site/src/main/tut/datatypes/io.md
@@ -105,7 +105,7 @@ def fib(n: Int, a: Long = 0, b: Long = 1): IO[Long] =
     if (n > 0) 
       fib(n - 1, b, b2)
     else 
-      IO.pure(b2)
+      IO.pure(a)
   }
 ```
 


### PR DESCRIPTION
fib should calculate (0), 1, 1, 2, ... starting from n = 0. Was: 1, 2…