### PR TITLE
Implemented very silly workaround for #807

### DIFF
--- a/core/shared/src/test/scala/cats/effect/ResourceSyntax.scala
+++ b/core/shared/src/test/scala/cats/effect/ResourceSyntax.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+object Test {
+  class Base()
+  case class Derived() extends Base
+
+  def fBase[F[+ _]](implicit F: Sync[F]): F[Either[Base, Nothing]] = F.delay(Left(new Base()))
+  def fDerived[F[+ _]](implicit F: Sync[F]): F[Either[Derived, Nothing]] = F.delay(Left(Derived()))
+
+  def f[F[+ _]](implicit F: Sync[F]): F[Either[Base, Nothing]] =
+    if (true) {
+      fBase
+    } else {
+      fDerived
+    }
+
+  def g2[F[+_, +_]](implicit F: Sync[F[Throwable, ?]]): Resource[F[Throwable, ?], Either[Base, Nothing]] = {
+    Resource.liftF[F[Throwable, +?], Either[Base, Nothing]](f[F[Throwable, +?]])
+      .map(x => x)
+  }
+
+  // this one fails, but not the above
+  def g[F[+_]](implicit F: Sync[F]): Resource[F, Either[Base, Nothing]] = {
+    Resource.liftF[F, Either[Base, Nothing]](f[F])
+      .map(x => x)
+      .flatMap(x => Resource.pure[F, Either[Base, Nothing]](x))
+  }
+
+}

--- a/core/shared/src/test/scala/cats/effect/ResourceSyntax.scala
+++ b/core/shared/src/test/scala/cats/effect/ResourceSyntax.scala
@@ -20,26 +20,26 @@ object Test {
   class Base()
   case class Derived() extends Base
 
-  def fBase[F[+ _]](implicit F: Sync[F]): F[Either[Base, Nothing]] = F.delay(Left(new Base()))
-  def fDerived[F[+ _]](implicit F: Sync[F]): F[Either[Derived, Nothing]] = F.delay(Left(Derived()))
+  def fBase[F[+_]](implicit F: Sync[F]): F[Either[Base, Nothing]] = F.delay(Left(new Base()))
+  def fDerived[F[+_]](implicit F: Sync[F]): F[Either[Derived, Nothing]] = F.delay(Left(Derived()))
 
-  def f[F[+ _]](implicit F: Sync[F]): F[Either[Base, Nothing]] =
+  def f[F[+_]](implicit F: Sync[F]): F[Either[Base, Nothing]] =
     if (true) {
       fBase
     } else {
       fDerived
     }
 
-  def g2[F[+_, +_]](implicit F: Sync[F[Throwable, ?]]): Resource[F[Throwable, ?], Either[Base, Nothing]] = {
-    Resource.liftF[F[Throwable, +?], Either[Base, Nothing]](f[F[Throwable, +?]])
+  def g2[F[+_, +_]](implicit F: Sync[F[Throwable, ?]]): Resource[F[Throwable, ?], Either[Base, Nothing]] =
+    Resource
+      .liftF[F[Throwable, +?], Either[Base, Nothing]](f[F[Throwable, +?]])
       .map(x => x)
-  }
 
   // this one fails, but not the above
-  def g[F[+_]](implicit F: Sync[F]): Resource[F, Either[Base, Nothing]] = {
-    Resource.liftF[F, Either[Base, Nothing]](f[F])
+  def g[F[+_]](implicit F: Sync[F]): Resource[F, Either[Base, Nothing]] =
+    Resource
+      .liftF[F, Either[Base, Nothing]](f[F])
       .map(x => x)
       .flatMap(x => Resource.pure[F, Either[Base, Nothing]](x))
-  }
 
 }


### PR DESCRIPTION
Would also appreciate a look from @neko-kai. I think this works around the issue. It's a little annoying, but I wasn't able to find anything more elegant, and the nice thing is that it doesn't touch binary compatibility. I *believe* it should also be fully source-compatible with all existing call-sites that weren't already broken.

Fixes #807 (I think)