### PR TITLE
Update discipline-scalatest to 1.0.0-RC3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ ThisBuild / startYear := Some(2017)
 val CompileTime = config("CompileTime").hide
 val SimulacrumVersion = "1.0.0"
 val CatsVersion = "2.1.0"
-val DisciplineScalatestVersion = "1.0.0-RC2"
+val DisciplineScalatestVersion = "1.0.0-RC3"
 
 addCommandAlias("ci", ";scalafmtSbtCheck ;scalafmtCheckAll ;test ;mimaReportBinaryIssues; doc")
 addCommandAlias("release", ";project root ;reload ;+publish ;sonatypeReleaseAll ;microsite/publishMicrosite")

--- a/laws/shared/src/test/scala/cats/effect/BaseTestsSuite.scala
+++ b/laws/shared/src/test/scala/cats/effect/BaseTestsSuite.scala
@@ -24,9 +24,15 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.Checkers
 import org.typelevel.discipline.Laws
-import org.typelevel.discipline.scalatest.Discipline
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 
-class BaseTestsSuite extends AnyFunSuite with Matchers with Checkers with Discipline with TestInstances with TestUtils {
+class BaseTestsSuite
+    extends AnyFunSuite
+    with Matchers
+    with Checkers
+    with FunSuiteDiscipline
+    with TestInstances
+    with TestUtils {
   /** For tests that need a usable [[TestContext]] reference. */
   def testAsync[A](name: String, tags: Tag*)(f: TestContext => Unit)(implicit pos: source.Position): Unit =
     // Overriding System.err


### PR DESCRIPTION
This release requires manual update 
Release notes: https://github.com/typelevel/discipline-scalatest/releases/tag/v1.0.0-RC3