### PR TITLE
Make Eithers in tryAcquire coherent

### DIFF
--- a/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
@@ -215,7 +215,7 @@ object Semaphore {
                   val newValue = m - n
 
                   (Right(newValue), Right((m, newValue)))
-                case w => (w, w)
+                case _ => (old, old)
               }
 
               (newState, previousAndNow)

--- a/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
@@ -215,14 +215,14 @@ object Semaphore {
                   val newValue = m - n
 
                   (Right(newValue), Right((m, newValue)))
-                case w                  => (w, w)
+                case w => (w, w)
               }
 
               (newState, previousAndNow)
             }
             .map {
               case Right((previous, now)) if now != previous => true
-              case _ => false
+              case _                                         => false
             }
       }
 

--- a/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
@@ -210,22 +210,19 @@ object Semaphore {
         else
           state
             .modify { old =>
-              val u = old match {
-                case Right(m) if m >= n => Right(m - n)
-                case w                  => w
+              val (newState, previousAndNow) = old match {
+                case Right(m) if m >= n =>
+                  val newValue = m - n
+
+                  (Right(newValue), Right((m, newValue)))
+                case w                  => (w, w)
               }
-              (u, (old, u))
+
+              (newState, previousAndNow)
             }
             .map {
-              case (previous, now) =>
-                now match {
-                  case Left(_) => false
-                  case Right(n) =>
-                    previous match {
-                      case Left(_)  => false
-                      case Right(m) => n != m
-                    }
-                }
+              case Right((previous, now)) if now != previous => true
+              case _ => false
             }
       }
 


### PR DESCRIPTION
Thanks to @biscout24 for highlighting the issue.

The two Eithers (old state, new state) were passed in a tuple, which could make a reader think all 4 combinations of states are possible. As it turns out, we only case about two of them, and two others (newState=left, oldState=right; newState=right, oldState=left) are impossible.

This PR encodes that in the types by building a single Either as the value returned from `modify`.