### PR TITLE
Add Blocker.blockOnK

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Blocker.scala
+++ b/core/shared/src/main/scala/cats/effect/Blocker.scala
@@ -44,6 +44,12 @@ final class Blocker private (val blockingContext: ExecutionContext) extends AnyV
    */
   def blockOn[F[_], A](fa: F[A])(implicit cs: ContextShift[F]): F[A] =
     cs.blockOn(this)(fa)
+
+  /**
+   * `blockOn` as a natural transformation.
+   */
+  def blockOnK[F[_]](implicit cs: ContextShift[F]): F ~> F =
+    λ[F ~> F](blockOn(_))
 }
 
 object Blocker extends BlockerPlatform {


### PR DESCRIPTION
This adds a `ContextShift.evalOnK` alternative for `Blocker`.  Unlike `evalOnK`, we can put this directly on the `Blocker` where it makes the most sense.