### PR TITLE
`start` as Resource - `background`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -204,6 +204,8 @@ trait Concurrent[F[_]] extends Async[F] {
    * Returns a [[Fiber]] that can be used to either join or cancel
    * the running computation, being similar in spirit (but not
    * in implementation) to starting a thread.
+   *
+   * @see [[syntax.ConcurrentOps#background]] for a safer alternative.
    */
   def start[A](fa: F[A]): F[Fiber[F, A]]
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -382,33 +382,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * In case the resource is closed while this IO is still running (e.g. due to a failure in `use`),
    * the background action will be canceled.
    *
-   *
-   * A basic example:
-   *
-   * {{{
-   *   val longProcess = (IO.sleep(5.seconds) *> IO(println("Ping!"))).foreverM
-   *
-   *   val srv: Resource[IO, ServerBinding[IO]] = for {
-   *     _ <- longProcess.background
-   *     server <- server.run
-   *   } yield server
-   *
-   *   val application = srv.use(binding => IO(println("Bound to " + binding)) *> IO.never)
-   * }}}
-   *
-   * Here, we are starting a background process as part of the application's startup.
-   * Afterwards, we initialize a server. Then, we use that server forever using `IO.never`.
-   * This will ensure we never close the server resource unless somebody cancels the whole `application` action.
-   *
-   * If at some point of using the resulting resource you want to wait for the result of the background action,
-   * you can do so by sequencing the value inside the resource.
-   *
-   * This will start the background process, wait 5 seconds, and cancel it in case it takes longer than that.
-   * Note: this pattern is exactly what [[timeout]] does in a more concise and less error-prone way.
-   *
-   * {{{
-   *   longProcess.background.use(await => IO.sleep(5.seconds) *> await)
-   * }}}
+   * @see [[cats.effect.syntax.ConcurrentOps#background]]
   */
   final def background(implicit cs: ContextShift[IO]): Resource[IO, IO[A @uncheckedVariance]] =
     Resource.make(start)(_.cancel).map(_.join)

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -383,7 +383,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * the background action will be canceled.
    *
    * @see [[cats.effect.syntax.ConcurrentOps#background]]
-  */
+   */
   final def background(implicit cs: ContextShift[IO]): Resource[IO, IO[A @uncheckedVariance]] =
     Resource.make(start)(_.cancel).map(_.join)
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -371,7 +371,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * finishes in error. In that case the second task doesn't get canceled,
    * which creates a potential memory leak.
    *
-   * Also see [[startResource]] for a safer alternative.
+   * Also see [[background]] for a safer alternative.
    */
   final def start(implicit cs: ContextShift[IO]): IO[Fiber[IO, A @uncheckedVariance]] =
     IOStart(cs, this)

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -370,9 +370,48 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * consider in the example above what would happen if the first task
    * finishes in error. In that case the second task doesn't get canceled,
    * which creates a potential memory leak.
+   *
+   * Also see [[startResource]] for a safer alternative.
    */
   final def start(implicit cs: ContextShift[IO]): IO[Fiber[IO, A @uncheckedVariance]] =
     IOStart(cs, this)
+
+  /**
+   * Returns a resource that will start execution of this IO in the background.
+   *
+   * In case the resource is closed while this IO is still running (e.g. due to a failure in `use`),
+   * the background action will be canceled.
+   *
+   *
+   * A basic example:
+   *
+   * {{{
+   *   val longProcess = (IO.sleep(5.seconds) *> IO(println("Ping!"))).foreverM
+   *
+   *   val srv: Resource[IO, ServerBinding[IO]] = for {
+   *     _ <- longProcess.background
+   *     server <- server.run
+   *   } yield server
+   *
+   *   val application = srv.use(binding => IO(println("Bound to " + binding)) *> IO.never)
+   * }}}
+   *
+   * Here, we are starting a background process as part of the application's startup.
+   * Afterwards, we initialize a server. Then, we use that server forever using `IO.never`.
+   * This will ensure we never close the server resource unless somebody cancels the whole `application` action.
+   *
+   * If at some point of using the resulting resource you want to wait for the result of the background action,
+   * you can do so by sequencing the value inside the resource.
+   *
+   * This will start the background process, wait 5 seconds, and cancel it in case it takes longer than that.
+   * Note: this pattern is exactly what [[timeout]] does in a more concise and less error-prone way.
+   *
+   * {{{
+   *   longProcess.background.use(await => IO.sleep(5.seconds) *> await)
+   * }}}
+  */
+  final def background(implicit cs: ContextShift[IO]): Resource[IO, IO[A @uncheckedVariance]] =
+    Resource.make(start)(_.cancel).map(_.join)
 
   /**
    * Makes the source `IO` uninterruptible such that a [[Fiber.cancel]]

--- a/core/shared/src/main/scala/cats/effect/syntax/ConcurrentSyntax.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/ConcurrentSyntax.scala
@@ -71,7 +71,7 @@ final class ConcurrentOps[F[_], A](val self: F[A]) extends AnyVal {
    *
    * In case the result of such an action is canceled, both processes will receive cancelation signals.
    * The same result can be achieved by using `anotherProcess &> longProcess` with the Parallel type class syntax.
-  */
+   */
   def background(implicit F: Concurrent[F]): Resource[F, F[A]] = Resource.make(F.start(self))(_.cancel).map(_.join)
 }
 

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -1026,13 +1026,15 @@ class IOTests extends BaseTestsSuite {
   testAsync("background cancels the action in cleanup") { ec =>
     implicit val contextShift = ec.contextShift[IO]
 
-    val f = Deferred[IO, Unit].flatMap { started => //wait for this before closing resource
-      Deferred[IO, ExitCase[Throwable]].flatMap { result =>
-        val bg = started.complete(()) *> IO.never.guaranteeCase(result.complete)
+    val f = Deferred[IO, Unit]
+      .flatMap { started => //wait for this before closing resource
+        Deferred[IO, ExitCase[Throwable]].flatMap { result =>
+          val bg = started.complete(()) *> IO.never.guaranteeCase(result.complete)
 
-        bg.background.use(_ => started.get) *> result.get
+          bg.background.use(_ => started.get) *> result.get
+        }
       }
-    }.unsafeToFuture()
+      .unsafeToFuture()
 
     ec.tick()
 
@@ -1042,11 +1044,13 @@ class IOTests extends BaseTestsSuite {
   testAsync("background allows awaiting the action") { ec =>
     implicit val contextShift = ec.contextShift[IO]
 
-    val f = Deferred[IO, Unit].flatMap { latch =>
-      val bg = latch.get *> IO.pure(42)
+    val f = Deferred[IO, Unit]
+      .flatMap { latch =>
+        val bg = latch.get *> IO.pure(42)
 
-      bg.background.use(await => latch.complete(()) *> await)
-    }.unsafeToFuture()
+        bg.background.use(await => latch.complete(()) *> await)
+      }
+      .unsafeToFuture()
 
     ec.tick()
 

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -1022,6 +1022,36 @@ class IOTests extends BaseTestsSuite {
     ec.tickOne()
     f.value shouldBe Some(Success(1))
   }
+
+  testAsync("background cancels the action in cleanup") { ec =>
+    implicit val contextShift = ec.contextShift[IO]
+
+    val f = Deferred[IO, Unit].flatMap { started => //wait for this before closing resource
+      Deferred[IO, ExitCase[Throwable]].flatMap { result =>
+        val bg = started.complete(()) *> IO.never.guaranteeCase(result.complete)
+
+        bg.background.use(_ => started.get) *> result.get
+      }
+    }.unsafeToFuture()
+
+    ec.tick()
+
+    f.value shouldBe Some(Success(ExitCase.Canceled))
+  }
+
+  testAsync("background allows awaiting the action") { ec =>
+    implicit val contextShift = ec.contextShift[IO]
+
+    val f = Deferred[IO, Unit].flatMap { latch =>
+      val bg = latch.get *> IO.pure(42)
+
+      bg.background.use(await => latch.complete(()) *> await)
+    }.unsafeToFuture()
+
+    ec.tick()
+
+    f.value shouldBe Some(Success(42))
+  }
 }
 
 object IOTests {


### PR DESCRIPTION
This includes several commits from #639 which will be properly cleaned up once the other PR is closed.

I'm not too attached to the name, but it carries a nice meaning that I believe will be friendly to users.

Closes #628 