### PR TITLE
Add getAndUpdate, updateAndGet to Ref

### DIFF
--- a/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
@@ -239,8 +239,6 @@ object Ref {
     def set(a: A): F[Unit] = F.delay(ar.set(a))
 
     override def getAndSet(a: A): F[A] = F.delay(ar.getAndSet(a))
-    override def updateAndGet(f: A => A): F[A] = F.delay(ar.updateAndGet(f(_)))
-    override def getAndUpdate(f: A => A): F[A] = F.delay(ar.getAndUpdate(f(_)))
 
     def access: F[(A, A => F[Boolean])] = F.delay {
       val snapshot = ar.get
@@ -259,7 +257,9 @@ object Ref {
       else None
     }
 
-    def update(f: A => A): F[Unit] = updateAndGet(f).void
+    def update(f: A => A): F[Unit] = modify { a =>
+      (f(a), ())
+    }
 
     def modify[B](f: A => (A, B)): F[B] = {
       @tailrec

--- a/core/shared/src/test/scala/cats/effect/concurrent/RefTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/RefTests.scala
@@ -56,6 +56,26 @@ class RefTests extends AsyncFunSuite with Matchers {
     run(op.map(_ shouldBe true).void)
   }
 
+  test("getAndUpdate - successful") {
+    val op = for {
+      r <- Ref[IO].of(0)
+      getAndUpdateResult <- r.getAndUpdate(_ + 1)
+      getResult <- r.get
+    } yield getAndUpdateResult == 0 && getResult == 1
+
+    run(op.map(_ shouldBe true).void)
+  }
+
+  test("updateAndGet - successful") {
+    val op = for {
+      r <- Ref[IO].of(0)
+      updateAndGetResult <- r.updateAndGet(_ + 1)
+      getResult <- r.get
+    } yield updateAndGetResult == 1 && getResult == 1
+
+    run(op.map(_ shouldBe true).void)
+  }
+
   test("access - successful") {
     val op = for {
       r <- Ref[IO].of(0)


### PR DESCRIPTION
Leaving `setAndGet(a: A): F[A]` out because it's useless (the parameter you pass is the return value).