### PR TITLE
Docs: swap wording to convey correct intent

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -685,7 +685,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
   /**
    * Returns a new value that transforms the result of the source,
    * given the `recover` or `map` functions, which get executed depending
-   * on whether the result is successful or if it ends in error.
+   * on whether the result ends in error or if it is successful.
    *
    * This is an optimization on usage of [[attempt]] and [[map]],
    * this equivalence being true:
@@ -711,7 +711,7 @@ sealed abstract class IO[+A] extends internals.IOBinaryCompat[A] {
   /**
    * Returns a new value that transforms the result of the source,
    * given the `recover` or `bind` functions, which get executed depending
-   * on whether the result is successful or if it ends in error.
+   * on whether the result ends in error or if it is successful.
    *
    * This is an optimization on usage of [[attempt]] and [[flatMap]],
    * this equivalence being available:

--- a/core/shared/src/main/scala/cats/effect/SyncIO.scala
+++ b/core/shared/src/main/scala/cats/effect/SyncIO.scala
@@ -257,7 +257,7 @@ final class SyncIO[+A] private (private val io: IO[A]) {
   /**
    * Returns a new value that transforms the result of the source,
    * given the `recover` or `map` functions, which get executed depending
-   * on whether the result is successful or if it ends in error.
+   * on whether the result ends in error or if it is successful.
    *
    * This is an optimization on usage of [[attempt]] and [[map]],
    * this equivalence being true:
@@ -283,7 +283,7 @@ final class SyncIO[+A] private (private val io: IO[A]) {
   /**
    * Returns a new value that transforms the result of the source,
    * given the `recover` or `bind` functions, which get executed depending
-   * on whether the result is successful or if it ends in error.
+   * on whether the result ends in error or if it is successful.
    *
    * This is an optimization on usage of [[attempt]] and [[flatMap]],
    * this equivalence being available:


### PR DESCRIPTION
Swapping wording to match `recover` (error) and then `map` (success)