### PR TITLE
Get rid of N.B. in documentation

### DIFF
--- a/site/src/main/tut/datatypes/clock.md
+++ b/site/src/main/tut/datatypes/clock.md
@@ -38,7 +38,7 @@ trait Clock[F[_]] {
 }
 ```
 
-N.B. this is NOT a type class, meaning that there is no coherence restriction. 
+Important: this is NOT a type class, meaning that there is no coherence restriction. 
 This is because the ability to inject custom implementations in time-based
 logic is essential.
 

--- a/site/src/main/tut/datatypes/contextshift.md
+++ b/site/src/main/tut/datatypes/contextshift.md
@@ -31,7 +31,7 @@ trait ContextShift[F[_]] {
 }
 ```
 
-N.B. this is NOT a type class, meaning that there is no coherence restriction. 
+Important: this is NOT a type class, meaning that there is no coherence restriction. 
 This is because the ability to customize the thread-pool used for `shift` is 
 essential on top of the JVM at least.
 

--- a/site/src/main/tut/datatypes/io.md
+++ b/site/src/main/tut/datatypes/io.md
@@ -249,7 +249,7 @@ So it is similar with `IO.async`, but in that registration function
 the user is expected to provide an `IO[Unit]` that captures the
 required cancellation logic.
 
-N.B. cancellation is the ability to interrupt an `IO` task before
+Important: cancellation is the ability to interrupt an `IO` task before
 completion, possibly releasing any acquired resources, useful in race
 conditions to prevent leaks.
 
@@ -402,7 +402,7 @@ def sleep(d: FiniteDuration)
 }
 ```
 
-N.B. if you don't specify cancellation logic for a task, then the task
+Important: if you don't specify cancellation logic for a task, then the task
 is NOT cancelable. So for example, using Java's blocking I/O still:
 
 ```tut:silent

--- a/site/src/main/tut/typeclasses/async.md
+++ b/site/src/main/tut/typeclasses/async.md
@@ -22,7 +22,7 @@ This type class allows the modeling of data types that:
 - Can emit one result on completion.
 - Can end in error
 
-N.B. on the "one result" signaling, this is not an "exactly once" requirement. At this point streaming types can implement `Async` and such an "exactly once" requirement is only clear in `Effect`.
+Important: on the "one result" signaling, this is not an "exactly once" requirement. At this point streaming types can implement `Async` and such an "exactly once" requirement is only clear in `Effect`.
 
 Therefore the signature exposed by the `Async.async` builder is this:
 
@@ -30,7 +30,7 @@ Therefore the signature exposed by the `Async.async` builder is this:
 (Either[Throwable, A] => Unit) => Unit
 ```
 
-N.B. such asynchronous processes are not cancelable. See the `Concurrent` alternative for that.
+Important: such asynchronous processes are not cancelable. See the `Concurrent` alternative for that.
 
 ### On Asynchrony
 
@@ -56,7 +56,7 @@ And many times the abstractions built to deal with asynchronous tasks also provi
 (A => Unit) => Cancelable
 ```
 
-This is approximately the signature of JavaScript's `setTimeout`, which will return a "task ID" that can be used to cancel it. N.B. this type class in particular is NOT describing cancelable async processes, see the `Concurrent` type class for that.
+This is approximately the signature of JavaScript's `setTimeout`, which will return a "task ID" that can be used to cancel it. Important: this type class in particular is NOT describing cancelable async processes, see the `Concurrent` type class for that.
 
 ### async
 


### PR DESCRIPTION
It took me a longer while to realise what `N.B.` means in the docs. IMO `important` is more readable and expresses the intent in a cleaner way