### PR TITLE
[naming things] CE3: Rename `yielding` to `cede`

### DIFF
--- a/playground.scala
+++ b/playground.scala
@@ -168,7 +168,7 @@ object playground {
           }
         } yield back
 
-        def yielding: PureIO[E, Unit] = unit
+        def surrender: PureIO[E, Unit] = unit
 
         def flatMap[A, B](fa: PureIO[E, A])(f: A => PureIO[E, B]): PureIO[E, B] =
           fa.flatMap(f)

--- a/playground.scala
+++ b/playground.scala
@@ -168,7 +168,7 @@ object playground {
           }
         } yield back
 
-        def surrender: PureIO[E, Unit] = unit
+        def cede: PureIO[E, Unit] = unit
 
         def flatMap[A, B](fa: PureIO[E, A])(f: A => PureIO[E, B]): PureIO[E, B] =
           fa.flatMap(f)

--- a/src/main/scala/ce3/concurrent.scala
+++ b/src/main/scala/ce3/concurrent.scala
@@ -48,8 +48,8 @@ trait Concurrent[F[_], E] extends MonadError[F, E] { self: Safe[F, E] =>
   // produces an effect which is already canceled (and doesn't introduce an async boundary)
   def canceled[A]: F[A]
 
-  // introduces a fairness boundary by yielding control to the underlying dispatcher
-  def yielding: F[Unit]
+  // introduces a fairness boundary by yielding (surrendering) control to the underlying dispatcher
+  def surrender: F[Unit]
 
   def racePair[A, B](fa: F[A], fb: F[B]): F[Either[(A, Fiber[F, E, B]), (Fiber[F, E, A], B)]]
 }

--- a/src/main/scala/ce3/concurrent.scala
+++ b/src/main/scala/ce3/concurrent.scala
@@ -48,8 +48,8 @@ trait Concurrent[F[_], E] extends MonadError[F, E] { self: Safe[F, E] =>
   // produces an effect which is already canceled (and doesn't introduce an async boundary)
   def canceled[A]: F[A]
 
-  // introduces a fairness boundary by yielding (surrendering) control to the underlying dispatcher
-  def surrender: F[Unit]
+  // introduces a fairness boundary by yielding control to the underlying dispatcher
+  def cede: F[Unit]
 
   def racePair[A, B](fa: F[A], fb: F[B]): F[Either[(A, Fiber[F, E, B]), (Fiber[F, E, A], B)]]
 }


### PR DESCRIPTION
So long, `yielding`...