### PR TITLE
Fix #848 and #883: broken links in the documentation and missing basepath when running microsite locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ You can build the microsite with `sbt microsite/makeMicrosite`.
 To preview your changes you need to have
 [jekyll](https://github.com/jekyll/jekyll) installed. This depends on your
 platform, but assuming you have ruby installed it could be as simple as `gem
-install jekyll`.
+install jekyll`. Alternatively, you can use the provided
+[Gemfile](https://bundler.io/gemfile.html) under `site` to install jekyll
+and the required plugins.
 
 Start a local server by navigating to `site/target/site`, then run `jekyll
 serve -b /cats-effect`. Finally point your browser at

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ platform, but assuming you have ruby installed it could be as simple as `gem
 install jekyll`.
 
 Start a local server by navigating to `site/target/site`, then run `jekyll
-serve`. Finally point your browser at
+serve -b /cats-effect`. Finally point your browser at
 [http://localhost:4000/cats-effect/](http://localhost:4000/cats-effect/). Any
 changes should be picked up immediately when you re-run `sbt
 microsite/makeMicrosite`.

--- a/build.sbt
+++ b/build.sbt
@@ -336,6 +336,9 @@ lazy val siteSettings = Seq(
       Map("permalink" -> "/", "title" -> "Home", "section" -> "home", "position" -> "0")
     )
   ),
+  micrositeConfigYaml := ConfigYml(
+    yamlPath = Some((resourceDirectory in Compile).value / "microsite" / "_config.yml")
+  ),
   micrositeCompilingDocsTool := WithMdoc,
   mdocIn := (sourceDirectory in Compile).value / "mdoc",
   fork in mdoc := true,

--- a/site/src/main/resources/microsite/_config.yml
+++ b/site/src/main/resources/microsite/_config.yml
@@ -1,0 +1,2 @@
+plugins:
+  - jekyll-relative-links


### PR DESCRIPTION
Fix #848: Correct configuration of jekyll-relative-links plugin to ensure .md links are converted to .html links when the microsite is built.
Fix #883: Specify basepath when serving microsite locally (`-b /cats-effect`) so it renders correctly. Also, added info about using the provided Gemfile to install jekyll and required plugins.