### PR TITLE
Removed [A] from Concurrent#canceled

### DIFF
--- a/src/test/scala/ce3/laws/Generators.scala
+++ b/src/test/scala/ce3/laws/Generators.scala
@@ -83,7 +83,7 @@ object Generators {
     genPureConc[E, A](depth).map(pc => F[E].uncancelable(_ => pc))
 
   def genCanceled[E, A: Arbitrary]: Gen[PureConc[E, A]] =
-    arbitrary[A].map(F[E].canceled(_))
+    arbitrary[A].map(F[E].canceled.as(_))
 
   def genCede[E]: Gen[PureConc[E, Unit]] =
     F[E].cede


### PR DESCRIPTION
There was really no need for it. By curry-howard, `A => A` is **True**, which is to say, `Unit`. This simplifies the signatures and avoids the need to constantly write `canceled(())`.