### PR TITLE
Fix Concurrency links to other pages

### DIFF
--- a/site/src/main/mdoc/concurrency/index.md
+++ b/site/src/main/mdoc/concurrency/index.md
@@ -6,8 +6,8 @@ position: 2
 
 # Concurrency
 
-- **[Concurency Basics](./basics.md)**: overview of important concepts related to Concurrency.
-- **[Deferred](./deferred.md)**: pure concurrency primitive built on top of `scala.concurrent.Promise`.
-- **[MVar](./mvar.md)**: a purely functional concurrency primitive that works like a concurrent queue
-- **[Ref](./ref.md)**: pure concurrency primitive built on top of `java.util.concurrent.atomic.AtomicReference`.
-- **[Semaphore](./semaphore.md)**: a pure functional semaphore.
+- **[Concurency Basics](./basics.html)**: overview of important concepts related to Concurrency.
+- **[Deferred](./deferred.html)**: pure concurrency primitive built on top of `scala.concurrent.Promise`.
+- **[MVar](./mvar.html)**: a purely functional concurrency primitive that works like a concurrent queue
+- **[Ref](./ref.html)**: pure concurrency primitive built on top of `java.util.concurrent.atomic.AtomicReference`.
+- **[Semaphore](./semaphore.html)**: a pure functional semaphore.


### PR DESCRIPTION
Not sure if it's the proper way to fix things, but they are leading to a non-existent page with `.md` suffix and works with `html` suffix here: https://typelevel.org/cats-effect/concurrency/