### PR TITLE
sbt microsites 0.7.27

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,5 +9,5 @@ addSbtPlugin("org.scala-js"              % "sbt-scalajs"              % "0.6.28"
 addSbtPlugin("org.scoverage"             % "sbt-scoverage"            % "1.6.0")
 addSbtPlugin("org.xerial.sbt"            % "sbt-sonatype"             % "2.5")
 addSbtPlugin("pl.project13.scala"        % "sbt-jmh"                  % "0.3.7")
-addSbtPlugin("com.47deg"                 % "sbt-microsites"           % "0.7.16")
+addSbtPlugin("com.47deg"                 % "sbt-microsites"           % "0.7.27")
 addSbtPlugin("org.portable-scala"        % "sbt-scalajs-crossproject" % "0.6.1")

--- a/site/src/main/tut/datatypes/io.md
+++ b/site/src/main/tut/datatypes/io.md
@@ -51,6 +51,7 @@ val program: IO[Unit] =
 program.unsafeRunSync()
 //=> hey!
 //=> hey!
+()
 ```
 
 The above example prints "hey!" twice, as the effect re-runs each time
@@ -1223,6 +1224,7 @@ program.unsafeRunSync()
 //=> Running ioB
 //=> Running ioC
 //=> Running ioA
+()
 ```
 
 If any of the `IO`s completes with a failure then the result of the whole computation will be failed, while the unfinished tasks get cancelled. Example:
@@ -1241,6 +1243,7 @@ parFailure.unsafeRunSync()
 //=> ioB was canceled!
 //=> java.lang.Exception: boom
 //=>  ... 43 elided
+()
 ```
 
 If one of the tasks fails immediately, then the other gets canceled and the computation completes immediately, so in this example the pairing via `parMapN` will not wait for 10 seconds before emitting the error:


### PR DESCRIPTION
Resolves the error in https://github.com/typelevel/cats-effect/pull/570, which is caused by trailing comments in tut sheds as described [here](https://github.com/tpolecat/tut/issues/243#issuecomment-438288206). Adding a trailing `()` fixes it, though it looks slightly odd.