### PR TITLE
Implemented postMessage polyfill for setImmediate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,7 @@ addCommandAlias("ciJS", "; project rootJS; headerCheck; scalafmtCheck; clean; te
 // we do the firefox ci *only* on core because we're only really interested in IO here
 addCommandAlias("ciFirefox", "; set Global / useFirefoxEnv := true; project rootJS; headerCheck; scalafmtCheck; clean; coreJS/test; set Global / useFirefoxEnv := false")
 
-addCommandAlias("prePR", "; +root/scalafmtAll; +root/headerCreate")
+addCommandAlias("prePR", "; root/clean; +root/scalafmtAll; +root/headerCreate")
 
 lazy val root = project.in(file("."))
   .aggregate(rootJVM, rootJS)

--- a/core/js/src/main/scala/cats/effect/unsafe/PolyfillExecutionContext.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/PolyfillExecutionContext.scala
@@ -80,6 +80,13 @@ private[unsafe] object PolyfillExecutionContext extends ExecutionContext {
 
       if (canUsePostMessage()) {
         // postMessage is what we use for most modern browsers (when not in a webworker)
+
+        // generate a unique messagePrefix for everything we do
+        // collision here is *extremely* unlikely, but the random makes it somewhat less so
+        // as an example, if end-user code is using the setImmediate.js polyfill, we don't
+        // want to accidentally collide. Then again, if they *are* using the polyfill, we
+        // would pick it up above unless they init us first. Either way, the odds of
+        // collision here are microscopic.
         val messagePrefix = "setImmediate$" + Random.nextInt() + "$"
 
         def onGlobalMessage(event: js.Dynamic): Unit = {


### PR DESCRIPTION
This is basically a polyfill for `setImmediate` on Firefox, Chrome, and other non-IE10+ browsers. The one modern case which isn't covered by this is web workers, which will have to wait until I can come up with a good way to test it.