### PR TITLE
Revise Deferred, MVarConcurrent, LinkedMap

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -181,7 +181,14 @@ val mimaSettings = Seq(
       exclude[IncompatibleSignatureProblem]("cats.effect.Resource.evalTap"),
       // change in encoding of value classes in generic methods https://github.com/lightbend/mima/issues/423
       exclude[IncompatibleSignatureProblem]("cats.effect.Blocker.apply"),
-      exclude[IncompatibleSignatureProblem]("cats.effect.Blocker.fromExecutorService")
+      exclude[IncompatibleSignatureProblem]("cats.effect.Blocker.fromExecutorService"),
+      // revise Deferred, MVarConcurrent, LinkedLongMap - https://github.com/typelevel/cats-effect/pull/918
+      exclude[IncompatibleResultTypeProblem]("cats.effect.concurrent.Deferred#State#Unset.waiting"),
+      exclude[DirectMissingMethodProblem]("cats.effect.concurrent.Deferred#State#Unset.copy"),
+      exclude[IncompatibleResultTypeProblem]("cats.effect.concurrent.Deferred#State#Unset.copy$default$1"),
+      exclude[DirectMissingMethodProblem]("cats.effect.concurrent.Deferred#State#Unset.this"),
+      exclude[MissingClassProblem]("cats.effect.concurrent.Deferred$Id"),
+      exclude[DirectMissingMethodProblem]("cats.effect.concurrent.Deferred#State#Unset.apply")
     )
   }
 )

--- a/core/shared/src/main/scala/cats/effect/concurrent/Deferred.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Deferred.scala
@@ -18,7 +18,7 @@ package cats
 package effect
 package concurrent
 
-import cats.effect.internals.{Callback, LinkedMap, TrampolineEC}
+import cats.effect.internals.{Callback, LinkedLongMap, TrampolineEC}
 import java.util.concurrent.atomic.AtomicReference
 
 import cats.effect.concurrent.Deferred.TransformedDeferred
@@ -148,7 +148,7 @@ object Deferred {
   def unsafeUncancelable[F[_]: Async, A]: Deferred[F, A] = unsafeTryableUncancelable[F, A]
 
   private def unsafeTryable[F[_]: Concurrent, A]: TryableDeferred[F, A] =
-    new ConcurrentDeferred[F, A](new AtomicReference(Deferred.State.Unset(LinkedMap.empty, 1)))
+    new ConcurrentDeferred[F, A](new AtomicReference(Deferred.State.Unset(LinkedLongMap.empty, 1)))
 
   private def unsafeTryableUncancelable[F[_]: Async, A]: TryableDeferred[F, A] =
     new UncancelableDeferred[F, A](Promise[A]())
@@ -156,7 +156,7 @@ object Deferred {
   sealed abstract private class State[A]
   private object State {
     final case class Set[A](a: A) extends State[A]
-    final case class Unset[A](waiting: LinkedMap[Long, A => Unit], nextId: Long) extends State[A]
+    final case class Unset[A](waiting: LinkedLongMap[A => Unit], nextId: Long) extends State[A]
   }
 
   final private class ConcurrentDeferred[F[_], A](ref: AtomicReference[State[A]])(implicit F: Concurrent[F])

--- a/core/shared/src/test/scala/cats/effect/internals/LinkedLongMapTests.scala
+++ b/core/shared/src/test/scala/cats/effect/internals/LinkedLongMapTests.scala
@@ -19,16 +19,16 @@ package cats.effect.internals
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.funsuite.AnyFunSuite
 
-final class LinkedMapTests extends AnyFunSuite with Matchers {
+final class LinkedLongMapTests extends AnyFunSuite with Matchers {
   test("empty map") {
-    val map = LinkedMap.empty[Int, Int]
+    val map = LinkedLongMap.empty[Long]
 
     map.isEmpty shouldBe true
   }
 
   test("inserting entries") {
-    val ns = (0 until 10).toList
-    val map = ns.foldLeft(LinkedMap.empty[Int, Int])((map, i) => map.updated(i, i))
+    val ns = (0L until 10L).toList
+    val map = ns.foldLeft(LinkedLongMap.empty[Long])((map, i) => map.updated(i, i))
 
     map.isEmpty shouldBe false
     map.keys.toList shouldBe ns
@@ -36,10 +36,10 @@ final class LinkedMapTests extends AnyFunSuite with Matchers {
   }
 
   test("dequeueing entries") {
-    val ns = (0 until 10).toList
-    val map = ns.foldLeft(LinkedMap.empty[Int, Int])((map, i) => map.updated(i, i))
+    val ns = (0L until 10L).toList
+    val map = ns.foldLeft(LinkedLongMap.empty[Long])((map, i) => map.updated(i, i))
 
-    var n = 0
+    var n = 0L
     var acc = map
     while (!acc.isEmpty) {
       val res = acc.dequeue
@@ -52,9 +52,9 @@ final class LinkedMapTests extends AnyFunSuite with Matchers {
   }
 
   test("removing entry") {
-    val ns = (0 until 10).toList
-    val map = ns.foldLeft(LinkedMap.empty[Int, Int])((map, i) => map.updated(i, i))
-    val n = 2
+    val ns = (0L until 10L).toList
+    val map = ns.foldLeft(LinkedLongMap.empty[Long])((map, i) => map.updated(i, i))
+    val n = 2L
 
     assert(map.keys.exists(_ == n))
     assert(map.values.exists(_ == n))


### PR DESCRIPTION
@johnynek came on Gitter the other day and found that the `Deferred` implementation was consuming a surprising amount of CPU on an app (chat logs are [here](https://gitter.im/typelevel/cats-effect?at=5f0644d68342f4627402286a)). It turns out that the `hashCode` method for the `Id` class that `Deferred` uses to uniquely index callbacks in the `get` method is pretty costly.

The revised implementation here uses the `AtomicReference` state field to track an extra `Long` that serves as a monotonic counter to uniquely index `get` callbacks. `MVarConcurrent` has similar details in its implementation, so I also changed that one. Both `Deferred` and `MVarConcurrent` use a `LinkedMap` under the hood, but only ever uses `Long`s as keys. However since they're the only two clients of that class, I renamed the class to `LinkedLongMap` and specialized it to `Long`s, which avoids extra boxing.

## Sample application
```scala
import cats.effect.concurrent.Deferred

object App extends IOApp {
  def loop(n: Int): IO[Unit] =
    for {
      d <- Deferred[IO, Unit]
      _ <- d.get.start
      _ <- d.get.start
      _ <- d.get.start
      _ <- d.get.start
      _ <- d.get.start
      _  <- loop(n)
    } yield ()

  override def run(args: List[String]): IO[ExitCode] = for {
    _ <- IO(println("Starting"))
    _ <- loop(1000000)
  } yield ExitCode.Success
}
```

Below are some profiling results for both master and the PR. I ran some throughput benchmarks but these data structures are somewhat tedious to benchmark since they rely on concurrency and as soon as you start forking or synchronizing, the costs of allocations look very miniscule. FWIW the program above saw virtually no difference between the master and the PR, but somebody could probably write a better concurrent benchmark.

I also ran some allocation tracing and this PR seems to produce a lot less garbage than the previous implementation.

## master
![image](https://user-images.githubusercontent.com/2617549/87215613-d1c3b580-c2fd-11ea-8ab5-b23040cb181d.png)

## PR
![image](https://user-images.githubusercontent.com/2617549/87215618-dc7e4a80-c2fd-11ea-997b-3961899cff83.png)
