### PR TITLE
Optimize redeem/redeemWith in instances

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -883,6 +883,11 @@ abstract private[effect] class IOLowPriorityInstances extends IOParallelNewtype 
     final override def guaranteeCase[A](fa: IO[A])(finalizer: ExitCase[Throwable] => IO[Unit]): IO[A] =
       fa.guaranteeCase(finalizer)
 
+    final override def redeem[A, B](fa: IO[A])(recover: Throwable => B, f: A => B): IO[B] =
+      fa.redeem(recover, f)
+    final override def redeemWith[A, B](fa: IO[A])(recover: Throwable => IO[B], bind: A => IO[B]): IO[B] =
+      fa.redeemWith(recover, bind)
+
     final override def delay[A](thunk: => A): IO[A] =
       IO.delay(thunk)
     final override def suspend[A](thunk: => IO[A]): IO[A] =

--- a/core/shared/src/main/scala/cats/effect/Sync.scala
+++ b/core/shared/src/main/scala/cats/effect/Sync.scala
@@ -118,18 +118,6 @@ object Sync {
     def raiseError[A](e: Throwable): EitherT[F, L, A] =
       EitherT.liftF(F.raiseError(e))
 
-    override def redeem[A, B](fa: EitherT[F, L, A])(recover: Throwable => B, f: A => B): EitherT[F, L, B] =
-      EitherT(F.redeem(fa.value)(e => Right(recover(e)), la => la.map(f)))
-
-    override def redeemWith[A, B](fa: EitherT[F, L, A])(recover: Throwable => EitherT[F, L, B], bind: A => EitherT[F, L, B]): EitherT[F, L, B] =
-      EitherT(F.redeemWith(fa.value)(
-        e => recover(e).value,
-        la => la match {
-          case Right(a) => bind(a).value
-          case _ => F.pure(la.asInstanceOf[Either[L, B]])
-        }
-      ))
-
     def bracketCase[A, B](
       acquire: EitherT[F, L, A]
     )(use: A => EitherT[F, L, B])(release: (A, ExitCase[Throwable]) => EitherT[F, L, Unit]): EitherT[F, L, B] =
@@ -177,18 +165,6 @@ object Sync {
 
     def raiseError[A](e: Throwable): OptionT[F, A] =
       OptionT.catsDataMonadErrorForOptionT[F, Throwable].raiseError(e)
-
-    override def redeem[A, B](fa: OptionT[F, A])(recover: Throwable => B, f: A => B): OptionT[F, B] =
-      OptionT(F.redeem(fa.value)(e => Some(recover(e)), la => la.map(f)))
-
-    override def redeemWith[A, B](fa: OptionT[F, A])(recover: Throwable => OptionT[F, B], bind: A => OptionT[F, B]): OptionT[F, B] =
-      OptionT(F.redeemWith(fa.value)(
-        e => recover(e).value,
-        la => la match {
-          case Some(a) => bind(a).value
-          case _ => F.pure(None)
-        }
-      ))
 
     def bracketCase[A, B](
       acquire: OptionT[F, A]


### PR DESCRIPTION
`ApplicativeError.redeem` and `MonadError.redeemWith` have been added in Cats, by @travisbrown in https://github.com/typelevel/cats/pull/3146, might as well take advantage of it by overriding the methods in our instances.

NOTE: for `EitherT`, `OptionT`, etc, these should be overridden in Cats, if they aren't already.