### PR TITLE
Update scalafmt-core to 2.1.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 2.1.0
+version = 2.1.1
 align = none
 align.openParenCallSite = true
 align.openParenDefnSite = true

--- a/core/shared/src/main/scala/cats/effect/Sync.scala
+++ b/core/shared/src/main/scala/cats/effect/Sync.scala
@@ -273,7 +273,8 @@ object Sync {
               case ((_, a), ec) =>
                 val r = release(a, ec).run
                 if (ec == ExitCase.Completed)
-                  r.flatMap { case (l, _) => ref.set(l) } else
+                  r.flatMap { case (l, _) => ref.set(l) }
+                else
                   r.void
             }
             .flatMap { lb =>
@@ -346,7 +347,8 @@ object Sync {
                 r.flatMap {
                   case Ior.Right(_) => F.unit
                   case other        => ref.set(other.void)
-                } else
+                }
+              else
                 r.void
             }
           }

--- a/core/shared/src/main/scala/cats/effect/internals/IOForkedStart.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOForkedStart.scala
@@ -51,12 +51,14 @@ private[effect] object IOForkedStart {
    * or `false` otherwise.
    */
   @tailrec def detect(task: IO[_], limit: Int = 8): Boolean =
-    if (limit > 0) task match {
-      case IO.Async(k, _)                => k.isInstanceOf[IOForkedStart[_]]
-      case IO.Bind(other, _)             => detect(other, limit - 1)
-      case IO.Map(other, _, _)           => detect(other, limit - 1)
-      case IO.ContextSwitch(other, _, _) => detect(other, limit - 1)
-      case _                             => false
+    if (limit > 0) {
+      task match {
+        case IO.Async(k, _)                => k.isInstanceOf[IOForkedStart[_]]
+        case IO.Bind(other, _)             => detect(other, limit - 1)
+        case IO.Map(other, _, _)           => detect(other, limit - 1)
+        case IO.ContextSwitch(other, _, _) => detect(other, limit - 1)
+        case _                             => false
+      }
     } else {
       false
     }


### PR DESCRIPTION
Scalafmt 2.1.1 inserts a new line after else word. https://github.com/scalameta/scalafmt/issues/1509
Scala-steward PR: https://github.com/typelevel/cats-effect/pull/669

This PR fixes scalafmt checks.