### PR TITLE
Added ciFirefox to the build for running coreJS/test on geckodriver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,14 @@ jobs:
             java: adopt@1.8
             scala: 2.13.3
             ci: ciJS
+          - os: ubuntu-latest
+            java: adopt@1.8
+            scala: 2.12.12
+            ci: ciFirefox
+          - os: ubuntu-latest
+            java: adopt@1.8
+            scala: 2.13.3
+            ci: ciFirefox
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (fast)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
+libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "1.0.0"
+
 addSbtPlugin("com.codecommit"     % "sbt-spiewak-sonatype"     % "0.14.0")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.1.1")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")


### PR DESCRIPTION
This is a necessary step before addressing the remainder of #956. With this, we run the `coreJS/test` process in Firefox. If you wish to replicate this locally, just install `geckodriver` (e.g. with Homebrew) and run `sbt ciFirefox`.