### PR TITLE
Dotty cross-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.11, 2.13.2]
-        java: [adopt@1.8, adopt@11, adopt@14, graalvm@20.0.0]
+        scala: [2.12.11, 0.24.0-RC1, 2.13.2]
+        java: [adopt@1.8, adopt@11, adopt@14, graalvm@20.1.0]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (fast)

--- a/build.sbt
+++ b/build.sbt
@@ -50,12 +50,11 @@ lazy val core = project.in(file("core"))
       "org.typelevel" %% "cats-core" % CatsVersion,
       "org.typelevel" %% "cats-free" % CatsVersion,
 
-      "com.codecommit" %% "coop" % "0.5.0",
-
       "org.typelevel" %% "cats-laws"         % CatsVersion % Test,
       "org.typelevel" %% "discipline-specs2" % "1.0.0"     % Test,
       "org.specs2"    %% "specs2-scalacheck" % "4.8.1"     % Test))
   .settings(dottySettings)
+  .settings(libraryDependencies += "com.codecommit" %% "coop" % "0.5.0")
 
 lazy val laws = project.in(file("laws"))
   .dependsOn(core)

--- a/build.sbt
+++ b/build.sbt
@@ -44,15 +44,7 @@ lazy val core = project.in(file("core"))
   .settings(
     name := "cats-effect",
 
-    libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats-core" % CatsVersion,
-      "org.typelevel" %% "cats-free" % CatsVersion,
-
-      "com.codecommit" %% "coop" % "0.4.0",
-
-      "org.typelevel" %% "cats-laws"         % CatsVersion % Test,
-      "org.typelevel" %% "discipline-specs2" % "1.0.0"     % Test,
-      "org.specs2"    %% "specs2-scalacheck" % "4.8.1"     % Test))
+    libraryDependencies += "org.typelevel" %% "cats-core" % CatsVersion)
 
 lazy val laws = project.in(file("laws"))
   .dependsOn(core)
@@ -61,6 +53,9 @@ lazy val laws = project.in(file("laws"))
 
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-laws" % CatsVersion,
+      "org.typelevel" %% "cats-free" % CatsVersion,
+
+      "com.codecommit" %% "coop" % "0.4.0",
 
       "org.typelevel" %% "discipline-specs2" % "1.0.0"     % Test,
       "org.specs2"    %% "specs2-scalacheck" % "4.8.1"     % Test))

--- a/build.sbt
+++ b/build.sbt
@@ -22,10 +22,10 @@ ThisBuild / organizationName := "Typelevel"
 ThisBuild / publishGithubUser := "djspiewak"
 ThisBuild / publishFullName := "Daniel Spiewak"
 
-ThisBuild / crossScalaVersions := Seq("2.12.11", "2.13.2")
+ThisBuild / crossScalaVersions := Seq("2.12.11", "0.24.0-RC1", "2.13.2")
 
 ThisBuild / githubWorkflowTargetBranches := Seq("ce3")      // for now
-ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@11", "adopt@14", "graalvm@20.0.0")
+ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@11", "adopt@14", "graalvm@20.1.0")
 ThisBuild / githubWorkflowBuild := WorkflowStep.Sbt(List("ci"))
 ThisBuild / githubWorkflowPublishTargetBranches := Seq()    // disable the publication job
 
@@ -38,6 +38,8 @@ Global / scmInfo := Some(
 
 val CatsVersion = "2.1.1"
 
+val dottySettings = Seq(libraryDependencies := libraryDependencies.value.map(_.withDottyCompat(scalaVersion.value)))
+
 lazy val root = project.in(file(".")).aggregate(core, laws)
 
 lazy val core = project.in(file("core"))
@@ -48,11 +50,12 @@ lazy val core = project.in(file("core"))
       "org.typelevel" %% "cats-core" % CatsVersion,
       "org.typelevel" %% "cats-free" % CatsVersion,
 
-      "com.codecommit" %% "coop" % "0.4.0",
+      "com.codecommit" %% "coop" % "0.5.0",
 
       "org.typelevel" %% "cats-laws"         % CatsVersion % Test,
       "org.typelevel" %% "discipline-specs2" % "1.0.0"     % Test,
       "org.specs2"    %% "specs2-scalacheck" % "4.8.1"     % Test))
+  .settings(dottySettings)
 
 lazy val laws = project.in(file("laws"))
   .dependsOn(core)
@@ -64,3 +67,4 @@ lazy val laws = project.in(file("laws"))
 
       "org.typelevel" %% "discipline-specs2" % "1.0.0"     % Test,
       "org.specs2"    %% "specs2-scalacheck" % "4.8.1"     % Test))
+  .settings(dottySettings)

--- a/core/src/main/scala/cats/effect/Managed.scala
+++ b/core/src/main/scala/cats/effect/Managed.scala
@@ -17,11 +17,11 @@
 package cats.effect
 
 // TODO names ("Managed" conflicts with ZIO, but honestly it's a better name for this than Resource or IsoRegion)
-trait Managed[R[_[_], _], F[_]] extends Async[R[F, ?]] with Region[R, F, Throwable] {
+trait Managed[R[_[_], _], F[_]] extends Async[R[F, *]] with Region[R, F, Throwable] {
 
   def to[S[_[_], _]]: PartiallyApplied[S]
 
   trait PartiallyApplied[S[_[_], _]] {
-    def apply[A](rfa: R[F, A])(implicit S: Async[S[F, ?]] with Region[S, F, Throwable]): S[F, A]
+    def apply[A](rfa: R[F, A])(implicit S: Async[S[F, *]] with Region[S, F, Throwable]): S[F, A]
   }
 }

--- a/core/src/main/scala/cats/effect/Outcome.scala
+++ b/core/src/main/scala/cats/effect/Outcome.scala
@@ -22,53 +22,73 @@ import cats.implicits._
 import scala.annotation.tailrec
 import scala.util.{Either, Left, Right}
 
-sealed trait Outcome[+F[_], +E, +A] extends Product with Serializable
+sealed trait Outcome[F[_], E, A] extends Product with Serializable {
+  import Outcome._
+
+  def fold[B](
+      canceled: => B,
+      errored: E => B,
+      completed: F[A] => B)
+      : B =
+    this match {
+      case Canceled() => canceled
+      case Errored(e) => errored(e)
+      case Completed(fa) => completed(fa)
+    }
+
+  def mapK[G[_]](f: F ~> G): Outcome[G, E, A] =
+    this match {
+      case Canceled() => Canceled()
+      case Errored(e) => Errored(e)
+      case Completed(fa) => Completed(f(fa))
+    }
+}
 
 private[effect] trait LowPriorityImplicits {
   import Outcome.{Canceled, Completed, Errored}
 
   // variant for when F[A] doesn't have a Show (which is, like, most of the time)
-  implicit def showUnknown[F[_], E: Show, A]: Show[Outcome[F, E, A]] = Show show {
-    case Canceled => "Canceled"
+  implicit def showUnknown[F[_], E, A](implicit E: Show[E]): Show[Outcome[F, E, A]] = Show show {
+    case Canceled() => "Canceled"
     case Errored(left) => s"Errored(${left.show})"
-    case c: Completed[_, _] => s"Completed(<unknown>)"
+    case c: Completed[_, _, _] => s"Completed(<unknown>)"
   }
 
   implicit def eq[F[_], E: Eq, A](implicit FA: Eq[F[A]]): Eq[Outcome[F, E, A]] = Eq instance {
-    case (Canceled, Canceled) => true
+    case (Canceled(), Canceled()) => true
     case (Errored(left), Errored(right)) => left === right
-    case (left: Completed[F, A], right: Completed[F, A]) => left.fa === right.fa
+    case (left: Completed[F, E, A], right: Completed[F, E, A]) => left.fa === right.fa
     case _ => false
   }
 
-  implicit def applicativeError[F[_], E](implicit F: Applicative[F[?]]): ApplicativeError[Outcome[F[?], E, ?], E] =
+  implicit def applicativeError[F[_], E](implicit F: Applicative[F]): ApplicativeError[Outcome[F, E, *], E] =
     new OutcomeApplicativeError[F, E]
 
-  protected class OutcomeApplicativeError[F[_]: Applicative, E] extends ApplicativeError[Outcome[F, E, ?], E] {
+  protected class OutcomeApplicativeError[F[_]: Applicative, E] extends ApplicativeError[Outcome[F, E, *], E] {
 
     def pure[A](x: A): Outcome[F, E, A] = Completed(x.pure[F])
 
     def handleErrorWith[A](fa: Outcome[F, E, A])(f: E => Outcome[F, E, A]): Outcome[F, E, A] =
-      fa.fold(Canceled, f, Completed(_: F[A]))
+      fa.fold(Canceled(), f, Completed(_: F[A]))
 
     def raiseError[A](e: E): Outcome[F, E, A] = Errored(e)
 
     def ap[A, B](ff: Outcome[F, E, A => B])(fa: Outcome[F, E, A]): Outcome[F, E, B] =
       (ff, fa) match {
-        case (c: Completed[F, A => B], Completed(fa)) =>
+        case (c: Completed[F, E, A => B], Completed(fa)) =>
           Completed(c.fa.ap(fa))
 
         case (Errored(e), _) =>
           Errored(e)
 
-        case (Canceled, _) =>
-          Canceled
+        case (Canceled(), _) =>
+          Canceled()
 
         case (_, Errored(e)) =>
           Errored(e)
 
-        case (_, Canceled) =>
-          Canceled
+        case (_, Canceled()) =>
+          Canceled()
       }
   }
 }
@@ -78,7 +98,7 @@ object Outcome extends LowPriorityImplicits {
   def fromEither[F[_]: Applicative, E, A](either: Either[E, A]): Outcome[F, E, A] =
     either.fold(Errored(_), a => Completed(a.pure[F]))
 
-  implicit class Syntax[F[_], E, A](val self: Outcome[F, E, A]) extends AnyVal {
+  /*implicit class Syntax[F[_], E, A](val self: Outcome[F, E, A]) extends AnyVal {
 
     def fold[B](
         canceled: => B,
@@ -95,64 +115,64 @@ object Outcome extends LowPriorityImplicits {
       case Outcome.Errored(e) => Outcome.Errored(e)
       case Outcome.Completed(fa) => Outcome.Completed(f(fa))
     }
-  }
+  }*/
 
   implicit def order[F[_], E: Order, A](implicit FA: Order[F[A]]): Order[Outcome[F, E, A]] =
     Order from {
-      case (Canceled, Canceled) => 0
+      case (Canceled(), Canceled()) => 0
       case (Errored(left), Errored(right)) => left.compare(right)
-      case (left: Completed[F, A], right: Completed[F, A]) => left.fa.compare(right.fa)
+      case (left: Completed[F, E, A], right: Completed[F, E, A]) => left.fa.compare(right.fa)
 
-      case (Canceled, _) => -1
-      case (_, Canceled) => 1
-      case (Errored(_), _: Completed[_, _]) => -1
-      case (_: Completed[_, _], Errored(_)) => 1
+      case (Canceled(), _) => -1
+      case (_, Canceled()) => 1
+      case (Errored(_), _: Completed[_, _, _]) => -1
+      case (_: Completed[_, _, _], Errored(_)) => 1
     }
 
-  implicit def show[F[_], E: Show, A](implicit FA: Show[F[A]]): Show[Outcome[F, E, A]] = Show show {
-    case Canceled => "Canceled"
+  implicit def show[F[_], E, A](implicit FA: Show[F[A]], E: Show[E]): Show[Outcome[F, E, A]] = Show show {
+    case Canceled() => "Canceled"
     case Errored(left) => s"Errored(${left.show})"
-    case right: Completed[F, A] => s"Completed(${right.fa.show})"
+    case right: Completed[F, E, A] => s"Completed(${right.fa.show})"
   }
 
-  implicit def monadError[F[_], E](implicit F: Monad[F[?]], FT: Traverse[F[?]]): MonadError[Outcome[F[?], E, ?], E] =
-    new OutcomeApplicativeError[F, E]()(F) with MonadError[Outcome[F, E, ?], E] {
+  implicit def monadError[F[_], E](implicit F: Monad[F], FT: Traverse[F]): MonadError[Outcome[F, E, *], E] =
+    new OutcomeApplicativeError[F, E]()(F) with MonadError[Outcome[F, E, *], E] {
 
       override def map[A, B](fa: Outcome[F, E, A])(f: A => B): Outcome[F, E, B] = fa match {
-        case c: Completed[F, A] => Completed(F.map(c.fa)(f))
+        case c: Completed[F, E, A] => Completed(F.map(c.fa)(f))
         case Errored(e) => Errored(e)
-        case Canceled => Canceled
+        case Canceled() => Canceled()
       }
 
       def flatMap[A, B](fa: Outcome[F, E, A])(f: A => Outcome[F, E, B]): Outcome[F, E, B] = fa match {
-        case ifac: Completed[F, A] =>
+        case ifac: Completed[F, E, A] =>
           val ifa = ifac.fa
 
           Traverse[F].traverse(ifa)(f) match {
-            case ifaac: Completed[F, F[B]] => Completed(Monad[F].flatten(ifaac.fa))
+            case ifaac: Completed[F, E, F[B]] => Completed(Monad[F].flatten(ifaac.fa))
             case Errored(e) => Errored(e)
-            case Canceled => Canceled
+            case Canceled() => Canceled()
           }
 
         case Errored(e) => Errored(e)
-        case Canceled => Canceled
+        case Canceled() => Canceled()
       }
 
       @tailrec
       def tailRecM[A, B](a: A)(f: A => Outcome[F, E, Either[A, B]]): Outcome[F, E, B] =
         f(a) match {
-          case c: Completed[F, Either[A, B]] =>
-            Traverse[F].sequence(c.fa) match {
+          case c: Completed[F, E, Either[A, B]] =>
+            Traverse[F].sequence[Either[A, *], B](c.fa) match {   // Dotty can't infer this
               case Left(a) => tailRecM(a)(f)
               case Right(fb) => Completed(fb)
             }
 
           case Errored(e) => Errored(e)
-          case Canceled => Canceled
+          case Canceled() => Canceled()
         }
     }
 
-  final case class Completed[F[_], A](fa: F[A]) extends Outcome[F, Nothing, A]
-  final case class Errored[E](e: E) extends Outcome[Nothing, E, Nothing]
-  case object Canceled extends Outcome[Nothing, Nothing, Nothing]
+  final case class Completed[F[_], E, A](fa: F[A]) extends Outcome[F, E, A]
+  final case class Errored[F[_], E, A](e: E) extends Outcome[F, E, A]
+  final case class Canceled[F[_], E, A]() extends Outcome[F, E, A]
 }

--- a/core/src/main/scala/cats/effect/Outcome.scala
+++ b/core/src/main/scala/cats/effect/Outcome.scala
@@ -98,25 +98,6 @@ object Outcome extends LowPriorityImplicits {
   def fromEither[F[_]: Applicative, E, A](either: Either[E, A]): Outcome[F, E, A] =
     either.fold(Errored(_), a => Completed(a.pure[F]))
 
-  /*implicit class Syntax[F[_], E, A](val self: Outcome[F, E, A]) extends AnyVal {
-
-    def fold[B](
-        canceled: => B,
-        errored: E => B,
-        completed: F[A] => B)
-        : B = self match {
-      case Canceled => canceled
-      case Errored(e) => errored(e)
-      case Completed(fa) => completed(fa)
-    }
-
-    def mapK[G[_]](f: F ~> G): Outcome[G, E, A] = self match {
-      case Outcome.Canceled => Outcome.Canceled
-      case Outcome.Errored(e) => Outcome.Errored(e)
-      case Outcome.Completed(fa) => Outcome.Completed(f(fa))
-    }
-  }*/
-
   implicit def order[F[_], E: Order, A](implicit FA: Order[F[A]]): Order[Outcome[F, E, A]] =
     Order from {
       case (Canceled(), Canceled()) => 0

--- a/core/src/main/scala/cats/effect/SyncManaged.scala
+++ b/core/src/main/scala/cats/effect/SyncManaged.scala
@@ -16,10 +16,9 @@
 
 package cats.effect
 
-import cats.~>
 import cats.implicits._
 
-trait SyncManaged[R[_[_], _], F[_]] extends Sync[R[F, ?]] with Region[R, F, Throwable] {
+trait SyncManaged[R[_[_], _], F[_]] extends Sync[R[F, *]] with Region[R, F, Throwable] {
   type Case[A] = Either[Throwable, A]
 
   def CaseInstance = catsStdInstancesForEither[Throwable]
@@ -27,6 +26,6 @@ trait SyncManaged[R[_[_], _], F[_]] extends Sync[R[F, ?]] with Region[R, F, Thro
   def to[S[_[_], _]]: PartiallyApplied[S]
 
   trait PartiallyApplied[S[_[_], _]] {
-    def apply[A](rfa: R[F, A])(implicit S: Sync[S[F, ?]] with Region[S, F, Throwable]): S[F, A]
+    def apply[A](rfa: R[F, A])(implicit S: Sync[S[F, *]] with Region[S, F, Throwable]): S[F, A]
   }
 }

--- a/core/src/main/scala/cats/effect/concurrent.scala
+++ b/core/src/main/scala/cats/effect/concurrent.scala
@@ -27,7 +27,7 @@ trait Fiber[F[_], E, A] {
 trait Concurrent[F[_], E] extends MonadError[F, E] { self: Safe[F, E] =>
   type Case[A] = Outcome[F, E, A]
 
-  final def CaseInstance: ApplicativeError[Outcome[F, E, ?], E] =
+  final def CaseInstance: ApplicativeError[Outcome[F, E, *], E] =
     Outcome.applicativeError[F, E](this)
 
   def start[A](fa: F[A]): F[Fiber[F, E, A]]

--- a/core/src/main/scala/cats/effect/package.scala
+++ b/core/src/main/scala/cats/effect/package.scala
@@ -30,7 +30,7 @@ package object effect {
     def apply[F[_], E](implicit F: ConcurrentBracket[F, E]): ConcurrentBracket[F, E] = F
   }
 
-  type ConcurrentRegion[R[_[_], _], F[_], E] = Concurrent[R[F, ?], E] with Region[R, F, E]
+  type ConcurrentRegion[R[_[_], _], F[_], E] = Concurrent[R[F, *], E] with Region[R, F, E]
 
   object ConcurrentRegion {
     def apply[R[_[_], _], F[_], E](implicit R: ConcurrentRegion[R, F, E]): ConcurrentRegion[R, F, E] = R
@@ -44,7 +44,7 @@ package object effect {
     def apply[F[_], E](implicit F: TemporalBracket[F, E]): TemporalBracket[F, E] = F
   }
 
-  type TemporalRegion[R[_[_], _], F[_], E] = Temporal[R[F, ?], E] with Region[R, F, E]
+  type TemporalRegion[R[_[_], _], F[_], E] = Temporal[R[F, *], E] with Region[R, F, E]
 
   object TemporalRegion {
     def apply[R[_[_], _], F[_], E](implicit R: TemporalRegion[R, F, E]): TemporalRegion[R, F, E] = R
@@ -56,7 +56,7 @@ package object effect {
     def apply[F[_]](implicit F: AsyncBracket[F]): AsyncBracket[F] = F
   }
 
-  type AsyncRegion[R[_[_], _], F[_]] = Async[R[F, ?]] with Region[R, F, Throwable]
+  type AsyncRegion[R[_[_], _], F[_]] = Async[R[F, *]] with Region[R, F, Throwable]
 
   object AsyncRegion {
     def apply[R[_[_], _], F[_]](implicit R: AsyncRegion[R, F]): AsyncRegion[R, F] = R

--- a/laws/src/main/scala/cats/effect/freeEval.scala
+++ b/laws/src/main/scala/cats/effect/freeEval.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.{Eq, Eval, Monad, MonadError}
+import cats.free.FreeT
+import cats.implicits._
+
+import scala.concurrent.duration._
+import java.time.Instant
+
+object freeEval {
+
+  type FreeSync[F[_], A] = FreeT[Eval, F, A]
+  type FreeEitherSync[A] = FreeSync[Either[Throwable, ?], A]
+
+  def run[F[_]: Monad, A](ft: FreeT[Eval, F, A]): F[A] =
+    ft.runM(_.value.pure[F])
+
+  implicit def syncForFreeT[F[_]](implicit F: MonadError[F, Throwable]): Sync[FreeT[Eval, F, ?]] =
+    new Sync[FreeT[Eval, F, ?]] {
+      private[this] val M: MonadError[FreeT[Eval, F, ?], Throwable] =
+        cats.effect.pure.catsFreeMonadErrorForFreeT2
+
+      def pure[A](x: A): FreeT[Eval, F, A] =
+        M.pure(x)
+
+      def handleErrorWith[A](fa: FreeT[Eval, F, A])(f: Throwable => FreeT[Eval, F, A]): FreeT[Eval, F, A] =
+        M.handleErrorWith(fa)(f)
+
+      def raiseError[A](e: Throwable): FreeT[Eval, F, A] =
+        M.raiseError(e)
+
+      def monotonic: FreeT[Eval, F, FiniteDuration] =
+        delay(System.nanoTime().nanos)
+
+      def realTime: FreeT[Eval, F, Instant] =
+        delay(Instant.now())
+
+      def flatMap[A, B](fa: FreeT[Eval, F, A])(f: A => FreeT[Eval, F, B]): FreeT[Eval, F, B] =
+        fa.flatMap(f)
+
+      def tailRecM[A, B](a: A)(f: A => FreeT[Eval, F, Either[A, B]]): FreeT[Eval, F, B] =
+        M.tailRecM(a)(f)
+
+      def delay[A](thunk: => A): FreeT[Eval, F, A] =
+        FreeT roll {
+          Eval always {
+            try {
+              pure(thunk)
+            } catch {
+              case t: Throwable =>
+                raiseError(t)
+            }
+          }
+        }
+    }
+
+  implicit def eqFreeSync[F[_]: Monad, A](implicit F: Eq[F[A]]): Eq[FreeT[Eval, F, A]] =
+    Eq.by(run(_))
+}

--- a/laws/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -44,7 +44,7 @@ trait AsyncLaws[F[_]] extends TemporalLaws[F, Throwable] with SyncLaws[F] {
     F.start(F.async[Unit](_ => F.pure(Some(fu)))).flatMap(_.cancel) <-> fu.attempt.void
 
   def neverIsDerivedFromAsync[A] =
-    F.never[A] <-> F.async(_ => F.pure(None))
+    F.never[A] <-> F.async[A](_ => F.pure(None))
 
   def executionContextCommutativity[A](fa: F[A]) =
     (fa *> F.executionContext) <-> (F.executionContext <* fa)

--- a/laws/src/main/scala/cats/effect/laws/AsyncRegionLaws.scala
+++ b/laws/src/main/scala/cats/effect/laws/AsyncRegionLaws.scala
@@ -17,8 +17,8 @@
 package cats.effect
 package laws
 
-trait AsyncRegionLaws[R[_[_], _], F[_]] extends AsyncLaws[R[F, ?]] with TemporalRegionLaws[R, F, Throwable] {
-  implicit val F: Async[R[F, ?]] with Region[R, F, Throwable]
+trait AsyncRegionLaws[R[_[_], _], F[_]] extends AsyncLaws[R[F, *]] with TemporalRegionLaws[R, F, Throwable] {
+  implicit val F: Async[R[F, *]] with Region[R, F, Throwable]
 }
 
 object AsyncRegionLaws {
@@ -26,8 +26,8 @@ object AsyncRegionLaws {
       R[_[_], _],
       F[_]](
     implicit
-      F0: Async[R[F, ?]] with Region[R, F, Throwable],
-      B0: Bracket.Aux[F, Throwable, Outcome[R[F, ?], Throwable, ?]])
+      F0: Async[R[F, *]] with Region[R, F, Throwable],
+      B0: Bracket.Aux[F, Throwable, Outcome[R[F, *], Throwable, *]])
       : AsyncRegionLaws[R, F] =
     new AsyncRegionLaws[R, F] {
       val F = F0

--- a/laws/src/main/scala/cats/effect/laws/AsyncRegionTests.scala
+++ b/laws/src/main/scala/cats/effect/laws/AsyncRegionTests.scala
@@ -26,7 +26,7 @@ import org.scalacheck.util.Pretty
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
-trait AsyncRegionTests[R[_[_], _], F[_]] extends AsyncTests[R[F, ?]] with TemporalRegionTests[R, F, Throwable] {
+trait AsyncRegionTests[R[_[_], _], F[_]] extends AsyncTests[R[F, *]] with TemporalRegionTests[R, F, Throwable] {
 
   val laws: AsyncRegionLaws[R, F]
 
@@ -51,9 +51,9 @@ trait AsyncRegionTests[R[_[_], _], F[_]] extends AsyncTests[R[F, ?]] with Tempor
       CogenC: Cogen[C],
       CogenE: Cogen[Throwable],
       CogenCase: Cogen[laws.F.Case[_]],
-      CogenCaseA: Cogen[Outcome[R[F, ?], Throwable, A]],
-      CogenCaseB: Cogen[Outcome[R[F, ?], Throwable, B]],
-      CogenCaseU: Cogen[Outcome[R[F, ?], Throwable, Unit]],
+      CogenCaseA: Cogen[Outcome[R[F, *], Throwable, A]],
+      CogenCaseB: Cogen[Outcome[R[F, *], Throwable, B]],
+      CogenCaseU: Cogen[Outcome[R[F, *], Throwable, Unit]],
       EqFA: Eq[R[F, A]],
       EqFB: Eq[R[F, B]],
       EqFC: Eq[R[F, C]],
@@ -67,23 +67,23 @@ trait AsyncRegionTests[R[_[_], _], F[_]] extends AsyncTests[R[F, ?]] with Tempor
       EqFEitherAU: Eq[R[F, Either[A, Unit]]],
       EqFEitherEitherEAU: Eq[R[F, Either[Either[Throwable, A], Unit]]],
       EqFEitherUEitherEA: Eq[R[F, Either[Unit, Either[Throwable, A]]]],
-      EqFOutcomeEA: Eq[R[F, Outcome[R[F, ?], Throwable, A]]],
-      EqFOutcomeEU: Eq[R[F, Outcome[R[F, ?], Throwable, Unit]]],
+      EqFOutcomeEA: Eq[R[F, Outcome[R[F, *], Throwable, A]]],
+      EqFOutcomeEU: Eq[R[F, Outcome[R[F, *], Throwable, Unit]]],
       EqFABC: Eq[R[F, (A, B, C)]],
       EqFInt: Eq[R[F, Int]],
       OrdFFD: Order[R[F, FiniteDuration]],
       GroupFD: Group[R[F, FiniteDuration]],
       exec: R[F, Boolean] => Prop,
-      iso: Isomorphisms[R[F, ?]],
+      iso: Isomorphisms[R[F, *]],
       faPP: R[F, A] => Pretty,
       fbPP: R[F, B] => Pretty,
       fuPP: R[F, Unit] => Pretty,
       aFUPP: (A => R[F, Unit]) => Pretty,
       ePP: Throwable => Pretty,
-      foaPP: F[Outcome[R[F, ?], Throwable, A]] => Pretty,
+      foaPP: F[Outcome[R[F, *], Throwable, A]] => Pretty,
       feauPP: R[F, Either[A, Unit]] => Pretty,
       feuaPP: R[F, Either[Unit, A]] => Pretty,
-      fouPP: R[F, Outcome[R[F, ?], Throwable, Unit]] => Pretty)
+      fouPP: R[F, Outcome[R[F, *], Throwable, Unit]] => Pretty)
       : RuleSet = {
 
     new RuleSet {
@@ -101,8 +101,8 @@ object AsyncRegionTests {
       R[_[_], _],
       F[_]](
     implicit
-      F0: Async[R[F, ?]] with Region[R, F, Throwable],
-      B0: Bracket.Aux[F, Throwable, Outcome[R[F, ?], Throwable, ?]])
+      F0: Async[R[F, *]] with Region[R, F, Throwable],
+      B0: Bracket.Aux[F, Throwable, Outcome[R[F, *], Throwable, *]])
       : AsyncRegionTests[R, F] = new AsyncRegionTests[R, F] {
     val laws = AsyncRegionLaws[R, F]
   }

--- a/laws/src/main/scala/cats/effect/laws/BracketTests.scala
+++ b/laws/src/main/scala/cats/effect/laws/BracketTests.scala
@@ -82,6 +82,6 @@ trait BracketTests[F[_], E] extends MonadErrorTests[F, E] {
 
 object BracketTests {
   def apply[F[_], E](implicit F0: Bracket[F, E]): BracketTests[F, E] { val laws: BracketLaws[F, E] { val F: F0.type } } = new BracketTests[F, E] {
-    val laws = BracketLaws[F, E]
+    val laws: BracketLaws[F, E] { val F: F0.type } = BracketLaws[F, E]
   }
 }

--- a/laws/src/main/scala/cats/effect/laws/ConcurrentLaws.scala
+++ b/laws/src/main/scala/cats/effect/laws/ConcurrentLaws.scala
@@ -59,10 +59,10 @@ trait ConcurrentLaws[F[_], E] extends MonadErrorLaws[F, E] {
     F.start(F.raiseError[Unit](e)).flatMap(_.join) <-> F.pure(Outcome.Errored(e))
 
   def fiberCancelationIsOutcomeCanceled =
-    F.start(F.never[Unit]).flatMap(f => f.cancel >> f.join) <-> F.pure(Outcome.Canceled)
+    F.start(F.never[Unit]).flatMap(f => f.cancel >> f.join) <-> F.pure(Outcome.Canceled())
 
   def fiberCanceledIsOutcomeCanceled =
-    F.start(F.canceled).flatMap(_.join) <-> F.pure(Outcome.Canceled)
+    F.start(F.canceled).flatMap(_.join) <-> F.pure(Outcome.Canceled())
 
   def fiberNeverIsNever =
     F.start(F.never[Unit]).flatMap(_.join) <-> F.never[Outcome[F, E, Unit]]
@@ -100,10 +100,10 @@ trait ConcurrentLaws[F[_], E] extends MonadErrorLaws[F, E] {
     F.uncancelable(p => F.race(fa, p(F.canceled))) <-> F.uncancelable(_ => fa.map(_.asLeft[Unit]))
 
   def uncancelableCancelCancels =
-    F.start(F.never[Unit]).flatMap(f => F.uncancelable(_ => f.cancel) >> f.join) <-> F.pure(Outcome.Canceled)
+    F.start(F.never[Unit]).flatMap(f => F.uncancelable(_ => f.cancel) >> f.join) <-> F.pure(Outcome.Canceled())
 
   def uncancelableStartIsCancelable =
-    F.uncancelable(_ => F.start(F.never[Unit]).flatMap(f => f.cancel >> f.join)) <-> F.pure(Outcome.Canceled)
+    F.uncancelable(_ => F.start(F.never[Unit]).flatMap(f => f.cancel >> f.join)) <-> F.pure(Outcome.Canceled())
 
   // the attempt here enforces the cancelation-dominates-over-errors semantic
   def uncancelableCanceledAssociatesRightOverFlatMap[A](a: A, f: A => F[Unit]) =

--- a/laws/src/main/scala/cats/effect/laws/ConcurrentRegionLaws.scala
+++ b/laws/src/main/scala/cats/effect/laws/ConcurrentRegionLaws.scala
@@ -17,8 +17,8 @@
 package cats.effect
 package laws
 
-trait ConcurrentRegionLaws[R[_[_], _], F[_], E] extends ConcurrentLaws[R[F, ?], E] with RegionLaws[R, F, E] {
-  implicit val F: Concurrent[R[F, ?], E] with Region[R, F, E]
+trait ConcurrentRegionLaws[R[_[_], _], F[_], E] extends ConcurrentLaws[R[F, *], E] with RegionLaws[R, F, E] {
+  implicit val F: Concurrent[R[F, *], E] with Region[R, F, E]
 }
 
 object ConcurrentRegionLaws {
@@ -27,8 +27,8 @@ object ConcurrentRegionLaws {
       F[_],
       E](
     implicit
-      F0: Concurrent[R[F, ?], E] with Region[R, F, E],
-      B0: Bracket.Aux[F, E, Outcome[R[F, ?], E, ?]])
+      F0: Concurrent[R[F, *], E] with Region[R, F, E],
+      B0: Bracket.Aux[F, E, Outcome[R[F, *], E, *]])
       : ConcurrentRegionLaws[R, F, E] =
     new ConcurrentRegionLaws[R, F, E] {
       val F = F0

--- a/laws/src/main/scala/cats/effect/laws/ConcurrentRegionTests.scala
+++ b/laws/src/main/scala/cats/effect/laws/ConcurrentRegionTests.scala
@@ -23,7 +23,7 @@ import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import org.scalacheck._
 import org.scalacheck.util.Pretty
 
-trait ConcurrentRegionTests[R[_[_], _], F[_], E] extends ConcurrentTests[R[F, ?], E] with RegionTests[R, F, E] {
+trait ConcurrentRegionTests[R[_[_], _], F[_], E] extends ConcurrentTests[R[F, *], E] with RegionTests[R, F, E] {
 
   val laws: ConcurrentRegionLaws[R, F, E]
 
@@ -46,9 +46,9 @@ trait ConcurrentRegionTests[R[_[_], _], F[_], E] extends ConcurrentTests[R[F, ?]
       CogenC: Cogen[C],
       CogenE: Cogen[E],
       CogenCase: Cogen[laws.F.Case[_]],
-      CogenCaseA: Cogen[Outcome[R[F, ?], E, A]],
-      CogenCaseB: Cogen[Outcome[R[F, ?], E, B]],
-      CogenCaseU: Cogen[Outcome[R[F, ?], E, Unit]],
+      CogenCaseA: Cogen[Outcome[R[F, *], E, A]],
+      CogenCaseB: Cogen[Outcome[R[F, *], E, B]],
+      CogenCaseU: Cogen[Outcome[R[F, *], E, Unit]],
       EqFA: Eq[R[F, A]],
       EqFB: Eq[R[F, B]],
       EqFC: Eq[R[F, C]],
@@ -61,20 +61,20 @@ trait ConcurrentRegionTests[R[_[_], _], F[_], E] extends ConcurrentTests[R[F, ?]
       EqFEitherAU: Eq[R[F, Either[A, Unit]]],
       EqFEitherEitherEAU: Eq[R[F, Either[Either[E, A], Unit]]],
       EqFEitherUEitherEA: Eq[R[F, Either[Unit, Either[E, A]]]],
-      EqFOutcomeEA: Eq[R[F, Outcome[R[F, ?], E, A]]],
-      EqFOutcomeEU: Eq[R[F, Outcome[R[F, ?], E, Unit]]],
+      EqFOutcomeEA: Eq[R[F, Outcome[R[F, *], E, A]]],
+      EqFOutcomeEU: Eq[R[F, Outcome[R[F, *], E, Unit]]],
       EqFABC: Eq[R[F, (A, B, C)]],
       EqFInt: Eq[R[F, Int]],
-      iso: Isomorphisms[R[F, ?]],
+      iso: Isomorphisms[R[F, *]],
       faPP: R[F, A] => Pretty,
       fbPP: R[F, B] => Pretty,
       fuPP: R[F, Unit] => Pretty,
       aFUPP: (A => R[F, Unit]) => Pretty,
       ePP: E => Pretty,
-      foaPP: F[Outcome[R[F, ?], E, A]] => Pretty,
+      foaPP: F[Outcome[R[F, *], E, A]] => Pretty,
       feauPP: R[F, Either[A, Unit]] => Pretty,
       feuaPP: R[F, Either[Unit, A]] => Pretty,
-      fouPP: R[F, Outcome[R[F, ?], E, Unit]] => Pretty)
+      fouPP: R[F, Outcome[R[F, *], E, Unit]] => Pretty)
       : RuleSet = {
 
     new RuleSet {
@@ -93,8 +93,8 @@ object ConcurrentRegionTests {
       F[_],
       E](
     implicit
-      F0: Concurrent[R[F, ?], E] with Region[R, F, E],
-      B0: Bracket.Aux[F, E, Outcome[R[F, ?], E, ?]])
+      F0: Concurrent[R[F, *], E] with Region[R, F, E],
+      B0: Bracket.Aux[F, E, Outcome[R[F, *], E, *]])
       : ConcurrentRegionTests[R, F, E] = new ConcurrentRegionTests[R, F, E] {
     val laws = ConcurrentRegionLaws[R, F, E]
   }

--- a/laws/src/main/scala/cats/effect/laws/ManagedLaws.scala
+++ b/laws/src/main/scala/cats/effect/laws/ManagedLaws.scala
@@ -30,7 +30,7 @@ object ManagedLaws {
       F[_]](
     implicit
       F0: Managed[R, F],
-      B0: Bracket.Aux[F, Throwable, Outcome[R[F, ?], Throwable, ?]])
+      B0: Bracket.Aux[F, Throwable, Outcome[R[F, *], Throwable, *]])
       : ManagedLaws[R, F] =
     new ManagedLaws[R, F] {
       val F = F0

--- a/laws/src/main/scala/cats/effect/laws/ManagedTests.scala
+++ b/laws/src/main/scala/cats/effect/laws/ManagedTests.scala
@@ -51,9 +51,9 @@ trait ManagedTests[R[_[_], _], F[_]] extends AsyncRegionTests[R, F] {
       CogenC: Cogen[C],
       CogenE: Cogen[Throwable],
       CogenCase: Cogen[laws.F.Case[_]],
-      CogenCaseA: Cogen[Outcome[R[F, ?], Throwable, A]],
-      CogenCaseB: Cogen[Outcome[R[F, ?], Throwable, B]],
-      CogenCaseU: Cogen[Outcome[R[F, ?], Throwable, Unit]],
+      CogenCaseA: Cogen[Outcome[R[F, *], Throwable, A]],
+      CogenCaseB: Cogen[Outcome[R[F, *], Throwable, B]],
+      CogenCaseU: Cogen[Outcome[R[F, *], Throwable, Unit]],
       EqFA: Eq[R[F, A]],
       EqFB: Eq[R[F, B]],
       EqFC: Eq[R[F, C]],
@@ -67,23 +67,23 @@ trait ManagedTests[R[_[_], _], F[_]] extends AsyncRegionTests[R, F] {
       EqFEitherAU: Eq[R[F, Either[A, Unit]]],
       EqFEitherEitherEAU: Eq[R[F, Either[Either[Throwable, A], Unit]]],
       EqFEitherUEitherEA: Eq[R[F, Either[Unit, Either[Throwable, A]]]],
-      EqFOutcomeEA: Eq[R[F, Outcome[R[F, ?], Throwable, A]]],
-      EqFOutcomeEU: Eq[R[F, Outcome[R[F, ?], Throwable, Unit]]],
+      EqFOutcomeEA: Eq[R[F, Outcome[R[F, *], Throwable, A]]],
+      EqFOutcomeEU: Eq[R[F, Outcome[R[F, *], Throwable, Unit]]],
       EqFABC: Eq[R[F, (A, B, C)]],
       EqFInt: Eq[R[F, Int]],
       OrdFFD: Order[R[F, FiniteDuration]],
       GroupFD: Group[R[F, FiniteDuration]],
       exec: R[F, Boolean] => Prop,
-      iso: Isomorphisms[R[F, ?]],
+      iso: Isomorphisms[R[F, *]],
       faPP: R[F, A] => Pretty,
       fbPP: R[F, B] => Pretty,
       fuPP: R[F, Unit] => Pretty,
       aFUPP: (A => R[F, Unit]) => Pretty,
       ePP: Throwable => Pretty,
-      foaPP: F[Outcome[R[F, ?], Throwable, A]] => Pretty,
+      foaPP: F[Outcome[R[F, *], Throwable, A]] => Pretty,
       feauPP: R[F, Either[A, Unit]] => Pretty,
       feuaPP: R[F, Either[Unit, A]] => Pretty,
-      fouPP: R[F, Outcome[R[F, ?], Throwable, Unit]] => Pretty)
+      fouPP: R[F, Outcome[R[F, *], Throwable, Unit]] => Pretty)
       : RuleSet = {
 
     new RuleSet {
@@ -102,7 +102,7 @@ object ManagedTests {
       F[_]](
     implicit
       F0: Managed[R, F],
-      B0: Bracket.Aux[F, Throwable, Outcome[R[F, ?], Throwable, ?]])
+      B0: Bracket.Aux[F, Throwable, Outcome[R[F, *], Throwable, *]])
       : ManagedTests[R, F] = new ManagedTests[R, F] {
     val laws = ManagedLaws[R, F]
   }

--- a/laws/src/main/scala/cats/effect/laws/RegionLaws.scala
+++ b/laws/src/main/scala/cats/effect/laws/RegionLaws.scala
@@ -20,7 +20,7 @@ package laws
 import cats.implicits._
 import cats.laws.MonadErrorLaws
 
-trait RegionLaws[R[_[_], _], F[_], E] extends MonadErrorLaws[R[F, ?], E] {
+trait RegionLaws[R[_[_], _], F[_], E] extends MonadErrorLaws[R[F, *], E] {
 
   implicit val F: Region[R, F, E]
 
@@ -31,17 +31,17 @@ trait RegionLaws[R[_[_], _], F[_], E] extends MonadErrorLaws[R[F, ?], E] {
 
   import F.CaseInstance
 
-  def regionEmptyBracketPure[A, B](acq: F[A], fb: F[B], release: (A, F.Case[_]) => F[Unit]) =
+  def regionEmptyBracketPure[A, B](acq: F[A], fb: F[B], release: (A, F.Case[A]) => F[Unit]) =
     F.supersededBy(F.openCase(acq)(release), F.liftF(fb)) <-> F.liftF(B.bracketCase(acq)(B.pure(_))(release) *> fb)
 
-  def regionNested[A, B, C](fa: F[A], f: A => F[B], fc: F[C], releaseA: (A, F.Case[_]) => F[Unit], releaseB: (B, F.Case[_]) => F[Unit]) =
+  def regionNested[A, B, C](fa: F[A], f: A => F[B], fc: F[C], releaseA: (A, F.Case[B]) => F[Unit], releaseB: (B, F.Case[B]) => F[Unit]) =
     F.supersededBy(F.openCase(fa)(releaseA).flatMap(a => F.openCase(f(a))(releaseB)), F.liftF(fc)) <-> F.liftF(B.bracketCase(fa)(a => B.bracketCase(f(a))(B.pure(_))(releaseB))(releaseA) *> fc)
 
   def regionExtend[A, B](fa: F[A], f: A => F[B], release: A => F[Unit]) =
     F.open(fa)(release).flatMap(f.andThen(F.liftF(_))) <-> F.liftF(B.bracket(fa)(f)(release))
 
-  def regionErrorCoherence[A](fa: F[A], f: A => E, release: (A, F.Case[_]) => F[Unit]) =
-    F.openCase(fa)(release).flatMap(a => F.raiseError[Unit](f(a))) <-> F.liftF(B.bracket(fa)(a => B.raiseError[Unit](f(a)))(a => release(a, CaseInstance.raiseError[Unit](f(a)))))
+  def regionErrorCoherence[A, E0](fa: F[A], f: A => E, release: (A, F.Case[E0]) => F[Unit]) =
+    F.openCase(fa)(release).flatMap(a => F.raiseError[Unit](f(a))) <-> F.liftF(B.bracket(fa)(a => B.raiseError[Unit](f(a)))(a => release(a, CaseInstance.raiseError[E0](f(a)))))
 
   def regionLiftFOpenUnit[A](fa: F[A]) =
     F.liftF(fa) <-> F.open(fa)(_ => B.unit)
@@ -57,5 +57,5 @@ object RegionLaws {
       F0: Region[R, F, E] { type Case[A] = Case0[A] },
       B0: Bracket[F, E] { type Case[A] = Case0[A] })    // this is legit-annoying
       : RegionLaws[R, F, E] =
-    new RegionLaws[R, F, E] { val F = F0; val B = B0 }
+    new RegionLaws[R, F, E] { val F: F0.type = F0; val B: B0.type = B0 }
 }

--- a/laws/src/main/scala/cats/effect/laws/RegionTests.scala
+++ b/laws/src/main/scala/cats/effect/laws/RegionTests.scala
@@ -23,7 +23,7 @@ import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._, Prop.forAll
 
-trait RegionTests[R[_[_], _], F[_], E] extends MonadErrorTests[R[F, ?], E] {
+trait RegionTests[R[_[_], _], F[_], E] extends MonadErrorTests[R[F, *], E] {
 
   val laws: RegionLaws[R, F, E]
 
@@ -44,7 +44,8 @@ trait RegionTests[R[_[_], _], F[_], E] extends MonadErrorTests[R[F, ?], E] {
       CogenB: Cogen[B],
       CogenC: Cogen[C],
       CogenE: Cogen[E],
-      CogenCase: Cogen[laws.F.Case[_]],
+      CogenCaseA: Cogen[laws.F.Case[A]],
+      CogenCaseB: Cogen[laws.F.Case[B]],
       EqRFA: Eq[R[F, A]],
       EqRFB: Eq[R[F, B]],
       EqRFC: Eq[R[F, C]],
@@ -54,7 +55,7 @@ trait RegionTests[R[_[_], _], F[_], E] extends MonadErrorTests[R[F, ?], E] {
       EqRFABC: Eq[R[F, (A, B, C)]],
       EqRFInt: Eq[R[F, Int]],
       EqRFUnit: Eq[R[F, Unit]],
-      iso: Isomorphisms[R[F, ?]])
+      iso: Isomorphisms[R[F, *]])
       : RuleSet = {
 
     new RuleSet {
@@ -66,7 +67,7 @@ trait RegionTests[R[_[_], _], F[_], E] extends MonadErrorTests[R[F, ?], E] {
         "empty is bracket . pure" -> forAll(laws.regionEmptyBracketPure[A, B] _),
         "nesting" -> forAll(laws.regionNested[A, B, C] _),
         "flatMap extends" -> forAll(laws.regionExtend[A, B] _),
-        "error coherence" -> forAll(laws.regionErrorCoherence[A] _),
+        "error coherence" -> forAll(laws.regionErrorCoherence[A, A] _),
         "liftF is open unit" -> forAll(laws.regionLiftFOpenUnit[A] _))
     }
   }

--- a/laws/src/main/scala/cats/effect/laws/SyncManagedLaws.scala
+++ b/laws/src/main/scala/cats/effect/laws/SyncManagedLaws.scala
@@ -17,7 +17,7 @@
 package cats.effect
 package laws
 
-trait SyncManagedLaws[R[_[_], _], F[_]] extends SyncLaws[R[F, ?]] with RegionLaws[R, F, Throwable] {
+trait SyncManagedLaws[R[_[_], _], F[_]] extends SyncLaws[R[F, *]] with RegionLaws[R, F, Throwable] {
   implicit val F: SyncManaged[R, F]
 
   def roundTrip[A](fa: R[F, A]) =

--- a/laws/src/main/scala/cats/effect/laws/SyncManagedTests.scala
+++ b/laws/src/main/scala/cats/effect/laws/SyncManagedTests.scala
@@ -22,7 +22,7 @@ import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._, Prop.forAll
 
-trait SyncManagedTests[R[_[_], _], F[_]] extends SyncTests[R[F, ?]] with RegionTests[R, F, Throwable] {
+trait SyncManagedTests[R[_[_], _], F[_]] extends SyncTests[R[F, *]] with RegionTests[R, F, Throwable] {
 
   val laws: SyncManagedLaws[R, F]
 
@@ -55,7 +55,7 @@ trait SyncManagedTests[R[_[_], _], F[_]] extends SyncTests[R[F, ?]] with RegionT
       EqRFInt: Eq[R[F, Int]],
       EqRFUnit: Eq[R[F, Unit]],
       exec: R[F, Boolean] => Prop,
-      iso: Isomorphisms[R[F, ?]])
+      iso: Isomorphisms[R[F, *]])
       : RuleSet = {
 
     new RuleSet {

--- a/laws/src/main/scala/cats/effect/laws/TemporalLaws.scala
+++ b/laws/src/main/scala/cats/effect/laws/TemporalLaws.scala
@@ -26,13 +26,13 @@ trait TemporalLaws[F[_], E] extends ConcurrentLaws[F, E] with ClockLaws[F] {
   implicit val F: Temporal[F, E]
 
   def monotonicSleepSumIdentity(delta: FiniteDuration) =
-    F.sleep(delta) >> F.monotonic <~> F.monotonic.map(delta +)
+    F.sleep(delta) >> F.monotonic <~> F.monotonic.map(delta + _)
 
   def sleepRaceMinimum(d1: FiniteDuration, d2: FiniteDuration) =
-    F.race(F.sleep(d1), F.sleep(d2)) >> F.monotonic <~> F.monotonic.map(d1.min(d2) +)
+    F.race(F.sleep(d1), F.sleep(d2)) >> F.monotonic <~> F.monotonic.map(d1.min(d2) + _)
 
   def startSleepMaximum(d1: FiniteDuration, d2: FiniteDuration) =
-    F.start(F.sleep(d1)).flatMap(f => F.sleep(d2) >> f.join) >> F.monotonic <~> F.monotonic.map(d1.max(d2) +)
+    F.start(F.sleep(d1)).flatMap(f => F.sleep(d2) >> f.join) >> F.monotonic <~> F.monotonic.map(d1.max(d2) + _)
 }
 
 object TemporalLaws {

--- a/laws/src/main/scala/cats/effect/laws/TemporalRegionLaws.scala
+++ b/laws/src/main/scala/cats/effect/laws/TemporalRegionLaws.scala
@@ -17,8 +17,8 @@
 package cats.effect
 package laws
 
-trait TemporalRegionLaws[R[_[_], _], F[_], E] extends TemporalLaws[R[F, ?], E] with ConcurrentRegionLaws[R, F, E] {
-  implicit val F: Temporal[R[F, ?], E] with Region[R, F, E]
+trait TemporalRegionLaws[R[_[_], _], F[_], E] extends TemporalLaws[R[F, *], E] with ConcurrentRegionLaws[R, F, E] {
+  implicit val F: Temporal[R[F, *], E] with Region[R, F, E]
 }
 
 object TemporalRegionLaws {
@@ -27,8 +27,8 @@ object TemporalRegionLaws {
       F[_],
       E](
     implicit
-      F0: Temporal[R[F, ?], E] with Region[R, F, E],
-      B0: Bracket.Aux[F, E, Outcome[R[F, ?], E, ?]])
+      F0: Temporal[R[F, *], E] with Region[R, F, E],
+      B0: Bracket.Aux[F, E, Outcome[R[F, *], E, *]])
       : TemporalRegionLaws[R, F, E] =
     new TemporalRegionLaws[R, F, E] {
       val F = F0

--- a/laws/src/main/scala/cats/effect/laws/TemporalRegionTests.scala
+++ b/laws/src/main/scala/cats/effect/laws/TemporalRegionTests.scala
@@ -25,7 +25,7 @@ import org.scalacheck.util.Pretty
 
 import scala.concurrent.duration.FiniteDuration
 
-trait TemporalRegionTests[R[_[_], _], F[_], E] extends TemporalTests[R[F, ?], E] with ConcurrentRegionTests[R, F, E] {
+trait TemporalRegionTests[R[_[_], _], F[_], E] extends TemporalTests[R[F, *], E] with ConcurrentRegionTests[R, F, E] {
 
   val laws: TemporalRegionLaws[R, F, E]
 
@@ -49,9 +49,9 @@ trait TemporalRegionTests[R[_[_], _], F[_], E] extends TemporalTests[R[F, ?], E]
       CogenC: Cogen[C],
       CogenE: Cogen[E],
       CogenCase: Cogen[laws.F.Case[_]],
-      CogenCaseA: Cogen[Outcome[R[F, ?], E, A]],
-      CogenCaseB: Cogen[Outcome[R[F, ?], E, B]],
-      CogenCaseU: Cogen[Outcome[R[F, ?], E, Unit]],
+      CogenCaseA: Cogen[Outcome[R[F, *], E, A]],
+      CogenCaseB: Cogen[Outcome[R[F, *], E, B]],
+      CogenCaseU: Cogen[Outcome[R[F, *], E, Unit]],
       EqFA: Eq[R[F, A]],
       EqFB: Eq[R[F, B]],
       EqFC: Eq[R[F, C]],
@@ -64,23 +64,23 @@ trait TemporalRegionTests[R[_[_], _], F[_], E] extends TemporalTests[R[F, ?], E]
       EqFEitherAU: Eq[R[F, Either[A, Unit]]],
       EqFEitherEitherEAU: Eq[R[F, Either[Either[E, A], Unit]]],
       EqFEitherUEitherEA: Eq[R[F, Either[Unit, Either[E, A]]]],
-      EqFOutcomeEA: Eq[R[F, Outcome[R[F, ?], E, A]]],
-      EqFOutcomeEU: Eq[R[F, Outcome[R[F, ?], E, Unit]]],
+      EqFOutcomeEA: Eq[R[F, Outcome[R[F, *], E, A]]],
+      EqFOutcomeEU: Eq[R[F, Outcome[R[F, *], E, Unit]]],
       EqFABC: Eq[R[F, (A, B, C)]],
       EqFInt: Eq[R[F, Int]],
       OrdFFD: Order[R[F, FiniteDuration]],
       GroupFD: Group[R[F, FiniteDuration]],
       exec: R[F, Boolean] => Prop,
-      iso: Isomorphisms[R[F, ?]],
+      iso: Isomorphisms[R[F, *]],
       faPP: R[F, A] => Pretty,
       fbPP: R[F, B] => Pretty,
       fuPP: R[F, Unit] => Pretty,
       aFUPP: (A => R[F, Unit]) => Pretty,
       ePP: E => Pretty,
-      foaPP: F[Outcome[R[F, ?], E, A]] => Pretty,
+      foaPP: F[Outcome[R[F, *], E, A]] => Pretty,
       feauPP: R[F, Either[A, Unit]] => Pretty,
       feuaPP: R[F, Either[Unit, A]] => Pretty,
-      fouPP: R[F, Outcome[R[F, ?], E, Unit]] => Pretty)
+      fouPP: R[F, Outcome[R[F, *], E, Unit]] => Pretty)
       : RuleSet = {
 
     new RuleSet {
@@ -99,8 +99,8 @@ object TemporalRegionTests {
       F[_],
       E](
     implicit
-      F0: Temporal[R[F, ?], E] with Region[R, F, E],
-      B0: Bracket.Aux[F, E, Outcome[R[F, ?], E, ?]])
+      F0: Temporal[R[F, *], E] with Region[R, F, E],
+      B0: Bracket.Aux[F, E, Outcome[R[F, *], E, *]])
       : TemporalRegionTests[R, F, E] = new TemporalRegionTests[R, F, E] {
     val laws = TemporalRegionLaws[R, F, E]
   }

--- a/laws/src/main/scala/cats/effect/laws/TemporalTests.scala
+++ b/laws/src/main/scala/cats/effect/laws/TemporalTests.scala
@@ -81,8 +81,9 @@ trait TemporalTests[F[_], E] extends ConcurrentTests[F, E] with ClockTests[F] {
 
     implicit val t = Tolerance(tolerance)
 
-    // bugs in scalac?
-    implicit val help = Tolerance[F[FiniteDuration]](Tolerance.lift[F, FiniteDuration])
+    // bugs in scalac*
+    implicit val help: Tolerance[F[FiniteDuration]] =
+      Tolerance[F[FiniteDuration]](Tolerance.lift[F, FiniteDuration])
 
     new RuleSet {
       val name = "temporal"

--- a/laws/src/main/scala/cats/effect/pure.scala
+++ b/laws/src/main/scala/cats/effect/pure.scala
@@ -16,7 +16,7 @@
 
 package cats.effect
 
-import cats.{~>, Eq, Functor, Group, Id, Monad, MonadError, Monoid, Show}
+import cats.{~>, Eq, Eval, Functor, Group, Id, Monad, MonadError, Monoid, Show}
 import cats.data.{Kleisli, WriterT}
 import cats.free.FreeT
 import cats.implicits._
@@ -24,6 +24,8 @@ import cats.implicits._
 import cats.mtl.implicits._
 
 import coop.{ApplicativeThread, ThreadT, MVar}
+
+import scala.concurrent.duration._
 
 object pure {
 
@@ -198,6 +200,45 @@ object pure {
 
       def raiseError[A](e: E) =
         F.raiseError(e)
+    }
+
+  def runSync[F[_]: Monad, A](ft: FreeT[Eval, F, A]): F[A] =
+    ft.runM(_.value.pure[F])
+
+  implicit def syncForFreeT[F[_]](implicit F: MonadError[F, Throwable]): Sync[FreeT[Eval, F, ?]] =
+    new Sync[FreeT[Eval, F, ?]] {
+      private[this] val M: MonadError[FreeT[Eval, F, ?], Throwable] =
+        catsFreeMonadErrorForFreeT2
+
+      def pure[A](x: A): FreeT[Eval, F, A] =
+        M.pure(x)
+
+      def handleErrorWith[A](fa: FreeT[Eval, F, A])(f: Throwable => FreeT[Eval, F, A]): FreeT[Eval, F, A] =
+        M.handleErrorWith(fa)(f)
+
+      def raiseError[A](e: Throwable): FreeT[Eval, F, A] =
+        M.raiseError(e)
+
+      def now: FreeT[Eval, F, FiniteDuration] =
+        delay(System.nanoTime().nanos)
+
+      def flatMap[A, B](fa: FreeT[Eval, F, A])(f: A => FreeT[Eval, F, B]): FreeT[Eval, F, B] =
+        fa.flatMap(f)
+
+      def tailRecM[A, B](a: A)(f: A => FreeT[Eval, F, Either[A, B]]): FreeT[Eval, F, B] =
+        M.tailRecM(a)(f)
+
+      def delay[A](thunk: => A): FreeT[Eval, F, A] =
+        FreeT roll {
+          Eval always {
+            try {
+              pure(thunk)
+            } catch {
+              case t: Throwable =>
+                raiseError(t)
+            }
+          }
+        }
     }
 
   implicit def concurrentBForPureConc[E]: ConcurrentBracket[PureConc[E, ?], E] =

--- a/laws/src/main/scala/cats/effect/pure.scala
+++ b/laws/src/main/scala/cats/effect/pure.scala
@@ -523,6 +523,9 @@ object pure {
         M.tailRecM(a)(f)
     }
 
+  implicit def eqFreeSync[F[_]: Monad, A](implicit F: Eq[F[A]]): Eq[FreeT[Eval, F, A]] =
+    Eq.by(runSync(_))
+
   implicit def eqPureConc[E: Eq, A: Eq]: Eq[PureConc[E, A]] = Eq.by(run(_))
 
   implicit def showPureConc[E: Show, A: Show]: Show[PureConc[E, A]] =

--- a/laws/src/test/scala/cats/effect/FreeSyncGenerators.scala
+++ b/laws/src/test/scala/cats/effect/FreeSyncGenerators.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ce3
+package laws
+
+import cats.{Eval, Monad, MonadError}
+import cats.free.FreeT
+
+import playground._
+
+import org.scalacheck.{Arbitrary, Cogen, Gen}
+import org.scalacheck.util.Pretty
+
+import scala.concurrent.duration.FiniteDuration
+import java.util.concurrent.TimeUnit
+
+object FreeSyncGenerators {
+  import OutcomeGenerators._
+
+  implicit def cogenFreeSync[F[_]: Monad, A: Cogen](implicit C: Cogen[F[A]]): Cogen[FreeT[Eval, F, A]] =
+    C.contramap(runSync(_))
+
+  def generators[F[_]](implicit F0: MonadError[F, Throwable]) =
+    new SyncGenerators[FreeT[Eval, F, ?]] {
+
+      val arbitraryE: Arbitrary[Throwable] =
+        Arbitrary(Arbitrary.arbitrary[Int].map(TestException(_)))
+
+      val cogenE: Cogen[Throwable] =
+        Cogen[Int].contramap(_.asInstanceOf[TestException].i)
+
+      val arbitraryFD: Arbitrary[FiniteDuration] = {
+        import TimeUnit._
+
+        val genTU = Gen.oneOf(NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS)
+
+        Arbitrary {
+          genTU flatMap { u =>
+            Gen.posNum[Long].map(FiniteDuration(_, u))
+          }
+        }
+      }
+
+      val F: Sync[FreeT[Eval, F, ?]] =
+        syncForFreeT[F]
+    }
+
+  implicit def arbitraryFreeSync[F[_], A: Arbitrary: Cogen](
+      implicit F: MonadError[F, Throwable])
+      : Arbitrary[FreeT[Eval, F, A]] =
+    Arbitrary(generators[F].generators[A])
+}
+
+final case class TestException(i: Int) extends Exception

--- a/laws/src/test/scala/cats/effect/FreeSyncGenerators.scala
+++ b/laws/src/test/scala/cats/effect/FreeSyncGenerators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Daniel Spiewak
+ * Copyright 2020 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,23 @@
  * limitations under the License.
  */
 
-package ce3
+package cats.effect
 package laws
 
 import cats.{Eval, Monad, MonadError}
 import cats.free.FreeT
 
-import playground._
+import freeEval._
 
 import org.scalacheck.{Arbitrary, Cogen, Gen}
-import org.scalacheck.util.Pretty
 
 import scala.concurrent.duration.FiniteDuration
 import java.util.concurrent.TimeUnit
 
 object FreeSyncGenerators {
-  import OutcomeGenerators._
 
   implicit def cogenFreeSync[F[_]: Monad, A: Cogen](implicit C: Cogen[F[A]]): Cogen[FreeT[Eval, F, A]] =
-    C.contramap(runSync(_))
+    C.contramap(run(_))
 
   def generators[F[_]](implicit F0: MonadError[F, Throwable]) =
     new SyncGenerators[FreeT[Eval, F, ?]] {

--- a/laws/src/test/scala/cats/effect/FreeSyncSpec.scala
+++ b/laws/src/test/scala/cats/effect/FreeSyncSpec.scala
@@ -26,7 +26,6 @@ import org.scalacheck.Prop
 import org.scalacheck.util.Pretty
 
 import org.specs2.ScalaCheck
-import org.specs2.matcher.Matcher
 import org.specs2.mutable._
 
 import org.typelevel.discipline.specs2.mutable.Discipline
@@ -42,15 +41,6 @@ class FreeSyncSpec extends Specification with Discipline with ScalaCheck {
 
   implicit def exec(sbool: FreeEitherSync[Boolean]): Prop =
     run(sbool).fold(Prop.exception(_), b => if (b) Prop.proved else Prop.falsified)
-
-  def beEqv[A: Eq: Show](expect: A): Matcher[A] = be_===[A](expect)
-
-  def be_===[A: Eq: Show](expect: A): Matcher[A] = (result: A) =>
-    (result === expect, s"${result.show} === ${expect.show}", s"${result.show} !== ${expect.show}")
-
-  Eq[Either[Throwable, Int]]
-
-  cats.Invariant[FreeEitherSync]
 
   checkAll(
     "FreeEitherSync",

--- a/laws/src/test/scala/cats/effect/FreeSyncSpec.scala
+++ b/laws/src/test/scala/cats/effect/FreeSyncSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ce3
+package laws
+
+import cats.{~>, Applicative, ApplicativeError, Eq, Eval, FlatMap, Monad, Monoid, Show}
+import cats.data.{EitherK, StateT}
+import cats.free.FreeT
+import cats.implicits._
+
+import coop.ThreadT
+
+import playground._
+
+import org.scalacheck.{Arbitrary, Cogen, Gen, Prop}, Arbitrary.arbitrary
+import org.scalacheck.util.Pretty
+
+import org.specs2.ScalaCheck
+import org.specs2.matcher.Matcher
+import org.specs2.mutable._
+
+import org.typelevel.discipline.specs2.mutable.Discipline
+
+class FreeSyncSpec extends Specification with Discipline with ScalaCheck {
+  import FreeSyncGenerators._
+
+  type FreeEitherSync[A] = FreeT[Eval, Either[Throwable, ?], A]
+
+  implicit def prettyFromShow[A: Show](a: A): Pretty =
+    Pretty.prettyString(a.show)
+
+  implicit val eqThrowable: Eq[Throwable] =
+    Eq.fromUniversalEquals
+
+  implicit def exec(sbool: FreeEitherSync[Boolean]): Prop =
+    runSync(sbool).fold(Prop.exception(_), b => if (b) Prop.proved else Prop.falsified)
+
+  def beEqv[A: Eq: Show](expect: A): Matcher[A] = be_===[A](expect)
+
+  def be_===[A: Eq: Show](expect: A): Matcher[A] = (result: A) =>
+    (result === expect, s"${result.show} === ${expect.show}", s"${result.show} !== ${expect.show}")
+
+  Eq[Either[Throwable, Int]]
+
+  checkAll(
+    "FreeEitherSync",
+    SyncTests[FreeEitherSync].sync[Int, Int, Int])
+}

--- a/laws/src/test/scala/cats/effect/Generators.scala
+++ b/laws/src/test/scala/cats/effect/Generators.scala
@@ -264,7 +264,7 @@ trait AsyncGenerators[F[_]] extends TemporalGenerators[F, Throwable] with SyncGe
       fo <- deeper[Option[F[Unit]]](
         Arbitrary(
           Gen.option[F[Unit]](
-            deeper[Unit](Arbitrary(arbitrary[Unit]), Cogen.cogenUnit))),
+            deeper[Unit])),
         Cogen.cogenOption(cogenFU))
     } yield F.async[A](k => F.delay(k(result)) >> fo)
 

--- a/laws/src/test/scala/cats/effect/Generators.scala
+++ b/laws/src/test/scala/cats/effect/Generators.scala
@@ -133,13 +133,12 @@ trait ClockGenerators[F[_]] extends ApplicativeGenerators[F] {
   implicit val F: Clock[F]
 
   protected implicit val arbitraryFD: Arbitrary[FiniteDuration]
-  protected implicit val cogenFD: Cogen[FiniteDuration]
 
   override protected def baseGen[A: Arbitrary: Cogen] =
     ("now" -> genNow[A]) :: super.baseGen[A]
 
   private def genNow[A: Arbitrary] =
-    arbitrary[FiniteDuration => A].map(F.now.map(_))
+    arbitrary[A].map(F.now.as(_))
 }
 
 trait SyncGenerators[F[_]] extends MonadErrorGenerators[F, Throwable] with ClockGenerators[F] {

--- a/laws/src/test/scala/cats/effect/Generators.scala
+++ b/laws/src/test/scala/cats/effect/Generators.scala
@@ -16,7 +16,7 @@
 
 package cats.effect
 
-import cats.{Applicative, ApplicativeError, Monad}
+import cats.{Applicative, ApplicativeError, Monad, MonadError}
 import cats.implicits._
 
 import org.scalacheck.{Arbitrary, Cogen, Gen}, Arbitrary.arbitrary
@@ -135,10 +135,15 @@ trait ClockGenerators[F[_]] extends ApplicativeGenerators[F] {
   protected implicit val arbitraryFD: Arbitrary[FiniteDuration]
 
   override protected def baseGen[A: Arbitrary: Cogen] =
-    ("now" -> genNow[A]) :: super.baseGen[A]
+    List(
+      "monotonic" -> genMonotonic[A],
+      "realTime" -> genRealTime[A]) ++ super.baseGen[A]
 
-  private def genNow[A: Arbitrary] =
-    arbitrary[A].map(F.now.as(_))
+  private def genMonotonic[A: Arbitrary] =
+    arbitrary[A].map(F.monotonic.as(_))
+
+  private def genRealTime[A: Arbitrary] =
+    arbitrary[A].map(F.realTime.as(_))
 }
 
 trait SyncGenerators[F[_]] extends MonadErrorGenerators[F, Throwable] with ClockGenerators[F] {

--- a/laws/src/test/scala/cats/effect/Generators.scala
+++ b/laws/src/test/scala/cats/effect/Generators.scala
@@ -122,7 +122,12 @@ trait ApplicativeErrorGenerators[F[_], E] extends ApplicativeGenerators[F] {
     } yield F.handleErrorWith(fa)(f)
   }
 }
-trait BracketGenerators[F[_], E] extends ApplicativeErrorGenerators[F, E] {
+
+trait MonadErrorGenerators[F[_], E] extends MonadGenerators[F] with ApplicativeErrorGenerators[F, E] {
+  implicit val F: MonadError[F, E]
+}
+
+trait BracketGenerators[F[_], E] extends MonadErrorGenerators[F, E] {
   implicit val F: Bracket[F, E]
   type Case[A] = F.Case[A]
   implicit def cogenCase[A: Cogen]: Cogen[Case[A]]
@@ -140,7 +145,7 @@ trait BracketGenerators[F[_], E] extends ApplicativeErrorGenerators[F, E] {
   }
 }
 
-trait ConcurrentGenerators[F[_], E] extends ApplicativeErrorGenerators[F, E] {
+trait ConcurrentGenerators[F[_], E] extends MonadErrorGenerators[F, E] {
   implicit val F: Concurrent[F, E]
 
   override protected def baseGen[A: Arbitrary: Cogen]: List[(String, Gen[F[A]])] = List(

--- a/laws/src/test/scala/cats/effect/Generators.scala
+++ b/laws/src/test/scala/cats/effect/Generators.scala
@@ -208,8 +208,8 @@ object OutcomeGenerators {
     val cogenE: Cogen[E] = implicitly
     implicit val F: ApplicativeError[Outcome[F, E, *], E] = Outcome.applicativeError[F, E]
 
-    override protected def baseGen[A: Arbitrary: Cogen]: List[(String, Gen[Outcome[F,E,A]])] = List(
-      "const(Canceled)" -> Gen.const(Outcome.Canceled)
+    override protected def baseGen[A: Arbitrary: Cogen]: List[(String, Gen[Outcome[F, E, A]])] = List(
+      "const(Canceled)" -> Gen.const(Outcome.Canceled[F, E, A]())
     ) ++ super.baseGen[A]
   }
 
@@ -219,8 +219,8 @@ object OutcomeGenerators {
     }
 
   implicit def cogenOutcome[F[_], E: Cogen, A](implicit A: Cogen[F[A]]): Cogen[Outcome[F, E, A]] = Cogen[Option[Either[E, F[A]]]].contramap {
-    case Outcome.Canceled => None
-    case c: Outcome.Completed[F, A] => Some(Right(c.fa))
+    case Outcome.Canceled() => None
+    case Outcome.Completed(fa) => Some(Right(fa))
     case Outcome.Errored(e) => Some(Left(e))
   }
 }

--- a/laws/src/test/scala/cats/effect/OutcomeSpec.scala
+++ b/laws/src/test/scala/cats/effect/OutcomeSpec.scala
@@ -29,14 +29,14 @@ class OutcomeSpec extends Specification with Discipline {
 
   // doesn't compile on scala 2.12
   // checkAll(
-  //   "Outcome[Id, Int, ?]",
-  //   MonadErrorTests[Outcome[Id, Int, ?], Int].monadError[Int, Int, Int])
+  //   "Outcome[Id, Int, *]",
+  //   MonadErrorTests[Outcome[Id, Int, *], Int].monadError[Int, Int, Int])
 
   checkAll(
-    "Outcome[Option, Int, ?]",
-    MonadErrorTests[Outcome[Option, Int, ?], Int].monadError[Int, Int, Int])
+    "Outcome[Option, Int, *]",
+    MonadErrorTests[Outcome[Option, Int, *], Int].monadError[Int, Int, Int])
 
   checkAll(
-    "Outcome[Eval, Int, ?]",
-    ApplicativeErrorTests[Outcome[Eval, Int, ?], Int].applicativeError[Int, Int, Int])
+    "Outcome[Eval, Int, *]",
+    ApplicativeErrorTests[Outcome[Eval, Int, *], Int].applicativeError[Int, Int, Int])
 }

--- a/laws/src/test/scala/cats/effect/PureConcGenerators.scala
+++ b/laws/src/test/scala/cats/effect/PureConcGenerators.scala
@@ -25,15 +25,15 @@ object PureConcGenerators {
 
   implicit def cogenPureConc[E: Cogen, A: Cogen]: Cogen[PureConc[E, A]] = Cogen[Outcome[Option, E, A]].contramap(run(_))
 
-  val generators = new ConcurrentGenerators[PureConc[Int, ?], Int] with BracketGenerators[PureConc[Int, ?], Int] {
+  val generators = new ConcurrentGenerators[PureConc[Int, *], Int] with BracketGenerators[PureConc[Int, *], Int] {
 
     val arbitraryE: Arbitrary[Int] = implicitly[Arbitrary[Int]]
 
     val cogenE: Cogen[Int] = Cogen[Int]
 
-    val F: ConcurrentBracket[PureConc[Int, ?], Int] = concurrentBForPureConc[Int]
+    val F: ConcurrentBracket[PureConc[Int, *], Int] = concurrentBForPureConc[Int]
 
-    def cogenCase[A: Cogen]: Cogen[Outcome[PureConc[Int, ?], Int, A]] = OutcomeGenerators.cogenOutcome[PureConc[Int, ?], Int, A]
+    def cogenCase[A: Cogen]: Cogen[Outcome[PureConc[Int, *], Int, A]] = OutcomeGenerators.cogenOutcome[PureConc[Int, *], Int, A]
   }
 
   implicit def arbitraryPureConc[A: Arbitrary: Cogen]: Arbitrary[PureConc[Int, A]] =

--- a/laws/src/test/scala/cats/effect/PureConcGenerators.scala
+++ b/laws/src/test/scala/cats/effect/PureConcGenerators.scala
@@ -23,19 +23,22 @@ import org.scalacheck.{Arbitrary, Cogen}
 object PureConcGenerators {
   import OutcomeGenerators._
 
-  implicit def cogenPureConc[E: Cogen, A: Cogen]: Cogen[PureConc[E, A]] = Cogen[Outcome[Option, E, A]].contramap(run(_))
+  implicit def cogenPureConc[E: Cogen, A: Cogen]: Cogen[PureConc[E, A]] =
+    Cogen[Outcome[Option, E, A]].contramap(run(_))
 
-  val generators = new ConcurrentGenerators[PureConc[Int, ?], Int] with BracketGenerators[PureConc[Int, ?], Int] {
+  def generators[E: Arbitrary: Cogen] =
+    new ConcurrentGenerators[PureConc[E, ?], E] with BracketGenerators[PureConc[E, ?], E] {
 
-    val arbitraryE: Arbitrary[Int] = implicitly[Arbitrary[Int]]
+      val arbitraryE: Arbitrary[E] = implicitly[Arbitrary[E]]
 
-    val cogenE: Cogen[Int] = Cogen[Int]
+      val cogenE: Cogen[E] = Cogen[E]
 
-    val F: ConcurrentBracket[PureConc[Int, ?], Int] = concurrentBForPureConc[Int]
+      val F: ConcurrentBracket[PureConc[E, ?], E] = concurrentBForPureConc[E]
 
-    def cogenCase[A: Cogen]: Cogen[Outcome[PureConc[Int, ?], Int, A]] = OutcomeGenerators.cogenOutcome[PureConc[Int, ?], Int, A]
-  }
+      def cogenCase[A: Cogen]: Cogen[Outcome[PureConc[E, ?], E, A]] =
+        OutcomeGenerators.cogenOutcome[PureConc[E, ?], E, A]
+    }
 
-  implicit def arbitraryPureConc[A: Arbitrary: Cogen]: Arbitrary[PureConc[Int, A]] =
-    Arbitrary(generators.generators[A])
+  implicit def arbitraryPureConc[E: Arbitrary: Cogen, A: Arbitrary: Cogen]: Arbitrary[PureConc[E, A]] =
+    Arbitrary(generators[E].generators[A])
 }

--- a/laws/src/test/scala/cats/effect/PureConcSpec.scala
+++ b/laws/src/test/scala/cats/effect/PureConcSpec.scala
@@ -16,7 +16,7 @@
 
 package cats.effect
 
-import cats.{Eq, Show}
+import cats.Show
 import cats.effect.laws.ConcurrentBracketTests
 import cats.implicits._
 
@@ -25,7 +25,6 @@ import pure._
 import org.scalacheck.util.Pretty
 
 import org.specs2.ScalaCheck
-import org.specs2.matcher.Matcher
 import org.specs2.mutable._
 
 import org.typelevel.discipline.specs2.mutable.Discipline
@@ -37,12 +36,7 @@ class PureConcSpec extends Specification with Discipline with ScalaCheck {
   implicit def prettyFromShow[A: Show](a: A): Pretty =
     Pretty.prettyString(a.show)
 
-  def beEqv[A: Eq: Show](expect: A): Matcher[A] = be_===[A](expect)
-
-  def be_===[A: Eq: Show](expect: A): Matcher[A] = (result: A) =>
-    (result === expect, s"${result.show} === ${expect.show}", s"${result.show} !== ${expect.show}")
-
   checkAll(
     "PureConc",
-    ConcurrentBracketTests[PureConc[Int, ?], Int].concurrentBracket[Int, Int, Int])
+    ConcurrentBracketTests[PureConc[Int, *], Int].concurrentBracket[Int, Int, Int])
 }

--- a/laws/src/test/scala/cats/effect/TimeTSpec.scala
+++ b/laws/src/test/scala/cats/effect/TimeTSpec.scala
@@ -16,7 +16,7 @@
 
 package cats.effect
 
-import cats.{Eq, Order, Show}
+import cats.{Eq, Order}
 import cats.data.Kleisli
 import cats.effect.laws.TemporalBracketTests
 import cats.implicits._
@@ -26,7 +26,6 @@ import pure._
 import TimeT._
 
 import org.specs2.ScalaCheck
-import org.specs2.matcher.Matcher
 import org.specs2.mutable._
 
 import org.scalacheck.{Arbitrary, Cogen, Gen, Prop}
@@ -48,10 +47,10 @@ class TimeTSpec extends Specification with Discipline with ScalaCheck with LowPr
   import PureConcGenerators._
 
   checkAll(
-    "TimeT[PureConc, ?]",
-    TemporalBracketTests[TimeT[PureConc[Int, ?], ?], Int].temporalBracket[Int, Int, Int](0.millis))
+    "TimeT[PureConc, *]",
+    TemporalBracketTests[TimeT[PureConc[Int, *], *], Int].temporalBracket[Int, Int, Int](0.millis))
 
-  implicit def exec(fb: TimeT[PureConc[Int, ?], Boolean]): Prop =
+  implicit def exec(fb: TimeT[PureConc[Int, *], Boolean]): Prop =
     Prop(pure.run(TimeT.run(fb)).fold(false, _ => false, _.getOrElse(false)))
 
   implicit def arbPositiveFiniteDuration: Arbitrary[FiniteDuration] = {
@@ -80,9 +79,4 @@ class TimeTSpec extends Specification with Discipline with ScalaCheck with LowPr
 
   implicit def cogenKleisli[F[_], R, A](implicit cg: Cogen[R => F[A]]): Cogen[Kleisli[F, R, A]] =
     cg.contramap(_.run)
-
-  def beEqv[A: Eq: Show](expect: A): Matcher[A] = be_===[A](expect)
-
-  def be_===[A: Eq: Show](expect: A): Matcher[A] = (result: A) =>
-    (result === expect, s"${result.show} === ${expect.show}", s"${result.show} !== ${expect.show}")
 }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -16,13 +16,26 @@
 
 import sbt._, Keys._
 
+import dotty.tools.sbtplugin.DottyPlugin, DottyPlugin.autoImport._
+
 object Common extends AutoPlugin {
 
-  override def requires = plugins.JvmPlugin
+  override def requires = plugins.JvmPlugin && DottyPlugin
   override def trigger = allRequirements
 
   override def projectSettings =
     Seq(
-      addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0"),
-      scalacOptions += "-Xcheckinit")
+      libraryDependencies ++= {
+        if (isDotty.value)
+          Nil
+        else
+          Seq(compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0"))
+      },
+
+      scalacOptions ++= {
+        if (isDotty.value)
+          Nil
+        else
+          Seq("-Xcheckinit")
+      })
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.14-0fd8581")
+addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.14-aa9e4e4")
 addSbtPlugin("com.codecommit" % "sbt-github-actions"   % "0.6.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.13.0")
+addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.14-0fd8581")
 addSbtPlugin("com.codecommit" % "sbt-github-actions"   % "0.6.2")


### PR DESCRIPTION
This was a bit of an undertaking, but… tada! Full Dotty compatibility.

A few things had to be modified as part of this. Most notably, `Outcome` had to be changed somewhat significantly. All the variance had to be removed due to the fact that having `A` be covariant actually forces `F` to be covariant in *its* type parameter (as opposed to the current state in master, where `F` itself is covariant but not the parameter). This is basically "the monad transformer problem", and it's an issue which is shared by `Resource`. Interestingly, it's not an issue which is correctly typechecked by scalac, which is why we never saw it before, but the current definitions *are* unsound. My guess would be that, in order to get `Resource` compiling on Dotty, the variance will have to go. It's worth playing it out to see though.

Another thing that had to change is the signature of `openCase` in `Region`, which loses its wildcard existential and picks up an extra type parameter. This is somewhat unavoidable due to Dotty's removal of higher-rank existentials (`forSome`). In order to forbid relatively direct *encodings* of higher-rank existentials, wildcards are forbidden as instantiations of higher-kinded type variables, such as `Case`. Adding the type parameter yields no loss of expressive power, though it does produce some unpleasant syntactic baggage. Either way, even in Scala 2, type parameters infer much better than wildcards, so this is probably an improvement overall even if it is aesthetically weird.

A subpoint of the existential loss is that the laws had to be rephrased, since `Case` is polymorphic *there* as well. Due to variance, the instances had to be made more specific.

Bizarrely, I've seen scalacheck test failures in the Dotty cross-build of this branch, but… not in the Scala 2 cross-builds. I'm putting that down to randomness because I never reproduced it, and in any case, it doesn't make any sense for Dotty to exhibit different scalacheck semantics than Scala 2 does, since scalacheck has yet to be cross-published for Dotty, meaning that they're literally running the same bytecode.