### PR TITLE
[Website docs] Fix home page path

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -323,7 +323,7 @@ lazy val siteSettings = Seq(
     file("README.md") -> ExtraMdFileConfig(
       "index.md",
       "home",
-      Map("section" -> "home", "position" -> "0")
+      Map("permalink" -> "/", "section" -> "home", "position" -> "0")
     )
   ),
   micrositeCompilingDocsTool := WithMdoc,

--- a/build.sbt
+++ b/build.sbt
@@ -323,7 +323,7 @@ lazy val siteSettings = Seq(
     file("README.md") -> ExtraMdFileConfig(
       "index.md",
       "home",
-      Map("permalink" -> "/", "section" -> "home", "position" -> "0")
+      Map("permalink" -> "/", "title" -> "Home", "section" -> "home", "position" -> "0")
     )
   ),
   micrositeCompilingDocsTool := WithMdoc,


### PR DESCRIPTION
Sets `permalink` property for root index page.

The new default use of `mdoc` in `sbt-microsites` led to some slight changes when using extra `.md` files. This change lets the site to serve again the root page correctly.