### PR TITLE
Link to Java 8 javadoc instead of EOL Java 9

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Timer.scala
+++ b/core/shared/src/main/scala/cats/effect/Timer.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration.FiniteDuration
  * This is the purely functional equivalent of:
  *
  *  - Java's
- *    [[https://docs.oracle.com/javase/9/docs/api/java/util/concurrent/ScheduledExecutorService.html ScheduledExecutorService]]
+ *    [[https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ScheduledExecutorService.html ScheduledExecutorService]]
  *  - JavaScript's
  *    [[https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout setTimeout]].
  *


### PR DESCRIPTION
* It's consistent with our other links
* It's consistent with what we build against
* It's not EOL
* I've already said too much about this one-bit diff