### PR TITLE
Fix #617: Make Resource covariant in F and A

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ matrix:
       env: COVERAGE=
 
 install:
-  - rvm use 2.6.0 --install --fuzzy
-  - gem update --system
+  - rvm use 2.6.5 --install --fuzzy
+  - yes | gem update --system --force
   - gem install sass
   - gem install jekyll -v 3.2.1
 

--- a/build.sbt
+++ b/build.sbt
@@ -168,7 +168,15 @@ val mimaSettings = Seq(
       exclude[DirectMissingMethodProblem]("cats.effect.IO.fromFuture"),
       // Incompatible signatures should not cause linking problems.
       exclude[IncompatibleSignatureProblem]("cats.effect.IO.ioParallel"),
-      exclude[IncompatibleSignatureProblem]("cats.effect.IOInstances.ioParallel")
+      exclude[IncompatibleSignatureProblem]("cats.effect.IOInstances.ioParallel"),
+      // Signature changes to make Resource covariant, should not cause linking problems. - https://github.com/typelevel/cats-effect/pull/731
+      exclude[IncompatibleSignatureProblem]("cats.effect.Resource.use"),
+      exclude[IncompatibleSignatureProblem]("cats.effect.Resource.flatMap"),
+      exclude[IncompatibleSignatureProblem]("cats.effect.Resource.map"),
+      exclude[IncompatibleSignatureProblem]("cats.effect.Resource.mapK"),
+      exclude[IncompatibleSignatureProblem]("cats.effect.Resource.allocated"),
+      exclude[IncompatibleSignatureProblem]("cats.effect.Resource.evalMap"),
+      exclude[IncompatibleSignatureProblem]("cats.effect.Resource.evalTap")
     )
   }
 )

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -459,7 +459,7 @@ abstract private[effect] class ResourceMonadError[F[_], E] extends ResourceMonad
       case Suspend(resource) =>
         Suspend(resource.attempt.map {
           case Left(error)               => Resource.pure[F, Either[E, A]](Left(error))
-          case Right(fa: Resource[F, A]) => catsSyntaxApplicativeError[Resource[F, *], E, A](fa).attempt
+          case Right(fa: Resource[F, A]) => attempt(fa)
         })
     }
 


### PR DESCRIPTION
Following the discussion in #617 this simply makes Resource covariant. Binary compatibility is not affected as non-generic parts of the method signatures are unchanged.