### PR TITLE
Implement map2Eval for IO

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -867,6 +867,16 @@ abstract private[effect] class IOLowPriorityInstances extends IOParallelNewtype 
 
     final override def map[A, B](fa: IO[A])(f: A => B): IO[B] =
       fa.map(f)
+
+    final override def map2Eval[A, B, C](fa: IO[A], fb: Eval[IO[B]])(fn: (A, B) => C): Eval[IO[C]] =
+      // we maybe can skip evaluating fb if fa is a failure
+      Eval.now(
+        for {
+          a <- fa
+          b <- fb.value
+        } yield fn(a, b)
+      )
+
     final override def flatMap[A, B](ioa: IO[A])(f: A => IO[B]): IO[B] =
       ioa.flatMap(f)
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -868,7 +868,11 @@ abstract private[effect] class IOLowPriorityInstances extends IOParallelNewtype 
     final override def map[A, B](fa: IO[A])(f: A => B): IO[B] =
       fa.map(f)
 
-    final override def map2Eval[A, B, C](fa: IO[A], fb: Eval[IO[B]])(fn: (A, B) => C): Eval[IO[C]] =
+    // We missed labeling this final when the class was written and changing
+    // in 2.x would break binary compatibility. In cats 3, this should be
+    // final to match the style (although, I don't think there is a performance
+    // difference).
+    override def map2Eval[A, B, C](fa: IO[A], fb: Eval[IO[B]])(fn: (A, B) => C): Eval[IO[C]] =
       // we maybe can skip evaluating fb if fa is a failure
       Eval.now(
         for {


### PR DESCRIPTION
map2Eval is often used when we want to recurse on the right hand side. The default implementation just calls `.map` on the Eval forcing the full evaluation to happen before we can return the `IO` instance.

We can instead just call `.value` once the `A` value from `fa` has been produced which can result in occasionally doing less work when `fa` is a failure, or never completes.