### PR TITLE
Add an Alternative instance for Fiber

### DIFF
--- a/laws/shared/src/test/scala/cats/effect/BaseTestsSuite.scala
+++ b/laws/shared/src/test/scala/cats/effect/BaseTestsSuite.scala
@@ -36,8 +36,8 @@ class BaseTestsSuite extends AnyFunSuite with Matchers with Checkers with Discip
     test(name, tags:_*)(silenceSystemErr(f(TestContext())))(pos)
   }
 
-  def checkAllAsync(name: String, f: TestContext => Laws#RuleSet): Unit = {
-    val context = TestContext()
+  def checkAllAsync(name: String, f: TestContext => Laws#RuleSet, deterministic: Boolean = false): Unit = {
+    val context = TestContext(deterministic)
     val ruleSet = f(context)
 
     for ((id, prop) <- ruleSet.all.properties)

--- a/laws/shared/src/test/scala/cats/effect/FiberTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/FiberTests.scala
@@ -20,7 +20,7 @@ package effect
 import cats.effect.laws.discipline.arbitrary._
 import cats.implicits._
 import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
-import cats.laws.discipline.ApplicativeTests
+import cats.laws.discipline.AlternativeTests
 import org.scalacheck.{Arbitrary, Cogen}
 
 import scala.concurrent.Promise
@@ -35,8 +35,8 @@ class FiberTests extends BaseTestsSuite {
 
   checkAllAsync("Fiber[IO, ?]", implicit ec => {
     implicit val cs = ec.contextShift[IO]
-    ApplicativeTests[Fiber[IO, ?]].applicative[Int, Int, Int]
-  })
+    AlternativeTests[Fiber[IO, ?]].alternative[Int, Int, Int]
+  }, deterministic = true)
 
   checkAllAsync("Fiber[IO, ?]", implicit ec => {
     implicit val cs = ec.contextShift[IO]


### PR DESCRIPTION
See issue #405 

This instance implements the notion of `|+|` as a parallel race between two of its sides. Whoever returns successfully (ie. without error) first wins. `empty` is chosen to be `raiseError(Empty)` where `Empty` is an unique exception subclass defined in the `Fiber` companion. This decision, IMO, prevents some issues that arise if `empty` was to be defined as `never`. First, it preserves absorption laws ie `ff <*> empty <-> empty` . Second, it preserves monoid identity laws ie. `<fail> |+| empty <-> <fail>` and `empty |+| <fail> <-> <fail>` (in case of `never`, `empty` consumes the failing computation).

To test the respective laws, I needed to change how `TestContext` behaves. Unfortunately, in the presence of both non-deterministic _combine_ and semiringal `Alternative` laws, this implementation might seem unlawful (please check the comments). But, if one eliminated non-determinism for the purpose of tests, it could be, at least partially, checked. For this to happen, I introduced the _detministic_ flag which makes `TestContext`:
- execute tasks without any randomness
- schedule new tasks in LIFO order (wrt to the clock)

This setting makes all races predictable (ie. first submitted task will always win). Currently it is used only to test `Alternative` laws.