### PR TITLE
Replaced global ContextShift/Timer instances on JVM

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/internals/IOAppPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOAppPlatform.scala
@@ -48,8 +48,11 @@ private[effect] object IOAppPlatform {
 
   // both lazily initiated on JVM platform to prevent
   // warm-up of underlying default EC's for code that does not require concurrency
-  def defaultTimer: Timer[IO] = IOTimer.global
-  def defaultContextShift: ContextShift[IO] = IOContextShift.global
+  def defaultTimer: Timer[IO] =
+    IOTimer(PoolUtils.ioAppGlobal)
+
+  def defaultContextShift: ContextShift[IO] =
+    IOContextShift(PoolUtils.ioAppGlobal)
 
   private def installHook(fiber: Fiber[IO, Int]): IO[Unit] =
     IO {

--- a/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
@@ -67,10 +67,6 @@ private[internals] object IOTimer {
   def apply(ec: ExecutionContext, sc: ScheduledExecutorService): Timer[IO] =
     new IOTimer(ec, sc)
 
-  /** Global instance, used by `IOApp`. */
-  lazy val global: Timer[IO] =
-    apply(ExecutionContext.Implicits.global)
-
   private[internals] lazy val scheduler: ScheduledExecutorService =
     Executors.newScheduledThreadPool(2, new ThreadFactory {
       def newThread(r: Runnable): Thread = {

--- a/core/jvm/src/main/scala/cats/effect/internals/PoolUtils.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/PoolUtils.scala
@@ -56,7 +56,7 @@ private[internals] object PoolUtils {
             case t: Throwable =>
               // under most circumstances, this will work even with fatal errors
               t.printStackTrace()
-              System.exit(-1)
+              System.exit(1)
           }
         }
       })

--- a/core/jvm/src/main/scala/cats/effect/internals/PoolUtils.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/PoolUtils.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package internals
+
+import scala.concurrent.ExecutionContext
+import scala.util.control.NonFatal
+
+import java.util.concurrent.{Executors, ThreadFactory}
+import java.util.concurrent.atomic.AtomicInteger
+
+private[internals] object PoolUtils {
+
+  // we can initialize this eagerly because the enclosing object is lazy
+  val ioAppGlobal: ExecutionContext = {
+    // lower-bound of 2 to prevent pathological deadlocks on virtual machines
+    val bound = math.max(2, Runtime.getRuntime().availableProcessors())
+
+    val executor = Executors.newFixedThreadPool(bound, new ThreadFactory {
+      val ctr = new AtomicInteger(0)
+      def newThread(r: Runnable): Thread = {
+        val back = new Thread(r)
+        back.setName(s"ioapp-compute-${ctr.getAndIncrement()}")
+        back.setDaemon(true)
+        back
+      }
+    })
+
+    exitOnFatal(ExecutionContext.fromExecutor(executor))
+  }
+
+  def exitOnFatal(ec: ExecutionContext): ExecutionContext = new ExecutionContext {
+    def execute(r: Runnable): Unit = {
+      ec.execute(new Runnable {
+        def run(): Unit = {
+          try {
+            r.run()
+          } catch {
+            case NonFatal(t) =>
+              reportFailure(t)
+
+            case t: Throwable =>
+              // under most circumstances, this will work even with fatal errors
+              t.printStackTrace()
+              System.exit(-1)
+          }
+        }
+      })
+    }
+
+    def reportFailure(t: Throwable): Unit =
+      ec.reportFailure(t)
+  }
+}

--- a/core/shared/src/main/scala/cats/effect/internals/IOContextShift.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOContextShift.scala
@@ -41,7 +41,7 @@ private[effect] object IOContextShift {
   def apply(ec: ExecutionContext): ContextShift[IO] =
     new IOContextShift(ec)
 
-  /** Global instance, used in `IOApp`. */
+  /** Global instance, used in `IOApp` on JavaScript (see: PoolUtils for the JVM semantics). */
   lazy val global: ContextShift[IO] =
     apply(ExecutionContext.Implicits.global)
 }


### PR DESCRIPTION
This pulls `IOApp` off the global `ExecutionContext` and onto a custom one that has better properties. Specifically:

- Crashes on truly fatal errors (rather than doing something horrible, like swallowing `OutOfMemoryError`)
- Lower-bounds the pool to 2 threads (global can go down to 1 if you only have 1 core). Having a 1-thread pool can cause deadlocks in poorly written code. Poorly written code is poor, but I'd rather not give them more headaches, and it's enough of an edge case that I'm okay with it.
- Avoids issues with global pool pollution by third-party code
- Avoids fork f***ing join, which is horrible for this kind of stuff

Related to #347. I'd like to hear from @rossabaker (and ideally @alexandru) as to their thoughts on the design tradeoffs here, and whether I should expand the impact at all.

I want to get this in 2.0 because, while it isn't breaking in the traditional sense, it's most definitely a very subtle compatibility shift and I don't want to catch people off guard.

Fixes #509 
Fixes #515