### PR TITLE
add IO[Future[A]]#liftFutureIO syntax

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1627,4 +1627,11 @@ object IO extends IOInstances {
     override def recover(e: Throwable) =
       Pure(Left(e))
   }
+
+  /**
+   * Nice little syntax to do `IO(mkFuture).liftFutureIO` instead of `IO.fromFuture(IO(mkFuture))`.
+   */
+  implicit final class FutureOps[A](private val iof: IO[Future[A]]) extends AnyVal {
+    def liftFutureIO(implicit cs: ContextShift[IO]): IO[A] = iof.flatMap(IOFromFuture.apply).guarantee(cs.shift)
+  }
 }


### PR DESCRIPTION
Nice little syntax to do `IO(mkFuture).liftFutureIO` instead of `IO.fromFuture(IO(mkFuture))`, because there are too many parentheses in the latter.