### PR TITLE
align scaladoc with examples from the official docs for IO.shift - fixes #559

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -880,9 +880,9 @@ private[effect] abstract class IOInstances extends IOLowPriorityInstances {
  *
  *         {{{
  *           import cats.effect.{IO, ContextShift}
- *           import scala.concurrent.ExecutionContext.Implicits.global
  *
- *           val contextShift = IO.contextShift(global)
+ *           val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(...))
+ *           val contextShift = IO.contextShift(ec)
  *         }}}
  *
  *         For example we can introduce an asynchronous

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -906,7 +906,7 @@ private[effect] abstract class IOInstances extends IOLowPriorityInstances {
  *
  *           IO.shift *> task
  *           // equivalent to
- *           implicitly[ContextShift[IO]].shift *> task
+ *           ContextShift[IO].shift *> task
  *         }}}
  *
  *         Or we can specify an asynchronous boundary ''after'' the

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -919,7 +919,7 @@ private[effect] abstract class IOInstances extends IOLowPriorityInstances {
  *         {{{
  *           task <* IO.shift
  *           // equivalent to
- *          task <* implicitly[ContextShift[IO]].shift
+ *          task <* ContextShift[IO].shift
  *         }}}
  *
  *         Example of where this might be useful:


### PR DESCRIPTION
Fixes #559