### PR TITLE
Fix invalid references in the documentation

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/internals/BlockerPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/BlockerPlatform.scala
@@ -70,7 +70,7 @@ private[effect] trait BlockerPlatform {
    * Creates a blocker that delegates to the supplied execution context.
    * 
    * This must not be used with general purpose contexts like
-   * `scala.concurrent.ExecutionContext.Implicits.global'.
+   * `scala.concurrent.ExecutionContext.Implicits.global`.
    */
   def liftExecutionContext(ec: ExecutionContext): Blocker
 

--- a/core/jvm/src/main/scala/cats/effect/internals/IOAppCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOAppCompanionPlatform.scala
@@ -71,7 +71,7 @@ private[effect] trait IOAppCompanionPlatform {
 
     /**
      * The main execution context for this app, provided by
-     * [[executionContextResoruce]].  Outside `run`, this context will
+     * [[executionContextResource]].  Outside `run`, this context will
      * reject all tasks.
      */
     protected final def executionContext: ExecutionContext =

--- a/core/shared/src/main/scala/cats/effect/Blocker.scala
+++ b/core/shared/src/main/scala/cats/effect/Blocker.scala
@@ -52,7 +52,7 @@ object Blocker extends BlockerPlatform {
    * Creates a blocker that delegates to the supplied execution context.
    * 
    * This must not be used with general purpose contexts like
-   * `scala.concurrent.ExecutionContext.Implicits.global'.
+   * `scala.concurrent.ExecutionContext.Implicits.global`.
    */
   def liftExecutionContext(ec: ExecutionContext): Blocker = new Blocker(ec)
 }

--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -575,7 +575,7 @@ object Concurrent {
       fa.start.bracket( fiber =>
         fiber.join.guaranteeCase {
           case ExitCase.Completed | ExitCase.Error(_) =>
-            (fiber.join.attempt.flatMap(f)).attempt.flatMap(r.complete)
+            fiber.join.attempt.flatMap(f).attempt.flatMap(r.complete)
           case _ => fiber.cancel >>
             r.complete(Left(new Exception("Continual fiber cancelled") with NoStackTrace))
         }.attempt

--- a/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
@@ -18,7 +18,6 @@ package cats
 package effect
 package concurrent
 
-import cats.effect.ExitCase
 import cats.effect.concurrent.Semaphore.TransformedSemaphore
 import cats.implicits._
 


### PR DESCRIPTION
This PR fixes typo and invalid closing backticks in the documentation