### PR TITLE
MVar: add "tryRead" fixes #732

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ val CompileTime = config("CompileTime").hide
 val SimulacrumVersion = "1.0.0"
 val CatsVersion = "2.1.1"
 val DisciplineScalatestVersion = "1.0.1"
+val SilencerVersion = "1.6.0"
 val customScalaJSVersion = Option(System.getenv("SCALAJS_VERSION"))
 
 addCommandAlias("ci", ";scalafmtSbtCheck ;scalafmtCheckAll ;test ;mimaReportBinaryIssues; doc")
@@ -239,6 +240,11 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       "org.typelevel" %%% "cats-laws" % CatsVersion % Test,
       "org.typelevel" %%% "discipline-scalatest" % DisciplineScalatestVersion % Test
     ),
+    libraryDependencies ++= Seq(
+      compilerPlugin(("com.github.ghik" % "silencer-plugin" % SilencerVersion).cross(CrossVersion.full)),
+      ("com.github.ghik" % "silencer-lib" % SilencerVersion % CompileTime).cross(CrossVersion.full),
+      ("com.github.ghik" % "silencer-lib" % SilencerVersion % Test).cross(CrossVersion.full)
+    ),
     libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, v)) if v <= 12 =>
@@ -329,9 +335,6 @@ lazy val siteSettings = Seq(
       "home",
       Map("permalink" -> "/", "title" -> "Home", "section" -> "home", "position" -> "0")
     )
-  ),
-  micrositeConfigYaml := ConfigYml(
-    yamlCustomProperties = Map("plugins" -> List("jekyll-relative-links"))
   ),
   micrositeCompilingDocsTool := WithMdoc,
   mdocIn := (sourceDirectory in Compile).value / "mdoc",

--- a/core/shared/src/main/scala/cats/effect/concurrent/MVar.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/MVar.scala
@@ -20,6 +20,7 @@ package concurrent
 import cats.effect.concurrent.MVar.{TransformedMVar, TransformedMVar2}
 import cats.effect.internals.{MVarAsync, MVarConcurrent}
 import cats.~>
+import com.github.ghik.silencer.silent
 
 /**
  * @define mVarDescription A mutable location, that is either empty or contains a value of type `A`.
@@ -58,7 +59,9 @@ sealed private[concurrent] trait MVarDocumentation extends Any {}
 /**
  * $mVarDescription
  */
+@deprecated("`MVar` is now deprecated in favour of a new generation `MVar2` with `tryRead` and `swap` support", "2.2.0")
 abstract class MVar[F[_], A] extends MVarDocumentation {
+
   /**
    * Returns `true` if the `MVar` is empty and can receive a `put`, or
    * `false` otherwise.
@@ -131,7 +134,9 @@ abstract class MVar[F[_], A] extends MVarDocumentation {
  * The `MVar2` is the successor of `MVar` with [[tryRead]] and [[swap]]. It was implemented separately only to maintain
  * binary compatibility with `MVar`.
  */
+@silent("deprecated")
 abstract class MVar2[F[_], A] extends MVar[F, A] {
+
   /**
    * Replaces a value in MVar and returns the old value.
 
@@ -158,6 +163,7 @@ abstract class MVar2[F[_], A] extends MVar[F, A] {
 
 /** Builders for [[MVar]]. */
 object MVar {
+
   /**
    * Builds an [[MVar]] value for `F` data types that are [[Concurrent]].
    *

--- a/laws/jvm/src/test/scala/cats/effect/MVarJVMTests.scala
+++ b/laws/jvm/src/test/scala/cats/effect/MVarJVMTests.scala
@@ -19,7 +19,7 @@ package cats.effect
 import java.util.concurrent.{ExecutorService, Executors, ThreadFactory, TimeUnit}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 
-import cats.effect.concurrent.{Deferred, MVar}
+import cats.effect.concurrent.{Deferred, MVar, MVar2}
 import cats.implicits._
 import org.scalatest.BeforeAndAfter
 import org.scalatest.matchers.should.Matchers
@@ -29,70 +29,70 @@ import scala.concurrent.duration._
 import scala.concurrent.{CancellationException, ExecutionContext}
 
 class MVarEmptyJVMParallelism1Tests extends BaseMVarJVMTests(1) {
-  def allocate(implicit cs: ContextShift[IO]): IO[MVar[IO, Unit]] =
+  def allocate(implicit cs: ContextShift[IO]): IO[MVar2[IO, Unit]] =
     MVar.empty[IO, Unit]
-  def allocateUncancelable: IO[MVar[IO, Unit]] =
+  def allocateUncancelable: IO[MVar2[IO, Unit]] =
     MVar.uncancelableEmpty[IO, Unit]
-  def acquire(ref: MVar[IO, Unit]): IO[Unit] =
+  def acquire(ref: MVar2[IO, Unit]): IO[Unit] =
     ref.take
-  def release(ref: MVar[IO, Unit]): IO[Unit] =
+  def release(ref: MVar2[IO, Unit]): IO[Unit] =
     ref.put(())
 }
 
 class MVarEmptyJVMParallelism2Tests extends BaseMVarJVMTests(2) {
-  def allocate(implicit cs: ContextShift[IO]): IO[MVar[IO, Unit]] =
+  def allocate(implicit cs: ContextShift[IO]): IO[MVar2[IO, Unit]] =
     MVar.empty[IO, Unit]
-  def allocateUncancelable: IO[MVar[IO, Unit]] =
+  def allocateUncancelable: IO[MVar2[IO, Unit]] =
     MVar.uncancelableEmpty[IO, Unit]
-  def acquire(ref: MVar[IO, Unit]): IO[Unit] =
+  def acquire(ref: MVar2[IO, Unit]): IO[Unit] =
     ref.take
-  def release(ref: MVar[IO, Unit]): IO[Unit] =
+  def release(ref: MVar2[IO, Unit]): IO[Unit] =
     ref.put(())
 }
 
 class MVarEmptyJVMParallelism4Tests extends BaseMVarJVMTests(4) {
-  def allocate(implicit cs: ContextShift[IO]): IO[MVar[IO, Unit]] =
+  def allocate(implicit cs: ContextShift[IO]): IO[MVar2[IO, Unit]] =
     MVar.empty[IO, Unit]
-  def allocateUncancelable: IO[MVar[IO, Unit]] =
+  def allocateUncancelable: IO[MVar2[IO, Unit]] =
     MVar.uncancelableEmpty[IO, Unit]
-  def acquire(ref: MVar[IO, Unit]): IO[Unit] =
+  def acquire(ref: MVar2[IO, Unit]): IO[Unit] =
     ref.take
-  def release(ref: MVar[IO, Unit]): IO[Unit] =
+  def release(ref: MVar2[IO, Unit]): IO[Unit] =
     ref.put(())
 }
 
 // -----------------------------------------------------------------
 
 class MVarFullJVMParallelism1Tests extends BaseMVarJVMTests(1) {
-  def allocate(implicit cs: ContextShift[IO]): IO[MVar[IO, Unit]] =
+  def allocate(implicit cs: ContextShift[IO]): IO[MVar2[IO, Unit]] =
     MVar.of[IO, Unit](())
-  def allocateUncancelable: IO[MVar[IO, Unit]] =
+  def allocateUncancelable: IO[MVar2[IO, Unit]] =
     MVar.uncancelableOf[IO, Unit](())
-  def acquire(ref: MVar[IO, Unit]): IO[Unit] =
+  def acquire(ref: MVar2[IO, Unit]): IO[Unit] =
     ref.put(())
-  def release(ref: MVar[IO, Unit]): IO[Unit] =
+  def release(ref: MVar2[IO, Unit]): IO[Unit] =
     ref.take
 }
 
 class MVarFullJVMParallelism2Tests extends BaseMVarJVMTests(2) {
-  def allocate(implicit cs: ContextShift[IO]): IO[MVar[IO, Unit]] =
+  def allocate(implicit cs: ContextShift[IO]): IO[MVar2[IO, Unit]] =
     MVar.of[IO, Unit](())
-  def allocateUncancelable: IO[MVar[IO, Unit]] =
+  def allocateUncancelable: IO[MVar2[IO, Unit]] =
     MVar.uncancelableOf[IO, Unit](())
-  def acquire(ref: MVar[IO, Unit]): IO[Unit] =
+  def acquire(ref: MVar2[IO, Unit]): IO[Unit] =
     ref.put(())
-  def release(ref: MVar[IO, Unit]): IO[Unit] =
+  def release(ref: MVar2[IO, Unit]): IO[Unit] =
     ref.take
 }
 
 class MVarFullJVMParallelism4Tests extends BaseMVarJVMTests(4) {
-  def allocate(implicit cs: ContextShift[IO]): IO[MVar[IO, Unit]] =
+  def allocate(implicit cs: ContextShift[IO]): IO[MVar2[IO, Unit]] =
     MVar.of[IO, Unit](())
-  def allocateUncancelable: IO[MVar[IO, Unit]] =
+  def allocateUncancelable: IO[MVar2[IO, Unit]] =
     MVar.uncancelableOf[IO, Unit](())
-  def acquire(ref: MVar[IO, Unit]): IO[Unit] =
+  def acquire(ref: MVar2[IO, Unit]): IO[Unit] =
     ref.put(())
-  def release(ref: MVar[IO, Unit]): IO[Unit] =
+  def release(ref: MVar2[IO, Unit]): IO[Unit] =
     ref.take
 }
 
@@ -137,10 +137,10 @@ abstract class BaseMVarJVMTests(parallelism: Int) extends AnyFunSuite with Match
   val iterations = if (isCI) 1000 else 10000
   val timeout = if (isCI) 30.seconds else 10.seconds
 
-  def allocate(implicit cs: ContextShift[IO]): IO[MVar[IO, Unit]]
-  def allocateUncancelable: IO[MVar[IO, Unit]]
-  def acquire(ref: MVar[IO, Unit]): IO[Unit]
-  def release(ref: MVar[IO, Unit]): IO[Unit]
+  def allocate(implicit cs: ContextShift[IO]): IO[MVar2[IO, Unit]]
+  def allocateUncancelable: IO[MVar2[IO, Unit]]
+  def acquire(ref: MVar2[IO, Unit]): IO[Unit]
+  def release(ref: MVar2[IO, Unit]): IO[Unit]
 
   // ----------------------------------------------------------------------------
 
@@ -148,7 +148,7 @@ abstract class BaseMVarJVMTests(parallelism: Int) extends AnyFunSuite with Match
     for (_ <- 0 until iterations) {
       val name = Thread.currentThread().getName
 
-      def get(df: MVar[IO, Unit]) =
+      def get(df: MVar2[IO, Unit]) =
         for {
           _ <- IO(Thread.currentThread().getName shouldNot be(name))
           _ <- acquire(df)


### PR DESCRIPTION
Motivation:

I found an open good first issue #732 while reading about `MVar`. This branch contains an attempt to implement it.

Modification:

- add `tryRead: F[Option[A]]` similar to [Control-Concurrent-MVar#tryRead](http://hackage.haskell.org/package/base-4.12.0.0/docs/Control-Concurrent-MVar.html#v:tryReadMVar)
- add a test and a line into the docs

I wonder does it do what is it intended to do? I am happy to amend it if I've missed something, suggestions are welcome. Thank you!