### PR TITLE
Restore binary compat in core on 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -157,7 +157,7 @@ val mimaSettings = Seq(
   mimaPreviousArtifacts := {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 13)) => Set.empty
-      case _ => Set.empty   // TODO put 2.0.0 here
+      case _ => Set(organization.value %% name.value % "1.0.0")
     }
   },
   mimaBinaryIssueFilters ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -157,7 +157,8 @@ val mimaSettings = Seq(
   mimaPreviousArtifacts := {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 13)) => Set.empty
-      case _ => Set(organization.value %% name.value % "1.0.0")
+      case Some((2, 12)) => Set(organization.value %% name.value % "1.0.0")
+      case _             => Set.empty
     }
   },
   mimaBinaryIssueFilters ++= {

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1203,6 +1203,10 @@ object IO extends IOInstances {
   def fromFuture[A](iof: IO[Future[A]])(implicit cs: ContextShift[IO]): IO[A] =
     iof.flatMap(IOFromFuture.apply).guarantee(cs.shift)
 
+  @deprecated("Use the variant that takes an implicit ContextShift.", "2.0.0")
+  private[effect] def fromFuture[A](iof: IO[Future[A]]): IO[A] =
+    iof.flatMap(IOFromFuture.apply)
+
   /**
    * Lifts an `Either[Throwable, A]` into the `IO[A]` context, raising
    * the throwable if it exists.

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1204,7 +1204,7 @@ object IO extends IOInstances {
     iof.flatMap(IOFromFuture.apply).guarantee(cs.shift)
 
   @deprecated("Use the variant that takes an implicit ContextShift.", "2.0.0")
-  private[effect] def fromFuture[A](iof: IO[Future[A]]): IO[A] =
+  private[IO] def fromFuture[A](iof: IO[Future[A]]): IO[A] =
     iof.flatMap(IOFromFuture.apply)
 
   /**


### PR DESCRIPTION
Brings back `fromFuture` in the old shape, but deprecated (only for documentation reasons, since the method can't legally be called anyway) and package-private.

Hopefully this can end up in 2.0.0.