### PR TITLE
Move `background` to Concurrent the trait, remove 2.11 leftovers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,14 +41,6 @@ val commonSettings = Seq(
     }
     .toList
     .flatten,
-  scalacOptions --= PartialFunction
-    .condOpt(CrossVersion.partialVersion(scalaVersion.value)) {
-      case Some((2, 11)) =>
-        // Falsely detects interpolation in @implicitNotFound
-        Seq("-Xlint:missing-interpolator")
-    }
-    .toList
-    .flatten,
   scalacOptions in (Compile, doc) ++= {
     val isSnapshot = git.gitCurrentTags.value.map(git.gitTagToVersionNumber.value).flatten.isEmpty
 

--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -244,8 +244,8 @@ trait Concurrent[F[_]] extends Async[F] {
    * In case the result of such an action is canceled, both processes will receive cancelation signals.
    * The same result can be achieved by using `anotherProcess &> longProcess` with the Parallel type class syntax.
    */
-  def background[A](fa: F[A])(implicit F: Concurrent[F]): Resource[F, F[A]] =
-    Resource.make(F.start(fa))(_.cancel).map(_.join)
+  def background[A](fa: F[A]): Resource[F, F[A]] =
+    Resource.make(start(fa))(_.cancel)(this).map(_.join)(this)
 
   /**
    * Run two tasks concurrently, creating a race between them and returns a

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -382,7 +382,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * In case the resource is closed while this IO is still running (e.g. due to a failure in `use`),
    * the background action will be canceled.
    *
-   * @see [[cats.effect.syntax.ConcurrentOps#background]]
+   * @see [[cats.effect.Concurrent#background]] for the generic version.
    */
   final def background(implicit cs: ContextShift[IO]): Resource[IO, IO[A @uncheckedVariance]] =
     Resource.make(start)(_.cancel).map(_.join)

--- a/core/shared/src/main/scala/cats/effect/syntax/ConcurrentSyntax.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/ConcurrentSyntax.scala
@@ -20,7 +20,6 @@ import cats.{Parallel, Traverse}
 
 import scala.concurrent.duration.FiniteDuration
 import cats.effect.{Concurrent, Timer}
-import cats.effect.Resource
 
 trait ConcurrentSyntax extends Concurrent.ToConcurrentOps {
   implicit def catsEffectSyntaxConcurrent[F[_], A](fa: F[A]): ConcurrentOps[F, A] =
@@ -36,43 +35,6 @@ final class ConcurrentOps[F[_], A](val self: F[A]) extends AnyVal {
 
   def timeoutTo(duration: FiniteDuration, fallback: F[A])(implicit F: Concurrent[F], timer: Timer[F]): F[A] =
     Concurrent.timeoutTo(self, duration, fallback)
-
-  /**
-   * Returns a resource that will start execution of this effect in the background.
-   *
-   * In case the resource is closed while this effect is still running (e.g. due to a failure in `use`),
-   * the background action will be canceled.
-   *
-   * A basic example with IO:
-   *
-   * {{{
-   *   val longProcess = (IO.sleep(5.seconds) *> IO(println("Ping!"))).foreverM
-   *
-   *   val srv: Resource[IO, ServerBinding[IO]] = for {
-   *     _ <- longProcess.background
-   *     server <- server.run
-   *   } yield server
-   *
-   *   val application = srv.use(binding => IO(println("Bound to " + binding)) *> IO.never)
-   * }}}
-   *
-   * Here, we are starting a background process as part of the application's startup.
-   * Afterwards, we initialize a server. Then, we use that server forever using `IO.never`.
-   * This will ensure we never close the server resource unless somebody cancels the whole `application` action.
-   *
-   * If at some point of using the resource you want to wait for the result of the background action,
-   * you can do so by sequencing the value inside the resource (it's equivalent to `join` on `Fiber`).
-   *
-   * This will start the background process, run another action, and wait for the result of the background process:
-   *
-   * {{{
-   *   longProcess.background.use(await => anotherProcess *> await)
-   * }}}
-   *
-   * In case the result of such an action is canceled, both processes will receive cancelation signals.
-   * The same result can be achieved by using `anotherProcess &> longProcess` with the Parallel type class syntax.
-   */
-  def background(implicit F: Concurrent[F]): Resource[F, F[A]] = Resource.make(F.start(self))(_.cancel).map(_.join)
 }
 
 final class ConcurrentObjOps[F[_]](private val F: Concurrent[F]) extends AnyVal {


### PR DESCRIPTION
Follow-up to #640, since #713 has been merged.