### PR TITLE
1.4.0: omnibus bug fix, feature, and scaladoc backport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ benchmarks/results
 .java-version
 .DS_Store
 .metals
+.bloop

--- a/core/js/src/main/scala/cats/effect/internals/BlockerPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/BlockerPlatform.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package internals
+
+import scala.concurrent.ExecutionContext
+
+private[effect] trait BlockerPlatform {
+
+  /** Blocker that delegates to the global execution context. */
+  lazy val global: Blocker = liftExecutionContext(ExecutionContext.Implicits.global)
+
+  def liftExecutionContext(ec: ExecutionContext): Blocker
+}

--- a/core/jvm/src/main/scala/cats/effect/internals/BlockerPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/BlockerPlatform.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package internals
+
+import scala.concurrent.ExecutionContext
+import java.util.concurrent.{ExecutorService, Executors, ThreadFactory}
+import cats.data.NonEmptyList
+
+private[effect] trait BlockerPlatform {
+
+  /**
+   * Creates a blocker that is backed by a cached thread pool.
+   */
+  def apply[F[_]](implicit F: Sync[F]): Resource[F, Blocker] =
+    fromExecutorService(F.delay(Executors.newCachedThreadPool(new ThreadFactory {
+      def newThread(r: Runnable) = {
+        val t = new Thread(r, "cats-effect-blocker")
+        t.setDaemon(true)
+        t
+      }
+    })))
+
+  /**
+   * Creates a blocker backed by the `ExecutorService` returned by the
+   * supplied task. The executor service is shut down upon finalization
+   * of the returned resource.
+   * 
+   * If there are pending tasks in the thread pool at time the returned
+   * `Blocker` is finalized, the finalizer fails with a `Blocker.OutstandingTasksAtShutdown` 
+   * exception.
+   */
+  def fromExecutorService[F[_]](makeExecutorService: F[ExecutorService])(implicit F: Sync[F]): Resource[F, Blocker] =
+    Resource.make(makeExecutorService) { ec =>
+        val tasks = F.delay {
+          val tasks = ec.shutdownNow()
+          val b = List.newBuilder[Runnable]
+          val itr = tasks.iterator
+          while (itr.hasNext)
+            b += itr.next
+          NonEmptyList.fromList(b.result)
+        }
+        F.flatMap(tasks) {
+          case Some(t) => F.raiseError(new OutstandingTasksAtShutdown(t))
+          case None => F.unit
+        }
+    }.map(es => liftExecutorService(es))
+
+  /**
+   * Creates a blocker that delegates to the supplied executor service.
+   */
+  def liftExecutorService(es: ExecutorService): Blocker =
+    liftExecutionContext(ExecutionContext.fromExecutorService(es))
+
+  /**
+   * Creates a blocker that delegates to the supplied execution context.
+   * 
+   * This must not be used with general purpose contexts like
+   * `scala.concurrent.ExecutionContext.Implicits.global'.
+   */
+  def liftExecutionContext(ec: ExecutionContext): Blocker
+
+  /** Thrown if there are tasks queued in the thread pool at the time a `Blocker` is finalized. */
+  final class OutstandingTasksAtShutdown(val tasks: NonEmptyList[Runnable]) extends IllegalStateException("There were outstanding tasks at time of shutdown of the thread pool")
+}

--- a/core/shared/src/main/scala/cats/effect/Blocker.scala
+++ b/core/shared/src/main/scala/cats/effect/Blocker.scala
@@ -30,19 +30,19 @@ import cats.effect.internals.BlockerPlatform
  *
  * Instances of this class should *not* be passed implicitly.
  */
-final class Blocker private (val blockingContext: ExecutionContext) {
+final class Blocker private (val blockingContext: ExecutionContext) extends AnyVal {
 
   /**
    * Like `Sync#delay` but the supplied thunk is evaluated on the blocking
    * execution context.
    */
   def delay[F[_], A](thunk: => A)(implicit F: Sync[F], cs: ContextShift[F]): F[A] =
-    evalOn(F.delay(thunk))
+    blockOn(F.delay(thunk))
 
   /**
-   * Evaluates the supplied task on the blocking execution context via `evalOn`.
+   * Evaluates the supplied task on the blocking execution context via `blockOn`.
    */
-  def evalOn[F[_], A](fa: F[A])(implicit cs: ContextShift[F]): F[A] =
+  def blockOn[F[_], A](fa: F[A])(implicit cs: ContextShift[F]): F[A] =
     cs.evalOn(this.blockingContext)(fa)
 }
 

--- a/core/shared/src/main/scala/cats/effect/Blocker.scala
+++ b/core/shared/src/main/scala/cats/effect/Blocker.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+
+import scala.concurrent.ExecutionContext
+
+import cats.effect.internals.BlockerPlatform
+
+/**
+ * An execution context that is safe to use for blocking operations.
+ *
+ * Used in conjunction with [[ContextShift]], this type allows us to write functions
+ * that require a special `ExecutionContext` for evaluation, while discouraging the
+ * use of a shared, general purpose pool (e.g. the global context).
+ *
+ * Instances of this class should *not* be passed implicitly.
+ */
+final class Blocker private (val blockingContext: ExecutionContext) {
+
+  /**
+   * Like `Sync#delay` but the supplied thunk is evaluated on the blocking
+   * execution context.
+   */
+  def delay[F[_], A](thunk: => A)(implicit F: Sync[F], cs: ContextShift[F]): F[A] =
+    evalOn(F.delay(thunk))
+
+  /**
+   * Evaluates the supplied task on the blocking execution context via `evalOn`.
+   */
+  def evalOn[F[_], A](fa: F[A])(implicit cs: ContextShift[F]): F[A] =
+    cs.evalOn(this.blockingContext)(fa)
+}
+
+object Blocker extends BlockerPlatform {
+
+  /**
+   * Creates a blocker that delegates to the supplied execution context.
+   * 
+   * This must not be used with general purpose contexts like
+   * `scala.concurrent.ExecutionContext.Implicits.global'.
+   */
+  def liftExecutionContext(ec: ExecutionContext): Blocker = new Blocker(ec)
+}

--- a/core/shared/src/main/scala/cats/effect/ContextShift.scala
+++ b/core/shared/src/main/scala/cats/effect/ContextShift.scala
@@ -56,7 +56,7 @@ trait ContextShift[F[_]] {
    *
    * The primary use case for this method is executing code on a
    * specific execution context. To execute blocking code, consider using
-   * the `evalOn(blocker)` overload instead.
+   * the `blockOn(blocker)` method instead.
    *
    * @param ec Execution context where the evaluation has to be scheduled
    * @param fa  Computation to evaluate using `ec`

--- a/core/shared/src/main/scala/cats/effect/ContextShift.scala
+++ b/core/shared/src/main/scala/cats/effect/ContextShift.scala
@@ -54,8 +54,9 @@ trait ContextShift[F[_]] {
    * back to the default execution environment of `F` at the completion of `fa`,
    * regardless of success or failure.
    *
-   * The primary use case for this method is executing blocking code on a
-   * dedicated execution context.
+   * The primary use case for this method is executing code on a
+   * specific execution context. To execute blocking code, consider using
+   * the `evalOn(blocker)` overload instead.
    *
    * @param ec Execution context where the evaluation has to be scheduled
    * @param fa  Computation to evaluate using `ec`

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -859,17 +859,51 @@ private[effect] abstract class IOInstances extends IOLowPriorityInstances {
 }
 
 /**
- * @define shiftDesc For example we can introduce an asynchronous
+ * @define shiftDesc Note there are 2 overloads of the `IO.shift` function:
+ *
+ *         - One that takes a `ContextShift` that manages the
+ *           thread-pool used to trigger async boundaries.
+ *         - Another that takes a Scala `ExecutionContext` as the
+ *           thread-pool.
+ *
+ *         Please use the former by default and use the latter
+ *         only for fine-grained control over the thread pool in
+ *         use.
+ *
+ *         By default, Cats Effect can provide instance of
+ *         `ContextShift[IO]` that manages thread-pools, but
+ *         only if there’s an `ExecutionContext` in scope or
+ *         if `IOApp` is used:
+ *
+ *         {{{
+ *           import cats.effect.{IO, ContextShift}
+ *
+ *           val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(...))
+ *           val contextShift = IO.contextShift(ec)
+ *         }}}
+ *
+ *         For example we can introduce an asynchronous
  *         boundary in the `flatMap` chain before a certain task:
+ *         {{{
+ *           val task = IO(println("task"))
+ *
+ *           IO.shift(contextShift).flatMap(_ => task)
+ *         }}}
+ *
+ *         Note that the ContextShift value is taken implicitly
+ *         from the context so you can just do this:
+ *
  *         {{{
  *           IO.shift.flatMap(_ => task)
  *         }}}
  *
  *         Or using Cats syntax:
  *         {{{
- *           import cats.syntax.all._
+ *           import cats.syntax.apply._
  *
  *           IO.shift *> task
+ *           // equivalent to
+ *           ContextShift[IO].shift *> task
  *         }}}
  *
  *         Or we can specify an asynchronous boundary ''after'' the
@@ -881,6 +915,8 @@ private[effect] abstract class IOInstances extends IOLowPriorityInstances {
  *         Or using Cats syntax:
  *         {{{
  *           task <* IO.shift
+ *           // equivalent to
+ *          task <* ContextShift[IO].shift
  *         }}}
  *
  *         Example of where this might be useful:
@@ -948,13 +984,13 @@ private[effect] abstract class IOInstances extends IOLowPriorityInstances {
  *          - preventing an overflow of the call stack in the case of
  *            improperly constructed `async` actions
  *
- *         Note there are 2 overloads of this function:
+ *          Note there are 2 overloads of this function:
  *
  *          - one that takes an [[Timer]] ([[IO.shift(implicit* link]])
  *          - one that takes a Scala `ExecutionContext` ([[IO.shift(ec* link]])
  *
- *         Use the former by default, use the later for fine grained
- *         control over the thread pool used.
+ *          Use the former by default, use the later for fine grained
+ *          control over the thread pool used.
  */
 object IO extends IOInstances {
 
@@ -1224,9 +1260,6 @@ object IO extends IOInstances {
    * Asynchronous boundary described as an effectful `IO`, managed
    * by the provided [[ContextShift]].
    *
-   * This operation can be used in `flatMap` chains to "shift" the
-   * continuation of the run-loop to another thread or call stack.
-   *
    * $shiftDesc
    *
    * @param cs is the [[ContextShift]] that's managing the thread-pool
@@ -1238,9 +1271,6 @@ object IO extends IOInstances {
   /**
    * Asynchronous boundary described as an effectful `IO`, managed
    * by the provided Scala `ExecutionContext`.
-   *
-   * This operation can be used in `flatMap` chains to "shift" the
-   * continuation of the run-loop to another thread or call stack.
    *
    * $shiftDesc
    *

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -567,8 +567,8 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    *
    * @param release is a function that gets called after `use`
    *        terminates, either normally or in error, or if it gets
-   *        canceled, receiving as input the resource that needs that
-   *        needs release, along with the result of `use`
+   *        canceled, receiving as input the resource that needs
+   *        release, along with the result of `use`
    *        (cancellation, error or successful result)
    */
   def bracketCase[B](use: A => IO[B])(release: (A, ExitCase[Throwable]) => IO[Unit]): IO[B] =

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -326,6 +326,12 @@ object Resource extends ResourceInstances with ResourcePlatform {
     Resource.suspend(fa.map(a => Resource.pure(a)))
 
   /**
+   * Lifts an applicative into a resource as a `FunctionK`.  The resource has a no-op release.
+   */
+  def liftK[F[_]](implicit F: Applicative[F]): F ~> Resource[F, ?] =
+    λ[F ~> Resource[F, ?]](Resource.liftF(_))
+
+  /**
     * Creates a [[Resource]] by wrapping a Java
     * [[https://docs.oracle.com/javase/8/docs/api/java/lang/AutoCloseable.html AutoCloseable]].
     *

--- a/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
@@ -24,6 +24,8 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import cats.effect.concurrent.Ref.TransformedRef
 import cats.instances.tuple._
 import cats.instances.function._
+import cats.syntax.functor._
+import cats.syntax.bifunctor._
 
 import scala.annotation.tailrec
 
@@ -280,5 +282,32 @@ object Ref {
       trans(F.compose[(A, ?)].compose[A => ?].map(underlying.access)(trans(_)))
   }
 
-}
+  implicit def catsInvariantForRef[F[_]: Functor]: Invariant[Ref[F, ?]] =
+    new Invariant[Ref[F, ?]] {
+      override def imap[A, B](fa: Ref[F, A])(f: A => B)(g: B => A): Ref[F, B] =
+        new Ref[F, B] {
+          override val get: F[B] = fa.get.map(f)
+          override def set(a: B): F[Unit] = fa.set(g(a))
+          override def getAndSet(a: B): F[B] = fa.getAndSet(g(a)).map(f)
+          override val access: F[(B, B => F[Boolean])] = fa.access.map {
+            _.bimap(f, _ compose g)
+          }
+          override def tryUpdate(f2: B => B): F[Boolean] =
+            fa.tryUpdate(g compose f2 compose f)
+          override def tryModify[C](f2: B => (B, C)): F[Option[C]] =
+            fa.tryModify (
+              f2.compose(f).map(_.leftMap(g))
+            )
+          override def update(f2: B => B): F[Unit] =
+            fa.update(g compose f2 compose f)
+          override def modify[C](f2: B => (B, C)): F[C] = fa.modify (
+            f2.compose(f).map(_.leftMap(g))
+          )
+          override def tryModifyState[C](state: State[B, C]): F[Option[C]] =
+            fa.tryModifyState(state.dimap(f)(g))
+          override def modifyState[C](state: State[B, C]): F[C] =
+            fa.modifyState(state.dimap(f)(g))
+        }
+    }
 
+}

--- a/core/shared/src/main/scala/cats/effect/syntax/ConcurrentSyntax.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/ConcurrentSyntax.scala
@@ -17,7 +17,6 @@
 package cats.effect.syntax
 
 import scala.concurrent.duration.FiniteDuration
-
 import cats.effect.{Concurrent, Timer}
 
 

--- a/core/shared/src/test/scala/cats/effect/AsyncTests.scala
+++ b/core/shared/src/test/scala/cats/effect/AsyncTests.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.Eq
+import cats.effect.concurrent.Ref
+import cats.implicits._
+import org.scalatest.compatible.Assertion
+import org.scalatest.AsyncFunSuite
+import org.scalatest.{Matchers, Succeeded}
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+
+class AsyncTests extends AsyncFunSuite with Matchers {
+
+  implicit override def executionContext: ExecutionContext = ExecutionContext.Implicits.global
+  implicit val timer: Timer[IO] = IO.timer(executionContext)
+  implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
+
+  private val smallDelay: IO[Unit] = timer.sleep(20.millis)
+
+  private def awaitEqual[A: Eq](t: IO[A], success: A): IO[Unit] =
+    t.flatMap(a => if (Eq[A].eqv(a, success)) IO.unit else smallDelay *> awaitEqual(t, success))
+
+  private def run(t: IO[Unit]): Future[Assertion] = t.as(Succeeded).unsafeToFuture
+
+  test("parSequenceN") {
+    val finalValue = 100
+    val r = Ref.unsafe[IO, Int](0)
+    val modifies = Async.parSequenceN(3)(List.fill(finalValue)(IO.shift *> r.update(_ + 1)))
+    run(IO.shift *> modifies.start *> awaitEqual(r.get, finalValue))
+  }
+
+}

--- a/core/shared/src/test/scala/cats/effect/ConcurrentTests.scala
+++ b/core/shared/src/test/scala/cats/effect/ConcurrentTests.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.Eq
+import cats.effect.concurrent.Ref
+import cats.implicits._
+import org.scalatest.compatible.Assertion
+import org.scalatest.AsyncFunSuite
+import org.scalatest.{Matchers, Succeeded}
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+
+class ConcurrentTests extends AsyncFunSuite with Matchers {
+
+  implicit override def executionContext: ExecutionContext = ExecutionContext.Implicits.global
+  implicit val timer: Timer[IO] = IO.timer(executionContext)
+  implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
+
+  private val smallDelay: IO[Unit] = timer.sleep(20.millis)
+
+  private def awaitEqual[A: Eq](t: IO[A], success: A): IO[Unit] =
+    t.flatMap(a => if (Eq[A].eqv(a, success)) IO.unit else smallDelay *> awaitEqual(t, success))
+
+  private def run(t: IO[Unit]): Future[Assertion] = t.as(Succeeded).unsafeToFuture
+
+  test("parSequenceN") {
+    val finalValue = 100
+    val r = Ref.unsafe[IO, Int](0)
+    val modifies = Concurrent.parSequenceN(3)(List.fill(finalValue)(IO.shift *> r.update(_ + 1)))
+    run(IO.shift *> modifies.start *> awaitEqual(r.get, finalValue))
+  }
+
+}

--- a/core/shared/src/test/scala/cats/effect/SyntaxTests.scala
+++ b/core/shared/src/test/scala/cats/effect/SyntaxTests.scala
@@ -16,7 +16,9 @@
 
 package cats.effect
 
+import cats.Traverse
 import cats.effect.syntax.AllCatsEffectSyntax
+
 import scala.concurrent.duration._
 
 object SyntaxTests extends AllCatsEffectSyntax {
@@ -38,7 +40,7 @@ object SyntaxTests extends AllCatsEffectSyntax {
     typed[F[A]](acquire.guaranteeCase(finalCase))
   }
 
-  def concurrentSyntax[F[_]: Concurrent, A, B](implicit timer: Timer[F]) = {
+  def concurrentSyntax[T[_]: Traverse, F[_], G[_], A, B](implicit F: Concurrent[F], timer: Timer[F]) = {
     val fa  = mock[F[A]]
     val fa2 = mock[F[A]]
     val fb  = mock[F[B]]

--- a/laws/shared/src/test/scala/cats/effect/RefTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/RefTests.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.effect.concurrent.Ref
+import cats.implicits._
+import cats.kernel.Eq
+import cats.laws.discipline._
+import org.scalacheck.Arbitrary
+
+class RefTests extends BaseTestsSuite {
+  implicit def arbitraryRef[A: Arbitrary]: Arbitrary[Ref[IO, A]] = Arbitrary {
+    Arbitrary.arbitrary[A].map(Ref.unsafe[IO, A](_))
+  }
+
+  implicit def eqRef[A: Eq]: Eq[Ref[IO, A]] = Eq.by(_.get.unsafeRunSync())
+
+  checkAll("Ref[IO, ?]", InvariantTests[Ref[IO, ?]].invariant[Int, Int, Int])
+}

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -115,6 +115,12 @@ class ResourceTests extends BaseTestsSuite {
     res.value shouldBe Some(Success(ExitCase.Canceled))
   }
 
+  testAsync("liftF(fa) <-> liftK.apply(fa)") { implicit ec =>
+    check { (fa: IO[String], f: String => IO[Int]) =>
+      Resource.liftF(fa).use(f) <-> Resource.liftK[IO].apply(fa).use(f)
+    }
+  }
+
   testAsync("evalMap") { implicit ec =>
     check { (f: Int => IO[Int]) =>
       Resource.liftF(IO(0)).evalMap(f).use(IO.pure) <-> f(0)

--- a/site/src/main/tut/datatypes/contextshift.md
+++ b/site/src/main/tut/datatypes/contextshift.md
@@ -103,3 +103,35 @@ object MyApp extends IOApp {
   }
 }
 ```
+
+## Blocker
+
+`Blocker` provides an `ExecutionContext` that is intended for executing blocking tasks and integrates directly with `ContextShift`. The previous example with `Blocker` looks like this:
+
+```tut:silent
+import scala.concurrent.ExecutionContext
+import cats.effect._
+
+def readName[F[_]: Sync: ContextShift](blocker: Blocker): F[String] = 
+  // Blocking operation, executed on special thread-pool
+  blocker.delay {
+    println("Enter your name: ")
+    scala.io.StdIn.readLine()
+  }
+
+object MyApp extends IOApp {
+
+  def run(args: List[String]) = {
+    val name = Blocker[IO].use { blocker =>
+      readName[IO](blocker)
+    }
+
+    for {
+      n <- name
+      _ <- IO(println(s"Hello, $n!"))
+    } yield ExitCode.Success
+  }
+}
+```
+
+In this version, `Blocker` was passed as an argument to `readName` to ensure the constructed task is never used on a non-blocking execution context.


### PR DESCRIPTION
* #554
* #556: Omits ContextShift#blockOn for binary compatibility
* #498: Omits syntax for binary compatibility
* #560
* #567
* #574
* #586
* #591

Should be released as version 1.4.0 for semantic versioning.
