### PR TITLE
Bracket: Do not evaluate "use" if "acquire" is canceled

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -8,3 +8,4 @@ assumeStandardLibraryStripMargin = true
 danglingParentheses = true
 rewrite.rules = [AvoidInfix, SortImports, RedundantBraces, RedundantParens, SortModifiers]
 docstrings = JavaDoc
+lineEndings=preserve

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -751,6 +751,26 @@ class IOTests extends BaseTestsSuite {
     effect shouldBe 1
   }
 
+  testAsync("bracket does not evaluate use on cancel") { implicit ec =>
+    implicit val contextShift = ec.contextShift[IO]
+    implicit val timer = ec.timer[IO]
+
+    var use = false
+    var release = false
+
+    val task = IO
+      .sleep(2.second)
+      .bracket(_ => IO { use = true })(_ => IO { release = true })
+      .timeoutTo[Unit](1.second, IO.never)
+
+    val f = task.unsafeToFuture()
+    ec.tick(2.second)
+
+    f.value shouldBe None
+    use shouldBe false
+    release shouldBe true
+  }
+
   test("unsafeRunSync works for IO.cancelBoundary") {
     val io = IO.cancelBoundary *> IO(1)
     io.unsafeRunSync() shouldBe 1


### PR DESCRIPTION
If `IO` is canceled during `acquire` in bracket, `use` is still evaluated. 
If `use` is cancelable then it will be canceled so to me it looks like an oversight.

Before the change:

`IO(println("A")) >> IO.cancelBoundary >> IO(println("B"))` will print "A"
`IO(println("A")) >> IO(println("B"))` will print "A" and then "B" unless it is canceled on flatmap.

After the change nothing should be printed at all.

See the gitter question: https://gitter.im/typelevel/cats-effect?at=5ddbe546f3ea522f26667d78

```scala
def acquire: IO[String] = {
  IO(logger.info("Resource acquiring...")) >> timer.sleep(5.seconds) >> IO {
    logger.info("Resource acquired")
    "some resource"
  }
}

def release(resource: String): IO[Unit] = {
  IO(logger.info(s"Releasing $resource"))
}

val action = acquire.bracket { r =>
  IO(logger.info(s"Using $r"))
}(release)

val result = action.timeoutTo(100.millis, IO {
  logger.info("Resource acquiring timed out")
})

IO(logger.info("Started")) >> result.as(ExitCode.Success)

21:25:33.589 Started
21:25:33.608 Resource acquiring...
21:25:38.609 Resource acquired
21:25:38.613 Using some resource
21:25:38.615 Releasing some resource
21:25:38.617 Resource acquiring timed out
```
cc @LMNet (if it doesn't turn out to be intended I'll fix it in Monix as well!)