### PR TITLE
Configure the global scheduler with system properties

### DIFF
--- a/core/jvm/src/test/scala/cats/effect/internals/JvmIOTimerTests.scala
+++ b/core/jvm/src/test/scala/cats/effect/internals/JvmIOTimerTests.scala
@@ -41,19 +41,19 @@ class JvmIOTimerTests extends AnyFunSuite with Matchers {
   }
 
   test("global scheduler: custom core pool size") {
-    withScheduler(Map("cats.effect.global_scheduler.threads.corePoolSize" -> "3")) { s =>
+    withScheduler(Map("cats.effect.global_scheduler.threads.core_pool_size" -> "3")) { s =>
       s.getCorePoolSize shouldBe 3
     }
   }
 
   test("global scheduler: invalid core pool size") {
-    withScheduler(Map("cats.effect.global_scheduler.threads.corePoolSize" -> "-1")) { s =>
+    withScheduler(Map("cats.effect.global_scheduler.threads.core_pool_size" -> "-1")) { s =>
       s.getCorePoolSize shouldBe 2
     }
   }
 
   test("global scheduler: malformed core pool size") {
-    withScheduler(Map("cats.effect.global_scheduler.threads.corePoolSize" -> "banana")) { s =>
+    withScheduler(Map("cats.effect.global_scheduler.threads.core_pool_size" -> "banana")) { s =>
       s.getCorePoolSize shouldBe 2
     }
   }

--- a/core/jvm/src/test/scala/cats/effect/internals/JvmIOTimerTests.scala
+++ b/core/jvm/src/test/scala/cats/effect/internals/JvmIOTimerTests.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package internals
+
+import java.util.concurrent.{ScheduledThreadPoolExecutor, TimeUnit}
+
+import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.util.control.NonFatal
+
+class JvmIOTimerTests extends AnyFunSuite with Matchers {
+  private def withScheduler(props: Map[String, String])(f: ScheduledThreadPoolExecutor => Unit): Unit = {
+    val s = IOTimer.mkGlobalScheduler(props)
+    try f(s)
+    finally {
+      try s.shutdownNow()
+      catch { case NonFatal(e) => e.printStackTrace() }
+    }
+  }
+
+  test("global scheduler: default core pool size") {
+    withScheduler(Map.empty) { s =>
+      s.getCorePoolSize shouldBe 2
+    }
+  }
+
+  test("global scheduler: custom core pool size") {
+    withScheduler(Map("cats.effect.global_scheduler.threads.corePoolSize" -> "3")) { s =>
+      s.getCorePoolSize shouldBe 3
+    }
+  }
+
+  test("global scheduler: invalid core pool size") {
+    withScheduler(Map("cats.effect.global_scheduler.threads.corePoolSize" -> "-1")) { s =>
+      s.getCorePoolSize shouldBe 2
+    }
+  }
+
+  test("global scheduler: malformed core pool size") {
+    withScheduler(Map("cats.effect.global_scheduler.threads.corePoolSize" -> "banana")) { s =>
+      s.getCorePoolSize shouldBe 2
+    }
+  }
+
+  test("global scheduler: default core thread timeout") {
+    withScheduler(Map.empty) { s =>
+      s.allowsCoreThreadTimeOut shouldBe false
+    }
+  }
+
+  test("global scheduler: custom core thread timeout") {
+    withScheduler(Map("cats.effect.global_scheduler.keep_alive_time_ms" -> "1000")) { s =>
+      s.allowsCoreThreadTimeOut shouldBe true
+      s.getKeepAliveTime(TimeUnit.MILLISECONDS) shouldBe 1000
+    }
+  }
+
+  test("global scheduler: invalid core thread timeout") {
+    withScheduler(Map("cats.effect.global_scheduler.keep_alive_time_ms" -> "0")) { s =>
+      s.allowsCoreThreadTimeOut shouldBe false
+    }
+  }
+
+  test("global scheduler: malformed core thread timeout") {
+    withScheduler(Map("cats.effect.global_scheduler.keep_alive_time_ms" -> "feral hogs")) { s =>
+      s.allowsCoreThreadTimeOut shouldBe false
+    }
+  }
+}

--- a/site/src/main/tut/datatypes/timer.md
+++ b/site/src/main/tut/datatypes/timer.md
@@ -62,6 +62,15 @@ final class MyTimer(ec: ExecutionContext, sc: ScheduledExecutorService) extends 
 }
 ```
 
+## Configuring the global Scheduler
+
+The one-argument overload of `IO.timer` lazily instantiates a global `ScheduledExecutorService`, which is never shut down.  This is fine for most applications, but leaks threads when the class is repeatedly loaded in the same JVM, as is common in testing. The global scheduler can be configured with the following system properties:
+
+* `cats.effect.global_scheduler.threads.core_pool_size`: sets the core pool size of the global scheduler. Defaults to `2`.
+* `cats.effect.global_scheduler.keep_alive_time_ms`: allows the global scheduler's core threads to timeout and terminate when idle. `0` keeps the threads from timing out. Defaults to `0`. Value is in milliseconds.
+
+These properties only apply on the JVM.
+
 Also see these related data types:
 
 - [Clock](./clock.html): for time measurements and getting the current clock


### PR DESCRIPTION
Global configuration through mutable system properties is a wart, but so are sbt sessions that run out of memory.  We'll aim higher in Cats-Effect 3.

Fixes #347.