### PR TITLE
Add asyncF law that body of `k` CANNOT affect continuation

### DIFF
--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -81,6 +81,18 @@ trait AsyncLaws[F[_]] extends SyncLaws[F] {
   def neverIsDerivedFromAsync[A] =
     F.never[A] <-> F.async[A]( _ => ())
 
+  def asyncFRaiseErrorIsNever[A](e: Throwable) =
+    F.never[A] <-> F.asyncF[A](_ => F.raiseError(e))
+
+  def asyncFIgnoredCallbackIsNever[A](fa: F[Unit]) =
+    F.never[A] <-> F.asyncF[A](_ => fa)
+
+  def asyncThrowIsRaiseError[A](e: Throwable) =
+    F.async[A](_ => throw e) <-> F.raiseError(e)
+
+  def asyncFThrowIsRaiseError[A](e: Throwable) =
+    F.asyncF[A](_ => throw e) <-> F.raiseError(e)
+
   def asyncCanBeDerivedFromAsyncF[A](k: (Either[Throwable, A] => Unit) => Unit) =
     F.async(k) <-> F.asyncF(cb => F.delay(k(cb)))
 

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -87,6 +87,9 @@ trait AsyncLaws[F[_]] extends SyncLaws[F] {
   def asyncFIgnoredCallbackIsNever[A](fa: F[Unit]) =
     F.never[A] <-> F.asyncF[A](_ => fa)
 
+  def asyncFTerminationIsOptional[A](a: A) =
+    F.asyncF[A](k => F.delay(k(Right(a))) *> F.never) <-> F.pure(a)
+
   def asyncThrowIsRaiseError[A](e: Throwable) =
     F.async[A](_ => throw e) <-> F.raiseError(e)
 

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
@@ -76,7 +76,7 @@ trait AsyncTests[F[_]] extends SyncTests[F] {
           default ++ Seq(
             "never is derived from async" -> Prop.lzy(laws.neverIsDerivedFromAsync[A]),
             "asyncF raiseError is never" -> forAll(laws.asyncFRaiseErrorIsNever[A] _),
-            "asyncF ignored callback is never" -> forAll(laws.asyncFIgnoredCallbackIsNever[A] _),
+            "asyncF ignored callback is never" -> forAll(laws.asyncFIgnoredCallbackIsNever[A] _)
           )
         else
           default

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
@@ -67,7 +67,8 @@ trait AsyncTests[F[_]] extends SyncTests[F] {
           "async can be derived from asyncF" -> forAll(laws.asyncCanBeDerivedFromAsyncF[A] _),
           "bracket release is called on Completed or Error" -> forAll(laws.bracketReleaseIsCalledOnCompletedOrError[A, B] _),
           "async throw is raiseError" -> forAll(laws.asyncThrowIsRaiseError[A] _),
-          "asyncF throw is raiseError" -> forAll(laws.asyncFThrowIsRaiseError[A] _)
+          "asyncF throw is raiseError" -> forAll(laws.asyncFThrowIsRaiseError[A] _),
+          "don't wait for asyncF to complete" -> forAll(laws.asyncFTerminationIsOptional[A] _)
         )
 
         // Activating the tests that detect non-termination only if allowed by Params,

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/AsyncTests.scala
@@ -65,13 +65,18 @@ trait AsyncTests[F[_]] extends SyncTests[F] {
           "repeated asyncF evaluation not memoized" -> forAll(laws.repeatedAsyncFEvaluationNotMemoized[A] _),
           "propagate errors through bind (async)" -> forAll(laws.propagateErrorsThroughBindAsync[A] _),
           "async can be derived from asyncF" -> forAll(laws.asyncCanBeDerivedFromAsyncF[A] _),
-          "bracket release is called on Completed or Error" -> forAll(laws.bracketReleaseIsCalledOnCompletedOrError[A, B] _))
+          "bracket release is called on Completed or Error" -> forAll(laws.bracketReleaseIsCalledOnCompletedOrError[A, B] _),
+          "async throw is raiseError" -> forAll(laws.asyncThrowIsRaiseError[A] _),
+          "asyncF throw is raiseError" -> forAll(laws.asyncFThrowIsRaiseError[A] _)
+        )
 
         // Activating the tests that detect non-termination only if allowed by Params,
         // because such tests might not be reasonable depending on evaluation model
         if (params.allowNonTerminationLaws)
           default ++ Seq(
-            "never is derived from async" -> Prop.lzy(laws.neverIsDerivedFromAsync[A])
+            "never is derived from async" -> Prop.lzy(laws.neverIsDerivedFromAsync[A]),
+            "asyncF raiseError is never" -> forAll(laws.asyncFRaiseErrorIsNever[A] _),
+            "asyncF ignored callback is never" -> forAll(laws.asyncFIgnoredCallbackIsNever[A] _),
           )
         else
           default


### PR DESCRIPTION
Add async laws that specify that content of register function CANNOT affect continuation (`asyncF raiseError is never` and `asyncF ignored callback is never`)

Also add async & asyncF laws for catching throws, which I think are important to have since these are FFI (as much as `delay` ?)

Note, ZIO fails all of the new laws, while cats-effect IO passes all of them, which is why I think it's important to have them since leaving them underspecified can produce deadlocks in downstream code