### PR TITLE
Remove unused Eq[IO[Either[F[A], A]]] from EffectTests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -182,6 +182,12 @@ val mimaSettings = Seq(
     )
   })
 
+// We broke binary compatibily for laws in 2.0
+val lawsMimaSettings = mimaSettings ++ Seq(
+  // TODO: set to 2.0.0 after release
+  mimaPreviousArtifacts := Set.empty
+)
+
 lazy val cmdlineProfile = sys.env.getOrElse("SBT_PROFILE", "")
 
 def profile: Project => Project = pr => cmdlineProfile match {
@@ -276,7 +282,7 @@ lazy val laws = crossProject(JSPlatform, JVMPlatform)
       "org.scalatest"  %%% "scalatest"  % ScalaTestVersion % Test))
 
   .jvmConfigure(_.enablePlugins(AutomateHeaderPlugin))
-  .jvmConfigure(_.settings(mimaSettings))
+  .jvmConfigure(_.settings(lawsMimaSettings))
   .jsConfigure(_.enablePlugins(AutomateHeaderPlugin))
   .jvmConfigure(profile)
   .jsConfigure(_.settings(scalaJSSettings))

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/ConcurrentEffectTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/ConcurrentEffectTests.scala
@@ -52,7 +52,6 @@ trait ConcurrentEffectTests[F[_]] extends ConcurrentTests[F] with EffectTests[F]
     EqIOA: Eq[IO[A]],
     EqIOU: Eq[IO[Unit]],
     EqIOEitherTA: Eq[IO[Either[Throwable, A]]],
-    EqIOEitherFAA: Eq[IO[Either[F[A], A]]],
     iso: Isomorphisms[F],
     params: Parameters): RuleSet = {
 

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/EffectTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/EffectTests.scala
@@ -52,7 +52,6 @@ trait EffectTests[F[_]] extends AsyncTests[F] {
     EqFInt: Eq[F[Int]],
     EqIOU: Eq[IO[Unit]],
     EqIOEitherTA: Eq[IO[Either[Throwable, A]]],
-    EqIOEitherFAA: Eq[IO[Either[F[A], A]]],
     EqIOA: Eq[IO[A]],
     iso: Isomorphisms[F],
     params: Parameters): RuleSet = {


### PR DESCRIPTION
As long as we're breaking binary compatibility in laws, we can eliminate two warnings with this.