### PR TITLE
Update docs about cancellation to reflect latest implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
 
 install:
   - rvm use 2.6.0 --install --fuzzy
-  - gem update --system
+  - yes | gem update --system
   - gem install sass
   - gem install jekyll -v 3.2.1
 

--- a/site/src/main/mdoc/datatypes/io.md
+++ b/site/src/main/mdoc/datatypes/io.md
@@ -369,15 +369,28 @@ asynchronous boundaries. It can be achieved in the following way:
   those operations is also possible to cancel. It includes, but is not limited to
   waiting on `Mvar.take`, `Mvar.put` and `Deferred.get`.
   
-  We should also note that `flatMap` chains are not auto-cancelable,
-  they are cancellable only if the `flatMap` chain happens *after*
-  an asynchronous boundary mentioned above. After an asynchronous
-  boundary, cancellation checks are performed on every N `flatMap`.
-  Asynchronous boundaries are important for fairness and it's not
-  reasonable to expect interruption in its' absence. With `IO`,
-  fairness needs to be managed explicitly, the protocol being easy
-  to follow and predictable in a WYSIWYG fashion. Try to avoid very
-  long, or never-ending loops without it.
+  We should also note that `flatMap` chains are only cancellable only if
+  the chain happens *after* an asynchronous boundary.
+  After an asynchronous boundary, cancellation checks are performed on every N `flatMap`.
+
+  Here is an example,
+  ```scala mdoc:reset:silent
+  import cats.effect.IO
+
+  def retryUntilRight[A, B](io: IO[Either[A, B]): IO[B] = {
+    io.flatMap {
+      case Right(b) => IO.pure(b)
+      case Left(a) => retryUntilRight(io)
+    }
+  }
+
+  // non-terminating IO that is NOT cancelable
+  val notCancellable: IO[Int] = retryUntilRight[A, B](IO(Left(0)))
+
+  // non-terminating IO that is cancelable because there is an
+  // async boundary created by IO.shift before `flatMap` chain
+  val cancellable: IO[Int] = IO.shift *> retryUntilRight[A, B](IO(Left(0)))
+  ```
   
 2. `IO` tasks that are cancelable, usually become non-terminating on
    `cancel`

--- a/site/src/main/mdoc/datatypes/io.md
+++ b/site/src/main/mdoc/datatypes/io.md
@@ -372,6 +372,7 @@ asynchronous boundaries. It can be achieved in the following way:
   We should also note that `flatMap` chains are only cancelable only if
   the chain happens *after* an asynchronous boundary.
   After an asynchronous boundary, cancellation checks are performed on every N `flatMap`.
+  The value of `N` is hardcoded to 512.
 
   Here is an example,
   ```scala mdoc:reset:silent

--- a/site/src/main/mdoc/datatypes/io.md
+++ b/site/src/main/mdoc/datatypes/io.md
@@ -371,7 +371,7 @@ asynchronous boundaries. It can be achieved in the following way:
   
   We should also note that `flatMap` chains are not auto-cancelable,
   they are cancellable only if the `flatMap` chain happens *after*
-  an asynchronous boundary mentioned above, after an asynchronous
+  an asynchronous boundary mentioned above. After an asynchronous
   boundary, cancellation checks are performed on every N `flatMap`.
   Asynchronous boundaries are important for fairness and it's not
   reasonable to expect interruption in its' absence. With `IO`,

--- a/site/src/main/mdoc/datatypes/io.md
+++ b/site/src/main/mdoc/datatypes/io.md
@@ -369,7 +369,7 @@ asynchronous boundaries. It can be achieved in the following way:
   those operations is also possible to cancel. It includes, but is not limited to
   waiting on `Mvar.take`, `Mvar.put` and `Deferred.get`.
   
-  We should also note that `flatMap` chains are only cancellable only if
+  We should also note that `flatMap` chains are only cancelable only if
   the chain happens *after* an asynchronous boundary.
   After an asynchronous boundary, cancellation checks are performed on every N `flatMap`.
 
@@ -385,11 +385,11 @@ asynchronous boundaries. It can be achieved in the following way:
   }
 
   // non-terminating IO that is NOT cancelable
-  val notCancellable: IO[Int] = retryUntilRight[A, B](IO(Left(0)))
+  val notCancelable: IO[Int] = retryUntilRight[A, B](IO(Left(0)))
 
   // non-terminating IO that is cancelable because there is an
   // async boundary created by IO.shift before `flatMap` chain
-  val cancellable: IO[Int] = IO.shift *> retryUntilRight[A, B](IO(Left(0)))
+  val cancelable: IO[Int] = IO.shift *> retryUntilRight[A, B](IO(Left(0)))
   ```
   
 2. `IO` tasks that are cancelable, usually become non-terminating on

--- a/site/src/main/mdoc/datatypes/io.md
+++ b/site/src/main/mdoc/datatypes/io.md
@@ -369,11 +369,15 @@ asynchronous boundaries. It can be achieved in the following way:
   those operations is also possible to cancel. It includes, but is not limited to
   waiting on `Mvar.take`, `Mvar.put` and `Deferred.get`.
   
-  We should also note that `flatMap` chains are not auto-cancelable. Asynchronous
-  boundaries are important for fairness and it's not reasonable to expect interruption
-  in its' absence. With `IO`, fairness needs to be managed explicitly, the protocol being
-  easy to follow and predictable in a WYSIWYG fashion. Try to avoid very long, 
-  or never-ending loops without it.
+  We should also note that `flatMap` chains are not auto-cancelable,
+  they are cancellable only if the `flatMap` chain happens *after*
+  an asynchronous boundary mentioned above, after an asynchronous
+  boundary, cancellation checks are performed on every N `flatMap`.
+  Asynchronous boundaries are important for fairness and it's not
+  reasonable to expect interruption in its' absence. With `IO`,
+  fairness needs to be managed explicitly, the protocol being easy
+  to follow and predictable in a WYSIWYG fashion. Try to avoid very
+  long, or never-ending loops without it.
   
 2. `IO` tasks that are cancelable, usually become non-terminating on
    `cancel`


### PR DESCRIPTION
Hi, I wish to update the docs to reflect the current implementation, but I am not sure how much implementation details to expose?

Another question: I notice the microsite does not work out of the box locally as the microsite project uses a non-default `baseUrl`, is this something we expect?