### PR TITLE
Tutorial webpage : fix link to IO data type URL

### DIFF
--- a/site/src/main/mdoc/tutorial/tutorial.md
+++ b/site/src/main/mdoc/tutorial/tutorial.md
@@ -21,8 +21,8 @@ classes and do not tie our code to `IO`.
 
 This tutorial assumes certain familiarity with functional programming. It is
 also a good idea to read cats-effect documentation prior to starting this
-tutorial, at least the [excellent documentation about `IO` data
-type](../datatypes/io.md).
+tutorial, at least the 
+[excellent documentation about `IO` data type](../datatypes/io.md).
 
 Please read this tutorial as training material, not as a best-practices
 document. As you gain more experience with cats-effect, probably you will find


### PR DESCRIPTION
In the https://typelevel.org/cats-effect/tutorial/tutorial.html webpage, a link redirecting to IO data type documentation is wrong (due to an issue on benbalter/jekyll-relative-links#61 )