### PR TITLE
Code of Conduct tweaks

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -12,4 +12,4 @@ Any questions, concerns, or moderation requests please contact a member of the p
 - Christopher Davenport [gitter](https://gitter.im/christopherdavenport) | [twitter](https://twitter.com/davenpcm) | [email](mailto:chris@christopherdavenport.tech)
 - Alexandru Nedelcu: [gitter](https://gitter.im/alexandru) | [twitter](https://twitter.com/alexelcu) | [email](mailto:coc@temp18.alexn.org)
 
-[Scala Code of Conduct]: https://www.scala-lang.org/conduct/
+[Scala Code of Conduct]: https://typelevel.org/code-of-conduct/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -12,4 +12,4 @@ Any questions, concerns, or moderation requests please contact a member of the p
 - Christopher Davenport [gitter](https://gitter.im/christopherdavenport) | [twitter](https://twitter.com/davenpcm) | [email](mailto:chris@christopherdavenport.tech)
 - Alexandru Nedelcu: [gitter](https://gitter.im/alexandru) | [twitter](https://twitter.com/alexelcu) | [email](mailto:coc@temp18.alexn.org)
 
-[Scala Code of Conduct]: https://typelevel.org/code-of-conduct/
+[Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ We use the standard pull request driven github workflow.  Pull requests are alwa
 
 Do *not* rebase commits that have been PR'd!  That history doesn't belong to you anymore, and it is not yours to rewrite.  This goes for maintainers and contributors alike.  Rebasing locally is completely fine (and encouraged), since linear history is pretty and checkpoint commits are not.  Just don't rebase something that's already out there unless you've *explicitly* marked it as a work in progress (e.g. `[WIP]`) in some clear and unambiguous way.
 
-cats-effect is a [Typelevel](http://typelevel.org/) project. This means we embrace pure, typeful, functional programming, and provide a safe and friendly environment for teaching, learning, and contributing as described in the [Code of Conduct](./CODE_OF_CONDUCT.md).
+cats-effect is a [Typelevel](http://typelevel.org/) project. This means we embrace pure, typeful, functional programming, and provide a safe and friendly environment for teaching, learning, and contributing as described in the [Code of Conduct].
 
 ### Contributing documentation
 
@@ -128,3 +128,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
+[Code of Conduct]: https://github.com/typelevel/cats-effect/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
Nothing substantial:

1. The link is broken on the website, so make it absolute.  Thanks to @etorreborre for the report.
2. Link to the Typelevel copy so we're not burdening Scala's moderators if people click through.