### PR TITLE
Restrict ArrayStack to AnyRef

### DIFF
--- a/core/shared/src/main/scala/cats/effect/internals/ArrayStack.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/ArrayStack.scala
@@ -23,7 +23,7 @@ package cats.effect.internals
  *
  * INTERNAL API.
  */
-final private[internals] class ArrayStack[A] private (
+final private[internals] class ArrayStack[A <: AnyRef] private (
   initialArray: Array[AnyRef],
   chunkSize: Int,
   initialIndex: Int

--- a/core/shared/src/test/scala/cats/effect/internals/ArrayStackTests.scala
+++ b/core/shared/src/test/scala/cats/effect/internals/ArrayStackTests.scala
@@ -21,20 +21,20 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class ArrayStackTests extends AnyFunSuite with Matchers with TestUtils {
   test("push and pop 8 items") {
-    val stack = new ArrayStack[Int]()
+    val stack = new ArrayStack[String]()
     var times = 0
 
     while (times < 10) {
       assert(stack.isEmpty, "stack.isEmpty")
-      for (i <- 0 until 8) stack.push(i)
+      for (i <- 0 until 8) stack.push(i.toString)
 
-      var list = List.empty[Int]
+      var list = List.empty[String]
       while (!stack.isEmpty) {
         assert(!stack.isEmpty, "!stack.isEmpty")
         list = stack.pop() :: list
       }
 
-      list shouldBe (0 until 8).toList
+      list shouldBe (0 until 8).map(_.toString).toList
       stack.pop().asInstanceOf[AnyRef] shouldBe null
       stack.isEmpty shouldBe true
 
@@ -43,20 +43,20 @@ class ArrayStackTests extends AnyFunSuite with Matchers with TestUtils {
   }
 
   test("push and pop 100 items") {
-    val stack = new ArrayStack[Int]()
+    val stack = new ArrayStack[String]()
     var times = 0
 
     while (times < 10) {
       assert(stack.isEmpty, "stack.isEmpty")
-      for (i <- 0 until 100) stack.push(i)
+      for (i <- 0 until 100) stack.push(i.toString)
 
-      var list = List.empty[Int]
+      var list = List.empty[String]
       while (!stack.isEmpty) {
         assert(!stack.isEmpty, "!stack.isEmpty")
         list = stack.pop() :: list
       }
 
-      list shouldBe (0 until 100).toList
+      list shouldBe (0 until 100).map(_.toString).toList
       stack.pop().asInstanceOf[AnyRef] shouldBe null
       stack.isEmpty shouldBe true
 
@@ -65,30 +65,30 @@ class ArrayStackTests extends AnyFunSuite with Matchers with TestUtils {
   }
 
   test("pushAll(stack)") {
-    val stack = new ArrayStack[Int]()
-    val stack2 = new ArrayStack[Int]()
+    val stack = new ArrayStack[String]()
+    val stack2 = new ArrayStack[String]()
 
-    for (i <- 0 until 100) stack2.push(i)
+    for (i <- 0 until 100) stack2.push(i.toString)
     stack.pushAll(stack2)
 
-    var list = List.empty[Int]
+    var list = List.empty[String]
     while (!stack.isEmpty) {
       assert(!stack.isEmpty)
       list = stack.pop() :: list
     }
 
-    list shouldBe (0 until 100).toList.reverse
+    list shouldBe (0 until 100).map(_.toString).toList.reverse
     stack.pop().asInstanceOf[AnyRef] shouldBe null
     stack.isEmpty shouldBe true
     stack2.isEmpty shouldBe false
   }
 
   test("pushAll(iterable)") {
-    val stack = new ArrayStack[Int]()
-    val expected = (0 until 100).toList
+    val stack = new ArrayStack[String]()
+    val expected = (0 until 100).map(_.toString).toList
     stack.pushAll(expected)
 
-    var list = List.empty[Int]
+    var list = List.empty[String]
     while (!stack.isEmpty) {
       assert(!stack.isEmpty)
       list = stack.pop() :: list
@@ -100,8 +100,8 @@ class ArrayStackTests extends AnyFunSuite with Matchers with TestUtils {
   }
 
   test("iterator") {
-    val stack = new ArrayStack[Int]()
-    val expected = (0 until 100).toList
+    val stack = new ArrayStack[String]()
+    val expected = (0 until 100).map(_.toString).toList
     for (i <- expected) stack.push(i)
     stack.iteratorReversed.toList shouldBe expected.reverse
   }


### PR DESCRIPTION
The internal `ArrayStack` here differs from the standard library's in that `pop()` returns `null` for the empty stack, but this is only possible for primitive types because of this extremely weird behavior in Scala 2 (which is fixed in Dotty):

```scala
scala> def foo[A]: A = null.asInstanceOf[A]
def foo[A] => A

scala> foo[Int]
val res0: Int = 0

scala> foo[Int].asInstanceOf[AnyRef]                   
val res1: AnyRef = null
```

As @smarter says:

> there's no universe where having `foo[Int].asInstanceOf[AnyRef]` return something different from `val x = foo[Int]; x.asInstanceOf[AnyRef]` makes sense

`ArrayStack` isn't currently used with primitive types anywhere outside its tests, and it's not part of the public Scala API, so I think it makes sense just to restrict it to `AnyRef` and adjust the tests to avoid this issue altogether.