### PR TITLE
CE3: Reusable generators

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,10 @@ val CatsVersion = "2.1.1"
 
 addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0")
 
+scalacOptions ++= Seq(
+  "-Xcheckinit"
+)
+
 libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-core" % CatsVersion,
   "org.typelevel" %% "cats-free" % CatsVersion,

--- a/src/main/scala/ce3/Outcome.scala
+++ b/src/main/scala/ce3/Outcome.scala
@@ -37,6 +37,7 @@ private[ce3] trait LowPriorityImplicits {
   implicit def applicativeError[F[_]: Applicative, E]: ApplicativeError[Outcome[F, E, ?], E] =
     new ExitCaseApplicativeError[F, E]
 
+  //todo needs renaming
   protected class ExitCaseApplicativeError[F[_]: Applicative, E] extends ApplicativeError[Outcome[F, E, ?], E] {
 
     def pure[A](x: A): Outcome[F, E, A] = Completed(x.pure[F])

--- a/src/test/scala/ce3/laws/Generators.scala
+++ b/src/test/scala/ce3/laws/Generators.scala
@@ -26,16 +26,8 @@ import cats.Functor
 import cats.MonadError
 import cats.Traverse
 
-final case class ArbitraryCogen[A](arbitrary: Arbitrary[A], cogen: Cogen[A])
-
-object ArbitraryCogen {
-  def apply[A](implicit A: ArbitraryCogen[A]): ArbitraryCogen[A] = A
-
-  implicit def deriveFromArbitraryAndCogen[A](implicit arb: Arbitrary[A], cogen: Cogen[A]): ArbitraryCogen[A] = ArbitraryCogen(arb,cogen)
-}
-
 trait GenK[F[_]] {
-  def apply[A: ArbitraryCogen]: Gen[F[A]]
+  def apply[A: Arbitrary: Cogen]: Gen[F[A]]
 }
 
 // Generators for * -> * kinded types
@@ -53,7 +45,7 @@ trait Generators1[F[_]] {
   //All generators possible at depth [[depth]]
   private def gen[A: Arbitrary: Cogen](depth: Int): Gen[F[A]] = {
     val genK: GenK[F] = new GenK[F] {
-      def apply[B: ArbitraryCogen]: Gen[F[B]] = Gen.delay(gen(depth + 1)(ArbitraryCogen[B].arbitrary, ArbitraryCogen[B].cogen))
+      def apply[B: Arbitrary: Cogen]: Gen[F[B]] = Gen.delay(gen(depth + 1))
     }
     
     val gens =

--- a/src/test/scala/ce3/laws/Generators.scala
+++ b/src/test/scala/ce3/laws/Generators.scala
@@ -50,7 +50,7 @@ trait Generators1[F[_]] {
     
     val gens =
       if(depth > maxDepth) baseGen[A]
-      else baseGen[A] ++ recursiveGen[A](genK)
+      else baseGen[A] ++ recursiveGen[A](genK) 
 
     Gen.oneOf(gens).flatMap(identity)
   }
@@ -71,15 +71,15 @@ trait ApplicativeGenerators[F[_]] extends Generators1[F] {
       genAp[A](deeper)
     )    
 
-  def genPure[A: Arbitrary]: Gen[F[A]] =
+  private def genPure[A: Arbitrary]: Gen[F[A]] =
     arbitrary[A].map(_.pure[F])
 
-  def genMap[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] = for {
+  private def genMap[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] = for {
     fa <- deeper[A]
     f <- Arbitrary.arbitrary[A => A]
   } yield F.map(fa)(f)
 
-  def genAp[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] = for {
+  private def genAp[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] = for {
     fa <- deeper[A]
     ff <- deeper[A => A]
   } yield F.ap(ff)(fa)
@@ -93,7 +93,7 @@ trait MonadGenerators[F[_]] extends ApplicativeGenerators[F]{
     genFlatMap(deeper)
   ) ++ super.recursiveGen(deeper)
 
-  def genFlatMap[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] = {
+  private def genFlatMap[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] = {
     for {
       fa <- deeper[A]
       f <- Gen.function1[A, F[A]](deeper[A])
@@ -115,11 +115,10 @@ trait MonadErrorGenerators[F[_], E] extends MonadGenerators[F] {
     genHandleErrorWith[A](deeper),
   ) ++ super.recursiveGen(deeper)
 
-
-  def genRaiseError[A]: Gen[F[A]] =
+  private def genRaiseError[A]: Gen[F[A]] =
     arbitrary[E].map(F.raiseError[A](_))
 
-  def genHandleErrorWith[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] = {
+  private def genHandleErrorWith[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] = {
     for {
       fa <- deeper[A]
       f <- Gen.function1[E, F[A]](deeper[A])
@@ -138,7 +137,7 @@ trait BracketGenerators[F[_], E] extends MonadErrorGenerators[F, E] {
 
   import OutcomeGenerators._
 
-  def genBracketCase[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] = {
+  private def genBracketCase[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] = {
     for {
       acquire <- deeper[A]
       use <- Gen.function1[A, F[A]](deeper[A])
@@ -163,30 +162,30 @@ trait ConcurrentGenerators[F[_], E] extends MonadErrorGenerators[F, E] {
     genJoin[A](deeper),
   ) ++ super.recursiveGen(deeper)
 
-  def genCanceled[A: Arbitrary]: Gen[F[A]] =
+  private def genCanceled[A: Arbitrary]: Gen[F[A]] =
     arbitrary[A].map(F.canceled.as(_))
 
-  def genCede[A: Arbitrary]: Gen[F[A]] =
+  private def genCede[A: Arbitrary]: Gen[F[A]] =
     arbitrary[A].map(F.cede.as(_))
 
-  def genNever[A]: Gen[F[A]] =
+  private def genNever[A]: Gen[F[A]] =
     F.never[A]
 
   // TODO we can't really use poll :-( since we can't Cogen FunctionK
-  def genUncancelable[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] =
+  private def genUncancelable[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] =
     deeper[A].map(pc => F.uncancelable(_ => pc))
 
-  def genStart[A: Arbitrary](deeper: GenK[F]): Gen[F[A]] =
+  private def genStart[A: Arbitrary](deeper: GenK[F]): Gen[F[A]] =
     deeper[Unit].flatMap(pc => arbitrary[A].map(a => F.start(pc).as(a)))
 
-  def genJoin[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] =
+  private def genJoin[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] =
     for {
       fiber <- deeper[A]
       cont <- deeper[Unit]
       a <- arbitrary[A]
     } yield F.start(fiber).flatMap(f => cont >> f.join).as(a)
 
-  def genRacePair[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] =
+  private def genRacePair[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] =
     for {
       fa <- deeper[A]
       fb <- deeper[A]

--- a/src/test/scala/ce3/laws/OutcomeSpec.scala
+++ b/src/test/scala/ce3/laws/OutcomeSpec.scala
@@ -37,8 +37,7 @@ class OutcomeSpec extends Specification with Discipline {
     "Outcome[Option, Int, ?]",
     MonadErrorTests[Outcome[Option, Int, ?], Int].monadError[Int, Int, Int])
 
-  //I'll need a moment to define ApplicativeErrorGenerators...
-  // checkAll(
-  //   "Outcome[Eval, Int, ?]",
-  //   ApplicativeErrorTests[Outcome[Eval, Int, ?], Int].applicativeError[Int, Int, Int])
+  checkAll(
+    "Outcome[Eval, Int, ?]",
+    ApplicativeErrorTests[Outcome[Eval, Int, ?], Int].applicativeError[Int, Int, Int])
 }

--- a/src/test/scala/ce3/laws/OutcomeSpec.scala
+++ b/src/test/scala/ce3/laws/OutcomeSpec.scala
@@ -27,7 +27,7 @@ import org.specs2.mutable.Specification
 import org.typelevel.discipline.specs2.mutable.Discipline
 
 class OutcomeSpec extends Specification with Discipline {
-  import Generators._
+  import OutcomeGenerators._
 
   checkAll(
     "Outcome[Id, Int, ?]",
@@ -37,7 +37,8 @@ class OutcomeSpec extends Specification with Discipline {
     "Outcome[Option, Int, ?]",
     MonadErrorTests[Outcome[Option, Int, ?], Int].monadError[Int, Int, Int])
 
-  checkAll(
-    "Outcome[Eval, Int, ?]",
-    ApplicativeErrorTests[Outcome[Eval, Int, ?], Int].applicativeError[Int, Int, Int])
+  //I'll need a moment to define ApplicativeErrorGenerators...
+  // checkAll(
+  //   "Outcome[Eval, Int, ?]",
+  //   ApplicativeErrorTests[Outcome[Eval, Int, ?], Int].applicativeError[Int, Int, Int])
 }

--- a/src/test/scala/ce3/laws/PureConcSpec.scala
+++ b/src/test/scala/ce3/laws/PureConcSpec.scala
@@ -36,14 +36,19 @@ import org.specs2.mutable._
 import org.typelevel.discipline.specs2.mutable.Discipline
 
 class PureConcSpec extends Specification with Discipline with ScalaCheck {
+  implicit val generators: Generators[PureConc[Int, *], Int] = new Generators[PureConc[Int, *], Int](λ[PureConc[Int, *] ~> Outcome[Option, Int, *]](run(_)))
+
   import Generators._
+  import generators.cogenPureConc
 
   checkAll(
     "PureConc",
     ConcurrentBracketTests[PureConc[Int, ?], Int].concurrentBracket[Int, Int, Int])
 
-  implicit def arbPureConc[E: Arbitrary: Cogen, A: Arbitrary: Cogen]: Arbitrary[PureConc[E, A]] =
-    Arbitrary(genPureConc[E, A](0))
+  implicit def arbPureConc[E: Arbitrary: Cogen, A: Arbitrary: Cogen](
+    implicit generators: Generators[PureConc[E, *], E]
+  ): Arbitrary[PureConc[E, A]] =
+    Arbitrary(generators.genF[A](0))
 
   implicit def prettyFromShow[A: Show](a: A): Pretty =
     Pretty.prettyString(a.show)


### PR DESCRIPTION
This is just an idea, but I noticed all of the generators only use the constructors / methods provided by the type class, the only thing that needs something more (`run`) being the `Cogen` instance.

Pushing this further would involve splitting the class into generators for monads, monaderrors, brackets, concurrents... which might or might not be easy to encode in Scala, but if it's possible - might give us a lot of niceness (e.g. generators for the Concurrent part of Resource, when it's available) for a very low cost.

Maybe we could use an encoding similar to what we do with laws extending from each other.