### PR TITLE
(Docs) Fix MLock constructor to not hang on first call to 'acquire'

### DIFF
--- a/site/src/main/tut/concurrency/mvar.md
+++ b/site/src/main/tut/concurrency/mvar.md
@@ -124,7 +124,7 @@ final class MLock(mvar: MVar[IO, Unit]) {
 
 object MLock {
   def apply(): IO[MLock] =
-    MVar[IO].empty[Unit].map(ref => new MLock(ref))
+    MVar[IO].of(()).map(ref => new MLock(ref))
 }
 ```
 


### PR DESCRIPTION
I think a coworker of mine found a bug in one of the `MVar` examples. https://typelevel.org/cats-effect/concurrency/mvar.html#use-case-asynchronous-lock-binary-semaphore-mutex

When you make a new `MLock`, it isn't initialized, so if you call `acquire` you will just be waiting forever. It basically starts in an already pre-acquired state which might be confusing. I replaced the `MVar[IO].empty[Unit]` call with a call to `MVar[IO].of(())` which should work.