### PR TITLE
Enforce shifting within IO.fromFuture

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -157,7 +157,7 @@ val mimaSettings = Seq(
   mimaPreviousArtifacts := {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 13)) => Set.empty
-      case _ => Set(organization.value %% name.value % "1.0.0")
+      case _ => Set.empty   // TODO put 2.0.0 here
     }
   },
   mimaBinaryIssueFilters ++= {
@@ -175,10 +175,7 @@ val mimaSettings = Seq(
       // Laws - https://github.com/typelevel/cats-effect/pull/473
       exclude[ReversedMissingMethodProblem]("cats.effect.laws.AsyncLaws.repeatedAsyncFEvaluationNotMemoized"),
       exclude[ReversedMissingMethodProblem]("cats.effect.laws.BracketLaws.bracketPropagatesTransformerEffects"),
-      exclude[ReversedMissingMethodProblem]("cats.effect.laws.discipline.BracketTests.bracketTrans"),
-      exclude[ReversedMissingMethodProblem]("cats.effect.Bracket.onCancel"),
-      exclude[ReversedMissingMethodProblem]("cats.effect.Concurrent.continual"),
-      exclude[ReversedMissingMethodProblem]("cats.effect.Concurrent#Ops.continual")
+      exclude[ReversedMissingMethodProblem]("cats.effect.laws.discipline.BracketTests.bracketTrans")
     )
   })
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1200,8 +1200,8 @@ object IO extends IOInstances {
    *
    * @see [[IO#unsafeToFuture]]
    */
-  def fromFuture[A](iof: IO[Future[A]]): IO[A] =
-    iof.flatMap(IOFromFuture.apply)
+  def fromFuture[A](iof: IO[Future[A]])(implicit cs: ContextShift[IO]): IO[A] =
+    iof.flatMap(IOFromFuture.apply).flatMap(a => cs.shift.map(_ => a))
 
   /**
    * Lifts an `Either[Throwable, A]` into the `IO[A]` context, raising

--- a/laws/jvm/src/test/scala/cats/effect/IOJVMTests.scala
+++ b/laws/jvm/src/test/scala/cats/effect/IOJVMTests.scala
@@ -23,7 +23,7 @@ import org.scalatest._
 import org.scalatest.funsuite.AnyFunSuite
 import cats.syntax.all._
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
 class IOJVMTests extends AnyFunSuite with Matchers {
@@ -143,5 +143,17 @@ class IOJVMTests extends AnyFunSuite with Matchers {
       if (th != null && th.isAlive)
         th.interrupt()
     }
+  }
+
+  test("fromFuture shifts continuation") {
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    implicit val CS: ContextShift[IO] = IO.contextShift(TestEC)
+
+    val ioa = IO.fromFuture(IO(Future(()))) >> IO {
+      Thread.currentThread().getName()
+    }
+
+    ioa.unsafeRunSync() shouldEqual ThreadName
   }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/ConcurrentEffectLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ConcurrentEffectLaws.scala
@@ -45,14 +45,16 @@ trait ConcurrentEffectLaws[F[_]] extends ConcurrentLaws[F] with EffectLaws[F] {
   }
 
   def runCancelableStartCancelCoherence[A](a: A) = {
+    import cats.effect.internals.IOFromFuture
+
     // Cancellation via runCancelable
     val f1: F[A] = for {
       effect1 <- Deferred.uncancelable[F, A]
-      latch    = Promise[Unit]()
+      latch   <- F.delay(Promise[Unit]())
       never    = F.cancelable[A] { _ => latch.success(()); effect1.complete(a) }
       cancel  <- F.liftIO(F.runCancelable(never)(_ => IO.unit).toIO)
       // Waiting for the task to start before cancelling it
-      _       <- F.liftIO(IO.fromFuture(IO.pure(latch.future)))
+      _       <- F.liftIO(IO(IOFromFuture(latch.future)).flatten)   // TODO get rid of this, IO, and Future here
       _       <- cancel
       result  <- effect1.get
     } yield result

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -254,18 +254,21 @@ class IOTests extends BaseTestsSuite {
   }
 
   testAsync("fromFuture works for values") { implicit ec =>
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
     check { (a: Int, f: Int => Long) =>
       IO.fromFuture(IO(Future(f(a)))) <-> IO(f(a))
     }
   }
 
   testAsync("fromFuture works for successful completed futures") { implicit ec =>
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
     check { (a: Int) =>
       IO.fromFuture(IO.pure(Future.successful(a))) <-> IO.pure(a)
     }
   }
 
   testAsync("fromFuture works for exceptions") { implicit ec =>
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
     check { (ex: Throwable) =>
       val io = IO.fromFuture[Int](IO(Future(throw ex)))
       io <-> IO.raiseError[Int](ex)
@@ -273,12 +276,14 @@ class IOTests extends BaseTestsSuite {
   }
 
   testAsync("fromFuture works for failed completed futures") { implicit ec =>
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
     check { (ex: Throwable) =>
       IO.fromFuture[Int](IO.pure(Future.failed(ex))) <-> IO.raiseError[Int](ex)
     }
   }
 
   testAsync("fromFuture protects against user code") { implicit ec =>
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
     check { (ex: Throwable) =>
       val io = IO.fromFuture[Int](IO(throw ex))
       io <-> IO.raiseError[Int](ex)
@@ -286,6 +291,7 @@ class IOTests extends BaseTestsSuite {
   }
 
   testAsync("fromFuture suspends side-effects") { implicit ec =>
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
     check { (a: Int, f: (Int, Int) => Int, g: (Int, Int) => Int) =>
       var effect = a
       val io1 = IO.fromFuture(IO(Future { effect = f(effect, a) }))


### PR DESCRIPTION
This is probably the most serious bit of compatibility breakage we're going to introduce in 2.0, since it can actually break source compatibility by forcing people to thread a `ContextShift[IO]` where one was not previously necessary. With that said, any cases where people *weren't* already `shift`ing following a `fromFuture` were probably bugs, so I'm more or less okay with that.

I hate the fact that I had to use `IOFromFuture` in the laws, but I'm not sure it's fundamentally worse than the fact that we were already using `IO` in the laws. I filed #545 to track that, as it will need to be excised in 3.0.

Fixes #444 