### PR TITLE
Add a bunch of useful functions directly on IO

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1362,6 +1362,9 @@ object IO extends IOInstances {
       case Left(err) => raiseError(err)
     }
 
+  /**
+   * Lifts an `Option[A]` into the `IO[A]` context, raising the throwable if the option is empty.
+   */
   def fromOption[A](option: Option[A])(orElse: => Throwable): IO[A] = option match {
     case None        => raiseError(orElse)
     case Some(value) => pure(value)

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -663,7 +663,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
   /**
    * Replaces failures in this IO with [[scala.None]].
    */
-  def option: IO[Option[A]] = map(Some(_)).handleErrorWith(_ => IO.none)
+  def option: IO[Option[A]] = redeem(_ => None, Some(_))
 
   /**
    * Handle any error, potentially recovering from it, by mapping it to another

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -679,8 +679,8 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * If [[parProduct]] is canceled, both actions are canceled.
    * Failure in either of the IOs will cancel the other one.
    *  */
-  def parProduct[B](another: IO[B])(implicit cs: ContextShift[IO]): IO[(A, B)] =
-    IO.Par.unwrap(IO.parApplicative.product(IO.Par(this), IO.Par(another)))
+  def parProduct[B](another: IO[B])(implicit p: NonEmptyParallel[IO]): IO[(A, B)] =
+    p.sequential(p.apply.product(p.parallel(this), p.parallel(another)))
 
   /**
    * Returns a new value that transforms the result of the source,
@@ -771,14 +771,14 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
    * Failure in either of the IOs will cancel the other one.
    * If the whole computation is canceled, both actions are also canceled.
    * */
-  def &>[B](another: IO[B])(implicit cs: ContextShift[IO]): IO[B] =
-    IO.Par.unwrap(IO.parApplicative.productR(IO.Par(this))(IO.Par(another)))
+  def &>[B](another: IO[B])(implicit p: NonEmptyParallel[IO]): IO[B] =
+    p.parProductR(this)(another)
 
   /**
    * Like [[&>]], but keeps the result of the source.
    * */
-  def <&[B](another: IO[B])(implicit cs: ContextShift[IO]): IO[A] =
-    another &> this
+  def <&[B](another: IO[B])(implicit p: NonEmptyParallel[IO]): IO[A] =
+    p.parProductL(this)(another)
 }
 
 abstract private[effect] class IOParallelNewtype extends internals.IOTimerRef with internals.IOCompanionBinaryCompat {

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -752,7 +752,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
   def void: IO[Unit] = map(_ => ())
 
   /**
-   * Run the current IO, then run [[another]], keeping its result.
+   * Runs the current IO, then run [[another]], keeping its result.
    * The result of [[this]] is ignored.
    * */
   def *>[B](another: IO[B]): IO[B] = flatMap(_ => another)
@@ -763,7 +763,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
   def <*[B](another: IO[B]): IO[A] = flatMap(another.as(_))
 
   /**
-   * Run the current IO and [[another]] in parallel.
+   * Runs the current IO and [[another]] in parallel.
    * The result of [[this]] is ignored.
    *
    * Failure in either of the IOs will cancel the other one.
@@ -1360,7 +1360,7 @@ object IO extends IOInstances {
       case Left(err) => raiseError(err)
     }
 
-  def fromOption[A](orElse: => Throwable)(option: Option[A]): IO[A] = option match {
+  def fromOption[A](option: Option[A])(orElse: => Throwable): IO[A] = option match {
     case None        => raiseError(orElse)
     case Some(value) => pure(value)
   }

--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/arbitrary.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/arbitrary.scala
@@ -19,7 +19,6 @@ package effect
 package laws
 package discipline
 
-import cats.syntax.all._
 import cats.effect.IO.Par
 import cats.effect.internals.IORunLoop
 import org.scalacheck.Arbitrary.{arbitrary => getArbitrary}

--- a/site/src/main/mdoc/concurrency/basics.md
+++ b/site/src/main/mdoc/concurrency/basics.md
@@ -240,7 +240,6 @@ Let's introduce asynchronous boundaries:
 ```scala mdoc:compile-only
 import java.util.concurrent.Executors
 import cats.effect.{ContextShift, Fiber, IO}
-import cats.syntax.apply._
 import scala.concurrent.ExecutionContext
 
 val ecOne = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor())

--- a/site/src/main/mdoc/datatypes/fiber.md
+++ b/site/src/main/mdoc/datatypes/fiber.md
@@ -34,7 +34,6 @@ Usage example:
 
 ```scala mdoc:reset:silent
 import cats.effect.{ContextShift, IO}
-import cats.syntax.apply._
 
 import scala.concurrent.ExecutionContext
 

--- a/site/src/main/mdoc/datatypes/io.md
+++ b/site/src/main/mdoc/datatypes/io.md
@@ -61,12 +61,12 @@ it is sequenced in the monadic chain.
 
 `IO` can suspend side effects and is thus a lazily evaluated data type, being many times compared with `Future` from the standard library and to understand the landscape in terms of the evaluation model (in Scala), consider this classification:
 
-|                    |        Eager        |            Lazy            |
-|:------------------:|:-------------------:|:--------------------------:|
-| **Synchronous**    |          A          |           () => A          |
-|                    |                     | [Eval[A]](https://typelevel.org/cats/datatypes/eval.html) |
-| **Asynchronous**   | (A => Unit) => Unit | () => (A => Unit) => Unit  |
-|                    |      Future[A]      |          IO[A]             |
+|                  |        Eager        |                           Lazy                            |
+| :--------------: | :-----------------: | :-------------------------------------------------------: |
+| **Synchronous**  |          A          |                          () => A                          |
+|                  |                     | [Eval[A]](https://typelevel.org/cats/datatypes/eval.html) |
+| **Asynchronous** | (A => Unit) => Unit |                 () => (A => Unit) => Unit                 |
+|                  |      Future[A]      |                           IO[A]                           |
 
 In comparison with Scala's `Future`, the `IO` data type preserves _referential transparency_ even when dealing with side effects and is lazily evaluated. In an eager language like Scala, this is the difference between a result and the function producing it.
 
@@ -260,7 +260,6 @@ certain time duration:
 
 ```scala mdoc:silent
 import java.util.concurrent.ScheduledExecutorService
-import cats.syntax.functor._
 import scala.concurrent.duration._
 
 def delayedTick(d: FiniteDuration)
@@ -337,7 +336,6 @@ asynchronous boundaries:
 
 ```scala mdoc:reset:silent
 import cats.effect._
-import cats.implicits._
 
 def fib(n: Int, a: Long, b: Long)(implicit cs: ContextShift[IO]): IO[Long] =
   IO.suspend {
@@ -378,7 +376,6 @@ asynchronous boundaries. It can be achieved in the following way:
 
 ```scala mdoc:reset:silent
 import cats.effect.{ContextShift, IO}
-import cats.implicits._
 import scala.concurrent.ExecutionContext
 
 implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
@@ -420,7 +417,6 @@ builder. The `delayedTick` example making use of the Java's
 import java.util.concurrent.ScheduledExecutorService
 
 import cats.effect.IO
-import cats.syntax.functor._
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -499,7 +495,6 @@ import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 
 import cats.effect.IO
-import cats.syntax.functor._
 
 import scala.concurrent.ExecutionContext
 import scala.io.Source
@@ -543,7 +538,6 @@ be tempted to do something like this:
 import java.io._
 
 import cats.effect.IO
-import cats.syntax.functor._
 
 import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
@@ -576,7 +570,6 @@ import java.io._
 import java.util.concurrent.atomic.AtomicBoolean
 
 import cats.effect.IO
-import cats.syntax.functor._
 
 import scala.util.control.NonFatal
 import scala.concurrent.ExecutionContext
@@ -639,7 +632,6 @@ Example:
 
 ```scala mdoc:reset:silent
 import cats.effect.{ContextShift, IO}
-import cats.syntax.apply._
 
 import scala.concurrent.ExecutionContext
 
@@ -677,7 +669,6 @@ this kind of code is impure and should be used with care:
 
 ```scala mdoc:reset:silent
 import cats.effect.IO
-import cats.syntax.apply._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -720,7 +711,6 @@ canceled:
 
 ```scala mdoc:reset:silent
 import cats.effect.IO
-import cats.syntax.apply._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -754,7 +744,6 @@ This operation is very similar to `IO.shift`, as it can be dropped in
 
 ```scala mdoc:reset:silent
 import cats.effect.IO
-import cats.syntax.apply._
 
 def fib(n: Int, a: Long, b: Long): IO[Long] =
   IO.suspend {
@@ -932,7 +921,6 @@ Via the `bracket` operation we can easily describe the above:
 import java.io._
 
 import cats.effect.IO
-import cats.syntax.functor._
 
 def readFirstLine(file: File): IO[String] =
   IO(new BufferedReader(new FileReader(file))).bracket { in =>
@@ -963,8 +951,6 @@ on cancellation as well. Consider this sample:
 import java.io._
 
 import cats.effect.{ContextShift, IO}
-import cats.syntax.apply._
-import cats.syntax.functor._
 
 import scala.concurrent.ExecutionContext
 
@@ -1009,8 +995,6 @@ might be needed to prevent it:
 import java.io._
 
 import cats.effect.{ContextShift, IO}
-import cats.syntax.apply._
-import cats.syntax.functor._
 
 import scala.concurrent.ExecutionContext
 
@@ -1187,7 +1171,6 @@ For example here's a way to implement retries with exponential back-off:
 
 ```scala mdoc:reset:silent
 import cats.effect.{IO, Timer}
-import cats.syntax.apply._
 
 import scala.concurrent.duration._
 
@@ -1243,7 +1226,6 @@ IO.shift.flatMap(_ => task)
 Or using `Cats` syntax:
 
 ```scala mdoc:silent
-import cats.syntax.apply._
 
 IO.shift *> task
 // equivalent to

--- a/site/src/main/mdoc/datatypes/ioapp.md
+++ b/site/src/main/mdoc/datatypes/ioapp.md
@@ -20,7 +20,6 @@ described by `IO`), you have to do something like this:
 
 ```scala mdoc:silent
 import cats.effect._
-import cats.syntax.all._
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
 
@@ -44,7 +43,6 @@ You can now use `cats.effect.IOApp` to describe pure programs:
 
 ```scala mdoc:reset:silent
 import cats.effect._
-import cats.syntax.all._
 
 object Main extends IOApp {
 
@@ -92,7 +90,6 @@ For example:
 ```scala mdoc:reset:silent
 import cats.effect.ExitCase.Canceled
 import cats.effect._
-import cats.syntax.all._
 import scala.concurrent.duration._
 
 object Main extends IOApp {

--- a/site/src/main/mdoc/datatypes/resource.md
+++ b/site/src/main/mdoc/datatypes/resource.md
@@ -18,7 +18,7 @@ abstract class Resource[F[_], A] {
 }
 ```
 
-Nested resources are released in reverse order of acquisition. Outer resources are released even if an inner use or release fails.
+Nested resources are released in reverse order of acquisition. Outer resources are released even if an inner acquisition, use or release fails.
 
 You can lift any `F[A]` with an `Applicative` instance into a `Resource[F, A]` with a no-op release via `Resource.liftF`:
 
@@ -34,7 +34,6 @@ Moreover it's possible to apply further effects to the wrapped resource without 
 
 ```scala mdoc:reset
 import cats.effect.{IO, Resource}
-import cats.implicits._
 
 val acquire: IO[String] = IO(println("Acquire cats...")) *> IO("cats")
 val release: String => IO[Unit] = _ => IO(println("...release everything"))
@@ -50,7 +49,6 @@ Resource.make(acquire)(release).evalMap(addDogs).use(report).unsafeRunSync
 
 ```scala mdoc:reset:silent
 import cats.effect.{IO, Resource}
-import cats.implicits._
 
 def mkResource(s: String) = {
   val acquire = IO(println(s"Acquiring $s")) *> IO.pure(s)

--- a/site/src/main/mdoc/datatypes/timer.md
+++ b/site/src/main/mdoc/datatypes/timer.md
@@ -36,7 +36,6 @@ As mentioned in the `IO` documentation, there's a default instance of `Timer[IO]
 import java.util.concurrent.ScheduledExecutorService
 
 import cats.effect.{IO, Timer, Clock}
-import cats.syntax.functor._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 


### PR DESCRIPTION
One of the factors in attracting new users is discoverability. I think some of the methods that really show the power of the IO data type are really hard to discover for newcomers, for example:

- run these two actions in parallel
- schedule this IO for later

This PR adds a couple of methods:
- right and left shark (seriously, it's really good to make them very visible!)
- `&>`, `<&`, `parProduct`
- `delayBy`
- `as` (with a lazy parameter, which is an improvement over the functor syntax anyway)
- `io.option` (catching throwables to options), `IO.none[A]: IO[Option[A]]`, `IO.fromOption`

I also noticed the methods we already have aren't really sorted, so as another PR I'd like to order them alphabetically (there were no symbolic methods so I put the operators at the end).

I'm aware this will likely spark a discussion around how rich we want the API to be. If you consider some of these redundant, or have ideas for other methods we could add directly to IO - I'm all ears!