### PR TITLE
Issue 696: Add a derivation for Timer[Resource[F, ?]] whenever Timer[F] is in scope

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Clock.scala
+++ b/core/shared/src/main/scala/cats/effect/Clock.scala
@@ -239,4 +239,17 @@ protected[effect] trait LowPriorityImplicits {
       def monotonic(unit: TimeUnit): IorT[F, L, Long] =
         IorT.liftF(clock.monotonic(unit))
     }
+
+  /**
+   * Derives a [[Clock]] instance for `cats.effect.Resource`,
+   * given we have one for `F[_]`.
+   */
+  implicit def deriveResource[F[_]](implicit F: Applicative[F], clock: Clock[F]): Clock[Resource[F, *]] =
+    new Clock[Resource[F, *]] {
+      def realTime(unit: TimeUnit): Resource[F, Long] =
+        Resource.liftF(clock.realTime(unit))
+
+      def monotonic(unit: TimeUnit): Resource[F, Long] =
+        Resource.liftF(clock.monotonic(unit))
+    }
 }

--- a/core/shared/src/main/scala/cats/effect/Timer.scala
+++ b/core/shared/src/main/scala/cats/effect/Timer.scala
@@ -155,6 +155,18 @@ object Timer {
         IorT.liftF(timer.sleep(duration))
     }
 
+  /**
+   * Derives a [[Timer]] instance for `cats.effect.Resource`,
+   * given we have one for `F[_]`.
+   */
+  implicit def deriveResource[F[_]](implicit F: Applicative[F], timer: Timer[F]): Timer[Resource[F, *]] =
+    new Timer[Resource[F, *]] {
+      val clock: Clock[Resource[F, *]] = Clock.deriveResource
+
+      def sleep(duration: FiniteDuration): Resource[F, Unit] =
+        Resource.liftF(timer.sleep(duration))
+    }
+
   implicit class TimerOps[F[_]](val self: Timer[F]) extends AnyVal {
 
     /**


### PR DESCRIPTION
Ref https://github.com/typelevel/cats-effect/issues/696