### PR TITLE
Fix bracketReleaseIsCalledOnCompletedOrError

### DIFF
--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -97,7 +97,7 @@ trait AsyncLaws[F[_]] extends SyncLaws[F] {
       // to run and set the promise.
       F.asyncF[Unit](cb => F.delay(cb(Right(()))) *> br.attempt.as(())) *> promise.get
     }
-    lh <-> F.pure(b)
+    lh <-> fa.attempt.as(b)
   }
 }
 


### PR DESCRIPTION
In bracketReleaseIsCalledOnCompletedOrError, account for the fact that `fa` action might spawn internal forks and may not be equal to F.pure by TestContext