### PR TITLE
Fixed cancelation semantics to block when canceling uncancelable

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -148,7 +148,7 @@ private[effect] final class IOFiber[A](name: String, scheduler: unsafe.Scheduler
           IO.unit
         } else {
           // it was masked, so we need to wait for it to finish whatever it was doing and cancel itself
-          suspend()   // allow someone else to take the runloop
+          suspend() // allow someone else to take the runloop
           join.void
         }
       } else {

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -180,7 +180,7 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
           _ <- f.cancel
         } yield ()
 
-        ioa must nonTerminate  // we're canceling an uncancelable never
+        ioa must nonTerminate // we're canceling an uncancelable never
         affected must beFalse
     }
 
@@ -535,7 +535,9 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
       lazy val cedeUntilStarted: IO[Unit] =
         IO(started).ifM(IO.unit, IO.cede >> cedeUntilStarted)
 
-      IO.uncancelable(_ => markStarted *> IO.never).start.flatMap(f => cedeUntilStarted *> f.cancel) must nonTerminate
+      IO.uncancelable(_ => markStarted *> IO.never)
+        .start
+        .flatMap(f => cedeUntilStarted *> f.cancel) must nonTerminate
     }
 
     "await cancelation of cancelation of uncancelable never" in ticked { implicit ticker =>
@@ -553,7 +555,8 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
 
       val test = for {
         first <- IO.uncancelable(_ => markStarted *> IO.never).start
-        second <- IO.uncancelable(p => cedeUntilStarted *> markStarted2 *> p(first.cancel)).start
+        second <-
+          IO.uncancelable(p => cedeUntilStarted *> markStarted2 *> p(first.cancel)).start
         _ <- cedeUntilStarted2
         _ <- second.cancel
       } yield ()

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -180,7 +180,7 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
           _ <- f.cancel
         } yield ()
 
-        ioa must completeAs(())
+        ioa must nonTerminate  // we're canceling an uncancelable never
         affected must beFalse
     }
 
@@ -526,6 +526,39 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
 
     "reliably cancel infinite IO.cede(s)" in real {
       IO.cede.foreverM.start.flatMap(f => IO.sleep(50.millis) >> f.cancel).as(ok)
+    }
+
+    "await uncancelable blocks in cancelation" in ticked { implicit ticker =>
+      var started = false
+
+      val markStarted = IO { started = true }
+      lazy val cedeUntilStarted: IO[Unit] =
+        IO(started).ifM(IO.unit, IO.cede >> cedeUntilStarted)
+
+      IO.uncancelable(_ => markStarted *> IO.never).start.flatMap(f => cedeUntilStarted *> f.cancel) must nonTerminate
+    }
+
+    "await cancelation of cancelation of uncancelable never" in ticked { implicit ticker =>
+      var started = false
+
+      val markStarted = IO { started = true }
+      lazy val cedeUntilStarted: IO[Unit] =
+        IO(started).ifM(IO.unit, IO.cede >> cedeUntilStarted)
+
+      var started2 = false
+
+      val markStarted2 = IO { started2 = true }
+      lazy val cedeUntilStarted2: IO[Unit] =
+        IO(started2).ifM(IO.unit, IO.cede >> cedeUntilStarted2)
+
+      val test = for {
+        first <- IO.uncancelable(_ => markStarted *> IO.never).start
+        second <- IO.uncancelable(p => cedeUntilStarted *> markStarted2 *> p(first.cancel)).start
+        _ <- cedeUntilStarted2
+        _ <- second.cancel
+      } yield ()
+
+      test must nonTerminate
     }
 
     platformSpecs

--- a/laws/shared/src/test/scala/cats/effect/PureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/PureConcSpec.scala
@@ -22,8 +22,7 @@ import cats.laws.discipline.arbitrary._
 import cats.implicits._
 import cats.effect.kernel.ParallelF
 import cats.effect.laws.ConcurrentTests
-import cats.effect.testkit.{pure, ParallelFGenerators, PureConcGenerators},
-pure._
+import cats.effect.testkit.{pure, ParallelFGenerators, PureConcGenerators}, pure._
 import cats.effect.implicits._
 
 // import org.scalacheck.rng.Seed


### PR DESCRIPTION
I believe this is the only thing that makes sense, otherwise you lose finalizer backpressure in those cases.