### PR TITLE
two simple syntax for `Resource`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/syntax/AllCatsEffectSyntax.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/AllCatsEffectSyntax.scala
@@ -23,3 +23,4 @@ trait AllCatsEffectSyntax
     with EffectSyntax
     with ConcurrentEffectSyntax
     with ParallelNSyntax
+    with ResourceSyntax

--- a/core/shared/src/main/scala/cats/effect/syntax/ResourceSyntax.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/ResourceSyntax.scala
@@ -17,13 +17,12 @@
 package cats.effect
 package syntax
 
-import cats.{Applicative}
+import cats.Applicative
 
 trait ResourceSyntax {
   implicit def toResourceOps[F[_], A](fa: F[A]) = new ResourceOps(fa)
   implicit def toResourceFOps[F[_], A](fra: F[Resource[F, A]]) =
     new ResourceFOps(fra)
-
 }
 
 final class ResourceOps[F[_], A](private val fa: F[A]) extends AnyVal {
@@ -31,8 +30,7 @@ final class ResourceOps[F[_], A](private val fa: F[A]) extends AnyVal {
     Resource.liftF(fa)
 }
 
-final class ResourceFOps[F[_], A](private val fra: F[Resource[F, A]])
-    extends AnyVal {
+final class ResourceFOps[F[_], A](private val fra: F[Resource[F, A]]) extends AnyVal {
   def flattenToResource(implicit F: Applicative[F]): Resource[F, A] =
     Resource.liftF(fra).flatMap(identity)
 }

--- a/core/shared/src/main/scala/cats/effect/syntax/ResourceSyntax.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/ResourceSyntax.scala
@@ -15,14 +15,24 @@
  */
 
 package cats.effect
+package syntax
 
-package object syntax {
-  object all extends AllCatsEffectSyntax
-  object bracket extends BracketSyntax
-  object async extends AsyncSyntax
-  object concurrent extends ConcurrentSyntax
-  object concurrentEffect extends ConcurrentEffectSyntax
-  object effect extends EffectSyntax
-  object paralleln extends ParallelNSyntax
-  object resource extends ResourceSyntax
+import cats.{Applicative}
+
+trait ResourceSyntax {
+  implicit def toResourceOps[F[_], A](fa: F[A]) = new ResourceOps(fa)
+  implicit def toResourceFOps[F[_], A](fra: F[Resource[F, A]]) =
+    new ResourceFOps(fra)
+
+}
+
+final class ResourceOps[F[_], A](private val fa: F[A]) extends AnyVal {
+  def liftToResource(implicit F: Applicative[F]): Resource[F, A] =
+    Resource.liftF(fa)
+}
+
+final class ResourceFOps[F[_], A](private val fra: F[Resource[F, A]])
+    extends AnyVal {
+  def flattenToResource(implicit F: Applicative[F]): Resource[F, A] =
+    Resource.liftF(fra).flatMap(identity)
 }

--- a/core/shared/src/test/scala/cats/effect/syntax/ResourceSyntaxTests.scala
+++ b/core/shared/src/test/scala/cats/effect/syntax/ResourceSyntaxTests.scala
@@ -14,15 +14,20 @@
  * limitations under the License.
  */
 
-package cats.effect
+package cats.effect.syntax
 
-package object syntax {
-  object all extends AllCatsEffectSyntax
-  object bracket extends BracketSyntax
-  object async extends AsyncSyntax
-  object concurrent extends ConcurrentSyntax
-  object concurrentEffect extends ConcurrentEffectSyntax
-  object effect extends EffectSyntax
-  object paralleln extends ParallelNSyntax
-  object resource extends ResourceSyntax
+import cats.effect.Resource
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import resource._
+import cats.instances.option._
+class ResourceSyntaxTests extends AnyFunSuite with Matchers {
+
+  test("F[A] liftToResources syntax") {
+    Option(1).liftToResource: Resource[Option, Int]
+  }
+
+  test("F[Resource[F, A]] flattenToResource syntax") {
+    Option(Resource.liftF(Option(1))).flattenToResource: Resource[Option, Int]
+  }
 }


### PR DESCRIPTION
I submit this PR to gauge interest. Personally I felt that the need to write a lot of `Resource.liftF` is a bit cumbersome, but this syntax, TBH isn't a huge improvement either. 