### PR TITLE
Added all the convenience materializers (and some handy overloads)

### DIFF
--- a/core/src/main/scala/cats/effect/Async.scala
+++ b/core/src/main/scala/cats/effect/Async.scala
@@ -31,3 +31,7 @@ trait Async[F[_]] extends Sync[F] with Temporal[F, Throwable] { self: Safe[F, Th
   def evalOn[A](fa: F[A], ec: ExecutionContext): F[A]
   def executionContext: F[ExecutionContext]
 }
+
+object Async {
+  def apply[F[_]](implicit F: Async[F]): F.type = F
+}

--- a/core/src/main/scala/cats/effect/Clock.scala
+++ b/core/src/main/scala/cats/effect/Clock.scala
@@ -32,5 +32,5 @@ trait Clock[F[_]] extends Applicative[F] {
 }
 
 object Clock {
-  def apply[F[_]](implicit F: Clock[F]): Clock[F] = F
+  def apply[F[_]](implicit F: Clock[F]): F.type = F
 }

--- a/core/src/main/scala/cats/effect/Effect.scala
+++ b/core/src/main/scala/cats/effect/Effect.scala
@@ -30,3 +30,7 @@ trait Effect[F[_]] extends Async[F] with Bracket[F, Throwable] {
       toK(G)(fa)
   }
 }
+
+object Effect {
+  def apply[F[_]](implicit F: Effect[F]): F.type = F
+}

--- a/core/src/main/scala/cats/effect/Managed.scala
+++ b/core/src/main/scala/cats/effect/Managed.scala
@@ -25,3 +25,7 @@ trait Managed[R[_[_], _], F[_]] extends Async[R[F, ?]] with Region[R, F, Throwab
     def apply[A](rfa: R[F, A])(implicit S: Async[S[F, ?]] with Region[S, F, Throwable]): S[F, A]
   }
 }
+
+object Managed {
+  def apply[R[_[_], _], F[_]](implicit R: Managed[R, F]): R.type = R
+}

--- a/core/src/main/scala/cats/effect/Sync.scala
+++ b/core/src/main/scala/cats/effect/Sync.scala
@@ -26,5 +26,5 @@ trait Sync[F[_]] extends MonadError[F, Throwable] with Clock[F] with Defer[F] {
 }
 
 object Sync {
-  def apply[F[_]](implicit F: Sync[F]): Sync[F] = F
+  def apply[F[_]](implicit F: Sync[F]): F.type = F
 }

--- a/core/src/main/scala/cats/effect/SyncEffect.scala
+++ b/core/src/main/scala/cats/effect/SyncEffect.scala
@@ -34,3 +34,7 @@ trait SyncEffect[F[_]] extends Sync[F] with Bracket[F, Throwable] {
       toK[G](G)(fa)
   }
 }
+
+object SyncEffect {
+  def apply[F[_]](implicit F: SyncEffect[F]): F.type = F
+}

--- a/core/src/main/scala/cats/effect/SyncManaged.scala
+++ b/core/src/main/scala/cats/effect/SyncManaged.scala
@@ -16,7 +16,6 @@
 
 package cats.effect
 
-import cats.~>
 import cats.implicits._
 
 trait SyncManaged[R[_[_], _], F[_]] extends Sync[R[F, ?]] with Region[R, F, Throwable] {
@@ -29,4 +28,8 @@ trait SyncManaged[R[_[_], _], F[_]] extends Sync[R[F, ?]] with Region[R, F, Thro
   trait PartiallyApplied[S[_[_], _]] {
     def apply[A](rfa: R[F, A])(implicit S: Sync[S[F, ?]] with Region[S, F, Throwable]): S[F, A]
   }
+}
+
+object SyncManaged {
+  def apply[R[_[_], _], F[_]](implicit R: SyncManaged[R, F]): R.type = R
 }

--- a/core/src/main/scala/cats/effect/Temporal.scala
+++ b/core/src/main/scala/cats/effect/Temporal.scala
@@ -25,4 +25,5 @@ trait Temporal[F[_], E] extends Concurrent[F, E] with Clock[F] { self: Safe[F, E
 
 object Temporal {
   def apply[F[_], E](implicit F: Temporal[F, E]): F.type = F
+  def apply[F[_]](implicit F: Temporal[F, _], d: DummyImplicit): F.type = F
 }

--- a/core/src/main/scala/cats/effect/concurrent.scala
+++ b/core/src/main/scala/cats/effect/concurrent.scala
@@ -76,4 +76,5 @@ trait Concurrent[F[_], E] extends MonadError[F, E] { self: Safe[F, E] =>
 
 object Concurrent {
   def apply[F[_], E](implicit F: Concurrent[F, E]): F.type = F
+  def apply[F[_]](implicit F: Concurrent[F, _], d: DummyImplicit): F.type = F
 }

--- a/core/src/main/scala/cats/effect/safe.scala
+++ b/core/src/main/scala/cats/effect/safe.scala
@@ -50,6 +50,7 @@ object Bracket {
   type Aux2[F[_], E, Case0[_, _]] = Bracket[F, E] { type Case[A] = Case0[E, A] }
 
   def apply[F[_], E](implicit F: Bracket[F, E]): F.type = F
+  def apply[F[_]](implicit F: Bracket[F, _], d: DummyImplicit): F.type = F
 }
 
 trait Region[R[_[_], _], F[_], E] extends Safe[R[F, ?], E] {
@@ -74,4 +75,7 @@ trait Region[R[_[_], _], F[_], E] extends Safe[R[F, ?], E] {
 object Region {
   type Aux[R[_[_], _], F[_], E, Case0[_]] = Region[R, F, E] { type Case[A] = Case0[A] }
   type Aux2[R[_[_], _], F[_], E, Case0[_, _]] = Region[R, F, E] { type Case[A] = Case0[E, A] }
+
+  def apply[R[_[_], _], F[_], E](implicit R: Region[R, F, E]): R.type = R
+  def apply[R[_[_], _], F[_]](implicit R: Region[R, F, _], d1: DummyImplicit): R.type = R
 }


### PR DESCRIPTION
One of the super-nice things here is we get to keep a lot of the materializer syntax we're already using. For example, `IO` will form a `ConcurrentBracket[IO, Throwable]`, but no other error type (and also specifically *not* `Region`). With this PR, you will be able to materialize its `ConcurrentBracket` specifically by writing `Concurrent[IO]`, and the result type will be fully inferred. You should, in theory, only need to use the two-argument version when some other complicated type inference thing makes the error type uninferrable.