### PR TITLE
IORunLoop#step bug

### DIFF
--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -495,6 +495,11 @@ class IOTests extends BaseTestsSuite {
     io.unsafeRunSync() shouldEqual 2
   }
 
+  test("uncancelable with unsafeRunSync") {
+    val io = IO.pure(1).uncancelable
+    io.unsafeRunSync() shouldBe 1
+  }
+
   test("map is stack-safe for unsafeRunSync") {
     import IOPlatform.{fusionMaxStackDepth => max}
     val f = (x: Int) => x + 1


### PR DESCRIPTION
After a chat on [Gitter conversation](https://gitter.im/typelevel/cats-effect?at=5cdebc5f6366992a94d3e51c) a PR to fix the following issue.

```scala
import cats.effects.IO

IO.pure(1).uncancelable.unsafeRunSync()

// Exception in thread "main" java.lang.AssertionError: unreachable
//  at cats.effect.IO.unsafeRunTimed(IO.scala:328)
//  at cats.effect.IO.unsafeRunSync(IO.scala:240)
```

This is caused because the callstack is still empty at that point in `IORunLoop#step` and as an optimization the `currentIO` doesn't get wrapped in `Async`.
This causes `unsafeRunTimed` to run into `case _ => throw AssertionError("unreachable")`