### PR TITLE
Update Discipline version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ val CatsVersion = "2.0.0-M1"
 val ScalaTestVersion = "3.1.0-SNAP9"
 val ScalaTestPlusScalaCheckVersion = "1.0.0-SNAP4"
 val ScalaCheckVersion = "1.14.0"
-val DisciplineVersion = "0.11.1"
+val DisciplineVersion = "0.11.2-M1"
 
 addCommandAlias("ci", ";test ;mimaReportBinaryIssues; doc")
 addCommandAlias("release", ";project root ;reload ;+publish ;sonatypeReleaseAll ;microsite/publishMicrosite")


### PR DESCRIPTION
When the tests are run here 0.11.1 is evicted and 0.11.2-M1 is used (which is why they're working), but for cats-effect-laws users with a configuration like this:

```scala
scalaVersion := "2.12.8"

libraryDependencies ++= Seq(
  "org.scalatest" %% "scalatest" % "3.1.0-SNAP9",
  "org.typelevel" %% "cats-effect-laws" % "2.0.0-M1",
  "org.typelevel" %% "discipline" % "0.11.2-M1",
  "org.scalatestplus" %% "scalatestplus-scalacheck" % "1.0.0-SNAP4"
)
```
…the eviction goes the wrong way:

```
[info] Here are other dependency conflicts that were resolved:
[info]  * org.typelevel:discipline_2.12:0.11.1 is selected over 0.11.2-M1
[info]      +- org.typelevel:cats-effect-laws_2.12:2.0.0-M1       (depends on 0.11.1)
[info]      +- org.typelevel:cats-laws_2.12:2.0.0-M1 ()           (depends on 0.11.2-M1)
[info]      +- default:cats-effect_2.12:0.1.0-SNAPSHOT            (depends on 0.11.2-M1)
[info]      +- org.typelevel:cats-kernel-laws_2.12:2.0.0-M1 ()    (depends on 0.11.2-M1)
```
And then you get "missing from the classpath" errors about `org.scalatest.prop.Checkers`.

It's easy enough to work around this by e.g. moving the cats-effect-laws dependency to the end of the list, but it'd be better just to fix it here.