### PR TITLE
onCancel + continual

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -144,6 +144,11 @@ val commonSettings = Seq(
         <name>Alexandru Nedelcu</name>
         <url>https://alexn.org</url>
       </developer>
+     <developer>
+        <id>SystemFw</id>
+        <name>Fabio Labella</name>
+        <url>https://github.com/systemfw</url>
+      </developer>
     </developers>,
 
   homepage := Some(url("https://typelevel.org/cats-effect/")),

--- a/build.sbt
+++ b/build.sbt
@@ -206,7 +206,10 @@ val mimaSettings = Seq(
       // Laws - https://github.com/typelevel/cats-effect/pull/473
       exclude[ReversedMissingMethodProblem]("cats.effect.laws.AsyncLaws.repeatedAsyncFEvaluationNotMemoized"),
       exclude[ReversedMissingMethodProblem]("cats.effect.laws.BracketLaws.bracketPropagatesTransformerEffects"),
-      exclude[ReversedMissingMethodProblem]("cats.effect.laws.discipline.BracketTests.bracketTrans")
+      exclude[ReversedMissingMethodProblem]("cats.effect.laws.discipline.BracketTests.bracketTrans"),
+      exclude[ReversedMissingMethodProblem]("cats.effect.Bracket.onCancel"),
+      exclude[ReversedMissingMethodProblem]("cats.effect.Concurrent.continual"),
+      exclude[ReversedMissingMethodProblem]("cats.effect.Concurrent#Ops.continual")
     )
   })
 

--- a/core/shared/src/main/scala/cats/effect/Bracket.scala
+++ b/core/shared/src/main/scala/cats/effect/Bracket.scala
@@ -143,7 +143,7 @@ trait Bracket[F[_], E] extends MonadError[F, E] {
    * restore the state to its previous value.
    *
    * {{{
-   * waitingOp.onCancel(_ => restoreState)
+   * waitingOp.onCancel(restoreState)
    * }}}
    *
    * A direct use of `bracket` is not a good fit for this case as it

--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -303,6 +303,53 @@ trait Concurrent[F[_]] extends Async[F] {
    */
   override def liftIO[A](ioa: IO[A]): F[A] =
     Concurrent.liftIO(ioa)(this)
+
+  /**
+   * If no interruption happens during the execution of this method,
+   * it behaves like `.attempt.flatMap`.
+   *
+   * Unlike `.attempt.flatMap` however, in the presence of
+   * interruption this method offers the _continual guarantee_:
+   * `fa` is interruptible, but if it completes execution, the
+   * effects of `f` are guaranteed to execute.
+   * This does not hold for `attempt.flatMap` since interruption can
+   * happen in between `flatMap` steps.
+   *
+   * The typical use case for this function arises in the
+   * implementation of concurrent abstractions, where you have
+   * asynchronous operations waiting on some condition (which have to
+   * be interruptible), mixed with operations that modify some shared
+   * state if the condition holds true (which need to be guaranteed
+   * to happen or the state will be inconsistent).
+   *
+   * Note that for the use case above:
+   * - We cannot use:
+   * {{{
+   * waitingOp.bracket(..., modifyOp)
+   * }}}
+   * because it makes `waitingOp` uninterruptible.
+   *
+   * - We cannot use
+   * {{{
+   *  waitingOp.guaranteeCase {
+   *    case Success => modifyOp(???)
+   *    ...
+   * }}}
+   * if we need to use the result of `waitingOp`.
+   *
+   * - We cannot use
+   * {{{
+   *  waitingOp.attempt.flatMap(modifyOp)
+   * }}}
+   *  because it could be interrupted after `waitingOp` is done, but
+   *  before `modifyOp` executes.
+   *
+   * To access this implementation as a standalone function, you can
+   * use [[Concurrent$.continual Concurrent.continual]] in the
+   * companion object.
+   */
+  def continual[A, B](fa: F[A])(f: Either[Throwable, A] => F[B]): F[B] =
+    Concurrent.continual(fa)(f)(this)
 }
 
 
@@ -473,6 +520,15 @@ object Concurrent {
 
     CancelableF(k)
   }
+
+  /**
+   * This is the default [[Concurrent.continual]] implementation.
+   */
+  def continual[F[_], A, B](fa: F[A])(f: Either[Throwable, A] => F[B])
+    (implicit F: Concurrent[F]): F[B] = {
+    fa.attempt.flatMap(f)
+  }
+
 
   /**
    * [[Concurrent]] instance built for `cats.data.EitherT` values initialized

--- a/core/shared/src/main/scala/cats/effect/syntax/BracketSyntax.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/BracketSyntax.scala
@@ -40,4 +40,7 @@ final class BracketOps[F[_], E, A](val self: F[A]) extends AnyVal {
 
   def uncancelable(implicit F: Bracket[F, E]): F[A] =
     F.uncancelable(self)
+
+  def onCancel(finalizer: F[Unit])(implicit F: Bracket[F, E]): F[A] =
+    F.onCancel(self)(finalizer)
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/BracketTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/BracketTests.scala
@@ -65,7 +65,9 @@ trait BracketTests[F[_], E] extends MonadErrorTests[F, E] {
         "uncancelable prevents Cancelled case" -> forAll(laws.uncancelablePreventsCanceledCase[A] _),
         "acquire and release of bracket are uncancelable" -> forAll(laws.acquireAndReleaseAreUncancelable[A, B] _),
         "guarantee is derived from bracket" -> forAll(laws.guaranteeIsDerivedFromBracket[A] _),
-        "guaranteeCase is derived from bracketCase" -> forAll(laws.guaranteeCaseIsDerivedFromBracketCase[A] _)
+        "guaranteeCase is derived from bracketCase" -> forAll(laws.guaranteeCaseIsDerivedFromBracketCase[A] _),
+        "onCancel is derived from guaranteeCase" -> forAll(laws.onCancelIsDerivedFromGuaranteeCase[A] _)
+
       )
     }
   }

--- a/laws/shared/src/test/scala/cats/effect/ConcurrentContinualTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ConcurrentContinualTests.scala
@@ -95,7 +95,6 @@ class ConcurrentContinualTests extends BaseTestsSuite {
   }
 
   testAsync("Concurrent.continual respects the continual guarantee") { implicit ec =>
-    pending
     import scala.concurrent.duration._
     implicit val cs = ec.contextShift[IO]
     implicit val timer = ec.timer[IO]

--- a/laws/shared/src/test/scala/cats/effect/ConcurrentContinualTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ConcurrentContinualTests.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.effect.concurrent.Ref
+import cats.implicits._
+import cats.effect.implicits._
+import scala.util.Success
+
+class ConcurrentContinualTests extends BaseTestsSuite {
+  testAsync("Concurrent.continual allows interruption of its input") { implicit ec =>
+    import scala.concurrent.duration._
+    implicit val cs = ec.contextShift[IO]
+    implicit val timer = ec.timer[IO]
+
+    val task = Ref[IO].of(false).flatMap { canceled =>
+      (IO.never: IO[Unit])
+        .onCancel(canceled.set(true))
+        .continual(_ => IO.unit)
+        .timeout(1.second)
+        .attempt >> canceled.get
+    }
+
+    val f = task.unsafeToFuture()
+    ec.tick(1.second)
+    f.value shouldBe Some(Success(true))
+  }
+
+
+  testAsync("Concurrent.continual backpressures on finalizers") { implicit ec =>
+    import scala.concurrent.duration._
+    implicit val cs = ec.contextShift[IO]
+    implicit val timer = ec.timer[IO]
+
+    val task = Ref[IO].of(false).flatMap { canceled =>
+      (IO.never: IO[Unit])
+        .onCancel(IO.sleep(1.second) >> canceled.set(true))
+        .continual(_ => IO.unit)
+        .timeout(1.second)
+        .attempt >> canceled.get
+    }
+
+    val f = task.unsafeToFuture()
+
+    ec.tick(1.second)
+    f.value shouldBe None
+
+    ec.tick(1.second)
+    f.value shouldBe Some(Success(true))
+  }
+
+  testAsync("Concurrent.continual behaves like flatMap on the happy path") { implicit ec =>
+    implicit val cs = ec.contextShift[IO]
+    val task = IO(1).continual(n => IO(n.right.get + 1)).map(_ + 1)
+
+    val f = task.unsafeToFuture()
+    ec.tick()
+    f.value shouldBe Some(Success(3))
+  }
+
+  testAsync("Concurrent.continual behaves like handleErrorWith on errors") { implicit ec =>
+    implicit val cs = ec.contextShift[IO]
+
+    val ex = new Exception("boom")
+    val task = IO.raiseError[Unit](ex).continual(n => IO(n.left.get))
+
+    val f = task.unsafeToFuture()
+    ec.tick()
+    f.value shouldBe Some(Success(ex))
+  }
+
+  testAsync("Concurrent.continual propagates errors in the continuation") { implicit ec =>
+    implicit val cs = ec.contextShift[IO]
+
+    val ex = new Exception("boom")
+    val task = IO(1).continual(_ => IO.raiseError(ex)).handleError(identity)
+
+    val f = task.unsafeToFuture()
+    ec.tick()
+    f.value shouldBe Some(Success(ex))
+  }
+
+  testAsync("Concurrent.continual respects the continual guarantee") { implicit ec =>
+    pending
+    import scala.concurrent.duration._
+    implicit val cs = ec.contextShift[IO]
+    implicit val timer = ec.timer[IO]
+
+    val task = Ref[IO].of(false).flatMap { completed =>
+      IO.unit
+        .continual(_ => (IO.sleep(2.second) >> completed.set(true)))
+        .timeout(1.second)
+        .attempt >> completed.get 
+    }
+
+    val f = task.unsafeToFuture()
+
+    ec.tick(1.second)
+    f.value shouldBe None
+
+    ec.tick(1.second)
+    f.value shouldBe Some(Success(true))
+  }
+}


### PR DESCRIPTION
This PR adds `onCancel` to execute an action on cancelation, and `continual`, an interruption safe equivalent of `attempt.flatMap`.

Although there is a longer discussion to be had wrt our cancelation model, in this PR I focused exclusively on implementing things in combinator land, with no internal changes: these should be usable today, by any effect. The main drawback right now is the heaviness of `continual`.

~~MiMa tells me this is fully binary compatible.~~ ( -.-" )

Breaks bincompat on 2.11 only