### PR TITLE
Some small changes for Dotty compatibility

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Bracket.scala
+++ b/core/shared/src/main/scala/cats/effect/Bracket.scala
@@ -197,7 +197,7 @@ object ExitCase {
   /**
    * An [[ExitCase]] signaling completion in failure.
    */
-  case class Error[+E](e: E) extends ExitCase[E]
+  final case class Error[+E](e: E) extends ExitCase[E]
 
   /**
    * An [[ExitCase]] signaling that the action was aborted.

--- a/core/shared/src/main/scala/cats/effect/Bracket.scala
+++ b/core/shared/src/main/scala/cats/effect/Bracket.scala
@@ -192,12 +192,12 @@ object ExitCase {
    * outcome for the user, but it does for the purposes of the
    * `bracket` operation.
    */
-  final case object Completed extends ExitCase[Nothing]
+  case object Completed extends ExitCase[Nothing]
 
   /**
    * An [[ExitCase]] signaling completion in failure.
    */
-  final case class Error[+E](e: E) extends ExitCase[E]
+  case class Error[+E](e: E) extends ExitCase[E]
 
   /**
    * An [[ExitCase]] signaling that the action was aborted.
@@ -209,7 +209,7 @@ object ExitCase {
    * Thus [[Bracket]] allows you to observe interruption conditions
    * and act on them.
    */
-  final case object Canceled extends ExitCase[Nothing]
+  case object Canceled extends ExitCase[Nothing]
 
   /**
    * Parametrized alias for the [[Completed]] data constructor.

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1051,7 +1051,7 @@ object IO extends IOInstances {
    * into the `IO`.
    */
   def delay[A](body: => A): IO[A] =
-    Delay(body _)
+    Delay(() => body)
 
   /**
    * Suspends a synchronous side effect which produces an `IO` in `IO`.
@@ -1062,7 +1062,7 @@ object IO extends IOInstances {
    * `IO`.
    */
   def suspend[A](thunk: => IO[A]): IO[A] =
-    Suspend(thunk _)
+    Suspend(() => thunk)
 
   /**
    * Suspends a pure value in `IO`.

--- a/core/shared/src/main/scala/cats/effect/SyncEffect.scala
+++ b/core/shared/src/main/scala/cats/effect/SyncEffect.scala
@@ -44,18 +44,18 @@ object SyncEffect {
    * [[SyncEffect]] instance built for `cats.data.EitherT` values initialized
    * with any `F` data type that also implements `SyncEffect`.
    */
-  implicit def catsEitherTSyncEffect[F[_]: SyncEffect]: SyncEffect[EitherT[F, Throwable, ?]] =
+  implicit def catsEitherTSyncEffect[F[_]: SyncEffect]: SyncEffect[EitherT[F, Throwable, *]] =
     new EitherTSyncEffect[F] { def F = SyncEffect[F] }
 
   /**
    * [[SyncEffect]] instance built for `cats.data.WriterT` values initialized
    * with any `F` data type that also implements `SyncEffect`.
    */
-  implicit def catsWriterTSyncEffect[F[_]: SyncEffect, L: Monoid]: SyncEffect[WriterT[F, L, ?]] =
+  implicit def catsWriterTSyncEffect[F[_]: SyncEffect, L: Monoid]: SyncEffect[WriterT[F, L, *]] =
     new WriterTSyncEffect[F, L] { def F = SyncEffect[F]; def L = Monoid[L] }
 
   private[effect] trait EitherTSyncEffect[F[_]]
-      extends SyncEffect[EitherT[F, Throwable, ?]]
+      extends SyncEffect[EitherT[F, Throwable, *]]
       with Sync.EitherTSync[F, Throwable] {
     protected def F: SyncEffect[F]
 
@@ -63,7 +63,7 @@ object SyncEffect {
       F.runSync(F.rethrow(fa.value))
   }
 
-  private[effect] trait WriterTSyncEffect[F[_], L] extends SyncEffect[WriterT[F, L, ?]] with Sync.WriterTSync[F, L] {
+  private[effect] trait WriterTSyncEffect[F[_], L] extends SyncEffect[WriterT[F, L, *]] with Sync.WriterTSync[F, L] {
     protected def F: SyncEffect[F]
     protected def L: Monoid[L]
 

--- a/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
@@ -278,7 +278,7 @@ object Ref {
     override def modifyState[B](state: State[A, B]): G[B] = trans(underlying.modifyState(state))
 
     override def access: G[(A, A => G[Boolean])] =
-      trans(F.compose[(A, ?)].compose[A => *].map(underlying.access)(trans(_)))
+      trans(F.compose[(A, *)].compose[A => *].map(underlying.access)(trans(_)))
   }
 
   implicit def catsInvariantForRef[F[_]: Functor]: Invariant[Ref[F, *]] =

--- a/core/shared/src/main/scala/cats/effect/internals/IOBracket.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOBracket.scala
@@ -140,7 +140,8 @@ private[effect] object IOBracket {
     private def applyRelease(e: ExitCase[Throwable]): IO[Unit] =
       IO.suspend {
         if (waitsForResult.compareAndSet(true, false))
-          release(e).redeemWith(ex => IO(p.success(())).flatMap(_ => IO.raiseError(ex)), _ => IO(p.success(())))
+          release(e)
+            .redeemWith[Unit](ex => IO(p.success(())).flatMap(_ => IO.raiseError(ex)), _ => IO { p.success(()); () })
         else
           IOFromFuture.apply(p.future)
       }

--- a/core/shared/src/main/scala/cats/effect/internals/IOConnection.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOConnection.scala
@@ -104,7 +104,7 @@ private[effect] object IOConnection {
         case list =>
           CancelUtils
             .cancelAll(list.iterator)
-            .redeemWith(ex => IO(p.success(())).flatMap(_ => IO.raiseError(ex)), _ => IO(p.success(())))
+            .redeemWith(ex => IO(p.success(())).flatMap(_ => IO.raiseError(ex)), _ => IO { p.success(()); () })
       }
     }
 

--- a/core/shared/src/main/scala/cats/effect/internals/IORunLoop.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IORunLoop.scala
@@ -68,7 +68,7 @@ private[effect] object IORunLoop {
     // For auto-cancellation
     var currentIndex = 0
 
-    do {
+    while ({
       currentIO match {
         case Bind(fa, bindNext) =>
           if (bFirst ne null) {
@@ -154,7 +154,8 @@ private[effect] object IORunLoop {
         if (conn.isCanceled) return
         currentIndex = 0
       }
-    } while (true)
+      true
+    }) ()
   }
 
   /**
@@ -170,7 +171,7 @@ private[effect] object IORunLoop {
     var hasUnboxed: Boolean = false
     var unboxed: AnyRef = null
 
-    do {
+    while ({
       currentIO match {
         case Bind(fa, bindNext) =>
           if (bFirst ne null) {
@@ -241,7 +242,8 @@ private[effect] object IORunLoop {
             bFirst = null
         }
       }
-    } while (true)
+      true
+    }) ()
     // $COVERAGE-OFF$
     null // Unreachable code
     // $COVERAGE-ON$
@@ -267,14 +269,15 @@ private[effect] object IORunLoop {
       return bFirst
 
     if (bRest eq null) return null
-    do {
+    while ({
       val next = bRest.pop()
       if (next eq null) {
         return null
       } else if (!next.isInstanceOf[IOFrame.ErrorHandler[_]]) {
         return next
       }
-    } while (true)
+      true
+    }) ()
     // $COVERAGE-OFF$
     null
     // $COVERAGE-ON$
@@ -290,13 +293,14 @@ private[effect] object IORunLoop {
       case _ =>
         if (bRest eq null) null
         else {
-          do {
+          while ({
             val ref = bRest.pop()
             if (ref eq null)
               return null
             else if (ref.isInstanceOf[IOFrame[_, _]])
               return ref.asInstanceOf[IOFrame[Any, IO[Any]]]
-          } while (true)
+            true
+          }) ()
           // $COVERAGE-OFF$
           null
           // $COVERAGE-ON$

--- a/core/shared/src/main/scala/cats/effect/internals/IOStart.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOStart.scala
@@ -32,7 +32,7 @@ private[effect] object IOStart {
       // Starting the source `IO`, with a new connection, because its
       // cancellation is now decoupled from our current one
       val conn2 = IOConnection()
-      val cb0 = { ea: Either[Throwable, A] =>
+      val cb0 = { (ea: Either[Throwable, A]) =>
         p.success(ea)
         ()
       }

--- a/core/shared/src/test/scala/cats/effect/AsyncTests.scala
+++ b/core/shared/src/test/scala/cats/effect/AsyncTests.scala
@@ -38,7 +38,7 @@ class AsyncTests extends AsyncFunSuite with Matchers {
   private def awaitEqual[A: Eq](t: IO[A], success: A): IO[Unit] =
     t.flatMap(a => if (Eq[A].eqv(a, success)) IO.unit else smallDelay *> awaitEqual(t, success))
 
-  private def run(t: IO[Unit]): Future[Assertion] = t.as(Succeeded).unsafeToFuture
+  private def run(t: IO[Unit]): Future[Assertion] = t.as(Succeeded).unsafeToFuture()
 
   test("F.parTraverseN(n)(collection)(f)") {
     val finalValue = 100

--- a/core/shared/src/test/scala/cats/effect/ConcurrentTests.scala
+++ b/core/shared/src/test/scala/cats/effect/ConcurrentTests.scala
@@ -38,7 +38,7 @@ class ConcurrentTests extends AsyncFunSuite with Matchers {
   private def awaitEqual[A: Eq](t: IO[A], success: A): IO[Unit] =
     t.flatMap(a => if (Eq[A].eqv(a, success)) IO.unit else smallDelay *> awaitEqual(t, success))
 
-  private def run(t: IO[Unit]): Future[Assertion] = t.as(Succeeded).unsafeToFuture
+  private def run(t: IO[Unit]): Future[Assertion] = t.as(Succeeded).unsafeToFuture()
 
   test("F.parTraverseN(n)(collection)(f)") {
     val finalValue = 100

--- a/core/shared/src/test/scala/cats/effect/IOAppTests.scala
+++ b/core/shared/src/test/scala/cats/effect/IOAppTests.scala
@@ -19,11 +19,10 @@ package effect
 
 import scala.concurrent.ExecutionContext
 import cats.effect.internals.{IOAppPlatform, TestUtils, TrampolineEC}
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.funsuite.AsyncFunSuite
 
-class IOAppTests extends AsyncFunSuite with Matchers with BeforeAndAfterAll with TestUtils {
+class IOAppTests extends AsyncFunSuite with Matchers with TestUtils {
   test("exits with specified code") {
     IOAppPlatform
       .mainFiber(Array.empty, Eval.now(implicitly[ContextShift[IO]]), Eval.now(implicitly[Timer[IO]]))(

--- a/core/shared/src/test/scala/cats/effect/IOAppTests.scala
+++ b/core/shared/src/test/scala/cats/effect/IOAppTests.scala
@@ -30,7 +30,7 @@ class IOAppTests extends AsyncFunSuite with Matchers with BeforeAndAfterAll with
         _ => IO.pure(ExitCode(42))
       )
       .flatMap(_.join)
-      .unsafeToFuture
+      .unsafeToFuture()
       .map(_ shouldEqual 42)
   }
 
@@ -40,7 +40,7 @@ class IOAppTests extends AsyncFunSuite with Matchers with BeforeAndAfterAll with
         args => IO.pure(ExitCode(args.mkString.toInt))
       )
       .flatMap(_.join)
-      .unsafeToFuture
+      .unsafeToFuture()
       .map(_ shouldEqual 123)
   }
 
@@ -49,7 +49,7 @@ class IOAppTests extends AsyncFunSuite with Matchers with BeforeAndAfterAll with
       IOAppPlatform
         .mainFiber(Array.empty, Eval.now(implicitly), Eval.now(implicitly))(_ => IO.raiseError(new Exception()))
         .flatMap(_.join)
-        .unsafeToFuture
+        .unsafeToFuture()
         .map(_ shouldEqual 1)
     }
   }

--- a/core/shared/src/test/scala/cats/effect/SyntaxTests.scala
+++ b/core/shared/src/test/scala/cats/effect/SyntaxTests.scala
@@ -27,7 +27,7 @@ object SyntaxTests extends AllCatsEffectSyntax {
     val _ = a
   }
 
-  def bracketSyntax[F[_]: Bracket[?[_], Throwable], A, B] = {
+  def bracketSyntax[F[_], A, B](implicit F: Bracket[F, Throwable]) = {
     val acquire = mock[F[A]]
     val use = mock[A => F[B]]
     val releaseCase = mock[(A, ExitCase[Throwable]) => F[Unit]]

--- a/core/shared/src/test/scala/cats/effect/concurrent/DeferredTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/DeferredTests.scala
@@ -39,7 +39,7 @@ class DeferredTests extends AsyncFunSuite with Matchers {
         .flatMap { p =>
           p.complete(0) *> p.get
         }
-        .unsafeToFuture
+        .unsafeToFuture()
         .map(_ shouldBe 0)
     }
 
@@ -48,7 +48,7 @@ class DeferredTests extends AsyncFunSuite with Matchers {
         .flatMap { p =>
           (p.complete(0) *> p.complete(1).attempt).product(p.get)
         }
-        .unsafeToFuture
+        .unsafeToFuture()
         .map {
           case (err, value) =>
             err.swap.toOption.get shouldBe an[IllegalStateException]
@@ -66,13 +66,13 @@ class DeferredTests extends AsyncFunSuite with Matchers {
         _ <- readGate.get
         res <- state.get
       } yield res
-      op.unsafeToFuture.map(_ shouldBe 2)
+      op.unsafeToFuture().map(_ shouldBe 2)
     }
   }
 
   def tryableTests(label: String, pc: TryableDeferredConstructor): Unit = {
     test(s"$label - tryGet returns None for unset Deferred") {
-      pc[Unit].flatMap(_.tryGet).unsafeToFuture.map(_ shouldBe None)
+      pc[Unit].flatMap(_.tryGet).unsafeToFuture().map(_ shouldBe None)
     }
 
     test(s"$label - tryGet returns Some() for set Deferred") {
@@ -82,7 +82,7 @@ class DeferredTests extends AsyncFunSuite with Matchers {
         result <- d.tryGet
       } yield result shouldBe Some(())
 
-      op.unsafeToFuture
+      op.unsafeToFuture()
     }
   }
 
@@ -108,7 +108,7 @@ class DeferredTests extends AsyncFunSuite with Matchers {
     } yield result
 
   test("concurrent - get - cancel before forcing") {
-    cancelBeforeForcing(Deferred.apply).unsafeToFuture.map(_ shouldBe None)
+    cancelBeforeForcing(Deferred.apply).unsafeToFuture().map(_ shouldBe None)
   }
 
   test("issue #380: complete doesn't block, test #1") {

--- a/core/shared/src/test/scala/cats/effect/concurrent/ExitCodeTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/ExitCodeTests.scala
@@ -24,13 +24,13 @@ import org.scalatestplus.scalacheck.Checkers
 
 class ExitCodeTests extends AnyFunSuite with Matchers with Checkers {
   test("fromInt(i) == fromInt(i & 0xff)") {
-    check { i: Int =>
+    check { (i: Int) =>
       ExitCode(i) == ExitCode(i & 0xff)
     }
   }
 
   test("code is in range from 0 to 255, inclusive") {
-    check { i: Int =>
+    check { (i: Int) =>
       val ec = ExitCode(i)
       ec.code >= 0 && ec.code < 256
     }

--- a/core/shared/src/test/scala/cats/effect/concurrent/RefTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/RefTests.scala
@@ -37,7 +37,7 @@ class RefTests extends AsyncFunSuite with Matchers {
   private def awaitEqual[A: Eq](t: IO[A], success: A): IO[Unit] =
     t.flatMap(a => if (Eq[A].eqv(a, success)) IO.unit else smallDelay *> awaitEqual(t, success))
 
-  private def run(t: IO[Unit]): Future[Assertion] = t.as(Succeeded).unsafeToFuture
+  private def run(t: IO[Unit]): Future[Assertion] = t.as(Succeeded).unsafeToFuture()
 
   test("concurrent modifications") {
     val finalValue = 100

--- a/core/shared/src/test/scala/cats/effect/concurrent/RefTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/RefTests.scala
@@ -53,7 +53,7 @@ class RefTests extends AsyncFunSuite with Matchers {
       getResult <- r.get
     } yield getAndSetResult == 0 && getResult == 1
 
-    run(op.map(_ shouldBe true))
+    run(op.map(_ shouldBe true).void)
   }
 
   test("access - successful") {
@@ -64,7 +64,7 @@ class RefTests extends AsyncFunSuite with Matchers {
       success <- setter(value + 1)
       result <- r.get
     } yield success && result == 1
-    run(op.map(_ shouldBe true))
+    run(op.map(_ shouldBe true).void)
   }
 
   test("access - setter should fail if value is modified before setter is called") {
@@ -76,7 +76,7 @@ class RefTests extends AsyncFunSuite with Matchers {
       success <- setter(value + 1)
       result <- r.get
     } yield !success && result == 5
-    run(op.map(_ shouldBe true))
+    run(op.map(_ shouldBe true).void)
   }
 
   test("access - setter should fail if called twice") {
@@ -89,7 +89,7 @@ class RefTests extends AsyncFunSuite with Matchers {
       cond2 <- setter(value + 1)
       result <- r.get
     } yield cond1 && !cond2 && result == 0
-    run(op.map(_ shouldBe true))
+    run(op.map(_ shouldBe true).void)
   }
 
   test("tryUpdate - modification occurs successfully") {
@@ -99,7 +99,7 @@ class RefTests extends AsyncFunSuite with Matchers {
       value <- r.get
     } yield result && value == 1
 
-    run(op.map(_ shouldBe true))
+    run(op.map(_ shouldBe true).void)
   }
 
   test("tryUpdate - should fail to update if modification has occurred") {
@@ -115,7 +115,7 @@ class RefTests extends AsyncFunSuite with Matchers {
       )
     } yield result
 
-    run(op.map(_ shouldBe false))
+    run(op.map(_ shouldBe false).void)
   }
 
   test("tryModifyState - modification occurs successfully") {
@@ -124,7 +124,7 @@ class RefTests extends AsyncFunSuite with Matchers {
       result <- r.tryModifyState(State.pure(1))
     } yield result.contains(1)
 
-    run(op.map(_ shouldBe true))
+    run(op.map(_ shouldBe true).void)
   }
 
   test("modifyState - modification occurs successfully") {
@@ -133,6 +133,6 @@ class RefTests extends AsyncFunSuite with Matchers {
       result <- r.modifyState(State.pure(1))
     } yield result == 1
 
-    run(op.map(_ shouldBe true))
+    run(op.map(_ shouldBe true).void)
   }
 }

--- a/core/shared/src/test/scala/cats/effect/concurrent/SemaphoreTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/SemaphoreTests.scala
@@ -37,7 +37,7 @@ class SemaphoreTests extends AsyncFunSuite with Matchers with EitherValues {
         .flatMap { s =>
           (0 until n).toList.traverse(_ => s.acquire).void *> s.available
         }
-        .unsafeToFuture
+        .unsafeToFuture()
         .map(_ shouldBe 0)
     }
 
@@ -50,7 +50,7 @@ class SemaphoreTests extends AsyncFunSuite with Matchers with EitherValues {
             t <- s.tryAcquire
           } yield t
         }
-        .unsafeToFuture
+        .unsafeToFuture()
         .map(_ shouldBe true)
     }
 
@@ -63,7 +63,7 @@ class SemaphoreTests extends AsyncFunSuite with Matchers with EitherValues {
             t <- s.tryAcquire
           } yield t
         }
-        .unsafeToFuture
+        .unsafeToFuture()
         .map(_ shouldBe false)
     }
 
@@ -149,7 +149,7 @@ class SemaphoreTests extends AsyncFunSuite with Matchers with EitherValues {
         .flatMap { s =>
           (acquires(s, permits), releases(s, permits)).parTupled *> s.count
         }
-        .unsafeToFuture
+        .unsafeToFuture()
         .map(_ shouldBe 0L)
     }
   }
@@ -165,7 +165,7 @@ class SemaphoreTests extends AsyncFunSuite with Matchers with EitherValues {
         // count stays at 2.
         s.acquireN(2L).timeout(1.milli).attempt *> s.release *> IO.sleep(10.millis) *> s.count
       }
-      .unsafeToFuture
+      .unsafeToFuture()
       .map(_ shouldBe 2L)
   }
 
@@ -178,7 +178,7 @@ class SemaphoreTests extends AsyncFunSuite with Matchers with EitherValues {
         // cancel, the permit count will be 2, otherwise 1
         s.withPermit(s.release).timeout(1.milli).attempt *> s.release *> IO.sleep(10.millis) *> s.count
       }
-      .unsafeToFuture
+      .unsafeToFuture()
       .map(_ shouldBe 1L)
   }
 

--- a/laws/shared/src/test/scala/cats/effect/FiberTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/FiberTests.scala
@@ -76,7 +76,7 @@ class FiberTests extends BaseTestsSuite {
       _ <- wait(joinFinalisersInstalled) *> joinFiber.cancel
     } yield ()
 
-    fa.unsafeToFuture
+    fa.unsafeToFuture()
     ec.tick()
 
     joinCanceled shouldBe true

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -114,7 +114,7 @@ class ResourceTests extends BaseTestsSuite {
         }
         .timeout(2.seconds)
 
-    val res = p.unsafeToFuture
+    val res = p.unsafeToFuture()
 
     ec.tick(3.seconds)
 


### PR DESCRIPTION
This is a set of changes that prepare for Dotty cross-building but are reasonable to do now:

* I've replaced kind-projector's `?` with `*`, [which will be supported in Dotty soon](https://github.com/lampepfl/dotty/pull/7775).
* Dotty is pickier about parentheses (which also helps readability and consistency in my view).
* Dotty doesn't support eta-expansion syntax for converting by-name parameters to `Function0`.
* Dotty warns on `final` on case objects, and it doesn't do anything on Scala 2.
* Dotty doesn't have `do-while`, and recommends the rewrite I've done here.
* In a few places we rely on Scala 2 value discarding, which I've changed to either `.void` or `; ()`.
* One test extends `BeforeAndAfterAll` but doesn't use any of its methods, and it was causing problems with my local Dotty build of ScalaTest, so I just removed it here.

After these changes (and #756) a few other things are necessary to get tests passing on Dotty (see [my branch here](https://github.com/travisbrown/cats-effect/commits/topic/dotty-experiment) for a complete list of the additional changes that are needed).

* Right now you have to publish Dotty locally from [my kind-projector branch](https://github.com/lampepfl/dotty/pull/7775).
* You also still need to publish ScalaTest locally if you want to run the tests.
* You have to use my [Simulacrum Scalafix rules](https://github.com/travisbrown/simulacrum-scalafix) to expand `@typeclass`.
* You have to use another of those Scalafix rules to expand kind-projector's polymorphic lambda value syntax, which isn't supported in my Dotty branch.
* There's a [bug with private constructors in Dotty](https://github.com/lampepfl/dotty/issues/8064) that you have to work around.
* There's a possible bug involving [type aliases](https://github.com/lampepfl/dotty/issues/8067) that also needs working around.
* There are a few places where Dotty can't infer types that Scala 2, or where you need to cast to `Any` (see [my `topic/dotty-experiment` branch](https://github.com/travisbrown/cats-effect/commits/topic/dotty-experiment) for details).

The good news is that if you make all of those changes and publish Dotty and ScalaTest locally, all tests pass on Dotty.