### PR TITLE
Revise Bracket CE2 #1

### DIFF
--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/BracketBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/BracketBenchmark.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cats.effect.benchmarks
+
+import java.util.concurrent.TimeUnit
+
+import cats.effect.IO
+import org.openjdk.jmh.annotations._
+
+/** To do comparative benchmarks between versions:
+ *
+ *     benchmarks/run-benchmark BracketBenchmark
+ *
+ * This will generate results in `benchmarks/results`.
+ *
+ * Or to run the benchmark from within sbt:
+ *
+ *     jmh:run -i 10 -wi 10 -f 2 -t 1 cats.effect.benchmarks.BracketBenchmark
+ *
+ * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+ * Please note that benchmarks should be usually executed at least in
+ * 10 iterations (as a rule of thumb), but more is better.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class BracketBenchmark {
+  @Param(Array("10000"))
+  var size: Int = _
+
+  @Benchmark
+  def happyPath(): Int = {
+    def loop(i: Int): IO[Int] =
+      if (i < size)
+        IO.pure(i)
+          .bracket(i => IO.pure(i + 1))(_ => IO.unit)
+          .flatMap(loop)
+      else
+        IO.pure(i)
+
+    loop(0).unsafeRunSync()
+  }
+
+}

--- a/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
@@ -43,6 +43,7 @@ final private[internals] class IOTimer private (ec: ExecutionContext, sc: Schedu
         val ref = ForwardCancelable()
         conn.push(ref.cancel)
         // Race condition test
+        // TODO: check for guard here?
         if (!conn.isCanceled) {
           val f = sc.schedule(new ShiftTick(conn, cb, ec), timespan.length, timespan.unit)
           ref.complete(IO {

--- a/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOTimer.scala
@@ -43,8 +43,7 @@ final private[internals] class IOTimer private (ec: ExecutionContext, sc: Schedu
         val ref = ForwardCancelable()
         conn.push(ref.cancel)
         // Race condition test
-        // TODO: check for guard here?
-        if (!conn.isCanceled) {
+        if (!conn.isCanceled || conn.isGuarded) {
           val f = sc.schedule(new ShiftTick(conn, cb, ec), timespan.length, timespan.unit)
           ref.complete(IO {
             f.cancel(false)

--- a/core/shared/src/main/scala/cats/effect/internals/IOBracket.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOBracket.scala
@@ -16,154 +16,83 @@
 
 package cats.effect.internals
 
-import cats.effect.IO.ContextSwitch
+import cats.effect.IO.{ContextSwitch, RaiseError}
 import cats.effect.{CancelToken, ExitCase, IO}
-import cats.effect.internals.TrampolineEC.immediate
 
-import scala.concurrent.{ExecutionContext, Promise}
-import scala.util.control.NonFatal
+import scala.concurrent.Promise
 import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.util.control.NonFatal
 
 private[effect] object IOBracket {
 
-  /**
-   * Implementation for `IO.bracketCase`.
-   */
-  def apply[A, B](acquire: IO[A])(use: A => IO[B])(release: (A, ExitCase[Throwable]) => IO[Unit]): IO[B] =
-    IO.Async { (conn, cb) =>
-      // Placeholder for the future finalizer
-      val deferredRelease = ForwardCancelable()
-      conn.push(deferredRelease.cancel)
-      // Race-condition check, avoiding starting the bracket if the connection
-      // was cancelled already, to ensure that `cancel` really blocks if we
-      // start `acquire` — n.b. `isCanceled` is visible here due to `push`
-      if (!conn.isCanceled) {
-        // Note `acquire` is uncancelable due to usage of `IORunLoop.start`
-        // (in other words it is disconnected from our IOConnection)
-        IORunLoop.start[A](acquire, new BracketStart(use, release, conn, deferredRelease, cb))
-      } else {
-        deferredRelease.complete(IO.unit)
-      }
-    }
-
-  // Internals of `IO.bracketCase`.
-  final private class BracketStart[A, B](
-    use: A => IO[B],
-    release: (A, ExitCase[Throwable]) => IO[Unit],
+  final private[effect] class BracketUseFrame(
     conn: IOConnection,
     deferredRelease: ForwardCancelable,
-    cb: Callback.T[B]
-  ) extends (Either[Throwable, A] => Unit)
-      with Runnable {
-    // This runnable is a dirty optimization to avoid some memory allocations;
-    // This class switches from being a Callback to a Runnable, but relies on
-    // the internal IO callback protocol to be respected (called at most once)
-    private[this] var result: Either[Throwable, A] = _
+    use: Any => IO[Any],
+    release: (Any, ExitCase[Throwable]) => IO[Unit]
+  ) extends IOFrame[Any, IO[Any]] {
 
-    def apply(ea: Either[Throwable, A]): Unit = {
-      if (result ne null) {
-        throw new IllegalStateException("callback called multiple times!")
+    override def apply(a: Any): IO[Any] = {
+      conn.unguard()
+
+      val frame = new BracketReleaseFrame(a, release)
+      deferredRelease.complete(frame.cancel)
+
+      if (!conn.isCanceled || conn.isGuarded) {
+        val onUse =
+          try use(a)
+          catch { case NonFatal(ex) => RaiseError(ex) }
+        onUse.flatMap(frame)
+      } else {
+        IO.unit
       }
-      // Introducing a light async boundary, otherwise executing the required
-      // logic directly will yield a StackOverflowException
-      result = ea
-      ec.execute(this)
     }
 
-    def run(): Unit = result match {
-      case Right(a) =>
-        val frame = new BracketReleaseFrame[A, B](a, release)
-
-        // Registering our cancelable token ensures that in case
-        // cancellation is detected, `release` gets called
-        deferredRelease.complete(frame.cancel)
-
-        // Check if IO wasn't already cancelled in acquire
-        if (!conn.isCanceled) {
-          val onNext = {
-            val fb =
-              try use(a)
-              catch { case NonFatal(e) => IO.raiseError(e) }
-            fb.flatMap(frame)
-          }
-          // Actual execution
-          IORunLoop.startCancelable(onNext, conn, cb)
-        }
-
-      case error @ Left(_) =>
-        deferredRelease.complete(IO.unit)
-        cb(error.asInstanceOf[Either[Throwable, B]])
-    }
-  }
-
-  /**
-   * Implementation for `IO.guaranteeCase`.
-   */
-  def guaranteeCase[A](source: IO[A], release: ExitCase[Throwable] => IO[Unit]): IO[A] =
-    IO.Async { (conn, cb) =>
-      // Light async boundary, otherwise this will trigger a StackOverflowException
-      ec.execute(new Runnable {
-        def run(): Unit = {
-          val frame = new EnsureReleaseFrame[A](release)
-          val onNext = source.flatMap(frame)
-          // Registering our cancelable token ensures that in case
-          // cancellation is detected, `release` gets called
-          conn.push(frame.cancel)
-          // Race condition check, avoiding starting `source` in case
-          // the connection was already cancelled — n.b. we don't need
-          // to trigger `release` otherwise, because it already happened
-          if (!conn.isCanceled) {
-            IORunLoop.startCancelable(onNext, conn, cb)
-          }
-        }
-      })
+    override def recover(e: Throwable): IO[Any] = {
+      conn.unguard()
+      deferredRelease.complete(IO.unit)
+      IO.raiseError(e)
     }
 
-  final private class BracketReleaseFrame[A, B](a: A, releaseFn: (A, ExitCase[Throwable]) => IO[Unit])
-      extends BaseReleaseFrame[A, B] {
-    def release(c: ExitCase[Throwable]): CancelToken[IO] =
-      releaseFn(a, c)
   }
 
-  final private class EnsureReleaseFrame[A](releaseFn: ExitCase[Throwable] => IO[Unit])
-      extends BaseReleaseFrame[Unit, A] {
-    def release(c: ExitCase[Throwable]): CancelToken[IO] =
-      releaseFn(c)
-  }
-
-  abstract private class BaseReleaseFrame[A, B] extends IOFrame[B, IO[B]] {
+  final private[effect] class BracketReleaseFrame(a: Any, releaseFn: (Any, ExitCase[Throwable]) => IO[Unit])
+      extends IOFrame[Any, IO[Any]] {
     // Guard used for thread-safety, to ensure the idempotency
     // of the release; otherwise `release` can be called twice
     private[this] val waitsForResult = new AtomicBoolean(true)
     private[this] val p: Promise[Unit] = Promise()
 
-    def release(c: ExitCase[Throwable]): CancelToken[IO]
+    def release(c: ExitCase[Throwable]): CancelToken[IO] =
+      releaseFn(a, c)
 
     private def applyRelease(e: ExitCase[Throwable]): IO[Unit] =
       IO.suspend {
-        if (waitsForResult.compareAndSet(true, false))
+        if (waitsForResult.compareAndSet(true, false)) {
           release(e)
             .redeemWith[Unit](ex => IO(p.success(())).flatMap(_ => IO.raiseError(ex)), _ => IO { p.success(()); () })
-        else
+        } else {
           IOFromFuture.apply(p.future)
+        }
       }
 
     final val cancel: CancelToken[IO] =
       applyRelease(ExitCase.Canceled).uncancelable
 
-    final def recover(e: Throwable): IO[B] =
+    final def recover(e: Throwable): IO[Any] =
       // Unregistering cancel token, otherwise we can have a memory leak;
       // N.B. conn.pop() happens after the evaluation of `release`, because
       // otherwise we might have a conflict with the auto-cancellation logic
       ContextSwitch(applyRelease(ExitCase.error(e)), makeUncancelable, disableUncancelableAndPop)
         .flatMap(new ReleaseRecover(e))
 
-    final def apply(b: B): IO[B] =
+    final def apply(a: Any): IO[Any] =
       // Unregistering cancel token, otherwise we can have a memory leak
       // N.B. conn.pop() happens after the evaluation of `release`, because
       // otherwise we might have a conflict with the auto-cancellation logic
       ContextSwitch(applyRelease(ExitCase.complete), makeUncancelable, disableUncancelableAndPop)
-        .map(_ => b)
+        .map(_ => a)
   }
 
   final private class ReleaseRecover(e: Throwable) extends IOFrame[Unit, IO[Nothing]] {
@@ -177,11 +106,6 @@ private[effect] object IOBracket {
     def apply(a: Unit): IO[Nothing] =
       IO.raiseError(e)
   }
-
-  /**
-   * Trampolined execution context used to preserve stack-safety.
-   */
-  private[this] val ec: ExecutionContext = immediate
 
   private[this] val makeUncancelable: IOConnection => IOConnection =
     _ => IOConnection.uncancelable

--- a/core/shared/src/main/scala/cats/effect/internals/IOConnection.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOConnection.scala
@@ -29,7 +29,8 @@ import scala.concurrent.Promise
  * Implementation notes:
  *
  *  - `cancel()` is idempotent
- *  - all methods are thread-safe / atomic
+ *  - cancellation methods ARE thread-safe / atomic
+ *  - guard methods ARE NOT thread-safe
  *
  * Used in the implementation of `cats.effect.IO`. Inspired by the
  * implementation of `StackedCancelable` from the Monix library.

--- a/core/shared/src/main/scala/cats/effect/internals/IOShift.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOShift.scala
@@ -30,7 +30,7 @@ private[effect] object IOShift {
     })
 
   def shiftOn[A](cs: ExecutionContext, targetEc: ExecutionContext, io: IO[A]): IO[A] =
-    IOBracket[Unit, A](IOShift(cs))(_ => io)((_, _) => IOShift(targetEc))
+    IOShift(cs).bracketCase(_ => io)((_, _) => IOShift(targetEc))
 
   final private[internals] class Tick(cb: Either[Throwable, Unit] => Unit) extends Runnable {
     def run() = cb(Callback.rightUnit)


### PR DESCRIPTION
## Motivation
An implementation detail of `IO.bracket` today is that it leverages `IO.Async` to guarantee non-interruptibility during the `acquire` action.

The implementation can be roughly described as follows:
1. With an `IO.Async` node, invoke a new run-loop for the `acquire` action whose connection is divorced from the active connection.
2. In the callback for the `acquire` run-loop, invoke a second run-loop for the `use` and `release` actions. Use the original connection so that cancellation is respected again.

Critically, the `acquire` action is executed in a run-loop from which it is infeasible to collect any state or context from (run-loop callbacks have the type signature `Either[Throwable, A] => Unit`). This represents a limitation for several applications like [fiber tracing](https://github.com/typelevel/cats-effect/pull/854) and [fiber-local state](https://github.com/typelevel/cats-effect/pull/836), where there is a need for a stable context that must be threaded along with the execution of a fiber. 

The current workaround is to pass a thread-safe `IOContext` class to which all run-loops have a reference, so that changes are consistently propagated across threads. This is rather unideal because the `IOContext` class is confined to a single fiber and is manipulated only by the thread the fiber is bound to. Synchronization is only necessary because the fiber may encounter asynchronous boundaries.

So the goal here is really to revise `bracket` so it's easier to thread state along the execution of a fiber.

## Design constraints
1. The public API *must* remain backwards compatible.
2. The new implementation *must* preserve CE2 semantics. Satisfying the CE2 laws is necessary, but it's crucial that the new implementation exhibits the exact same behavior as before. Proving this exhaustively may be non-trivial.

## Proposed solution
I followed the most obvious solution first. The idea is to introduce a new instruction to the `IO` encoding called `Bracket`. An internal concept of "guards" is introduced to facilitate uninterruptible execution in `acquire` actions.

For context, there are several points at which cancellation is observed and respected (I might have missed some):
1. auto-cancellation
2. exit of an asynchronous boundary
3. after `acquire` completes and before `use` begins

The main issue here is that `acquire` must execute to completion, so that it can finish registration of the `release` finalizer. Guards are used to help facilitate this. The behavior of guards is described as follows:
1. Before entering a bracket acquire region, set guard flag to true.
2. After exiting a bracket acquire region, set guard flag to false.
3. Whenever cancellation is checked, the guard flag is also checked. If a fiber observes itself to be cancelled, but the guard flag is on, ignore cancellation and continue. Note that cancellers would backpressure on the deferred finalizer that is registered before `acquire` executes.

Additionally, `acquire` actions are made `uncancelable`. This ensures that asynchronous operations can't be cancelled, so they must resume the run-loop to complete the `release` registration.

## Benchmarks
### 2.0.0
```
[info] Benchmark                   (size)   Mode  Cnt    Score   Error  Units
[info] BracketBenchmark.happyPath   10000  thrpt    5  469.289 ± 4.529  ops/s
```
### PR
```
[info] Benchmark                   (size)   Mode  Cnt    Score   Error  Units
[info] BracketBenchmark.happyPath   10000  thrpt    5  351.519 ± 4.413  ops/s
```

So there's a 25% performance degradation here. I haven't looked into it, but I'm certain that it's because several additional `IO` nodes are being inserted into the tree to facilitate `Bracket`. If we inlined some of that code, we could trim it down quite a bit.

## Alternative implementations
1. Make the async callbacks fit the signature we want. This might necessitate an additional layer of indirection that would look ugly, but I think it would work.
2. Leverage the Java memory model. In particular, the memory model specifies that writes to a non-volatile variable by one thread are visible to reads of that variable in another thread, as long as there is a write by the first thread/read by the second thread to a volatile variable interleaved between the non-volatile accesses. These memory semantics hold for atomics as well. The runtime would have to be programmed to ensure that the volatile is read from or written to whenever exiting or entering an asynchronous boundary respectively. Obviously, this approach is ridiculously hard to reason about.
3. Cats Effect 3 will feature a [brand new interruption model](https://github.com/typelevel/cats-effect/issues/681) that can express `bracket` in a way that satisfies our requirements here.
4. Use `Promise` in `IOBracket` to pass back context from the invoked run-loop. This approach definitely has the least risk and effort involved. Maybe I should have written out this one first 😅 

I'm particularly interested in option 4, will probably open a PR for it this weekend. Let me know if there are other approaches worth considering.