### PR TITLE
Remove Bracket constraint from Resource.mapK

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -204,13 +204,20 @@ sealed abstract class Resource[+F[_], +A] {
   def map[G[x] >: F[x], B](f: A => B)(implicit F: Applicative[G]): Resource[G, B] =
     flatMap(a => Resource.pure[G, B](f(a)))
 
+  @deprecated("Use the overload that doesn't require Bracket", "2.2.0")
+  private[effect] def mapK[G[x] >: F[x], H[_]](f: G ~> H,
+                                               B: Bracket[G, Throwable],
+                                               D: Defer[H],
+                                               G: Applicative[H]): Resource[H, A] =
+    this.mapK[G, H](f)(D, G)
+
   /**
    * Given a natural transformation from `F` to `G`, transforms this
    * Resource from effect `F` to effect `G`.
    */
   def mapK[G[x] >: F[x], H[_]](
     f: G ~> H
-  )(implicit B: Bracket[G, Throwable], D: Defer[H], G: Applicative[H]): Resource[H, A] =
+  )(implicit D: Defer[H], G: Applicative[H]): Resource[H, A] =
     this match {
       case Allocate(resource) =>
         Allocate(f(resource).map { case (a, r) => (a, r.andThen(u => f(u))) })


### PR DESCRIPTION
As far as I could see, in the current form it's only used to satisfy the same constraint when calling `mapK` recursively.

I added an overload and made the old one private, so code outside of CE shouldn't be hit with any incompatibility. I had to merge the argument lists to reduce the ambiguity locally, but it compiles to the same signature in JVM bytecode, so we should be good.