### PR TITLE
Revert MonoidK for IO.Par and Alternative for Fiber

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -750,24 +750,6 @@ private[effect] abstract class IOParallelNewtype
       final override def unit: IO.Par[Unit] =
         par(IO.unit)
     }
-
-  case object Empty extends RuntimeException("Empty")
-  private[effect] def ioParMonoidK(implicit cs: ContextShift[IO]): MonoidK[IO.Par] = new MonoidK[IO.Par] {
-    import IO.Par.{unwrap, apply => par}
-    override def empty[A] = par(IO.raiseError(Empty))
-
-    private def rethrow[A](io: IO[Either[Throwable, A]], onEmpty: Throwable): IO[A] = io.flatMap(_.fold(IO.raiseError, IO.pure)).handleErrorWith {
-      case Empty => IO.raiseError(onEmpty)
-      case otherwise => IO.raiseError(otherwise)
-    }
-    override def combineK[A](x: IO.Par[A], y: IO.Par[A]) = par(IO.racePair(unwrap(x).attempt, unwrap(y).attempt).flatMap {
-      case Left((Left(ex), fiberY))  => rethrow(fiberY.join, ex)
-      case Left((Right(a), fiberY))  => fiberY.cancel.map(_ => a)
-      case Right((fiberX, Left(ey))) => rethrow(fiberX.join, ey)
-      case Right((fiberX, Right(a))) => fiberX.cancel.map(_ => a)
-    })
-  }
-
 }
 
 private[effect] abstract class IOLowPriorityInstances extends IOParallelNewtype {
@@ -876,8 +858,6 @@ private[effect] abstract class IOInstances extends IOLowPriorityInstances {
     final override def combineK[A](a: IO[A], b: IO[A]): IO[A] =
       ApplicativeError[IO, Throwable].handleErrorWith(a)(_ => b)
   }
-
-  implicit def parMonoidK(implicit cs: ContextShift[IO]): MonoidK[IO.Par] = ioParMonoidK
 }
 
 /**

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
@@ -125,13 +125,13 @@ import scala.util.control.NonFatal
  *   assert(f.value == Some(Success(2))
  * }}}
  */
-final class TestContext private (deterministic: Boolean) extends ExecutionContext { self =>
+final class TestContext private () extends ExecutionContext { self =>
   import TestContext.{State, Task}
 
   private[this] var stateRef = State(
     lastID = 0,
     clock = Duration.Zero,
-    tasks = SortedSet.empty[Task](Task.ordering(if (deterministic) Task.lifo else Task.fifo)),
+    tasks = SortedSet.empty[Task],
     lastReportedFailure = None
   )
 
@@ -305,11 +305,12 @@ final class TestContext private (deterministic: Boolean) extends ExecutionContex
   private def extractOneTask(current: State, clock: FiniteDuration): Option[(Task, SortedSet[Task])] = {
     current.tasks.headOption.filter(_.runsAt <= clock) match {
       case Some(value) =>
-        val forExecution = if (deterministic) value else  {
-          val firstTick = value.runsAt
+        val firstTick = value.runsAt
+        val forExecution = {
           val arr = current.tasks.iterator.takeWhile(_.runsAt == firstTick).take(10).toArray
           arr(Random.nextInt(arr.length))
         }
+
         val remaining = current.tasks - forExecution
         Some((forExecution, remaining))
 
@@ -333,8 +334,8 @@ final class TestContext private (deterministic: Boolean) extends ExecutionContex
 
 object TestContext {
   /** Builder for [[TestContext]] instances. */
-  def apply(deterministic: Boolean = false): TestContext =
-    new TestContext(deterministic)
+  def apply(): TestContext =
+    new TestContext
 
   /** Used internally by [[TestContext]], represents the internal
    * state used for task scheduling and execution.
@@ -389,16 +390,17 @@ object TestContext {
    * Internal API — defines ordering for [[Task]], to be used by `SortedSet`.
    */
   private[TestContext] object Task {
-    val fifo = implicitly[Ordering[Long]]
-    val lifo = fifo.reverse
+    implicit val ordering: Ordering[Task] =
+      new Ordering[Task] {
+        val longOrd = implicitly[Ordering[Long]]
 
-    def ordering(longOrd: Ordering[Long]): Ordering[Task] = new Ordering[Task] {
-      override def compare(x: Task, y: Task) = x.runsAt.compare(y.runsAt) match {
-        case nonZero if nonZero != 0 =>
-          nonZero
-        case _ =>
-          longOrd.compare(x.id, y.id)
+        def compare(x: Task, y: Task): Int =
+          x.runsAt.compare(y.runsAt) match {
+            case nonZero if nonZero != 0 =>
+              nonZero
+            case _ =>
+              longOrd.compare(x.id, y.id)
+          }
       }
-    }
   }
 }

--- a/laws/shared/src/test/scala/cats/effect/BaseTestsSuite.scala
+++ b/laws/shared/src/test/scala/cats/effect/BaseTestsSuite.scala
@@ -36,8 +36,8 @@ class BaseTestsSuite extends AnyFunSuite with Matchers with Checkers with Discip
     test(name, tags:_*)(silenceSystemErr(f(TestContext())))(pos)
   }
 
-  def checkAllAsync(name: String, f: TestContext => Laws#RuleSet, deterministic: Boolean = false): Unit = {
-    val context = TestContext(deterministic)
+  def checkAllAsync(name: String, f: TestContext => Laws#RuleSet): Unit = {
+    val context = TestContext()
     val ruleSet = f(context)
 
     for ((id, prop) <- ruleSet.all.properties)

--- a/laws/shared/src/test/scala/cats/effect/FiberTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/FiberTests.scala
@@ -20,7 +20,7 @@ package effect
 import cats.effect.laws.discipline.arbitrary._
 import cats.implicits._
 import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
-import cats.laws.discipline.AlternativeTests
+import cats.laws.discipline.ApplicativeTests
 import org.scalacheck.{Arbitrary, Cogen}
 
 import scala.concurrent.Promise
@@ -35,8 +35,8 @@ class FiberTests extends BaseTestsSuite {
 
   checkAllAsync("Fiber[IO, ?]", implicit ec => {
     implicit val cs = ec.contextShift[IO]
-    AlternativeTests[Fiber[IO, ?]].alternative[Int, Int, Int]
-  }, deterministic = true)
+    ApplicativeTests[Fiber[IO, ?]].applicative[Int, Int, Int]
+  })
 
   checkAllAsync("Fiber[IO, ?]", implicit ec => {
     implicit val cs = ec.contextShift[IO]

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -48,11 +48,6 @@ class IOTests extends BaseTestsSuite {
     CommutativeApplicativeTests[IO.Par].commutativeApplicative[Int, Int, Int]
   })
 
-  checkAllAsync("IO.Par", implicit ec => {
-    implicit val cs = ec.contextShift[IO]
-    MonoidKTests[IO.Par].monoidK[Int]
-  }, deterministic = true)
-
   checkAllAsync("IO", implicit ec => {
     implicit val cs = ec.contextShift[IO]
     ParallelTests[IO, IO.Par].parallel[Int, Int]


### PR DESCRIPTION
The instances were unlawful as specified. It's possible for us to fix this by doing the following:

- Create a structure much like `Coyoneda` within `Fiber`
- Define an explicit representation of a *canceled* `Fiber` (needed for `empty`)

The latter is the tricky one, since we have no direct ways of representing this right now due to `join`'s extremely restricted type (this causes other problems, too). The former is also slightly annoying. For posterity, there are two options on the former:

- Embed it within a custom `Fiber` subtype within the `Alternative` instance, exposed only to that `Alternative` instance. This has the advantage of keeping mainline `Fiber` quite clean, but the disadvantage of requiring a typecase in each combinator to re-specialize the `Fiber` type. This also implies that it wouldn't compose lawfully over other `Fiber` combinators, which is a serious concern.
- Push it into the upstream `Fiber` trait. This is really annoying because it would complicate `Fiber` quite a lot, but it would also bring a lot of attendant power and would compose nicely even over things that are not `Alternative`.

Given that the latter seems like the better design choice, and the *already* extant need for a first-class representation of a canceled `Fiber` in order to implement `empty`, I think we're probably in Cats Effect 3 territory all around.

Fixes #593 