### PR TITLE
Backport Scala.js IOApp signal handler fix from #540

### DIFF
--- a/core/js/src/main/scala/cats/effect/internals/IOAppPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOAppPlatform.scala
@@ -82,7 +82,7 @@ private[effect] object IOAppPlatform {
     def handler(code: Int) = () =>
       fiber.cancel.unsafeRunAsync { result =>
         result.swap.foreach(Logger.reportFailure)
-        IO(sys.exit(code + 128))
+        sys.exit(code + 128)
       }
 
     IO {


### PR DESCRIPTION
Without this, a signaled app exits successfully instead of with the expected exit code.