### PR TITLE
Add combinators for more CE2 parity

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -37,9 +37,6 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
   def >>[B](that: => IO[B]): IO[B] =
      flatMap(_ => that)
 
-  def <<[B](that: => IO[B]): IO[A] =
-    that.flatMap(_ => this)
-
   def as[B](b: B): IO[B] =
     map(_ => b)
 
@@ -284,7 +281,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     Uncancelable(body)
 
   private[this] val _unit: IO[Unit] = Pure(())
-  val unit: IO[Unit] = _unit
+  def unit: IO[Unit] = _unit
 
   // utilities
 


### PR DESCRIPTION
Quick PR for adding some more combinators to get CE2 parity. I was going to add `guaranteeCase` but it seems like we can't because `IO` is covariant in `A` whereas `Outcome` is invariant, and I think that causes a contravariance issue with `Function1`. Has that been identified as an issue?