### PR TITLE
Update scaladoc for Ref.getAndUpdate

### DIFF
--- a/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
@@ -60,7 +60,7 @@ abstract class Ref[F[_], A] {
   def set(a: A): F[Unit]
 
   /**
-   * Updates the current value using `f` and returns the value that was updated.
+   * Updates the current value using `f` and returns the previous value.
    *
    * In case of retries caused by concurrent modifications,
    * the returned value will be the last one before a successful update.


### PR DESCRIPTION
Make it explicit that it's the previous value that is returned. To me at least, it's ambiguous whether "the value that was updated" refers to the new updated value or the previous one.

```
@ val r = Ref.unsafe[IO, Int](0)
r: Ref[IO, Int] = cats.effect.concurrent.Ref$SyncRef@11eed657

@ r.getAndUpdate(_ + 1).unsafeRunSync
res0: Int = 0

@
```