### PR TITLE
Microsite: use bundler for installing Jekyll & Ruby deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ benchmarks/results
 .DS_Store
 .metals
 .bloop
+.bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,11 @@ matrix:
       env: COVERAGE=
 
 install:
-  - rvm use 2.6.0 --install --fuzzy
-  - gem update --system
-  - gem install sass
-  - gem install jekyll -v 3.2.1
+  - rvm install 2.6
+  # In case we want to reinstall all Ruby dependencies from scratch:
+  #   rvm --force gemset delete 2.6@cats-effect
+  - rvm use 2.6@cats-effect --install --default --create
+  - bundle install --system --gemfile=site/Gemfile
 
 script:
   - export SBT_PROFILE=$COVERAGE
@@ -46,3 +47,4 @@ cache:
     - $HOME/.ivy2/cache
     - $HOME/.coursier/cache
     - $HOME/.sbt
+    - $HOME/.rvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - rvm install 2.6
   # In case we want to reinstall all Ruby dependencies from scratch:
   #   rvm --force gemset delete 2.6@cats-effect
-  - rvm use 2.6@cats-effect --install --default --create
+  - rvm use 2.6@cats-effect --default --create
   - bundle install --system --gemfile=site/Gemfile
 
 script:

--- a/site/Gemfile
+++ b/site/Gemfile
@@ -1,0 +1,4 @@
+source 'http://rubygems.org'
+
+gem "jekyll", ">= 3.2.1", "< 4.0.0"
+gem "sass"

--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -1,0 +1,62 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.1.5)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    eventmachine (1.2.7)
+    ffi (1.11.3)
+    forwardable-extended (2.6.0)
+    http_parser.rb (0.6.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    jekyll (3.8.6)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 0.7)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 1.14)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 4)
+      safe_yaml (~> 1.0)
+    jekyll-sass-converter (1.5.2)
+      sass (~> 3.4)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (1.17.0)
+    liquid (4.0.3)
+    listen (3.2.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.3.6)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (4.0.1)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
+    rouge (3.14.0)
+    safe_yaml (1.0.5)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll (>= 3.2.1, < 4.0.0)
+  sass
+
+BUNDLED WITH
+   1.17.3


### PR DESCRIPTION
Notes:

- instead of doing `gem install jekyll`, we're switching to usage of [bundler](https://bundler.io/) for managing our Ruby dependencies via a [Gemfile](https://bundler.io/gemfile.html)
- `gem update --system` is totally not needed, not sure why it was even there, of course it creates conflicts
- we can use a "gem set"  (e.g. `@cats-effect`, which sets a specific GEM_HOME where system dependencies get installed) if we need to reinstall all dependencies from scratch (in this context I don't think it's needed, but it's nice to have it there as a comment, in case of future conflicts)