### PR TITLE
Mega Project Reorganization Of Doom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [0.25.0-RC2, 2.12.11, 2.13.2]
-        java: [adopt@1.8, adopt@11, adopt@14, graalvm@20.1.0]
+        java:
+          - adopt@1.8
+          - adopt@11
+          - adopt@14
+          - graalvm8@20.1.0
         ci: [ciJVM]
         include:
           - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
         os: [ubuntu-latest]
         scala: [0.25.0-RC2, 2.12.11, 2.13.2]
         java: [adopt@1.8, adopt@11, adopt@14, graalvm@20.1.0]
+        ci: [ciJVM]
+        include:
+          - os: ubuntu-latest
+            java: adopt@1.8
+            scala: 2.13.2
+            ci: ciJS
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (fast)
@@ -76,4 +82,4 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
-      - run: sbt ++${{ matrix.scala }} ci
+      - run: sbt ++${{ matrix.scala }} '${{ matrix.ci }}'

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,12 @@
+version = 2.4.2
+align = none
+align.openParenCallSite = true
+align.openParenDefnSite = true
+maxColumn = 120
+continuationIndent.defnSite = 2
+assumeStandardLibraryStripMargin = true
+danglingParentheses = true
+rewrite.rules = [AvoidInfix, SortImports, RedundantBraces, RedundantParens, SortModifiers]
+docstrings = JavaDoc
+lineEndings=preserve
+newlines.afterCurlyLambda = preserve

--- a/build.sbt
+++ b/build.sbt
@@ -36,8 +36,19 @@ Global / scmInfo := Some(
 
 val CatsVersion = "2.1.1"
 
+addCommandAlias("ciJVM", "; project rootJVM; headerCheck; clean; testIfRelevant; mimaReportBinaryIssuesIfRelevant")
+addCommandAlias("ciJS", "; project rootJS; headerCheck; clean; testIfRelevant")
+
 lazy val root = project.in(file("."))
-  .aggregate(kernel.jvm, kernel.js, testkit.jvm, testkit.js, laws.jvm, laws.js, core.jvm, core.js)
+  .aggregate(rootJVM, rootJS)
+  .settings(noPublishSettings)
+
+lazy val rootJVM = project
+  .aggregate(kernel.jvm, testkit.jvm, laws.jvm, core.jvm)
+  .settings(noPublishSettings)
+
+lazy val rootJS = project
+  .aggregate(kernel.js, testkit.js, laws.js, core.js)
   .settings(noPublishSettings)
 
 /**

--- a/build.sbt
+++ b/build.sbt
@@ -22,16 +22,21 @@ ThisBuild / organizationName := "Typelevel"
 ThisBuild / publishGithubUser := "djspiewak"
 ThisBuild / publishFullName := "Daniel Spiewak"
 
-val ScalaJSOS = "ubuntu-latest"
+val PrimaryOS = "ubuntu-latest"
+
 val ScalaJSScala = "2.13.2"
 val ScalaJSJava = "adopt@1.8"
 
 ThisBuild / crossScalaVersions := Seq("0.25.0-RC2", "2.12.11", ScalaJSScala)
 
 ThisBuild / githubWorkflowTargetBranches := Seq("ce3")      // for now
-ThisBuild / githubWorkflowJavaVersions := Seq(ScalaJSJava, "adopt@11", "adopt@14", "graalvm@20.1.0")
 
-ThisBuild / githubWorkflowOSes := Seq(ScalaJSOS)
+val LTSJava = "adopt@11"
+val LatestJava = "adopt@14"
+val GraalVM8 = "graalvm8@20.1.0"
+
+ThisBuild / githubWorkflowJavaVersions := Seq(ScalaJSJava, LTSJava, LatestJava, GraalVM8)
+ThisBuild / githubWorkflowOSes := Seq(PrimaryOS)
 
 ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("${{ matrix.ci }}")))
 
@@ -39,7 +44,7 @@ ThisBuild / githubWorkflowBuildMatrixAdditions += "ci" -> List("ciJVM")
 
 ThisBuild / githubWorkflowBuildMatrixInclusions +=
   MatrixInclude(
-    Map("os" -> ScalaJSOS, "java" -> ScalaJSJava, "scala" -> ScalaJSScala),
+    Map("os" -> PrimaryOS, "java" -> ScalaJSJava, "scala" -> ScalaJSScala),
     Map("ci" -> "ciJS"))
 
 Global / homepage := Some(url("https://github.com/typelevel/cats-effect"))

--- a/build.sbt
+++ b/build.sbt
@@ -22,10 +22,25 @@ ThisBuild / organizationName := "Typelevel"
 ThisBuild / publishGithubUser := "djspiewak"
 ThisBuild / publishFullName := "Daniel Spiewak"
 
-ThisBuild / crossScalaVersions := Seq("0.25.0-RC2", "2.12.11", "2.13.2")
+val ScalaJSOS = "ubuntu-latest"
+val ScalaJSScala = "2.13.2"
+val ScalaJSJava = "adopt@1.8"
+
+ThisBuild / crossScalaVersions := Seq("0.25.0-RC2", "2.12.11", ScalaJSScala)
 
 ThisBuild / githubWorkflowTargetBranches := Seq("ce3")      // for now
-ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@11", "adopt@14", "graalvm@20.1.0")
+ThisBuild / githubWorkflowJavaVersions := Seq(ScalaJSJava, "adopt@11", "adopt@14", "graalvm@20.1.0")
+
+ThisBuild / githubWorkflowOSes := Seq(ScalaJSOS)
+
+ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("${{ matrix.ci }}")))
+
+ThisBuild / githubWorkflowBuildMatrixAdditions += "ci" -> List("ciJVM")
+
+ThisBuild / githubWorkflowBuildMatrixInclusions +=
+  MatrixInclude(
+    Map("os" -> ScalaJSOS, "java" -> ScalaJSJava, "scala" -> ScalaJSScala),
+    Map("ci" -> "ciJS"))
 
 Global / homepage := Some(url("https://github.com/typelevel/cats-effect"))
 

--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -16,51 +16,67 @@
 
 package cats
 
-import cats.data.Kleisli
+import cats.effect.{kernel => cekernel}
 
 package object effect {
-  type BracketThrow[F[_]] = Bracket[F, Throwable]
-  type RegionThrow[R[_[_], _], F[_]] = Region[R, F, Throwable]
 
-  type ConcurrentThrow[F[_]] = Concurrent[F, Throwable]
+  type Outcome[F[_], E, A] = cekernel.Outcome[F, E, A]
+  val Outcome = cekernel.Outcome
 
-  type ConcurrentBracket[F[_], E] = Concurrent[F, E] with Bracket[F, E]
+  type Bracket[F[_], E] = cekernel.Bracket[F, E]
+  val Bracket = cekernel.Bracket
 
-  object ConcurrentBracket {
-    def apply[F[_], E](implicit F: ConcurrentBracket[F, E]): ConcurrentBracket[F, E] = F
-  }
+  type Region[R[_[_], _], F[_], E] = cekernel.Region[R, F, E]
+  val Region = cekernel.Region
 
-  type ConcurrentRegion[R[_[_], _], F[_], E] = Concurrent[R[F, *], E] with Region[R, F, E]
+  type Concurrent[F[_], E] = cekernel.Concurrent[F, E]
+  val Concurrent = cekernel.Concurrent
 
-  object ConcurrentRegion {
-    def apply[R[_[_], _], F[_], E](implicit R: ConcurrentRegion[R, F, E]): ConcurrentRegion[R, F, E] = R
-  }
+  type Fiber[F[_], E, A] = cekernel.Fiber[F, E, A]
 
-  type TemporalThrow[F[_]] = Temporal[F, Throwable]
+  type Clock[F[_]] = cekernel.Clock[F]
+  val Clock = cekernel.Clock
 
-  type TemporalBracket[F[_], E] = Temporal[F, E] with Bracket[F, E]
+  type Temporal[F[_], E] = cekernel.Temporal[F, E]
+  val Temporal = cekernel.Temporal
 
-  object TemporalBracket {
-    def apply[F[_], E](implicit F: TemporalBracket[F, E]): TemporalBracket[F, E] = F
-  }
+  type Sync[F[_]] = cekernel.Sync[F]
+  val Sync = cekernel.Sync
 
-  type TemporalRegion[R[_[_], _], F[_], E] = Temporal[R[F, *], E] with Region[R, F, E]
+  type SyncEffect[F[_]] = cekernel.SyncEffect[F]
+  val SyncEffect = cekernel.SyncEffect
 
-  object TemporalRegion {
-    def apply[R[_[_], _], F[_], E](implicit R: TemporalRegion[R, F, E]): TemporalRegion[R, F, E] = R
-  }
+  type Async[F[_]] = cekernel.Async[F]
+  val Async = cekernel.Async
 
-  type AsyncBracket[F[_]] = Async[F] with Bracket[F, Throwable]
+  type Managed[R[_[_], _], F[_]] = cekernel.Managed[R, F]
+  val Managed = cekernel.Managed
 
-  object AsyncBracket {
-    def apply[F[_]](implicit F: AsyncBracket[F]): AsyncBracket[F] = F
-  }
+  type Effect[F[_]] = cekernel.Effect[F]
+  val Effect = cekernel.Effect
 
-  type AsyncRegion[R[_[_], _], F[_]] = Async[R[F, *]] with Region[R, F, Throwable]
+  type BracketThrow[F[_]] = cekernel.BracketThrow[F]
+  type RegionThrow[R[_[_], _], F[_]] = cekernel.RegionThrow[R, F]
 
-  object AsyncRegion {
-    def apply[R[_[_], _], F[_]](implicit R: AsyncRegion[R, F]): AsyncRegion[R, F] = R
-  }
+  type ConcurrentThrow[F[_]] = cekernel.ConcurrentThrow[F]
 
-  type TimeT[F[_], A] = Kleisli[F, Time, A]
+  type ConcurrentBracket[F[_], E] = cekernel.ConcurrentBracket[F, E]
+  val ConcurrentBracket = cekernel.ConcurrentBracket
+
+  type ConcurrentRegion[R[_[_], _], F[_], E] = cekernel.ConcurrentRegion[R, F, E]
+  val ConcurrentRegion = cekernel.ConcurrentRegion
+
+  type TemporalThrow[F[_]] = cekernel.TemporalThrow[F]
+
+  type TemporalBracket[F[_], E] = cekernel.TemporalBracket[F, E]
+  val TemporalBracket = cekernel.TemporalBracket
+
+  type TemporalRegion[R[_[_], _], F[_], E] = cekernel.TemporalRegion[R, F, E]
+  val TemporalRegion = cekernel.TemporalRegion
+
+  type AsyncBracket[F[_]] = cekernel.AsyncBracket[F]
+  val AsyncBracket = cekernel.AsyncBracket
+
+  type AsyncRegion[R[_[_], _], F[_]] = cekernel.AsyncRegion[R, F]
+  val AsyncRegion = cekernel.AsyncRegion
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Clock.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Clock.scala
@@ -14,28 +14,21 @@
  * limitations under the License.
  */
 
-package cats.effect
-package laws
+package cats.effect.kernel
 
-import cats.effect.kernel.{Bracket, Managed, Outcome}
+import cats.Applicative
 
-trait ManagedLaws[R[_[_], _], F[_]] extends AsyncRegionLaws[R, F] {
-  implicit val F: Managed[R, F]
+import scala.concurrent.duration.FiniteDuration
 
-  def roundTrip[A](rfa: R[F, A]) =
-    F.to[R](rfa) <-> rfa
+trait Clock[F[_]] extends Applicative[F] {
+
+  // (monotonic, monotonic).mapN(_ <= _)
+  def monotonic: F[FiniteDuration]
+
+  // lawless (unfortunately), but meant to represent current (when sequenced) system time
+  def realTime: F[FiniteDuration]
 }
 
-object ManagedLaws {
-  def apply[
-      R[_[_], _],
-      F[_]](
-    implicit
-      F0: Managed[R, F],
-      B0: Bracket.Aux[F, Throwable, Outcome[R[F, *], Throwable, *]])
-      : ManagedLaws[R, F] =
-    new ManagedLaws[R, F] {
-      val F = F0
-      val B = B0
-    }
+object Clock {
+  def apply[F[_]](implicit F: Clock[F]): F.type = F
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Managed.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Managed.scala
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-package cats.effect
+package cats.effect.kernel
 
-import cats.implicits._
-
-trait SyncManaged[R[_[_], _], F[_]] extends Sync[R[F, *]] with Region[R, F, Throwable] {
-  type Case[A] = Either[Throwable, A]
-
-  def CaseInstance = catsStdInstancesForEither[Throwable]
+// TODO names ("Managed" conflicts with ZIO, but honestly it's a better name for this than Resource or IsoRegion)
+trait Managed[R[_[_], _], F[_]] extends Async[R[F, *]] with Region[R, F, Throwable] {
 
   def to[S[_[_], _]]: PartiallyApplied[S]
 
   trait PartiallyApplied[S[_[_], _]] {
-    def apply[A](rfa: R[F, A])(implicit S: Sync[S[F, *]] with Region[S, F, Throwable]): S[F, A]
+    def apply[A](rfa: R[F, A])(implicit S: Async[S[F, *]] with Region[S, F, Throwable]): S[F, A]
   }
 }
 
-object SyncManaged {
-  def apply[R[_[_], _], F[_]](implicit R: SyncManaged[R, F]): R.type = R
+object Managed {
+  def apply[R[_[_], _], F[_]](implicit R: Managed[R, F]): R.type = R
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package cats.effect
+package cats.effect.kernel
 
 import cats.{~>, Applicative, ApplicativeError, Eq, Monad, MonadError, Order, Show, Traverse}
 import cats.implicits._
@@ -44,7 +44,7 @@ sealed trait Outcome[F[_], E, A] extends Product with Serializable {
     }
 }
 
-private[effect] trait LowPriorityImplicits {
+private[kernel] trait LowPriorityImplicits {
   import Outcome.{Canceled, Completed, Errored}
 
   // variant for when F[A] doesn't have a Show (which is, like, most of the time)

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package cats.effect
+package cats.effect.kernel
 
 import cats.{Defer, MonadError}
 import cats.data.OptionT

--- a/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package cats.effect
+package cats.effect.kernel
 
 import cats.{~>, ApplicativeError, MonadError}
 import cats.syntax.either._

--- a/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+package object kernel {
+
+  type BracketThrow[F[_]] = Bracket[F, Throwable]
+  type RegionThrow[R[_[_], _], F[_]] = Region[R, F, Throwable]
+
+  type ConcurrentThrow[F[_]] = Concurrent[F, Throwable]
+
+  type ConcurrentBracket[F[_], E] = Concurrent[F, E] with Bracket[F, E]
+
+  object ConcurrentBracket {
+    def apply[F[_], E](implicit F: ConcurrentBracket[F, E]): ConcurrentBracket[F, E] = F
+  }
+
+  type ConcurrentRegion[R[_[_], _], F[_], E] = Concurrent[R[F, *], E] with Region[R, F, E]
+
+  object ConcurrentRegion {
+    def apply[R[_[_], _], F[_], E](implicit R: ConcurrentRegion[R, F, E]): ConcurrentRegion[R, F, E] = R
+  }
+
+  type TemporalThrow[F[_]] = Temporal[F, Throwable]
+
+  type TemporalBracket[F[_], E] = Temporal[F, E] with Bracket[F, E]
+
+  object TemporalBracket {
+    def apply[F[_], E](implicit F: TemporalBracket[F, E]): TemporalBracket[F, E] = F
+  }
+
+  type TemporalRegion[R[_[_], _], F[_], E] = Temporal[R[F, *], E] with Region[R, F, E]
+
+  object TemporalRegion {
+    def apply[R[_[_], _], F[_], E](implicit R: TemporalRegion[R, F, E]): TemporalRegion[R, F, E] = R
+  }
+
+  type AsyncBracket[F[_]] = Async[F] with Bracket[F, Throwable]
+
+  object AsyncBracket {
+    def apply[F[_]](implicit F: AsyncBracket[F]): AsyncBracket[F] = F
+  }
+
+  type AsyncRegion[R[_[_], _], F[_]] = Async[R[F, *]] with Region[R, F, Throwable]
+
+  object AsyncRegion {
+    def apply[R[_[_], _], F[_]](implicit R: AsyncRegion[R, F]): AsyncRegion[R, F] = R
+  }
+}

--- a/kernel/shared/src/main/scala/cats/effect/kernel/safe.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/safe.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package cats.effect
+package cats.effect.kernel
 
 import cats.{ApplicativeError, MonadError}
 import cats.data.OptionT

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AllSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AllSyntax.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.syntax
+
+trait AllSyntax extends AsyncSyntax
+    with ConcurrentSyntax

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AsyncSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AsyncSyntax.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.syntax
+
+import cats.effect.kernel.Async
+
+import scala.concurrent.ExecutionContext
+
+trait AsyncSyntax {
+  implicit def asyncOps[F[_], A](wrapped: F[A]): AsyncOps[F, A] =
+    new AsyncOps(wrapped)
+}
+
+final class AsyncOps[F[_], A](val wrapped: F[A]) extends AnyVal {
+  def evalOn(ec: ExecutionContext)(implicit F: Async[F]): F[A] =
+    Async[F].evalOn(wrapped, ec)
+}

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/ConcurrentSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/ConcurrentSyntax.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.syntax
+
+import cats.effect.kernel.{Concurrent, Fiber}
+
+trait ConcurrentSyntax {
+  implicit def concurrentOps[F[_], A, E](
+    wrapped: F[A]
+  ): ConcurrentOps[F, A, E] =
+    new ConcurrentOps(wrapped)
+}
+
+final class ConcurrentOps[F[_], A, E](val wrapped: F[A]) extends AnyVal {
+
+  def start(implicit F: Concurrent[F, E]): F[Fiber[F, E, A]] = F.start(wrapped)
+
+}

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/package.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/package.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.syntax
+
+package object syntax extends AllSyntax {}

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncBracketLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncBracketLaws.scala
@@ -17,6 +17,8 @@
 package cats.effect
 package laws
 
+import cats.effect.kernel.AsyncBracket
+
 trait AsyncBracketLaws[F[_]] extends AsyncLaws[F] with TemporalBracketLaws[F, Throwable] {
   implicit val F: AsyncBracket[F]
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncBracketTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncBracketTests.scala
@@ -18,6 +18,7 @@ package cats.effect
 package laws
 
 import cats.{Eq, Group, Order}
+import cats.effect.kernel.{AsyncBracket, Outcome}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -17,6 +17,7 @@
 package cats.effect
 package laws
 
+import cats.effect.kernel.Async
 import cats.implicits._
 
 import scala.concurrent.ExecutionContext

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncRegionLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncRegionLaws.scala
@@ -17,8 +17,10 @@
 package cats.effect
 package laws
 
+import cats.effect.kernel.{AsyncRegion, Bracket, Outcome}
+
 trait AsyncRegionLaws[R[_[_], _], F[_]] extends AsyncLaws[R[F, *]] with TemporalRegionLaws[R, F, Throwable] {
-  implicit val F: Async[R[F, *]] with Region[R, F, Throwable]
+  implicit val F: AsyncRegion[R, F]
 }
 
 object AsyncRegionLaws {
@@ -26,7 +28,7 @@ object AsyncRegionLaws {
       R[_[_], _],
       F[_]](
     implicit
-      F0: Async[R[F, *]] with Region[R, F, Throwable],
+      F0: AsyncRegion[R, F],
       B0: Bracket.Aux[F, Throwable, Outcome[R[F, *], Throwable, *]])
       : AsyncRegionLaws[R, F] =
     new AsyncRegionLaws[R, F] {

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncRegionTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncRegionTests.scala
@@ -18,6 +18,7 @@ package cats.effect
 package laws
 
 import cats.{Eq, Group, Order}
+import cats.effect.kernel.{AsyncRegion, Bracket, Outcome}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._
@@ -101,7 +102,7 @@ object AsyncRegionTests {
       R[_[_], _],
       F[_]](
     implicit
-      F0: Async[R[F, *]] with Region[R, F, Throwable],
+      F0: AsyncRegion[R, F],
       B0: Bracket.Aux[F, Throwable, Outcome[R[F, *], Throwable, *]])
       : AsyncRegionTests[R, F] = new AsyncRegionTests[R, F] {
     val laws = AsyncRegionLaws[R, F]

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
@@ -18,6 +18,7 @@ package cats.effect
 package laws
 
 import cats.{Eq, Group, Order}
+import cats.effect.kernel.{Async, Outcome}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._, Prop.forAll

--- a/laws/shared/src/main/scala/cats/effect/laws/BracketLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/BracketLaws.scala
@@ -17,6 +17,7 @@
 package cats.effect
 package laws
 
+import cats.effect.kernel.Bracket
 import cats.laws.MonadErrorLaws
 
 trait BracketLaws[F[_], E] extends MonadErrorLaws[F, E] {

--- a/laws/shared/src/main/scala/cats/effect/laws/BracketTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/BracketTests.scala
@@ -18,6 +18,7 @@ package cats.effect
 package laws
 
 import cats.Eq
+import cats.effect.kernel.Bracket
 import cats.data.EitherT
 import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms

--- a/laws/shared/src/main/scala/cats/effect/laws/ClockLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ClockLaws.scala
@@ -17,6 +17,7 @@
 package cats.effect
 package laws
 
+import cats.effect.kernel.Clock
 import cats.implicits._
 import cats.laws.ApplicativeLaws
 

--- a/laws/shared/src/main/scala/cats/effect/laws/ClockTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ClockTests.scala
@@ -18,6 +18,7 @@ package cats.effect
 package laws
 
 import cats.Eq
+import cats.effect.kernel.Clock
 import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 

--- a/laws/shared/src/main/scala/cats/effect/laws/ConcurrentBracketLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ConcurrentBracketLaws.scala
@@ -17,11 +17,12 @@
 package cats.effect
 package laws
 
+import cats.effect.kernel.{ConcurrentBracket, Outcome}
 import cats.implicits._
 
 trait ConcurrentBracketLaws[F[_], E] extends ConcurrentLaws[F, E] with BracketLaws[F, E] {
 
-  implicit val F: Concurrent[F, E] with Bracket[F, E]
+  implicit val F: ConcurrentBracket[F, E]
 
   // TODO this test is unobservable (because F.unit === F.uncancelable(_ => release))
   // ...also it's unexpectedly failing randomly?
@@ -67,6 +68,6 @@ trait ConcurrentBracketLaws[F[_], E] extends ConcurrentLaws[F, E] with BracketLa
 }
 
 object ConcurrentBracketLaws {
-  def apply[F[_], E](implicit F0: Concurrent[F, E] with Bracket[F, E]): ConcurrentBracketLaws[F, E] =
+  def apply[F[_], E](implicit F0: ConcurrentBracket[F, E]): ConcurrentBracketLaws[F, E] =
     new ConcurrentBracketLaws[F, E] { val F = F0 }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/ConcurrentBracketTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ConcurrentBracketTests.scala
@@ -18,6 +18,7 @@ package cats.effect
 package laws
 
 import cats.Eq
+import cats.effect.kernel.{ConcurrentBracket, Outcome}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._, Prop.forAll
@@ -86,7 +87,7 @@ trait ConcurrentBracketTests[F[_], E] extends ConcurrentTests[F, E] with Bracket
 }
 
 object ConcurrentBracketTests {
-  def apply[F[_], E](implicit F0: Concurrent[F, E] with Bracket[F, E]): ConcurrentBracketTests[F, E] = new ConcurrentBracketTests[F, E] {
+  def apply[F[_], E](implicit F0: ConcurrentBracket[F, E]): ConcurrentBracketTests[F, E] = new ConcurrentBracketTests[F, E] {
     val laws = ConcurrentBracketLaws[F, E]
   }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/ConcurrentLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ConcurrentLaws.scala
@@ -17,6 +17,7 @@
 package cats.effect
 package laws
 
+import cats.effect.kernel.{Concurrent, Outcome}
 import cats.implicits._
 import cats.laws.MonadErrorLaws
 

--- a/laws/shared/src/main/scala/cats/effect/laws/ConcurrentRegionLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ConcurrentRegionLaws.scala
@@ -17,8 +17,10 @@
 package cats.effect
 package laws
 
+import cats.effect.kernel.{Bracket, ConcurrentRegion, Outcome}
+
 trait ConcurrentRegionLaws[R[_[_], _], F[_], E] extends ConcurrentLaws[R[F, *], E] with RegionLaws[R, F, E] {
-  implicit val F: Concurrent[R[F, *], E] with Region[R, F, E]
+  implicit val F: ConcurrentRegion[R, F, E]
 }
 
 object ConcurrentRegionLaws {
@@ -27,7 +29,7 @@ object ConcurrentRegionLaws {
       F[_],
       E](
     implicit
-      F0: Concurrent[R[F, *], E] with Region[R, F, E],
+      F0: ConcurrentRegion[R, F, E],
       B0: Bracket.Aux[F, E, Outcome[R[F, *], E, *]])
       : ConcurrentRegionLaws[R, F, E] =
     new ConcurrentRegionLaws[R, F, E] {

--- a/laws/shared/src/main/scala/cats/effect/laws/ConcurrentRegionTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ConcurrentRegionTests.scala
@@ -18,6 +18,7 @@ package cats.effect
 package laws
 
 import cats.Eq
+import cats.effect.kernel.{Bracket, ConcurrentRegion, Outcome}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._
@@ -93,7 +94,7 @@ object ConcurrentRegionTests {
       F[_],
       E](
     implicit
-      F0: Concurrent[R[F, *], E] with Region[R, F, E],
+      F0: ConcurrentRegion[R, F, E],
       B0: Bracket.Aux[F, E, Outcome[R[F, *], E, *]])
       : ConcurrentRegionTests[R, F, E] = new ConcurrentRegionTests[R, F, E] {
     val laws = ConcurrentRegionLaws[R, F, E]

--- a/laws/shared/src/main/scala/cats/effect/laws/ConcurrentTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ConcurrentTests.scala
@@ -18,6 +18,7 @@ package cats.effect
 package laws
 
 import cats.Eq
+import cats.effect.kernel.{Concurrent, Outcome}
 import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 

--- a/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
@@ -17,6 +17,8 @@
 package cats.effect
 package laws
 
+import cats.effect.kernel.Effect
+
 trait EffectLaws[F[_]] extends AsyncBracketLaws[F] {
   implicit val F: Effect[F]
 

--- a/laws/shared/src/main/scala/cats/effect/laws/EffectTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/EffectTests.scala
@@ -18,6 +18,7 @@ package cats.effect
 package laws
 
 import cats.{Eq, Group, Order}
+import cats.effect.kernel.{Effect, Outcome}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._, Prop.forAll

--- a/laws/shared/src/main/scala/cats/effect/laws/ManagedTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ManagedTests.scala
@@ -18,6 +18,7 @@ package cats.effect
 package laws
 
 import cats.{Eq, Group, Order}
+import cats.effect.kernel.{Bracket, Managed, Outcome}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._, Prop.forAll

--- a/laws/shared/src/main/scala/cats/effect/laws/RegionLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/RegionLaws.scala
@@ -17,6 +17,7 @@
 package cats.effect
 package laws
 
+import cats.effect.kernel.{Bracket, Region}
 import cats.implicits._
 import cats.laws.MonadErrorLaws
 
@@ -54,8 +55,8 @@ object RegionLaws {
       Case0[_],
       E](
     implicit
-      F0: Region[R, F, E] { type Case[A] = Case0[A] },
-      B0: Bracket[F, E] { type Case[A] = Case0[A] })    // this is legit-annoying
+      F0: Region.Aux[R, F, E, Case0],
+      B0: Bracket.Aux[F, E, Case0])    // this is legit-annoying
       : RegionLaws[R, F, E] =
     new RegionLaws[R, F, E] { val F: F0.type = F0; val B: B0.type = B0 }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/RegionTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/RegionTests.scala
@@ -18,6 +18,7 @@ package cats.effect
 package laws
 
 import cats.Eq
+import cats.effect.kernel.{Bracket, Region}
 import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
@@ -80,8 +81,8 @@ object RegionTests {
       Case0[_],
       E](
     implicit
-      F0: Region[R, F, E] { type Case[A] = Case0[A] },
-      B: Bracket[F, E] { type Case[A] = Case0[A] })
+      F0: Region.Aux[R, F, E, Case0],
+      B: Bracket.Aux[F, E, Case0])
       : RegionTests[R, F, E] =
     new RegionTests[R, F, E] {
       val laws = RegionLaws[R, F, Case0, E]

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncEffectLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncEffectLaws.scala
@@ -17,6 +17,8 @@
 package cats.effect
 package laws
 
+import cats.effect.kernel.SyncEffect
+
 trait SyncEffectLaws[F[_]] extends SyncLaws[F] with BracketLaws[F, Throwable] {
   implicit val F: SyncEffect[F]
 

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncEffectTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncEffectTests.scala
@@ -19,6 +19,7 @@ package laws
 
 import cats.Eq
 import cats.data.EitherT
+import cats.effect.kernel.SyncEffect
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._, Prop.forAll

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
@@ -17,6 +17,7 @@
 package cats.effect
 package laws
 
+import cats.effect.kernel.Sync
 import cats.implicits._
 import cats.laws.MonadErrorLaws
 

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncManagedLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncManagedLaws.scala
@@ -17,6 +17,8 @@
 package cats.effect
 package laws
 
+import cats.effect.kernel.{Bracket, SyncManaged}
+
 trait SyncManagedLaws[R[_[_], _], F[_]] extends SyncLaws[R[F, *]] with RegionLaws[R, F, Throwable] {
   implicit val F: SyncManaged[R, F]
 

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncManagedTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncManagedTests.scala
@@ -18,6 +18,7 @@ package cats.effect
 package laws
 
 import cats.Eq
+import cats.effect.kernel.{Bracket, SyncManaged}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._, Prop.forAll

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncTests.scala
@@ -19,6 +19,7 @@ package laws
 
 import cats.Eq
 import cats.data.EitherT
+import cats.effect.kernel.Sync
 import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 

--- a/laws/shared/src/main/scala/cats/effect/laws/TemporalBracketLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/TemporalBracketLaws.scala
@@ -17,11 +17,13 @@
 package cats.effect
 package laws
 
+import cats.effect.kernel.TemporalBracket
+
 trait TemporalBracketLaws[F[_], E] extends TemporalLaws[F, E] with ConcurrentBracketLaws[F, E] {
-  implicit val F: Temporal[F, E] with Bracket[F, E]
+  implicit val F: TemporalBracket[F, E]
 }
 
 object TemporalBracketLaws {
-  def apply[F[_], E](implicit F0: Temporal[F, E] with Bracket[F, E]): TemporalBracketLaws[F, E] =
+  def apply[F[_], E](implicit F0: TemporalBracket[F, E]): TemporalBracketLaws[F, E] =
     new TemporalBracketLaws[F, E] { val F = F0 }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/TemporalBracketTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/TemporalBracketTests.scala
@@ -18,6 +18,7 @@ package cats.effect
 package laws
 
 import cats.{Eq, Group, Order}
+import cats.effect.kernel.{Outcome, TemporalBracket}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._
@@ -88,7 +89,7 @@ trait TemporalBracketTests[F[_], E] extends TemporalTests[F, E] with ConcurrentB
 }
 
 object TemporalBracketTests {
-  def apply[F[_], E](implicit F0: Temporal[F, E] with Bracket[F, E]): TemporalBracketTests[F, E] = new TemporalBracketTests[F, E] {
+  def apply[F[_], E](implicit F0: TemporalBracket[F, E]): TemporalBracketTests[F, E] = new TemporalBracketTests[F, E] {
     val laws = TemporalBracketLaws[F, E]
   }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/TemporalLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/TemporalLaws.scala
@@ -17,6 +17,7 @@
 package cats.effect
 package laws
 
+import cats.effect.kernel.Temporal
 import cats.implicits._
 
 import scala.concurrent.duration.FiniteDuration

--- a/laws/shared/src/main/scala/cats/effect/laws/TemporalRegionLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/TemporalRegionLaws.scala
@@ -17,8 +17,10 @@
 package cats.effect
 package laws
 
+import cats.effect.kernel.{Bracket, Outcome, TemporalRegion}
+
 trait TemporalRegionLaws[R[_[_], _], F[_], E] extends TemporalLaws[R[F, *], E] with ConcurrentRegionLaws[R, F, E] {
-  implicit val F: Temporal[R[F, *], E] with Region[R, F, E]
+  implicit val F: TemporalRegion[R, F, E]
 }
 
 object TemporalRegionLaws {
@@ -27,7 +29,7 @@ object TemporalRegionLaws {
       F[_],
       E](
     implicit
-      F0: Temporal[R[F, *], E] with Region[R, F, E],
+      F0: TemporalRegion[R, F, E],
       B0: Bracket.Aux[F, E, Outcome[R[F, *], E, *]])
       : TemporalRegionLaws[R, F, E] =
     new TemporalRegionLaws[R, F, E] {

--- a/laws/shared/src/main/scala/cats/effect/laws/TemporalRegionTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/TemporalRegionTests.scala
@@ -18,6 +18,7 @@ package cats.effect
 package laws
 
 import cats.{Eq, Group, Order}
+import cats.effect.kernel.{Bracket, Outcome, TemporalRegion}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._
@@ -99,7 +100,7 @@ object TemporalRegionTests {
       F[_],
       E](
     implicit
-      F0: Temporal[R[F, *], E] with Region[R, F, E],
+      F0: TemporalRegion[R, F, E],
       B0: Bracket.Aux[F, E, Outcome[R[F, *], E, *]])
       : TemporalRegionTests[R, F, E] = new TemporalRegionTests[R, F, E] {
     val laws = TemporalRegionLaws[R, F, E]

--- a/laws/shared/src/main/scala/cats/effect/laws/TemporalTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/TemporalTests.scala
@@ -18,6 +18,7 @@ package cats.effect
 package laws
 
 import cats.{Eq, Group, Order}
+import cats.effect.kernel.{Outcome, Temporal}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._, Prop.forAll

--- a/laws/shared/src/test/scala/cats/effect/FreeSyncSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/FreeSyncSpec.scala
@@ -18,9 +18,8 @@ package cats.effect
 package laws
 
 import cats.{Eq, Show}
+import cats.effect.testkit.{freeEval, FreeSyncGenerators}, freeEval._
 import cats.implicits._
-
-import freeEval._
 
 import org.scalacheck.Prop
 import org.scalacheck.util.Pretty

--- a/laws/shared/src/test/scala/cats/effect/OutcomeSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/OutcomeSpec.scala
@@ -17,6 +17,8 @@
 package cats.effect
 
 import cats.{Eval/*, Id*/}
+import cats.effect.kernel.Outcome
+import cats.effect.testkit.OutcomeGenerators
 import cats.implicits._
 import cats.laws.discipline.{ApplicativeErrorTests, MonadErrorTests}
 

--- a/laws/shared/src/test/scala/cats/effect/PureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/PureConcSpec.scala
@@ -18,9 +18,8 @@ package cats.effect
 
 import cats.Show
 import cats.effect.laws.ConcurrentBracketTests
+import cats.effect.testkit.{pure, OutcomeGenerators, PureConcGenerators}, pure._
 import cats.implicits._
-
-import pure._
 
 import org.scalacheck.util.Pretty
 

--- a/laws/shared/src/test/scala/cats/effect/TimeTSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/TimeTSpec.scala
@@ -36,7 +36,7 @@ import scala.concurrent.duration._
 
 import java.util.concurrent.TimeUnit
 
-private[effect] trait LowPriorityInstances {
+private[testkit] trait LowPriorityInstances {
 
   implicit def eqTimeT[F[_], A](implicit FA: Eq[F[A]]): Eq[TimeT[F, A]] =
     Eq.by(TimeT.run(_))

--- a/laws/shared/src/test/scala/cats/effect/TimeTSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/TimeTSpec.scala
@@ -19,10 +19,10 @@ package cats.effect.testkit
 import cats.{Eq, Order}
 import cats.data.Kleisli
 import cats.effect.laws.TemporalBracketTests
-import cats.effect.testkit.{pure, OutcomeGenerators, PureConcGenerators, TimeT}, pure.PureConc
 import cats.implicits._
 import cats.laws.discipline.arbitrary._
 
+import pure.PureConc
 import TimeT._
 
 import org.specs2.ScalaCheck

--- a/laws/shared/src/test/scala/cats/effect/TimeTSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/TimeTSpec.scala
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package cats.effect
+package cats.effect.testkit
 
 import cats.{Eq, Order}
 import cats.data.Kleisli
 import cats.effect.laws.TemporalBracketTests
+import cats.effect.testkit.{pure, OutcomeGenerators, PureConcGenerators, TimeT}, pure.PureConc
 import cats.implicits._
 import cats.laws.discipline.arbitrary._
 
-import pure._
 import TimeT._
 
 import org.specs2.ScalaCheck

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.codecommit"     % "sbt-spiewak-sonatype"     % "0.14-b638a8d")
+addSbtPlugin("com.codecommit"     % "sbt-spiewak-sonatype"     % "0.14-7a3eea2")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.1.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")

--- a/testkit/shared/src/main/scala/cats/effect/testkit/FreeSyncGenerators.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/FreeSyncGenerators.scala
@@ -15,12 +15,12 @@
  */
 
 package cats.effect
-package laws
+package testkit
 
 import cats.{Eval, Monad, MonadError}
+import cats.effect.kernel.Sync
+import cats.effect.testkit.freeEval._
 import cats.free.FreeT
-
-import freeEval._
 
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 

--- a/testkit/shared/src/main/scala/cats/effect/testkit/Generators.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/Generators.scala
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package cats.effect
+package cats.effect.testkit
 
 import cats.{Applicative, ApplicativeError, Monad, MonadError}
+import cats.effect.kernel._
 import cats.implicits._
 
 import org.scalacheck.{Arbitrary, Cogen, Gen}, Arbitrary.arbitrary

--- a/testkit/shared/src/main/scala/cats/effect/testkit/PureConcGenerators.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/PureConcGenerators.scala
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package cats.effect
+package cats.effect.testkit
 
-import pure._
+import cats.effect.kernel.{ConcurrentBracket, Outcome}
+import cats.effect.testkit.pure._
 
 import org.scalacheck.{Arbitrary, Cogen}
 

--- a/testkit/shared/src/main/scala/cats/effect/testkit/TimeT.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/TimeT.scala
@@ -15,9 +15,11 @@
  */
 
 package cats.effect
+package testkit
 
 import cats.{~>, Group, Monad, Monoid}
 import cats.data.Kleisli
+import cats.effect.kernel.{Concurrent, ConcurrentBracket, ConcurrentRegion, Bracket, Fiber, Outcome, Region, Safe, Temporal, TemporalBracket, TemporalRegion}
 import cats.implicits._
 
 import scala.concurrent.duration._

--- a/testkit/shared/src/main/scala/cats/effect/testkit/freeEval.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/freeEval.scala
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-package cats.effect
+package cats.effect.testkit
 
 import cats.{Eq, Eval, Monad, MonadError}
+import cats.effect.kernel._
 import cats.free.FreeT
 import cats.implicits._
 
 import scala.concurrent.duration._
+
+
 object freeEval {
 
   type FreeSync[F[_], A] = FreeT[Eval, F, A]
@@ -32,7 +35,7 @@ object freeEval {
   implicit def syncForFreeT[F[_]](implicit F: MonadError[F, Throwable]): Sync[FreeT[Eval, F, *]] =
     new Sync[FreeT[Eval, F, *]] {
       private[this] val M: MonadError[FreeT[Eval, F, *], Throwable] =
-        cats.effect.pure.catsFreeMonadErrorForFreeT2
+        cats.effect.testkit.pure.catsFreeMonadErrorForFreeT2
 
       def pure[A](x: A): FreeT[Eval, F, A] =
         M.pure(x)

--- a/testkit/shared/src/main/scala/cats/effect/testkit/package.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/package.scala
@@ -16,25 +16,8 @@
 
 package cats.effect
 
-import cats.~>
-import cats.implicits._
+import cats.data.Kleisli
 
-trait SyncEffect[F[_]] extends Sync[F] with Bracket[F, Throwable] {
-  type Case[A] = Either[Throwable, A]
-
-  def CaseInstance = catsStdInstancesForEither[Throwable]
-
-  def to[G[_]]: PartiallyApplied[G] =
-    new PartiallyApplied[G]
-
-  def toK[G[_]](implicit G: Sync[G] with Bracket[G, Throwable]): F ~> G
-
-  final class PartiallyApplied[G[_]] {
-    def apply[A](fa: F[A])(implicit G: Sync[G] with Bracket[G, Throwable]): G[A] =
-      toK[G](G)(fa)
-  }
-}
-
-object SyncEffect {
-  def apply[F[_]](implicit F: SyncEffect[F]): F.type = F
+package object testkit {
+  type TimeT[F[_], A] = Kleisli[F, Time, A]
 }

--- a/testkit/shared/src/main/scala/cats/effect/testkit/pure.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/pure.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package cats.effect
+package cats.effect.testkit
 
 import cats.{~>, Eq, Functor, Group, Id, Monad, MonadError, Monoid, Show}
 import cats.data.{Kleisli, WriterT}
+import cats.effect.kernel._
 import cats.free.FreeT
 import cats.implicits._
 


### PR DESCRIPTION
I scaladoc'd each of the projects in the build.sbt. That's a pretty decent place to start if you're looking at this

- Split the typeclasses out into **kernel** with forwarders in the `cats.effect` package object (for nicer user syntax)
- Moved test utility style things into **testkit** (e.g. `PureConc`, `TimeT`, generators, etc). Eventually, `TestContext` and friends will also be here
- **core** is now the future home of `IO`

So there's a strong distinction here between the "batteries included" **core** dependency (`org.typelevel::cats-effect:3.0.0`) that users will want vs the "batteries not included" **kernel** dependency (`org.typelevel::cats-effect-kernel:3.0.0`) that datatype implementors will want.