### PR TITLE
Sync for FreeT Eval

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,15 +44,7 @@ lazy val core = project.in(file("core"))
   .settings(
     name := "cats-effect",
 
-    libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats-core" % CatsVersion,
-      "org.typelevel" %% "cats-free" % CatsVersion,
-
-      "com.codecommit" %% "coop" % "0.4.0",
-
-      "org.typelevel" %% "cats-laws"         % CatsVersion % Test,
-      "org.typelevel" %% "discipline-specs2" % "1.0.0"     % Test,
-      "org.specs2"    %% "specs2-scalacheck" % "4.8.1"     % Test))
+    libraryDependencies += "org.typelevel" %% "cats-core" % CatsVersion)
 
 lazy val laws = project.in(file("laws"))
   .dependsOn(core)
@@ -61,6 +53,9 @@ lazy val laws = project.in(file("laws"))
 
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-laws" % CatsVersion,
+      "org.typelevel" %% "cats-free" % CatsVersion,
+
+      "com.codecommit" %% "coop" % "0.4.0",
 
       "org.typelevel" %% "discipline-specs2" % "1.0.0"     % Test,
       "org.specs2"    %% "specs2-scalacheck" % "4.8.1"     % Test))

--- a/core/src/main/scala/cats/effect/Async.scala
+++ b/core/src/main/scala/cats/effect/Async.scala
@@ -31,3 +31,7 @@ trait Async[F[_]] extends Sync[F] with Temporal[F, Throwable] { self: Safe[F, Th
   def evalOn[A](fa: F[A], ec: ExecutionContext): F[A]
   def executionContext: F[ExecutionContext]
 }
+
+object Async {
+  def apply[F[_]](implicit F: Async[F]): F.type = F
+}

--- a/core/src/main/scala/cats/effect/Clock.scala
+++ b/core/src/main/scala/cats/effect/Clock.scala
@@ -32,5 +32,5 @@ trait Clock[F[_]] extends Applicative[F] {
 }
 
 object Clock {
-  def apply[F[_]](implicit F: Clock[F]): Clock[F] = F
+  def apply[F[_]](implicit F: Clock[F]): F.type = F
 }

--- a/core/src/main/scala/cats/effect/Effect.scala
+++ b/core/src/main/scala/cats/effect/Effect.scala
@@ -30,3 +30,7 @@ trait Effect[F[_]] extends Async[F] with Bracket[F, Throwable] {
       toK(G)(fa)
   }
 }
+
+object Effect {
+  def apply[F[_]](implicit F: Effect[F]): F.type = F
+}

--- a/core/src/main/scala/cats/effect/Managed.scala
+++ b/core/src/main/scala/cats/effect/Managed.scala
@@ -25,3 +25,7 @@ trait Managed[R[_[_], _], F[_]] extends Async[R[F, ?]] with Region[R, F, Throwab
     def apply[A](rfa: R[F, A])(implicit S: Async[S[F, ?]] with Region[S, F, Throwable]): S[F, A]
   }
 }
+
+object Managed {
+  def apply[R[_[_], _], F[_]](implicit R: Managed[R, F]): R.type = R
+}

--- a/core/src/main/scala/cats/effect/Sync.scala
+++ b/core/src/main/scala/cats/effect/Sync.scala
@@ -26,5 +26,5 @@ trait Sync[F[_]] extends MonadError[F, Throwable] with Clock[F] with Defer[F] {
 }
 
 object Sync {
-  def apply[F[_]](implicit F: Sync[F]): Sync[F] = F
+  def apply[F[_]](implicit F: Sync[F]): F.type = F
 }

--- a/core/src/main/scala/cats/effect/SyncEffect.scala
+++ b/core/src/main/scala/cats/effect/SyncEffect.scala
@@ -34,3 +34,7 @@ trait SyncEffect[F[_]] extends Sync[F] with Bracket[F, Throwable] {
       toK[G](G)(fa)
   }
 }
+
+object SyncEffect {
+  def apply[F[_]](implicit F: SyncEffect[F]): F.type = F
+}

--- a/core/src/main/scala/cats/effect/SyncManaged.scala
+++ b/core/src/main/scala/cats/effect/SyncManaged.scala
@@ -16,7 +16,6 @@
 
 package cats.effect
 
-import cats.~>
 import cats.implicits._
 
 trait SyncManaged[R[_[_], _], F[_]] extends Sync[R[F, ?]] with Region[R, F, Throwable] {
@@ -29,4 +28,8 @@ trait SyncManaged[R[_[_], _], F[_]] extends Sync[R[F, ?]] with Region[R, F, Thro
   trait PartiallyApplied[S[_[_], _]] {
     def apply[A](rfa: R[F, A])(implicit S: Sync[S[F, ?]] with Region[S, F, Throwable]): S[F, A]
   }
+}
+
+object SyncManaged {
+  def apply[R[_[_], _], F[_]](implicit R: SyncManaged[R, F]): R.type = R
 }

--- a/core/src/main/scala/cats/effect/Temporal.scala
+++ b/core/src/main/scala/cats/effect/Temporal.scala
@@ -25,4 +25,5 @@ trait Temporal[F[_], E] extends Concurrent[F, E] with Clock[F] { self: Safe[F, E
 
 object Temporal {
   def apply[F[_], E](implicit F: Temporal[F, E]): F.type = F
+  def apply[F[_]](implicit F: Temporal[F, _], d: DummyImplicit): F.type = F
 }

--- a/core/src/main/scala/cats/effect/concurrent.scala
+++ b/core/src/main/scala/cats/effect/concurrent.scala
@@ -76,4 +76,5 @@ trait Concurrent[F[_], E] extends MonadError[F, E] { self: Safe[F, E] =>
 
 object Concurrent {
   def apply[F[_], E](implicit F: Concurrent[F, E]): F.type = F
+  def apply[F[_]](implicit F: Concurrent[F, _], d: DummyImplicit): F.type = F
 }

--- a/core/src/main/scala/cats/effect/safe.scala
+++ b/core/src/main/scala/cats/effect/safe.scala
@@ -50,6 +50,7 @@ object Bracket {
   type Aux2[F[_], E, Case0[_, _]] = Bracket[F, E] { type Case[A] = Case0[E, A] }
 
   def apply[F[_], E](implicit F: Bracket[F, E]): F.type = F
+  def apply[F[_]](implicit F: Bracket[F, _], d: DummyImplicit): F.type = F
 }
 
 trait Region[R[_[_], _], F[_], E] extends Safe[R[F, ?], E] {
@@ -74,4 +75,7 @@ trait Region[R[_[_], _], F[_], E] extends Safe[R[F, ?], E] {
 object Region {
   type Aux[R[_[_], _], F[_], E, Case0[_]] = Region[R, F, E] { type Case[A] = Case0[A] }
   type Aux2[R[_[_], _], F[_], E, Case0[_, _]] = Region[R, F, E] { type Case[A] = Case0[E, A] }
+
+  def apply[R[_[_], _], F[_], E](implicit R: Region[R, F, E]): R.type = R
+  def apply[R[_[_], _], F[_]](implicit R: Region[R, F, _], d1: DummyImplicit): R.type = R
 }

--- a/laws/src/main/scala/cats/effect/freeEval.scala
+++ b/laws/src/main/scala/cats/effect/freeEval.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.{Eq, Eval, Monad, MonadError}
+import cats.free.FreeT
+import cats.implicits._
+
+import scala.concurrent.duration._
+import java.time.Instant
+
+object freeEval {
+
+  type FreeSync[F[_], A] = FreeT[Eval, F, A]
+  type FreeEitherSync[A] = FreeSync[Either[Throwable, ?], A]
+
+  def run[F[_]: Monad, A](ft: FreeT[Eval, F, A]): F[A] =
+    ft.runM(_.value.pure[F])
+
+  implicit def syncForFreeT[F[_]](implicit F: MonadError[F, Throwable]): Sync[FreeT[Eval, F, ?]] =
+    new Sync[FreeT[Eval, F, ?]] {
+      private[this] val M: MonadError[FreeT[Eval, F, ?], Throwable] =
+        cats.effect.pure.catsFreeMonadErrorForFreeT2
+
+      def pure[A](x: A): FreeT[Eval, F, A] =
+        M.pure(x)
+
+      def handleErrorWith[A](fa: FreeT[Eval, F, A])(f: Throwable => FreeT[Eval, F, A]): FreeT[Eval, F, A] =
+        M.handleErrorWith(fa)(f)
+
+      def raiseError[A](e: Throwable): FreeT[Eval, F, A] =
+        M.raiseError(e)
+
+      def monotonic: FreeT[Eval, F, FiniteDuration] =
+        delay(System.nanoTime().nanos)
+
+      def realTime: FreeT[Eval, F, Instant] =
+        delay(Instant.now())
+
+      def flatMap[A, B](fa: FreeT[Eval, F, A])(f: A => FreeT[Eval, F, B]): FreeT[Eval, F, B] =
+        fa.flatMap(f)
+
+      def tailRecM[A, B](a: A)(f: A => FreeT[Eval, F, Either[A, B]]): FreeT[Eval, F, B] =
+        M.tailRecM(a)(f)
+
+      def delay[A](thunk: => A): FreeT[Eval, F, A] =
+        FreeT roll {
+          Eval always {
+            try {
+              pure(thunk)
+            } catch {
+              case t: Throwable =>
+                raiseError(t)
+            }
+          }
+        }
+    }
+
+  implicit def eqFreeSync[F[_]: Monad, A](implicit F: Eq[F[A]]): Eq[FreeT[Eval, F, A]] =
+    Eq.by(run(_))
+}

--- a/laws/src/main/scala/cats/effect/pure.scala
+++ b/laws/src/main/scala/cats/effect/pure.scala
@@ -16,7 +16,7 @@
 
 package cats.effect
 
-import cats.{~>, Eq, Functor, Group, Id, Monad, MonadError, Monoid, Show}
+import cats.{~>, Eq, Eval, Functor, Group, Id, Monad, MonadError, Monoid, Show}
 import cats.data.{Kleisli, WriterT}
 import cats.free.FreeT
 import cats.implicits._
@@ -24,6 +24,8 @@ import cats.implicits._
 import cats.mtl.implicits._
 
 import coop.{ApplicativeThread, ThreadT, MVar}
+
+import scala.concurrent.duration._
 
 object pure {
 
@@ -198,6 +200,45 @@ object pure {
 
       def raiseError[A](e: E) =
         F.raiseError(e)
+    }
+
+  def runSync[F[_]: Monad, A](ft: FreeT[Eval, F, A]): F[A] =
+    ft.runM(_.value.pure[F])
+
+  implicit def syncForFreeT[F[_]](implicit F: MonadError[F, Throwable]): Sync[FreeT[Eval, F, ?]] =
+    new Sync[FreeT[Eval, F, ?]] {
+      private[this] val M: MonadError[FreeT[Eval, F, ?], Throwable] =
+        catsFreeMonadErrorForFreeT2
+
+      def pure[A](x: A): FreeT[Eval, F, A] =
+        M.pure(x)
+
+      def handleErrorWith[A](fa: FreeT[Eval, F, A])(f: Throwable => FreeT[Eval, F, A]): FreeT[Eval, F, A] =
+        M.handleErrorWith(fa)(f)
+
+      def raiseError[A](e: Throwable): FreeT[Eval, F, A] =
+        M.raiseError(e)
+
+      def now: FreeT[Eval, F, FiniteDuration] =
+        delay(System.nanoTime().nanos)
+
+      def flatMap[A, B](fa: FreeT[Eval, F, A])(f: A => FreeT[Eval, F, B]): FreeT[Eval, F, B] =
+        fa.flatMap(f)
+
+      def tailRecM[A, B](a: A)(f: A => FreeT[Eval, F, Either[A, B]]): FreeT[Eval, F, B] =
+        M.tailRecM(a)(f)
+
+      def delay[A](thunk: => A): FreeT[Eval, F, A] =
+        FreeT roll {
+          Eval always {
+            try {
+              pure(thunk)
+            } catch {
+              case t: Throwable =>
+                raiseError(t)
+            }
+          }
+        }
     }
 
   implicit def concurrentBForPureConc[E]: ConcurrentBracket[PureConc[E, ?], E] =

--- a/laws/src/main/scala/cats/effect/pure.scala
+++ b/laws/src/main/scala/cats/effect/pure.scala
@@ -523,6 +523,9 @@ object pure {
         M.tailRecM(a)(f)
     }
 
+  implicit def eqFreeSync[F[_]: Monad, A](implicit F: Eq[F[A]]): Eq[FreeT[Eval, F, A]] =
+    Eq.by(runSync(_))
+
   implicit def eqPureConc[E: Eq, A: Eq]: Eq[PureConc[E, A]] = Eq.by(run(_))
 
   implicit def showPureConc[E: Show, A: Show]: Show[PureConc[E, A]] =

--- a/laws/src/test/scala/cats/effect/FreeSyncGenerators.scala
+++ b/laws/src/test/scala/cats/effect/FreeSyncGenerators.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ce3
+package laws
+
+import cats.{Eval, Monad, MonadError}
+import cats.free.FreeT
+
+import playground._
+
+import org.scalacheck.{Arbitrary, Cogen, Gen}
+import org.scalacheck.util.Pretty
+
+import scala.concurrent.duration.FiniteDuration
+import java.util.concurrent.TimeUnit
+
+object FreeSyncGenerators {
+  import OutcomeGenerators._
+
+  implicit def cogenFreeSync[F[_]: Monad, A: Cogen](implicit C: Cogen[F[A]]): Cogen[FreeT[Eval, F, A]] =
+    C.contramap(runSync(_))
+
+  def generators[F[_]](implicit F0: MonadError[F, Throwable]) =
+    new SyncGenerators[FreeT[Eval, F, ?]] {
+
+      val arbitraryE: Arbitrary[Throwable] =
+        Arbitrary(Arbitrary.arbitrary[Int].map(TestException(_)))
+
+      val cogenE: Cogen[Throwable] =
+        Cogen[Int].contramap(_.asInstanceOf[TestException].i)
+
+      val arbitraryFD: Arbitrary[FiniteDuration] = {
+        import TimeUnit._
+
+        val genTU = Gen.oneOf(NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS)
+
+        Arbitrary {
+          genTU flatMap { u =>
+            Gen.posNum[Long].map(FiniteDuration(_, u))
+          }
+        }
+      }
+
+      val F: Sync[FreeT[Eval, F, ?]] =
+        syncForFreeT[F]
+    }
+
+  implicit def arbitraryFreeSync[F[_], A: Arbitrary: Cogen](
+      implicit F: MonadError[F, Throwable])
+      : Arbitrary[FreeT[Eval, F, A]] =
+    Arbitrary(generators[F].generators[A])
+}
+
+final case class TestException(i: Int) extends Exception

--- a/laws/src/test/scala/cats/effect/FreeSyncGenerators.scala
+++ b/laws/src/test/scala/cats/effect/FreeSyncGenerators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Daniel Spiewak
+ * Copyright 2020 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,23 @@
  * limitations under the License.
  */
 
-package ce3
+package cats.effect
 package laws
 
 import cats.{Eval, Monad, MonadError}
 import cats.free.FreeT
 
-import playground._
+import freeEval._
 
 import org.scalacheck.{Arbitrary, Cogen, Gen}
-import org.scalacheck.util.Pretty
 
 import scala.concurrent.duration.FiniteDuration
 import java.util.concurrent.TimeUnit
 
 object FreeSyncGenerators {
-  import OutcomeGenerators._
 
   implicit def cogenFreeSync[F[_]: Monad, A: Cogen](implicit C: Cogen[F[A]]): Cogen[FreeT[Eval, F, A]] =
-    C.contramap(runSync(_))
+    C.contramap(run(_))
 
   def generators[F[_]](implicit F0: MonadError[F, Throwable]) =
     new SyncGenerators[FreeT[Eval, F, ?]] {

--- a/laws/src/test/scala/cats/effect/FreeSyncSpec.scala
+++ b/laws/src/test/scala/cats/effect/FreeSyncSpec.scala
@@ -26,7 +26,6 @@ import org.scalacheck.Prop
 import org.scalacheck.util.Pretty
 
 import org.specs2.ScalaCheck
-import org.specs2.matcher.Matcher
 import org.specs2.mutable._
 
 import org.typelevel.discipline.specs2.mutable.Discipline
@@ -42,15 +41,6 @@ class FreeSyncSpec extends Specification with Discipline with ScalaCheck {
 
   implicit def exec(sbool: FreeEitherSync[Boolean]): Prop =
     run(sbool).fold(Prop.exception(_), b => if (b) Prop.proved else Prop.falsified)
-
-  def beEqv[A: Eq: Show](expect: A): Matcher[A] = be_===[A](expect)
-
-  def be_===[A: Eq: Show](expect: A): Matcher[A] = (result: A) =>
-    (result === expect, s"${result.show} === ${expect.show}", s"${result.show} !== ${expect.show}")
-
-  Eq[Either[Throwable, Int]]
-
-  cats.Invariant[FreeEitherSync]
 
   checkAll(
     "FreeEitherSync",

--- a/laws/src/test/scala/cats/effect/FreeSyncSpec.scala
+++ b/laws/src/test/scala/cats/effect/FreeSyncSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ce3
+package laws
+
+import cats.{~>, Applicative, ApplicativeError, Eq, Eval, FlatMap, Monad, Monoid, Show}
+import cats.data.{EitherK, StateT}
+import cats.free.FreeT
+import cats.implicits._
+
+import coop.ThreadT
+
+import playground._
+
+import org.scalacheck.{Arbitrary, Cogen, Gen, Prop}, Arbitrary.arbitrary
+import org.scalacheck.util.Pretty
+
+import org.specs2.ScalaCheck
+import org.specs2.matcher.Matcher
+import org.specs2.mutable._
+
+import org.typelevel.discipline.specs2.mutable.Discipline
+
+class FreeSyncSpec extends Specification with Discipline with ScalaCheck {
+  import FreeSyncGenerators._
+
+  type FreeEitherSync[A] = FreeT[Eval, Either[Throwable, ?], A]
+
+  implicit def prettyFromShow[A: Show](a: A): Pretty =
+    Pretty.prettyString(a.show)
+
+  implicit val eqThrowable: Eq[Throwable] =
+    Eq.fromUniversalEquals
+
+  implicit def exec(sbool: FreeEitherSync[Boolean]): Prop =
+    runSync(sbool).fold(Prop.exception(_), b => if (b) Prop.proved else Prop.falsified)
+
+  def beEqv[A: Eq: Show](expect: A): Matcher[A] = be_===[A](expect)
+
+  def be_===[A: Eq: Show](expect: A): Matcher[A] = (result: A) =>
+    (result === expect, s"${result.show} === ${expect.show}", s"${result.show} !== ${expect.show}")
+
+  Eq[Either[Throwable, Int]]
+
+  checkAll(
+    "FreeEitherSync",
+    SyncTests[FreeEitherSync].sync[Int, Int, Int])
+}

--- a/laws/src/test/scala/cats/effect/Generators.scala
+++ b/laws/src/test/scala/cats/effect/Generators.scala
@@ -264,7 +264,7 @@ trait AsyncGenerators[F[_]] extends TemporalGenerators[F, Throwable] with SyncGe
       fo <- deeper[Option[F[Unit]]](
         Arbitrary(
           Gen.option[F[Unit]](
-            deeper[Unit](Arbitrary(arbitrary[Unit]), Cogen.cogenUnit))),
+            deeper[Unit])),
         Cogen.cogenOption(cogenFU))
     } yield F.async[A](k => F.delay(k(result)) >> fo)
 

--- a/laws/src/test/scala/cats/effect/Generators.scala
+++ b/laws/src/test/scala/cats/effect/Generators.scala
@@ -133,13 +133,12 @@ trait ClockGenerators[F[_]] extends ApplicativeGenerators[F] {
   implicit val F: Clock[F]
 
   protected implicit val arbitraryFD: Arbitrary[FiniteDuration]
-  protected implicit val cogenFD: Cogen[FiniteDuration]
 
   override protected def baseGen[A: Arbitrary: Cogen] =
     ("now" -> genNow[A]) :: super.baseGen[A]
 
   private def genNow[A: Arbitrary] =
-    arbitrary[FiniteDuration => A].map(F.now.map(_))
+    arbitrary[A].map(F.now.as(_))
 }
 
 trait SyncGenerators[F[_]] extends MonadErrorGenerators[F, Throwable] with ClockGenerators[F] {

--- a/laws/src/test/scala/cats/effect/Generators.scala
+++ b/laws/src/test/scala/cats/effect/Generators.scala
@@ -16,7 +16,7 @@
 
 package cats.effect
 
-import cats.{Applicative, ApplicativeError, Monad}
+import cats.{Applicative, ApplicativeError, Monad, MonadError}
 import cats.implicits._
 
 import org.scalacheck.{Arbitrary, Cogen, Gen}, Arbitrary.arbitrary
@@ -135,10 +135,15 @@ trait ClockGenerators[F[_]] extends ApplicativeGenerators[F] {
   protected implicit val arbitraryFD: Arbitrary[FiniteDuration]
 
   override protected def baseGen[A: Arbitrary: Cogen] =
-    ("now" -> genNow[A]) :: super.baseGen[A]
+    List(
+      "monotonic" -> genMonotonic[A],
+      "realTime" -> genRealTime[A]) ++ super.baseGen[A]
 
-  private def genNow[A: Arbitrary] =
-    arbitrary[A].map(F.now.as(_))
+  private def genMonotonic[A: Arbitrary] =
+    arbitrary[A].map(F.monotonic.as(_))
+
+  private def genRealTime[A: Arbitrary] =
+    arbitrary[A].map(F.realTime.as(_))
 }
 
 trait SyncGenerators[F[_]] extends MonadErrorGenerators[F, Throwable] with ClockGenerators[F] {

--- a/laws/src/test/scala/cats/effect/Generators.scala
+++ b/laws/src/test/scala/cats/effect/Generators.scala
@@ -122,7 +122,12 @@ trait ApplicativeErrorGenerators[F[_], E] extends ApplicativeGenerators[F] {
     } yield F.handleErrorWith(fa)(f)
   }
 }
-trait BracketGenerators[F[_], E] extends ApplicativeErrorGenerators[F, E] {
+
+trait MonadErrorGenerators[F[_], E] extends MonadGenerators[F] with ApplicativeErrorGenerators[F, E] {
+  implicit val F: MonadError[F, E]
+}
+
+trait BracketGenerators[F[_], E] extends MonadErrorGenerators[F, E] {
   implicit val F: Bracket[F, E]
   type Case[A] = F.Case[A]
   implicit def cogenCase[A: Cogen]: Cogen[Case[A]]
@@ -140,7 +145,7 @@ trait BracketGenerators[F[_], E] extends ApplicativeErrorGenerators[F, E] {
   }
 }
 
-trait ConcurrentGenerators[F[_], E] extends ApplicativeErrorGenerators[F, E] {
+trait ConcurrentGenerators[F[_], E] extends MonadErrorGenerators[F, E] {
   implicit val F: Concurrent[F, E]
 
   override protected def baseGen[A: Arbitrary: Cogen]: List[(String, Gen[F[A]])] = List(

--- a/laws/src/test/scala/cats/effect/PureConcGenerators.scala
+++ b/laws/src/test/scala/cats/effect/PureConcGenerators.scala
@@ -23,19 +23,22 @@ import org.scalacheck.{Arbitrary, Cogen}
 object PureConcGenerators {
   import OutcomeGenerators._
 
-  implicit def cogenPureConc[E: Cogen, A: Cogen]: Cogen[PureConc[E, A]] = Cogen[Outcome[Option, E, A]].contramap(run(_))
+  implicit def cogenPureConc[E: Cogen, A: Cogen]: Cogen[PureConc[E, A]] =
+    Cogen[Outcome[Option, E, A]].contramap(run(_))
 
-  val generators = new ConcurrentGenerators[PureConc[Int, ?], Int] with BracketGenerators[PureConc[Int, ?], Int] {
+  def generators[E: Arbitrary: Cogen] =
+    new ConcurrentGenerators[PureConc[E, ?], E] with BracketGenerators[PureConc[E, ?], E] {
 
-    val arbitraryE: Arbitrary[Int] = implicitly[Arbitrary[Int]]
+      val arbitraryE: Arbitrary[E] = implicitly[Arbitrary[E]]
 
-    val cogenE: Cogen[Int] = Cogen[Int]
+      val cogenE: Cogen[E] = Cogen[E]
 
-    val F: ConcurrentBracket[PureConc[Int, ?], Int] = concurrentBForPureConc[Int]
+      val F: ConcurrentBracket[PureConc[E, ?], E] = concurrentBForPureConc[E]
 
-    def cogenCase[A: Cogen]: Cogen[Outcome[PureConc[Int, ?], Int, A]] = OutcomeGenerators.cogenOutcome[PureConc[Int, ?], Int, A]
-  }
+      def cogenCase[A: Cogen]: Cogen[Outcome[PureConc[E, ?], E, A]] =
+        OutcomeGenerators.cogenOutcome[PureConc[E, ?], E, A]
+    }
 
-  implicit def arbitraryPureConc[A: Arbitrary: Cogen]: Arbitrary[PureConc[Int, A]] =
-    Arbitrary(generators.generators[A])
+  implicit def arbitraryPureConc[E: Arbitrary: Cogen, A: Arbitrary: Cogen]: Arbitrary[PureConc[E, A]] =
+    Arbitrary(generators[E].generators[A])
 }


### PR DESCRIPTION
Depends on #876 (for sanity)

Capturing side-effects in `Eval`! What could go wrong?!

It's a really uncanny feeling, writing these magic side-effect capturing thingies for pre-existing types. It's like I'm imbuing them with some sort of mystical power that they did not previously possess.

My next step in this vein is to add a `Temporal[FreeT[S, F, ?], E]` where `Temporal[F, E]`. Once that's done, the next-next step is `Async[ContT[F, Unit, ?]]` where `Temporal[F, Throwable]` *and* `Sync[F]`, at which point we should just magically for free get the following instance:

```scala
Async[
  ContT[
    Kleisli[
      FreeT[
        Eval,
        Kleisli[
          Kleisli[
            FreeT[
              ThreadF,
              Kleisli[
                Outcome[Id, Throwable, ?],
                FiberCtx[Throwable],
                ?],
              ?],
            MVar.Universe,
            ?],
          Time,
          ?],
        ?],
      ExecutionContext,
      ?],
    Unit,
    ?]]
```

Or, with everything realiased:

```scala
Async[ContAsync[FreeSync[TimeT[PureConc[Throwable, ?], ?], ?], ?]]
```

Which I think is very, very cool. This will also form an `Effect`.