### PR TITLE
Create `IOResourceApp` as an alternative to `IOApp`

### DIFF
--- a/core/js/src/main/scala/cats/effect/internals/IOResourceAppPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOResourceAppPlatform.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package internals
+
+import cats.implicits._
+import scala.concurrent.duration._
+import scala.scalajs.js
+
+private[effect] object IOResourceAppPlatform {
+  def main(args: Array[String], cs: Eval[ContextShift[IO]], timer: Eval[Timer[IO]])(
+    run: List[String] => Resource[IO, ExitCode]
+  ): Unit =
+    mainProcess(args, cs, timer)(run).unsafeRunAsync {
+      case Left(t) =>
+        Logger.reportFailure(t)
+        setExitCode(ExitCode.Error.code)
+      case Right(code) =>
+        setExitCode(code.code)
+    }
+
+  def mainProcess(args: Array[String], cs: Eval[ContextShift[IO]], timer: Eval[Timer[IO]])(
+    run: List[String] => Resource[IO, ExitCode]
+  ): IO[ExitCode] =
+    run(args.toList)
+      .evalMap(exitCode => runKeepAlive(cs, timer)(IO(exitCode)))
+      .allocated
+      .flatMap {
+        case (exitCode, shutdownAction) =>
+          installHandler(shutdownAction).as(exitCode)
+      }
+      .handleErrorWith { e =>
+        IO {
+          Logger.reportFailure(e)
+          ExitCode.Error
+        }
+      }
+
+  /**
+   * Sets the exit code with `process.exitCode = code` for runtimes
+   * that support it.  This allows a graceful shutdown with a specific
+   * exit code.
+   *
+   * If the call is not supported, does a `sys.exit(code)` on any
+   * non-zero exit code.
+   *
+   * @see https://nodejs.org/api/process.html#process_process_exitcode
+   **/
+  private def setExitCode(code: Int): Unit =
+    try js.Dynamic.global.process.exitCode = code
+    catch {
+      case _: js.JavaScriptException =>
+        if (code != 0) sys.exit(code)
+    }
+
+  def runKeepAlive(contextShift: Eval[ContextShift[IO]], timer: Eval[Timer[IO]]): IO[ExitCode] => IO[ExitCode] =
+    process => {
+      // An infinite heartbeat to keep main alive.  This is similar to
+      // `IO.never`, except `IO.never` doesn't schedule any tasks and is
+      // insufficient to keep main alive.  The tick is fast enough that
+      // it isn't silently discarded, as longer ticks are, but slow
+      // enough that we don't interrupt often.  1 hour was chosen
+      // empirically.
+      def keepAlive: IO[Nothing] = timer.value.sleep(1.hour) >> keepAlive
+
+      val program = process.handleErrorWith { t =>
+        IO(Logger.reportFailure(t)) *> IO.pure(ExitCode.Error)
+      }
+
+      IO.race(keepAlive, program)(contextShift.value)
+        .flatMap {
+          case Left(_) =>
+            // This case is unreachable, but scalac won't let us omit it.
+            IO.raiseError(new AssertionError("IOApp keep alive failed unexpectedly."))
+          case Right(exitCode) =>
+            IO.pure(exitCode)
+        }
+    }
+
+  val defaultTimer: Timer[IO] = IOTimer.global
+  val defaultContextShift: ContextShift[IO] = IOContextShift.global
+
+  private def installHandler(shutdownAction: IO[Unit]): IO[Unit] = {
+    def handler(code: Int) =
+      () =>
+        shutdownAction.unsafeRunAsync { result =>
+          result.swap.foreach(Logger.reportFailure)
+          sys.exit(code + 128)
+      }
+
+    IO {
+      if (!js.isUndefined(js.Dynamic.global.process)) {
+        val process = js.Dynamic.global.process
+        process.on("SIGHUP", handler(1))
+        process.on("SIGINT", handler(2))
+        process.on("SIGTERM", handler(15))
+        ()
+      }
+    }
+  }
+}

--- a/core/js/src/main/scala/cats/effect/internals/IOResourceAppPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOResourceAppPlatform.scala
@@ -101,7 +101,7 @@ private[effect] object IOResourceAppPlatform {
         shutdownAction.unsafeRunAsync { result =>
           result.swap.foreach(Logger.reportFailure)
           sys.exit(code + 128)
-      }
+        }
 
     IO {
       if (!js.isUndefined(js.Dynamic.global.process)) {

--- a/core/jvm/src/main/scala/cats/effect/internals/IOResourceAppPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOResourceAppPlatform.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package internals
+
+import cats.Eval
+import cats.effect.{ContextShift, ExitCode, IO, Resource, Timer}
+
+private[effect] object IOResourceAppPlatform {
+  def main(args: Array[String], contextShift: Eval[ContextShift[IO]], timer: Eval[Timer[IO]])(
+    run: List[String] => Resource[IO, ExitCode]
+  ): Unit = {
+    val code: Int = mainProcess(args, contextShift, timer)(run).unsafeRunSync().code
+    if (code == 0) {
+      // Return naturally from main. This allows any non-daemon
+      // threads to gracefully complete their work, and managed
+      // environments to execute their own shutdown hooks.
+      ()
+    } else {
+      sys.exit(code)
+    }
+  }
+
+  def mainProcess(args: Array[String], cs: Eval[ContextShift[IO]], timer: Eval[Timer[IO]])(
+    run: List[String] => Resource[IO, ExitCode]
+  ): IO[ExitCode] = {
+    val _ = cs.hashCode() + timer.hashCode()
+    run(args.toList).allocated
+      .flatMap {
+        case (exitCode, shutdownAction) =>
+          installHook(shutdownAction).map(_ => exitCode)
+      }
+      .handleErrorWith { e =>
+        IO {
+          Logger.reportFailure(e)
+          ExitCode.Error
+        }
+      }
+  }
+
+  private def installHook(shutdownAction: IO[Unit]): IO[Unit] =
+    IO {
+      sys.addShutdownHook {
+        // Should block the thread until all finalizers are executed
+        shutdownAction.unsafeRunSync()
+      }
+      ()
+    }
+}

--- a/core/shared/src/main/scala/cats/effect/IOResourceApp.scala
+++ b/core/shared/src/main/scala/cats/effect/IOResourceApp.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+
+import cats.Eval
+
+import cats.effect.internals.{IOAppPlatform, IOResourceAppPlatform}
+
+trait IOResourceApp {
+
+  /**
+   * Produces the `Resource[IO, ExitCode]` to be run as an app.
+   *
+   * @return the [[cats.effect.ExitCode]] the JVM exits with
+   */
+  def run(args: List[String]): Resource[IO, ExitCode]
+
+  /**
+   * The main method that runs the `IO` returned by [[run]] and exits
+   * the app with the resulting code on completion.
+   */
+  def main(args: Array[String]): Unit =
+    IOResourceAppPlatform.main(args, Eval.later(contextShift), Eval.later(timer))(run)
+
+  /**
+   * Provides an implicit [[ContextShift]] for the app.
+   *
+   * The default on top of the JVM is lazily constructed as a fixed
+   * thread pool based on number available of available CPUs (see
+   * `PoolUtils`).
+   *
+   * On top of JavaScript, the global execution context is used
+   * (i.e. `scala.concurrent.ExecutionContext.Implicits.global`).
+   *
+   * Users can override this value in order to customize the main
+   * thread-pool on top of the JVM, or to customize the run-loop on
+   * top of JavaScript.
+   */
+  implicit protected def contextShift: ContextShift[IO] =
+    IOAppPlatform.defaultContextShift
+
+  /**
+   * Provides an implicit [[Timer]] for the app.
+   *
+   * Users can override this value in order to customize the
+   * underlying scheduler being used.
+   *
+   * The default on top of the JVM uses an internal scheduler built with Java's
+   * [[https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executors.html#newScheduledThreadPool-int- Executors.newScheduledThreadPool]]
+   * (configured with one or two threads) and that defers the execution of the
+   * scheduled ticks (the bind continuations get shifted) to the app's [[contextShift]].
+   *
+   * On top of JavaScript the default timer will simply use the standard
+   * [[https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout setTimeout]].
+   */
+  implicit protected def timer: Timer[IO] =
+    IOAppPlatform.defaultTimer
+}

--- a/core/shared/src/main/scala/cats/effect/IOResourceApp.scala
+++ b/core/shared/src/main/scala/cats/effect/IOResourceApp.scala
@@ -22,7 +22,6 @@ import cats.Eval
 import cats.effect.internals.{IOAppPlatform, IOResourceAppPlatform}
 
 trait IOResourceApp {
-
   /**
    * Produces the `Resource[IO, ExitCode]` to be run as an app.
    *

--- a/core/shared/src/test/scala/cats/effect/IOResourceAppTests.scala
+++ b/core/shared/src/test/scala/cats/effect/IOResourceAppTests.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+
+import scala.concurrent.ExecutionContext
+import cats.effect.internals.{IOResourceAppPlatform, TestUtils, TrampolineEC}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.funsuite.AsyncFunSuite
+
+class IOResourceAppTests extends AsyncFunSuite with Matchers with TestUtils {
+  test("exits with specified code") {
+    IOResourceAppPlatform
+      .mainProcess(Array.empty, Eval.now(implicitly[ContextShift[IO]]), Eval.now(implicitly[Timer[IO]]))(
+        _ => Resource.pure[IO, ExitCode](ExitCode(42))
+      )
+      .unsafeToFuture()
+      .map(_.code shouldEqual 42)
+  }
+
+  test("accepts arguments") {
+    IOResourceAppPlatform
+      .mainProcess(Array("1", "2", "3"), Eval.now(implicitly), Eval.now(implicitly))(
+        args => Resource.pure[IO, ExitCode](ExitCode(args.mkString.toInt))
+      )
+      .unsafeToFuture()
+      .map(_.code shouldEqual 123)
+  }
+
+  test("raised error exits with 1") {
+    silenceSystemErr {
+      IOResourceAppPlatform
+        .mainProcess(Array.empty, Eval.now(implicitly), Eval.now(implicitly))(
+          _ => Resource.liftF(IO.raiseError(new Exception()))
+        )
+        .unsafeToFuture()
+        .map(_.code shouldEqual 1)
+    }
+  }
+
+  implicit override def executionContext: ExecutionContext = TrampolineEC.immediate
+  implicit val timer: Timer[IO] = IO.timer(executionContext)
+  implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
+}


### PR DESCRIPTION
Create an `IOResourceApp` as an alternative to `IOApp`, implemented by providing the method:
```scala
def run(args: List[String]): Resource[IO, ExitCode]
```

The `IOApp` seems to shut down by doing the equivalent of a `kill -9` by running `Fiber.cancel`.

Given that I (and probably quite a few other people) use `Resource`s to create and run their services, it seemed to make more sense to use the `Resource.allocated` method to start a server and add a system shutdown hook using the `F[Unit]` shutdown function returned from `allocated`. This allows us to return a `Resource[IO, ExitCode]` from the `main` method rather than a `IO[ExitCode]`, and also negate the need to run `.use(_ => IO.never)` to convert a `Resource[IO, _]` to `IO[ExitCode]` in `IOApp`.

I've done a little testing with a local app and it seems to behave in a sane way, in that it shuts down `Resource`s when the app is shutdown.

I realise the js code might be very shonky/completely unusable, but I've done as best as I can to replicate (read "blatantly copy-and-paste") from the `IOAppPlatform` implementations, and the tests pass so 🤷‍♂

More than happy to hear any feedback. If things look vaguely sane it would make sense to move the duplicated code I've copied from `IOApp*`