### PR TITLE
Switch to xenial and openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 language: scala
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,16 @@ language: scala
 
 matrix:
   include:
-    - jdk: oraclejdk8
+    - jdk: openjdk8
       scala: 2.11.12
       env: COVERAGE=coverage
     - jdk: openjdk11
       scala: 2.11.12
       env: COVERAGE=
-    - jdk: oraclejdk8
+    - jdk: openjdk8
       scala: 2.12.8
       env: COVERAGE=
-    - jdk: oraclejdk8
+    - jdk: openjdk8
       scala: 2.13.0-M5
       env: COVERAGE=
     - jdk: openjdk11


### PR DESCRIPTION
[openjdk11 builds are broken](https://travis-ci.community/t/install-of-openjdk11-is-failing-again/3061) again on trusty. xenial has it preinstalled, and [trusty is EOL](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment) on April 30. Let's switch now.

More breaking news: oraclejdk8 doesn't install on xenial, so let's try openjdk8.