### PR TITLE
Fix resolution of Clock implicits

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Clock.scala
+++ b/core/shared/src/main/scala/cats/effect/Clock.scala
@@ -139,13 +139,6 @@ object Clock extends LowPriorityImplicits {
         F.delay(unit.convert(System.nanoTime(), NANOSECONDS))
     }
 
-  /**
-   * Default implicit instance — given there's an implicit [[Timer]]
-   * in scope, extracts a [[Clock]] instance from it.
-   */
-  implicit def extractFromTimer[F[_]](implicit timer: Timer[F]): Clock[F] =
-    timer.clock
-
   implicit class ClockOps[F[_]](val self: Clock[F]) extends AnyVal {
 
     /**
@@ -158,7 +151,7 @@ object Clock extends LowPriorityImplicits {
   }
 }
 
-protected[effect] trait LowPriorityImplicits {
+protected[effect] trait LowPriorityImplicits extends LowerPriorityImplicits {
 
   /**
    * Derives a [[Clock]] instance for `cats.data.EitherT`,
@@ -252,4 +245,14 @@ protected[effect] trait LowPriorityImplicits {
       def monotonic(unit: TimeUnit): Resource[F, Long] =
         Resource.liftF(clock.monotonic(unit))
     }
+}
+
+protected[effect] trait LowerPriorityImplicits {
+
+  /**
+   * Default implicit instance — given there's an implicit [[Timer]]
+   * in scope, extracts a [[Clock]] instance from it.
+   */
+  implicit def extractFromTimer[F[_]](implicit timer: Timer[F]): Clock[F] =
+    timer.clock
 }

--- a/laws/shared/src/test/scala/cats/effect/TimerTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/TimerTests.scala
@@ -38,6 +38,16 @@ class TimerTests extends AsyncFunSuite with Matchers {
   type IorTIO[A] = IorT[IO, Int, A]
   type ResourceIO[A] = Resource[IO, A]
 
+  def resolveClock = {
+    Clock[EitherTIO]
+    Clock[OptionTIO]
+    Clock[WriterTIO]
+    Clock[KleisliIO]
+    Clock[StateTIO]
+    Clock[IorTIO]
+    Clock[ResourceIO]
+  }
+
   test("Timer[IO].clock.realTime") {
     val time = System.currentTimeMillis()
     val io = timer.clock.realTime(MILLISECONDS)


### PR DESCRIPTION
The default from Timer is the least specific.
But it was defined in a subtype and hence ambiguous.
To fix that move it to a supertype.

In an ideal world (Scala 2.13) we would not need any low priority traits.
But a bug in Scala 2.12 causes it to turn a blind eye to higher-kinded specificity.

Fixes #784