### PR TITLE
Eliminate boxing in IORunLoop.step

### DIFF
--- a/core/shared/src/main/scala/cats/effect/internals/IORunLoop.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IORunLoop.scala
@@ -231,18 +231,18 @@ private[effect] object IORunLoop {
       }
 
       if (hasUnboxed) {
-        val _unboxed = unboxed
         popNextBind(bFirst, bRest) match {
           case null =>
-            return (if (currentIO ne null) currentIO else Pure(_unboxed))
+            return (if (currentIO ne null) currentIO else Pure(unboxed))
               .asInstanceOf[IO[A]]
           case bind =>
-            currentIO =
-              try bind(_unboxed)
+            val fa =
+              try bind(unboxed)
               catch { case NonFatal(ex) => RaiseError(ex) }
             hasUnboxed = false
             unboxed = null
             bFirst = null
+            currentIO = fa
         }
       }
       true

--- a/core/shared/src/main/scala/cats/effect/internals/IORunLoop.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IORunLoop.scala
@@ -255,14 +255,9 @@ private[effect] object IORunLoop {
   private def suspendAsync[A](currentIO: IO[A], bFirst: Bind, bRest: CallStack): IO[A] =
     // Encountered an instruction that can't be interpreted synchronously,
     // so suspend it in an Async node that can be invoked later.
-    // If we had previous `flatMap` operations then we need to resume
-    // the loop with the collected stack.
-    if (bFirst != null || (bRest != null && !bRest.isEmpty))
-      Async { (conn, cb) =>
-        loop(currentIO, conn, cb.asInstanceOf[Callback], null, bFirst, bRest)
-      }
-    else
-      currentIO
+    Async { (conn, cb) =>
+      loop(currentIO, conn, cb.asInstanceOf[Callback], null, bFirst, bRest)
+    }
 
   /**
    * Pops the next bind function from the stack, but filters out


### PR DESCRIPTION
In the current `IORunLoop.step` implementation, the compiler boxes `currentIO`, `bFirst`, `bRest` and `unboxed` in an `ObjectRef` because they are all mutable variables that are captured in a lambda. This degrades performance for certain programs, particularly all `SyncIO` programs and all `IO` programs before they encounter the first asynchronous boundary (that are run with `unsafeRunSync`).

I only had enough patience to run the `DeepBindBenchmark` and `ShallowBindBenchmark`, whose results are shown below. Benchmarks were run on a MacBook Pro 15" 2015. Most of the other benchmarks probably see improved performance as well, but I talk more about that later.

## 2.0.0 results
```
[info] Benchmark                   (size)   Mode  Cnt     Score    Error  Units
[info] ShallowBindBenchmark.async   10000  thrpt    5   120.309 ± 11.319  ops/s
[info] ShallowBindBenchmark.delay   10000  thrpt    5  3859.484 ± 25.209  ops/s
[info] ShallowBindBenchmark.pure    10000  thrpt    5  4612.369 ± 58.177  ops/s

[info] Benchmark                (size)   Mode  Cnt     Score     Error  Units
[info] DeepBindBenchmark.async    3000  thrpt    5   336.482 ±  12.969  ops/s
[info] DeepBindBenchmark.delay    3000  thrpt    5  5312.525 ± 133.527  ops/s
[info] DeepBindBenchmark.pure     3000  thrpt    5  5748.930 ± 131.806  ops/s
```

## PR results
```
[info] Benchmark                   (size)   Mode  Cnt     Score     Error  Units
[info] ShallowBindBenchmark.async   10000  thrpt    5   119.277 ±  15.213  ops/s
[info] ShallowBindBenchmark.delay   10000  thrpt    5  5049.250 ±  51.853  ops/s
[info] ShallowBindBenchmark.pure    10000  thrpt    5  5696.337 ± 339.613  ops/s

[info] Benchmark                (size)   Mode  Cnt     Score    Error  Units
[info] DeepBindBenchmark.async    3000  thrpt    5   338.091 ± 34.497  ops/s
[info] DeepBindBenchmark.delay    3000  thrpt    5  6907.871 ± 70.006  ops/s
[info] DeepBindBenchmark.pure     3000  thrpt    5  7481.769 ± 95.016  ops/s
```

So there's quite a notable improvement, around 19-23% based on these benchmarks.

I realized that there's a bit of a blind spot in the benchmarks in master. `IORunLoop` includes two separate run-loop implementations, one that supports asynchronous evaluation and one that doesn't. Most of the benchmarks just invoke the synchronous run-loop, but in reality, most useful programs are shifted onto the asynchronous run-loop. Both run-loops likely observe different performance characteristics (the corresponding bytecode for each method are quite different). So it may be worth filling those gaps in to provide a more "realistic" benchmark.