### PR TITLE
WIP: Fiber local state PoC

### DIFF
--- a/core/js/src/main/scala/cats/effect/internals/IOTimer.scala
+++ b/core/js/src/main/scala/cats/effect/internals/IOTimer.scala
@@ -33,7 +33,7 @@ final private[internals] class IOTimer(ec: ExecutionContext) extends Timer[IO] {
 
   def sleep(timespan: FiniteDuration): IO[Unit] =
     IO.Async(new IOForkedStart[Unit] {
-      def apply(conn: IOConnection, cb: Either[Throwable, Unit] => Unit): Unit = {
+      def apply(conn: IOConnection, ctx: IOContext, cb: Either[Throwable, Unit] => Unit): Unit = {
         val task = setTimeout(timespan.toMillis, ec, new ScheduledTick(conn, cb))
         // On the JVM this would need a ForwardCancelable,
         // but not on top of JS as we don't have concurrency

--- a/core/jvm/src/main/scala/cats/effect/internals/Example.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/Example.scala
@@ -27,12 +27,12 @@ object Example extends IOApp {
   def program: IO[Unit] =
     for {
       ref <- FiberRef.of(5)
-      a1  <- ref.get
-      _   <- print(a1)
-      _   <- ref.set(10)
-      _   <- IO.shift
-      a2  <- ref.get
-      _   <- print(a2)
+      a1 <- ref.get
+      _ <- print(a1)
+      _ <- ref.set(10)
+      _ <- IO.shift
+      a2 <- ref.get
+      _ <- print(a2)
     } yield ()
 
   override def run(args: List[String]): IO[ExitCode] =

--- a/core/jvm/src/main/scala/cats/effect/internals/Example.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/Example.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.internals
+
+import cats.effect.{ExitCode, FiberRef, IO, IOApp}
+
+object Example extends IOApp {
+
+  def print(msg: Int): IO[Unit] =
+    IO.delay(println(msg))
+
+  // Should print 5 and then 10
+  def program: IO[Unit] =
+    for {
+      ref <- FiberRef.of(5)
+      a1  <- ref.get
+      _   <- print(a1)
+      _   <- ref.set(10)
+      _   <- IO.shift
+      a2  <- ref.get
+      _   <- print(a2)
+    } yield ()
+
+  override def run(args: List[String]): IO[ExitCode] =
+    program.as(ExitCode.Success)
+}

--- a/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
@@ -38,7 +38,7 @@ final private[internals] class IOTimer private (ec: ExecutionContext, sc: Schedu
 
   override def sleep(timespan: FiniteDuration): IO[Unit] =
     IO.Async(new IOForkedStart[Unit] {
-      def apply(conn: IOConnection, cb: T[Unit]): Unit = {
+      def apply(conn: IOConnection, ctx: IOContext, cb: T[Unit]): Unit = {
         // Doing what IO.cancelable does
         val ref = ForwardCancelable()
         conn.push(ref.cancel)

--- a/core/shared/src/main/scala/cats/effect/FiberRef.scala
+++ b/core/shared/src/main/scala/cats/effect/FiberRef.scala
@@ -16,15 +16,15 @@
 
 package cats.effect
 
-import cats.effect.internals.{FiberRefId, IOFiberRef}
+import cats.effect.internals.IOFiberRef
 
-final class FiberRef[A] private (refId: FiberRefId, initial: A) {
+final class FiberRef[A] private (initial: A) {
 
   def get: IO[A] =
-    IOFiberRef.get(refId).map(_.getOrElse(initial))
+    IOFiberRef.get(this).map(_.getOrElse(initial))
 
   def set(value: A): IO[Unit] =
-    IOFiberRef.set(refId, value)
+    IOFiberRef.set(this, value)
 
   def getAndSet(value: A): IO[A] =
     get.flatMap { a =>
@@ -61,9 +61,10 @@ final class FiberRef[A] private (refId: FiberRefId, initial: A) {
 
 object FiberRef {
 
+  def unsafe[A](initial: A): FiberRef[A] =
+    new FiberRef[A](initial)
+
   def of[A](initial: A): IO[FiberRef[A]] =
-    for {
-      refId <- IOFiberRef.allocate
-    } yield new FiberRef[A](refId, initial)
+    IO.delay(unsafe(initial))
 
 }

--- a/core/shared/src/main/scala/cats/effect/FiberRef.scala
+++ b/core/shared/src/main/scala/cats/effect/FiberRef.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.effect.internals.{FiberRefId, IOFiberRef}
+
+final class FiberRef[A] private (refId: FiberRefId, initial: A) {
+
+  def get: IO[A] =
+    IOFiberRef.get(refId).map(_.getOrElse(initial))
+
+  def set(value: A): IO[Unit] =
+    IOFiberRef.set(refId, value)
+
+  def getAndSet(value: A): IO[A] =
+    get.flatMap { a =>
+      set(value).as(a)
+    }
+
+  def update(f: A => A): IO[Unit] =
+    get.flatMap { a =>
+      set(f(a))
+    }
+
+  def getAndUpdate(f: A => A): IO[A] =
+    get.flatMap { a =>
+      val newA = f(a)
+      set(newA).as(a)
+    }
+
+  def updateAndGet(f: A => A): IO[A] =
+    get.flatMap { a =>
+      val newA = f(a)
+      set(newA).as(newA)
+    }
+
+  def modify[B](f: A => (A, B)): IO[B] =
+    get.flatMap { a =>
+      val (newA, b) = f(a)
+      set(newA).as(b)
+    }
+
+  def reset: IO[Unit] =
+    set(initial)
+
+}
+
+object FiberRef {
+
+  def of[A](initial: A): IO[FiberRef[A]] =
+    for {
+      refId <- IOFiberRef.allocate
+    } yield new FiberRef[A](refId, initial)
+
+}

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -27,8 +27,6 @@ import scala.util.control.NonFatal
 import scala.util.{Failure, Left, Right, Success, Try}
 import cats.data.Ior
 
-import scala.collection.mutable
-
 /**
  * A pure abstraction representing the intention to perform a
  * side effect, where the result of that side effect may be obtained
@@ -1625,5 +1623,5 @@ object IO extends IOInstances {
       Pure(Left(e))
   }
 
-  final private[effect] case class FiberLocal[+A](k: mutable.HashMap[FiberRefId, AnyRef] => A) extends IO[A]
+  private[effect] case object Introspect extends IO[FiberState]
 }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1610,6 +1610,8 @@ object IO extends IOInstances {
     restore: (A, Throwable, IOConnection, IOConnection) => IOConnection
   ) extends IO[A]
 
+  private[effect] case object Introspect extends IO[FiberLocals]
+
   /* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-= */
 
   /**
@@ -1623,5 +1625,4 @@ object IO extends IOInstances {
       Pure(Left(e))
   }
 
-  private[effect] case object Introspect extends IO[FiberState]
 }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -27,6 +27,8 @@ import scala.util.control.NonFatal
 import scala.util.{Failure, Left, Right, Success, Try}
 import cats.data.Ior
 
+import scala.collection.mutable
+
 /**
  * A pure abstraction representing the intention to perform a
  * side effect, where the result of that side effect may be obtained
@@ -1622,4 +1624,6 @@ object IO extends IOInstances {
     override def recover(e: Throwable) =
       Pure(Left(e))
   }
+
+  final private[effect] case class FiberLocal[+A](k: mutable.HashMap[FiberRefId, AnyRef] => A) extends IO[A]
 }

--- a/core/shared/src/main/scala/cats/effect/Local.scala
+++ b/core/shared/src/main/scala/cats/effect/Local.scala
@@ -16,12 +16,9 @@
 
 package cats.effect
 
-package object internals {
-
-  /**
-   * Handy alias for the registration functions of [[IO.Async]].
-   */
-  private[effect] type Start[+A] =
-    (IOConnection, IOContext, Callback.T[A]) => Unit
-
+trait Local[F[_]] extends Async[F] {
+  // TODP: suspend in F
+//  def ref[A](initial: A): FiberRef[F, A]
+//
+//  def copyForkRef[A](initial: A, combine: (A, A) => A): FiberRef[F, A]
 }

--- a/core/shared/src/main/scala/cats/effect/internals/ForwardCancelable.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/ForwardCancelable.scala
@@ -35,11 +35,11 @@ final private[effect] class ForwardCancelable private () {
   private[this] val state = new AtomicReference[State](init)
 
   val cancel: CancelToken[IO] = {
-    @tailrec def loop(conn: IOConnection, cb: Callback.T[Unit]): Unit =
+    @tailrec def loop(conn: IOConnection, ctx: IOContext, cb: Callback.T[Unit]): Unit =
       state.get() match {
         case current @ Empty(list) =>
           if (!state.compareAndSet(current, Empty(cb :: list)))
-            loop(conn, cb)
+            loop(conn, ctx, cb)
 
         case Active(token) =>
           state.lazySet(finished) // GC purposes

--- a/core/shared/src/main/scala/cats/effect/internals/IOBracket.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOBracket.scala
@@ -30,7 +30,7 @@ private[effect] object IOBracket {
    * Implementation for `IO.bracketCase`.
    */
   def apply[A, B](acquire: IO[A])(use: A => IO[B])(release: (A, ExitCase[Throwable]) => IO[Unit]): IO[B] =
-    IO.Async { (conn, cb) =>
+    IO.Async { (conn, ctx, cb) =>
       // Placeholder for the future finalizer
       val deferredRelease = ForwardCancelable()
       conn.push(deferredRelease.cancel)
@@ -40,7 +40,7 @@ private[effect] object IOBracket {
       if (!conn.isCanceled) {
         // Note `acquire` is uncancelable due to usage of `IORunLoop.start`
         // (in other words it is disconnected from our IOConnection)
-        IORunLoop.start[A](acquire, new BracketStart(use, release, conn, deferredRelease, cb))
+        IORunLoop.restart[A](acquire, ctx, new BracketStart(use, release, conn, ctx, deferredRelease, cb))
       } else {
         deferredRelease.complete(IO.unit)
       }
@@ -51,6 +51,7 @@ private[effect] object IOBracket {
     use: A => IO[B],
     release: (A, ExitCase[Throwable]) => IO[Unit],
     conn: IOConnection,
+    ctx: IOContext,
     deferredRelease: ForwardCancelable,
     cb: Callback.T[B]
   ) extends (Either[Throwable, A] => Unit)
@@ -87,7 +88,7 @@ private[effect] object IOBracket {
             fb.flatMap(frame)
           }
           // Actual execution
-          IORunLoop.startCancelable(onNext, conn, cb)
+          IORunLoop.restartCancelable(onNext, conn, ctx, cb)
         }
 
       case error @ Left(_) =>
@@ -100,7 +101,7 @@ private[effect] object IOBracket {
    * Implementation for `IO.guaranteeCase`.
    */
   def guaranteeCase[A](source: IO[A], release: ExitCase[Throwable] => IO[Unit]): IO[A] =
-    IO.Async { (conn, cb) =>
+    IO.Async { (conn, _, cb) =>
       // Light async boundary, otherwise this will trigger a StackOverflowException
       ec.execute(new Runnable {
         def run(): Unit = {

--- a/core/shared/src/main/scala/cats/effect/internals/IOContext.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOContext.scala
@@ -14,14 +14,34 @@
  * limitations under the License.
  */
 
-package cats.effect
+package cats.effect.internals
 
-package object internals {
+import java.util.concurrent.ConcurrentHashMap
 
-  /**
-   * Handy alias for the registration functions of [[IO.Async]].
-   */
-  private[effect] type Start[+A] =
-    (IOConnection, IOContext, Callback.T[A]) => Unit
+import cats.effect.FiberRef
+
+/**
+ * Represents the state of execution for a
+ * single fiber.
+ */
+final private[effect] class IOContext {
+
+  // TODO: lazy?
+  private val locals: ConcurrentHashMap[FiberRef[Any], Any] = new ConcurrentHashMap()
+
+  def putLocal(key: FiberRef[Any], value: Any): Unit = {
+    locals.put(key, value)
+    ()
+  }
+
+  def getLocal(key: FiberRef[Any]): Option[Any] =
+    Option(locals.get(key))
+
+}
+
+object IOContext {
+
+  def apply(): IOContext =
+    new IOContext
 
 }

--- a/core/shared/src/main/scala/cats/effect/internals/IOFiberRef.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOFiberRef.scala
@@ -21,17 +21,18 @@ import cats.effect.{FiberRef, IO}
 private[effect] object IOFiberRef {
 
   def get[A](ref: FiberRef[A]): IO[Option[A]] =
-    IO.Introspect.map { state =>
-      val k = ref.asInstanceOf[FiberRef[AnyRef]]
-      state.get(k).map(_.asInstanceOf[A])
+    IO.Async { (_, ctx, cb) =>
+      val k = ref.asInstanceOf[FiberRef[Any]]
+      val v = ctx.getLocal(k).map(_.asInstanceOf[A])
+      cb(Right(v))
     }
 
   def set[A](ref: FiberRef[A], value: A): IO[Unit] =
-    IO.Introspect.map { state =>
-      val k = ref.asInstanceOf[FiberRef[AnyRef]]
-      val v = value.asInstanceOf[AnyRef]
-      state.put(k, v)
-      ()
+    IO.Async { (_, ctx, cb) =>
+      val k = ref.asInstanceOf[FiberRef[Any]]
+      val v = value.asInstanceOf[Any]
+      ctx.putLocal(k, v)
+      cb(Right(()))
     }
 
 }

--- a/core/shared/src/main/scala/cats/effect/internals/IOFiberRef.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOFiberRef.scala
@@ -28,16 +28,15 @@ private[effect] object IOFiberRef {
     }
 
   def get[A](refId: FiberRefId): IO[Option[A]] =
-    IO.FiberLocal { state =>
+    IO.Introspect.map { state =>
       state.get(refId).map(_.asInstanceOf[A])
     }
 
   def set[A](refId: FiberRefId, value: A): IO[Unit] =
-    IO.FiberLocal { state =>
+    IO.Introspect.map { state =>
       state.put(refId, value.asInstanceOf[AnyRef])
       ()
     }
-
 
   private val nextFiberRefId = new AtomicLong(1)
 

--- a/core/shared/src/main/scala/cats/effect/internals/IOParMap.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOParMap.scala
@@ -29,7 +29,7 @@ private[effect] object IOParMap {
   def apply[A, B, C](cs: ContextShift[IO], fa: IO[A], fb: IO[B])(f: (A, B) => C): IO[C] =
     IO.Async(
       new IOForkedStart[C] {
-        def apply(conn: IOConnection, cb: Callback.T[C]) =
+        def apply(conn: IOConnection, ctx: IOContext, cb: Callback.T[C]) =
           // For preventing stack-overflow errors; using a
           // trampolined execution context, so no thread forks
           TrampolineEC.immediate.execute(new ParMapRunnable(cs, fa, fb, f, conn, cb))

--- a/core/shared/src/main/scala/cats/effect/internals/IORace.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IORace.scala
@@ -58,7 +58,7 @@ private[effect] object IORace {
         Logger.reportFailure(err)
       }
 
-    val start: Start[Either[A, B]] = (conn, cb) => {
+    val start: Start[Either[A, B]] = (conn, _, cb) => {
       val active = new AtomicBoolean(true)
       // Cancelable connection for the left value
       val connL = IOConnection()
@@ -94,7 +94,7 @@ private[effect] object IORace {
    * Implementation for `IO.racePair`
    */
   def pair[A, B](cs: ContextShift[IO], lh: IO[A], rh: IO[B]): IO[Pair[A, B]] = {
-    val start: Start[Pair[A, B]] = (conn, cb) => {
+    val start: Start[Pair[A, B]] = (conn, _, cb) => {
       val active = new AtomicBoolean(true)
       // Cancelable connection for the left value
       val connL = IOConnection()

--- a/core/shared/src/main/scala/cats/effect/internals/IOShift.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOShift.scala
@@ -25,7 +25,7 @@ private[effect] object IOShift {
   /** Implementation for `IO.shift`. */
   def apply(ec: ExecutionContext): IO[Unit] =
     IO.Async(new IOForkedStart[Unit] {
-      def apply(conn: IOConnection, cb: Callback.T[Unit]): Unit =
+      def apply(conn: IOConnection, ctx: IOContext, cb: Callback.T[Unit]): Unit =
         ec.execute(new Tick(cb))
     })
 

--- a/core/shared/src/main/scala/cats/effect/internals/IOStart.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOStart.scala
@@ -26,7 +26,7 @@ private[effect] object IOStart {
    * Implementation for `IO.start`.
    */
   def apply[A](cs: ContextShift[IO], fa: IO[A]): IO[Fiber[IO, A]] = {
-    val start: Start[Fiber[IO, A]] = (_, cb) => {
+    val start: Start[Fiber[IO, A]] = (_, _, cb) => {
       // Memoization
       val p = Promise[Either[Throwable, A]]()
 

--- a/core/shared/src/main/scala/cats/effect/internals/package.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/package.scala
@@ -16,6 +16,8 @@
 
 package cats.effect
 
+import scala.collection.mutable
+
 package object internals {
 
   /**
@@ -24,5 +26,6 @@ package object internals {
   private[effect] type Start[+A] =
     (IOConnection, Callback.T[A]) => Unit
 
+  private[effect] type FiberState = mutable.HashMap[FiberRefId, AnyRef]
   private[effect] type FiberRefId = Long
 }

--- a/core/shared/src/main/scala/cats/effect/internals/package.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/package.scala
@@ -26,6 +26,5 @@ package object internals {
   private[effect] type Start[+A] =
     (IOConnection, Callback.T[A]) => Unit
 
-  private[effect] type FiberState = mutable.HashMap[FiberRefId, AnyRef]
-  private[effect] type FiberRefId = Long
+  private[effect] type FiberLocals = mutable.HashMap[FiberRef[AnyRef], AnyRef]
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/util/TestContext.scala
@@ -17,7 +17,7 @@
 package cats.effect.laws.util
 
 import cats.effect.internals.Callback.T
-import cats.effect.internals.{IOConnection, IOForkedStart, IOShift}
+import cats.effect.internals.{IOConnection, IOContext, IOForkedStart, IOShift}
 import cats.effect._
 
 import scala.collection.immutable.SortedSet
@@ -190,7 +190,7 @@ final class TestContext private () extends ExecutionContext { self =>
 
       override def shift: F[Unit] =
         F.liftIO(IO.Async(new IOForkedStart[Unit] {
-          def apply(conn: IOConnection, cb: T[Unit]): Unit =
+          def apply(conn: IOConnection, ctx: IOContext, cb: T[Unit]): Unit =
             self.execute(tick(cb))
         }))
 


### PR DESCRIPTION
This a PoC for supporting fiber-local state inside `cats.effect.IO`. I began to implement some of the ideas I laid out in #828 . I didn't get much feedback in the original issue, so hopefully there can be some more discussion here. I'd certainly like to hear whether or not this even belongs in this library.

## Changes
- Added a new `IO` primitive operation, `FiberLocal`, which ideally encapsulates all fiber-local behavior
- Support `FiberLocal` instruction in the `IO` interpreter.
- Added a new type `FiberRef` that leverages the new `IO` op to implement fiber local state. Unfortunately this is specific to `IO`.

## Usage
```scala
def printLine[A: Show](msg: A): IO[Unit] =
    IO.delay(println(msg.show))

  def program: IO[Unit] =
    for {
      ref <- FiberRef.of(5)
      a1  <- ref.get
      _   <- printLine(a1)
      _   <- ref.set(10)
      a2  <- ref.get
      _   <- printLine(a2)
    } yield ()
```

## TODO/Ideas
- [ ] Tests
- [ ] Docs
- [ ] Cleanup
- [ ] Java ThreadLocal integration?
- [ ] think about forking behavior

Adding onto some of the ideas in #828, you could start to implement some very basic, runtime non-invasive, application tracing. You could implement a userspace `Tracer` type with a `tracepoint` method that captures slices of stack traces and holds it in fiber-local state

cc @djspiewak @alexandru