### PR TITLE
Ref#modifyOr and Ref#updateOr

### DIFF
--- a/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
@@ -120,9 +120,19 @@ abstract class Ref[F[_], A] {
   def update(f: A => A): F[Unit]
 
   /**
+   * Like `update`, but can terminate early with an error value without retrying.
+   */
+  def updateOr[E](f: A => Either[E, A]): F[Option[E]]
+
+  /**
    * Like `tryModify` but does not complete until the update has been successfully made.
    */
   def modify[B](f: A => (A, B)): F[B]
+
+  /**
+   * Like `modify`, but can terminate early with an error value without retrying.
+   */
+  def modifyOr[E, B](f: A => Either[E, (A, B)]): F[Either[E, B]]
 
   /**
    * Update the value of this ref with a state computation.
@@ -264,6 +274,9 @@ object Ref {
       (f(a), ())
     }
 
+    def updateOr[E](f: A => Either[E, A]): F[Option[E]] =
+      modifyOr(a => f(a).map((_, ()))).map(_.left.toOption)
+
     def modify[B](f: A => (A, B)): F[B] = {
       @tailrec
       def spin: B = {
@@ -271,6 +284,21 @@ object Ref {
         val (u, b) = f(c)
         if (!ar.compareAndSet(c, u)) spin
         else b
+      }
+      F.delay(spin)
+    }
+
+    def modifyOr[E, B](f: A => Either[E, (A, B)]): F[Either[E, B]] = {
+      @tailrec
+      def spin: Either[E, B] = {
+        val c = ar.get
+        f(c) match {
+          case Right((u, b)) => {
+            if (!ar.compareAndSet(c, u)) spin
+            else Right(b)
+          }
+          case Left(e) => Left(e)
+        }
       }
       F.delay(spin)
     }
@@ -295,7 +323,9 @@ object Ref {
     override def tryUpdate(f: A => A): G[Boolean] = trans(underlying.tryUpdate(f))
     override def tryModify[B](f: A => (A, B)): G[Option[B]] = trans(underlying.tryModify(f))
     override def update(f: A => A): G[Unit] = trans(underlying.update(f))
+    override def updateOr[E](f: A => Either[E, A]): G[Option[E]] = trans(underlying.updateOr(f))
     override def modify[B](f: A => (A, B)): G[B] = trans(underlying.modify(f))
+    override def modifyOr[E, B](f: A => Either[E, (A, B)]): G[Either[E, B]] = trans(underlying.modifyOr(f))
     override def tryModifyState[B](state: State[A, B]): G[Option[B]] = trans(underlying.tryModifyState(state))
     override def modifyState[B](state: State[A, B]): G[B] = trans(underlying.modifyState(state))
 
@@ -318,8 +348,12 @@ object Ref {
             fa.tryModify(f2.compose(f).map(_.leftMap(g)))
           override def update(f2: B => B): F[Unit] =
             fa.update(g.compose(f2).compose(f))
+          override def updateOr[E](f2: B => Either[E, B]): F[Option[E]] =
+            fa.updateOr(f2.compose(f).map(_.map(g)))
           override def modify[C](f2: B => (B, C)): F[C] =
             fa.modify(f2.compose(f).map(_.leftMap(g)))
+          override def modifyOr[E, C](f2: B => Either[E, (B, C)]): F[Either[E, C]] =
+            fa.modifyOr(f2.compose(f).map(_.map(_.leftMap(g))))
           override def tryModifyState[C](state: State[B, C]): F[Option[C]] =
             fa.tryModifyState(state.dimap(f)(g))
           override def modifyState[C](state: State[B, C]): F[C] =

--- a/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
@@ -28,6 +28,7 @@ import cats.instances.either._
 import cats.syntax.functor._
 import cats.syntax.bifunctor._
 import cats.syntax.flatMap._
+import cats.syntax.either._
 
 import scala.annotation.tailrec
 
@@ -320,7 +321,7 @@ object Ref {
         case (a, set) =>
           f(a) match {
             case Right((a, b)) => set(a).ifM(ifTrue = F.pure(Right(b)), ifFalse = modifyOr(f))
-            case Left(e)       => F.pure(Left(e))
+            case l @ Left(_)   => F.pure(l.rightCast[B])
           }
       }
 

--- a/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
@@ -288,7 +288,7 @@ object Ref {
     }
   }
 
-  implicit class RefOps[F[_], A](val ref: Ref[F, A]) extends AnyVal {
+  implicit final class RefOps[F[_], A](private val ref: Ref[F, A]) extends AnyVal {
 
     /**
      * Like `update`, but can terminate early without retrying.
@@ -319,7 +319,7 @@ object Ref {
       ref.access.flatMap {
         case (a, set) =>
           f(a) match {
-            case Right((a, b)) => set(a).ifM(F.pure(Right(b)), modifyOr(f))
+            case Right((a, b)) => set(a).ifM(ifTrue = F.pure(Right(b)), ifFalse = modifyOr(f))
             case Left(e)       => F.pure(Left(e))
           }
       }

--- a/core/shared/src/test/scala/cats/effect/concurrent/RefTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/RefTests.scala
@@ -136,6 +136,30 @@ class RefTests extends AsyncFunSuite with Matchers {
     run(op.map(_ shouldBe false).void)
   }
 
+  test("updateOr - short-circuit") {
+    val op = for {
+      r <- Ref[IO].of(0)
+      result <- r.updateOr {
+        case 0 => Left("123")
+        case _ => Right(1)
+      }
+    } yield result
+
+    run(op.map(_ shouldBe Some("123")).void)
+  }
+
+  test("modifyOr - short-circuit") {
+    val op = for {
+      r <- Ref[IO].of(0)
+      result <- r.modifyOr {
+        case 0 => Left("123")
+        case _ => Right((1, true))
+      }
+    } yield result
+
+    run(op.map(_ shouldBe Left("123")).void)
+  }
+
   test("tryModifyState - modification occurs successfully") {
     val op = for {
       r <- Ref[IO].of(0)

--- a/core/shared/src/test/scala/cats/effect/concurrent/RefTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/RefTests.scala
@@ -139,10 +139,7 @@ class RefTests extends AsyncFunSuite with Matchers {
   test("updateMaybe - successful") {
     val op = for {
       r <- Ref[IO].of(0)
-      result <- r.updateMaybe {
-        case 0 => Some(1)
-        case _ => None
-      }
+      result <- r.updateMaybe(_ => Some(1))
     } yield result
 
     run(op.map(_ shouldBe true).void)
@@ -151,10 +148,7 @@ class RefTests extends AsyncFunSuite with Matchers {
   test("updateMaybe - short-circuit") {
     val op = for {
       r <- Ref[IO].of(0)
-      result <- r.updateMaybe {
-        case 0 => None
-        case _ => Some(1)
-      }
+      result <- r.updateMaybe(_ => None)
     } yield result
 
     run(op.map(_ shouldBe false).void)
@@ -162,10 +156,7 @@ class RefTests extends AsyncFunSuite with Matchers {
   test("modifyMaybe - successful") {
     val op = for {
       r <- Ref[IO].of(0)
-      result <- r.modifyMaybe {
-        case 0 => Some((1, 2))
-        case _ => None
-      }
+      result <- r.modifyMaybe(_ => Some((1, 2)))
     } yield result
 
     run(op.map(_ shouldBe Some(2)).void)
@@ -174,10 +165,7 @@ class RefTests extends AsyncFunSuite with Matchers {
   test("modifyMaybe - short-circuit") {
     val op = for {
       r <- Ref[IO].of(0)
-      result <- r.modifyMaybe {
-        case 0 => None
-        case _ => Some((1, 2))
-      }
+      result <- r.modifyMaybe(_ => None)
     } yield result
 
     run(op.map(_ shouldBe None).void)
@@ -186,10 +174,7 @@ class RefTests extends AsyncFunSuite with Matchers {
   test("updateOr - successful") {
     val op = for {
       r <- Ref[IO].of(0)
-      result <- r.updateOr {
-        case 0 => Right(1)
-        case _ => Left("fail")
-      }
+      result <- r.updateOr(_ => Right(1))
     } yield result
 
     run(op.map(_ shouldBe None).void)
@@ -198,10 +183,7 @@ class RefTests extends AsyncFunSuite with Matchers {
   test("updateOr - short-circuit") {
     val op = for {
       r <- Ref[IO].of(0)
-      result <- r.updateOr {
-        case 0 => Left("fail")
-        case _ => Right(1)
-      }
+      result <- r.updateOr(_ => Left("fail"))
     } yield result
 
     run(op.map(_ shouldBe Some("fail")).void)
@@ -210,10 +192,7 @@ class RefTests extends AsyncFunSuite with Matchers {
   test("modifyOr - successful") {
     val op = for {
       r <- Ref[IO].of(0)
-      result <- r.modifyOr {
-        case 0 => Right((1, "success"))
-        case _ => Left("fail")
-      }
+      result <- r.modifyOr(_ => Right((1, "success")))
     } yield result
 
     run(op.map(_ shouldBe Right("success")).void)
@@ -222,10 +201,7 @@ class RefTests extends AsyncFunSuite with Matchers {
   test("modifyOr - short-circuit") {
     val op = for {
       r <- Ref[IO].of(0)
-      result <- r.modifyOr {
-        case 0 => Left("fail")
-        case _ => Right((1, true))
-      }
+      result <- r.modifyOr(_ => Left("fail"))
     } yield result
 
     run(op.map(_ shouldBe Left("fail")).void)

--- a/core/shared/src/test/scala/cats/effect/concurrent/RefTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/RefTests.scala
@@ -136,28 +136,99 @@ class RefTests extends AsyncFunSuite with Matchers {
     run(op.map(_ shouldBe false).void)
   }
 
+  test("updateMaybe - successful") {
+    val op = for {
+      r <- Ref[IO].of(0)
+      result <- r.updateMaybe {
+        case 0 => Some(1)
+        case _ => None
+      }
+    } yield result
+
+    run(op.map(_ shouldBe true).void)
+  }
+
+  test("updateMaybe - short-circuit") {
+    val op = for {
+      r <- Ref[IO].of(0)
+      result <- r.updateMaybe {
+        case 0 => None
+        case _ => Some(1)
+      }
+    } yield result
+
+    run(op.map(_ shouldBe false).void)
+  }
+  test("modifyMaybe - successful") {
+    val op = for {
+      r <- Ref[IO].of(0)
+      result <- r.modifyMaybe {
+        case 0 => Some((1, 2))
+        case _ => None
+      }
+    } yield result
+
+    run(op.map(_ shouldBe Some(2)).void)
+  }
+
+  test("modifyMaybe - short-circuit") {
+    val op = for {
+      r <- Ref[IO].of(0)
+      result <- r.modifyMaybe {
+        case 0 => None
+        case _ => Some((1, 2))
+      }
+    } yield result
+
+    run(op.map(_ shouldBe None).void)
+  }
+
+  test("updateOr - successful") {
+    val op = for {
+      r <- Ref[IO].of(0)
+      result <- r.updateOr {
+        case 0 => Right(1)
+        case _ => Left("fail")
+      }
+    } yield result
+
+    run(op.map(_ shouldBe None).void)
+  }
+
   test("updateOr - short-circuit") {
     val op = for {
       r <- Ref[IO].of(0)
       result <- r.updateOr {
-        case 0 => Left("123")
+        case 0 => Left("fail")
         case _ => Right(1)
       }
     } yield result
 
-    run(op.map(_ shouldBe Some("123")).void)
+    run(op.map(_ shouldBe Some("fail")).void)
+  }
+
+  test("modifyOr - successful") {
+    val op = for {
+      r <- Ref[IO].of(0)
+      result <- r.modifyOr {
+        case 0 => Right((1, "success"))
+        case _ => Left("fail")
+      }
+    } yield result
+
+    run(op.map(_ shouldBe Right("success")).void)
   }
 
   test("modifyOr - short-circuit") {
     val op = for {
       r <- Ref[IO].of(0)
       result <- r.modifyOr {
-        case 0 => Left("123")
+        case 0 => Left("fail")
         case _ => Right((1, true))
       }
     } yield result
 
-    run(op.map(_ shouldBe Left("123")).void)
+    run(op.map(_ shouldBe Left("fail")).void)
   }
 
   test("tryModifyState - modification occurs successfully") {


### PR DESCRIPTION
Add combinators that allow for short-circuit behavior in CAS retry loops. This is useful when you want to perform an atomic state transition under specific conditions, but if those conditions aren't met, terminate early so no extra contention is placed on the atomic.

Maybe there's room for expressing some of the existing combinators in terms of these new ones. I could also see an `updateMaybe` or `modifyMaybe` that just take a `A => Option[A]`.