### PR TITLE
Using blocker in Resorce.fromAutoClosable

### DIFF
--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -20,6 +20,7 @@ package effect
 import cats.data.Kleisli
 import cats.effect.concurrent.Deferred
 import cats.effect.laws.discipline.arbitrary._
+import cats.effect.laws.util.TestContext
 import cats.implicits._
 import cats.kernel.laws.discipline.MonoidTests
 import cats.laws._
@@ -92,25 +93,58 @@ class ResourceTests extends BaseTestsSuite {
     }
   }
 
-  testAsync("resource from AutoCloseable is auto closed") { implicit ec =>
-    implicit val ctx: ContextShift[IO] = ec.ioContextShift
-
-    val blocker = Blocker.liftExecutionContext(ec)
-
+  test("resource from AutoCloseable is auto closed") {
     var closed = false
     val autoCloseable = new AutoCloseable {
       override def close(): Unit = closed = true
     }
 
     val result = Resource
-      .fromAutoCloseable(blocker)(IO(autoCloseable))
+      .fromAutoCloseable(IO(autoCloseable))
+      .use(_ => IO.pure("Hello world"))
+      .unsafeRunSync()
+
+    result shouldBe "Hello world"
+    closed shouldBe true
+  }
+
+  testAsync("resource from AutoCloseableBlocking is auto closed and executes in the blocking context") { implicit ec =>
+    implicit val ctx: ContextShift[IO] = ec.ioContextShift
+
+    val blockingEc = TestContext()
+    val blocker = Blocker.liftExecutionContext(blockingEc)
+
+    var closed = false
+    val autoCloseable = new AutoCloseable {
+      override def close(): Unit = closed = true
+    }
+
+    var acquired = false
+    val acquire = IO {
+      acquired = true
+      autoCloseable
+    }
+
+    val result = Resource
+      .fromAutoCloseableBlocking(blocker)(acquire)
       .use(_ => IO.pure("Hello world"))
       .unsafeToFuture()
 
+    // Check that acquire ran inside the blocking context.
     ec.tick()
+    acquired shouldBe false
+    blockingEc.tick()
+    acquired shouldBe true
 
-    result.value shouldBe Some(Success("Hello world"))
+    // Check that close was called and ran inside the blocking context.
+    ec.tick()
+    closed shouldBe false
+    blockingEc.tick()
     closed shouldBe true
+
+    // Check the final result.
+    ec.tick()
+    result.value shouldBe Some(Success("Hello world"))
   }
 
   testAsync("liftF") { implicit ec =>

--- a/site/src/main/mdoc/datatypes/resource.md
+++ b/site/src/main/mdoc/datatypes/resource.md
@@ -97,7 +97,7 @@ def readAllLines(bufferedReader: BufferedReader, blocker: Blocker)(implicit cs: 
   }
 
 def reader(file: File, blocker: Blocker)(implicit cs: ContextShift[IO]): Resource[IO, BufferedReader] =
-  Resource.fromAutoCloseable(blocker)(IO {
+  Resource.fromAutoCloseableBlocking(blocker)(IO {
       new BufferedReader(new FileReader(file))
     }
   )
@@ -115,7 +115,7 @@ import cats.effect._
 import cats.syntax.flatMap._
 
 def reader[F[_]](file: File, blocker: Blocker)(implicit F: Sync[F], cs: ContextShift[F]): Resource[F, BufferedReader] =
-  Resource.fromAutoCloseable(blocker)(F.delay {
+  Resource.fromAutoCloseableBlocking(blocker)(F.delay {
     new BufferedReader(new FileReader(file))
   })
 


### PR DESCRIPTION
Yesterday @mpilquist suggested in the gitter channel that most classes that implement `AutoClosable` are blocking in its construction and `close`. As such, those operations should be called using a **Blocker**. Thus, this makes `Resource.fromAutoClosable` conceptually _"broken"_.
This PR attempts to solve that problem.

I have a couple of questions:

+ Do you all agree that this should be the expected behavior or not?
+ ~I believe not all `AutoClosable` are blocking, should we ignore that minority just for sake of consistency? or maybe we should leave both alternatives?~
+ ~Assuming we decide to get rid of the old method, what should we do with it? It has to be preserved for binary compatibility, but it shouldn't be exposed for use anymore. I think we could deprecate it. However, @kubukoz suggests that it could be made `private` and that will preserve binary compatibility.~
+ ~The current implementation has the possibility of calling `blockOn` over acquire two times. If someone constructs it using the blocker itself. I do not know if that has any consequence or if we can just ignore it. In any case, I was thinking, why not use a _by-name_ parameter for it instead?~
+ ~I am not 100% happy with the test. First, I do not like the idea of using the same `ec` for the blocker, but the other option that will work for JS & JVM is global, but being a test I guess I am just overthinking. The other thing that bothers me, is if there is a way to check if `close` was executed inside the blocker.~
+ ~Maybe we should use `java.nio.file.Files.newBufferedReader` and `Path` in the documentation?~