### PR TITLE
Cancel should always wait for the finalizer

### DIFF
--- a/core/shared/src/main/scala/cats/effect/internals/IOBracket.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOBracket.scala
@@ -135,7 +135,7 @@ private[effect] object IOBracket {
     private def applyRelease(e: ExitCase[Throwable]): IO[Unit] =
       IO.suspend {
         if (waitsForResult.compareAndSet(true, false))
-          release(e).map(_ => p.success(()))
+          release(e).redeemWith(ex => IO(p.success(())).flatMap(_ => IO.raiseError(ex)), _ => IO(p.success(())))
         else
           IOFromFuture.apply(p.future)
       }

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -1057,7 +1057,7 @@ class IOTests extends BaseTestsSuite {
     f.value shouldBe Some(Success(42))
   }
 
-  testAsync("cancel should always wait for the finalizer") { implicit ec =>
+  testAsync("cancel should wait for the release finalizer on success") { implicit ec =>
     implicit val contextShift = ec.contextShift[IO]
 
     val fa = for {
@@ -1072,6 +1072,52 @@ class IOTests extends BaseTestsSuite {
     ec.tick()
 
     f.value shouldBe None
+  }
+
+  testAsync("cancel should wait for the release finalizer on failure") { implicit ec =>
+    implicit val contextShift = ec.contextShift[IO]
+    implicit val timer = ec.timer[IO]
+
+    val dummy = new RuntimeException("dummy")
+
+    val fa = for {
+      pa <- Deferred[IO, Unit]
+      fiber <- IO.unit.bracket(_ => pa.complete(()) >> IO.unit)(_ => IO.sleep(1.second) >> IO.raiseError(dummy)).start
+      _ <- pa.get
+      _ <- fiber.cancel
+    } yield ()
+
+    val f = fa.unsafeToFuture()
+
+    ec.tick()
+    f.value shouldBe None
+
+    ec.tick(1.second)
+    f.value shouldBe Some(Success(()))
+  }
+
+  testAsync("cancel should wait for the use finalizer") { implicit ec =>
+    implicit val contextShift = ec.contextShift[IO]
+    implicit val timer = ec.timer[IO]
+
+    val fa = for {
+      pa <- Deferred[IO, Unit]
+      fibA <- IO.unit
+        .bracket(
+          _ => (pa.complete(()) >> IO.never).guarantee(IO.sleep(2.second))
+        )(_ => IO.unit)
+        .start
+      _ <- pa.get
+      _ <- fibA.cancel
+    } yield ()
+
+    val f = fa.unsafeToFuture()
+
+    ec.tick()
+    f.value shouldBe None
+
+    ec.tick(2.second)
+    f.value shouldBe Some(Success(()))
   }
 }
 

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -1056,6 +1056,23 @@ class IOTests extends BaseTestsSuite {
 
     f.value shouldBe Some(Success(42))
   }
+
+  testAsync("cancel should always wait for the finalizer") { implicit ec =>
+    implicit val contextShift = ec.contextShift[IO]
+
+    val fa = for {
+      pa <- Deferred[IO, Unit]
+      fiber <- IO.unit.bracket(_ => pa.complete(()) >> IO.unit)(_ => IO.never).start
+      _ <- pa.get
+      _ <- fiber.cancel
+    } yield ()
+
+    val f = fa.unsafeToFuture()
+
+    ec.tick()
+
+    f.value shouldBe None
+  }
 }
 
 object IOTests {

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -1062,7 +1062,7 @@ class IOTests extends BaseTestsSuite {
 
     val fa = for {
       pa <- Deferred[IO, Unit]
-      fiber <- IO.unit.bracket(_ => pa.complete(()) >> IO.unit)(_ => IO.never).start
+      fiber <- IO.unit.bracket(_ => pa.complete(()))(_ => IO.never).start
       _ <- pa.get
       _ <- fiber.cancel
     } yield ()
@@ -1082,7 +1082,7 @@ class IOTests extends BaseTestsSuite {
 
     val fa = for {
       pa <- Deferred[IO, Unit]
-      fiber <- IO.unit.bracket(_ => pa.complete(()) >> IO.unit)(_ => IO.sleep(1.second) >> IO.raiseError(dummy)).start
+      fiber <- IO.unit.bracket(_ => pa.complete(()))(_ => IO.sleep(1.second) >> IO.raiseError(dummy)).start
       _ <- pa.get
       _ <- fiber.cancel
     } yield ()


### PR DESCRIPTION
Fixes #721

Not 100% sure about the test, I'm counting on final suggestions from @djspiewak and @kubukoz and we could include it in the laws as well

The problem was happening when `release` has been already called by other action