### PR TITLE
Docs: fix broken links; fixes #772

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ cats-effect is a [Typelevel](http://typelevel.org/) project. This means we embra
 
 ### Contributing documentation
 
-The sources for the cats-effect microsite can be found in `site/src/main/tut`.
+The sources for the cats-effect microsite can be found in `site/src/main/mdoc`.
 The menu structure is in `site/src/main/resources/microsite/data/menu.yml`.
 
 You can build the microsite with `sbt microsite/makeMicrosite`.

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import microsites.ExtraMdFileConfig
+import microsites.{ConfigYml, ExtraMdFileConfig}
+
 import scala.sys.process._
 import scala.xml.Elem
 import scala.xml.transform.{RewriteRule, RuleTransformer}
@@ -328,6 +329,9 @@ lazy val siteSettings = Seq(
       "home",
       Map("permalink" -> "/", "title" -> "Home", "section" -> "home", "position" -> "0")
     )
+  ),
+  micrositeConfigYaml := ConfigYml(
+    yamlCustomProperties = Map("plugins" -> List("jekyll-relative-links"))
   ),
   micrositeCompilingDocsTool := WithMdoc,
   mdocIn := (sourceDirectory in Compile).value / "mdoc",

--- a/site/Gemfile
+++ b/site/Gemfile
@@ -1,4 +1,5 @@
 source 'http://rubygems.org'
 
 gem "jekyll", ">= 3.2.1", "< 4.0.0"
+gem "jekyll-relative-links"
 gem "sass"

--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -27,6 +27,8 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
+    jekyll-relative-links (0.6.1)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-watch (2.2.1)
@@ -56,6 +58,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (>= 3.2.1, < 4.0.0)
+  jekyll-relative-links
   sass
 
 BUNDLED WITH

--- a/site/src/main/mdoc/concurrency/index.md
+++ b/site/src/main/mdoc/concurrency/index.md
@@ -6,8 +6,8 @@ position: 2
 
 # Concurrency
 
-- **[Concurency Basics](./basics.html)**: overview of important concepts related to Concurrency.
-- **[Deferred](./deferred.html)**: pure concurrency primitive built on top of `scala.concurrent.Promise`.
-- **[MVar](./mvar.html)**: a purely functional concurrency primitive that works like a concurrent queue
-- **[Ref](./ref.html)**: pure concurrency primitive built on top of `java.util.concurrent.atomic.AtomicReference`.
-- **[Semaphore](./semaphore.html)**: a pure functional semaphore.
+- **[Concurency Basics](./basics.md)**: overview of important concepts related to Concurrency.
+- **[Deferred](./deferred.md)**: pure concurrency primitive built on top of `scala.concurrent.Promise`.
+- **[MVar](./mvar.md)**: a purely functional concurrency primitive that works like a concurrent queue
+- **[Ref](./ref.md)**: pure concurrency primitive built on top of `java.util.concurrent.atomic.AtomicReference`.
+- **[Semaphore](./semaphore.md)**: a pure functional semaphore.

--- a/site/src/main/mdoc/concurrency/mvar.md
+++ b/site/src/main/mdoc/concurrency/mvar.md
@@ -49,8 +49,8 @@ It has these fundamental (atomic) operations:
 <p class="extra" markdown='1'>
 In this context "<i>asynchronous blocking</i>" means that we are not blocking
 any threads. Instead the implementation uses callbacks to notify clients
-when the operation has finished (notifications exposed by means of [Async](../typeclasses/async.html) or
-[Concurrent](../typeclasses/concurrent.html) data types such as [IO](../datatypes/io.html))
+when the operation has finished (notifications exposed by means of [Async](../typeclasses/async.md) or
+[Concurrent](../typeclasses/concurrent.md) data types such as [IO](../datatypes/io.md))
 and it thus works on top of JavaScript as well.
 </p>
 

--- a/site/src/main/mdoc/datatypes/index.md
+++ b/site/src/main/mdoc/datatypes/index.md
@@ -9,13 +9,13 @@ position: 1
 {:.responsive-pic}
 ![datatypes cheat sheet](../img/datatypes-cheat-sheet.png)
 
-### [IO](./io.md)
+### [IO](io.md)
 A data type for encoding synchronous and asynchronous side effects as pure values
 
-### [SyncIO](./syncio.md)
+### [SyncIO](syncio.md)
 A data type for encoding synchronous side effects as pure values
 
-### [Fiber](./fiber.md)
+### [Fiber](fiber.md)
 A pure result of a [Concurrent](../typeclasses/concurrent.md) data type being started concurrently and that can be either joined or canceled
 
 ```scala

--- a/site/src/main/mdoc/datatypes/io.md
+++ b/site/src/main/mdoc/datatypes/io.md
@@ -110,7 +110,7 @@ def fib(n: Int, a: Long = 0, b: Long = 1): IO[Long] =
   }
 ```
 
-`IO` implements all the typeclasses shown in the [hierarchy](../typeclasses/). Therefore
+`IO` implements all the typeclasses shown in the [hierarchy](../typeclasses/index.md). Therefore
 all those operations are available for `IO`, in addition to some
 others.
 

--- a/site/src/main/mdoc/datatypes/syncio.md
+++ b/site/src/main/mdoc/datatypes/syncio.md
@@ -8,7 +8,7 @@ scaladoc: "#cats.effect.SyncIO"
 
 A pure abstraction representing the intention to perform a side effect, where the result of that side effect is obtained synchronously.
 
-`SyncIO` is similar to [IO](./io.md), but does not support asynchronous computations. Consequently, a `SyncIO` can be run synchronously to obtain a result via `unsafeRunSync`. This is unlike `IO#unsafeRunSync`, which cannot be safely called in general. Doing so on the JVM blocks the calling thread while the async part of the computation is run and doing so on Scala.js throws an exception upon encountering an async boundary.
+`SyncIO` is similar to [IO](io.md), but does not support asynchronous computations. Consequently, a `SyncIO` can be run synchronously to obtain a result via `unsafeRunSync`. This is unlike `IO#unsafeRunSync`, which cannot be safely called in general. Doing so on the JVM blocks the calling thread while the async part of the computation is run and doing so on Scala.js throws an exception upon encountering an async boundary.
 
 ## Constructing SyncIO values
 


### PR DESCRIPTION
Motivation:

- Links to the relative markdown pages stopped working.

Modification:

- Add jekyll plugin to support relative links.
- Modify links to ".html" to ".md" to keep warning when file doesn't exist such as

```
warning: datatypes/index.md:12:5: Unknown link 'datatypes/io2.md', did you mean 'datatypes/io.md'?
### [IO](io2.md)
    ^^^^^^^^^^^^
```

It wouldn't happen if you point to an html.

Result:

- Relative links started to work and warnings are in place.