### PR TITLE
More laws and cleanup

### DIFF
--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -26,11 +26,11 @@ import scala.util.{Left, Right}
 trait AsyncLaws[F[_]] extends TemporalLaws[F, Throwable] with SyncLaws[F] {
   implicit val F: Async[F]
 
-  def asyncRightIsPure[A](a: A) =
-    F.async[A](k => F.delay(k(Right(a))).as(None)) <-> F.pure(a)
+  def asyncRightIsSequencedPure[A](a: A, fu: F[Unit]) =
+    F.async[A](k => F.delay(k(Right(a))) >> fu.as(None)) <-> (fu >> F.pure(a))
 
-  def asyncLeftIsRaiseError[A](e: Throwable) =
-    F.async[A](k => F.delay(k(Left(e))).as(None)) <-> F.raiseError(e)
+  def asyncLeftIsSequencedRaiseError[A](e: Throwable, fu: F[Unit]) =
+    F.async[A](k => F.delay(k(Left(e))) >> fu.as(None)) <-> (fu >> F.raiseError(e))
 
   def asyncRepeatedCallbackIgnored[A](a: A) =
     F.async[A](k => F.delay(k(Right(a))) >> F.delay(k(Right(a))).as(None)) <-> F.pure(a)

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -41,10 +41,6 @@ trait AsyncLaws[F[_]] extends TemporalLaws[F, Throwable] with SyncLaws[F] {
   def asyncCancelTokenIsUnsequencedOnError[A](e: Throwable, fu: F[Unit]) =
     F.async[A](k => F.delay(k(Left(e))) >> F.pure(Some(fu))) <-> F.raiseError(e)
 
-  // commented out until we can figure out how to ensure cancelation *during* the suspension
-  /*def asyncCancelTokenIsSequencedOnCancel(fu: F[Unit]) =
-    F.start(F.async[Unit](_ => F.pure(Some(fu)))).flatMap(_.cancel) <-> fu.attempt.void*/
-
   def neverIsDerivedFromAsync[A] =
     F.never[A] <-> F.async[A](_ => F.pure(None))
 

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
@@ -87,7 +87,6 @@ trait AsyncTests[F[_]] extends TemporalTests[F, Throwable] with SyncTests[F] {
           laws.asyncCancelTokenIsUnsequencedOnCompletion[A] _),
         "async cancel token is unsequenced on error" -> forAll(
           laws.asyncCancelTokenIsUnsequencedOnError[A] _),
-        // "async cancel token is sequenced on cancel" -> forAll(laws.asyncCancelTokenIsSequencedOnCancel _),
         "never is derived from async" -> laws.neverIsDerivedFromAsync[A],
         "executionContext commutativity" -> forAll(laws.executionContextCommutativity[A] _),
         "evalOn local pure" -> forAll(laws.evalOnLocalPure _),

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
@@ -51,6 +51,7 @@ trait AsyncTests[F[_]] extends TemporalTests[F, Throwable] with SyncTests[F] {
       EqFU: Eq[F[Unit]],
       EqE: Eq[Throwable],
       EqFEC: Eq[F[ExecutionContext]],
+      EqFAB: Eq[F[Either[A, B]]],
       EqFEitherEU: Eq[F[Either[Throwable, Unit]]],
       EqFEitherEA: Eq[F[Either[Throwable, A]]],
       EqFEitherUA: Eq[F[Either[Unit, A]]],
@@ -79,7 +80,8 @@ trait AsyncTests[F[_]] extends TemporalTests[F, Throwable] with SyncTests[F] {
 
       val props = Seq(
         "async right is sequenced pure" -> forAll(laws.asyncRightIsSequencedPure[A] _),
-        "async left is sequenced raiseError" -> forAll(laws.asyncLeftIsSequencedRaiseError[A] _),
+        "async left is sequenced raiseError" -> forAll(
+          laws.asyncLeftIsSequencedRaiseError[A] _),
         "async repeated callback is ignored" -> forAll(laws.asyncRepeatedCallbackIgnored[A] _),
         "async cancel token is unsequenced on complete" -> forAll(
           laws.asyncCancelTokenIsUnsequencedOnCompletion[A] _),

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
@@ -78,8 +78,8 @@ trait AsyncTests[F[_]] extends TemporalTests[F, Throwable] with SyncTests[F] {
       val parents = Seq(temporal[A, B, C](tolerance), sync[A, B, C])
 
       val props = Seq(
-        "async right is pure" -> forAll(laws.asyncRightIsPure[A] _),
-        "async left is raiseError" -> forAll(laws.asyncLeftIsRaiseError[A] _),
+        "async right is sequenced pure" -> forAll(laws.asyncRightIsSequencedPure[A] _),
+        "async left is sequenced raiseError" -> forAll(laws.asyncLeftIsSequencedRaiseError[A] _),
         "async repeated callback is ignored" -> forAll(laws.asyncRepeatedCallbackIgnored[A] _),
         "async cancel token is unsequenced on complete" -> forAll(
           laws.asyncCancelTokenIsUnsequencedOnCompletion[A] _),

--- a/laws/shared/src/main/scala/cats/effect/laws/ConcurrentTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ConcurrentTests.scala
@@ -46,6 +46,7 @@ trait ConcurrentTests[F[_], E] extends MonadErrorTests[F, E] {
       EqFC: Eq[F[C]],
       EqFU: Eq[F[Unit]],
       EqE: Eq[E],
+      EqFAB: Eq[F[Either[A, B]]],
       EqFEitherEU: Eq[F[Either[E, Unit]]],
       EqFEitherEA: Eq[F[Either[E, A]]],
       EqFEitherUA: Eq[F[Either[Unit, A]]],
@@ -70,6 +71,9 @@ trait ConcurrentTests[F[_], E] extends MonadErrorTests[F, E] {
       val parents = Seq(monadError[A, B, C])
 
       val props = Seq(
+        "race derives from racePair (left)" -> forAll(laws.raceDerivesFromRacePairLeft[A, B] _),
+        "race derives from racePair (right)" -> forAll(
+          laws.raceDerivesFromRacePairRight[A, B] _),
         "race canceled identity (left)" -> forAll(laws.raceCanceledIdentityLeft[A] _),
         "race canceled identity (right)" -> forAll(laws.raceCanceledIdentityRight[A] _),
         "race never identity attempt (left)" -> forAll(laws.raceNeverIdentityLeft[A] _),

--- a/laws/shared/src/main/scala/cats/effect/laws/EffectTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/EffectTests.scala
@@ -51,6 +51,7 @@ trait EffectTests[F[_]] extends AsyncTests[F] {
       EqFU: Eq[F[Unit]],
       EqE: Eq[Throwable],
       EqFEC: Eq[F[ExecutionContext]],
+      EqFAB: Eq[F[Either[A, B]]],
       EqFEitherEU: Eq[F[Either[Throwable, Unit]]],
       EqFEitherEA: Eq[F[Either[Throwable, A]]],
       EqFEitherUA: Eq[F[Either[Unit, A]]],

--- a/laws/shared/src/main/scala/cats/effect/laws/TemporalTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/TemporalTests.scala
@@ -48,6 +48,7 @@ trait TemporalTests[F[_], E] extends ConcurrentTests[F, E] with ClockTests[F] {
       EqFC: Eq[F[C]],
       EqFU: Eq[F[Unit]],
       EqE: Eq[E],
+      EqFAB: Eq[F[Either[A, B]]],
       EqFEitherEU: Eq[F[Either[E, Unit]]],
       EqFEitherEA: Eq[F[Either[E, A]]],
       EqFEitherUA: Eq[F[Either[Unit, A]]],


### PR DESCRIPTION
I went back and slightly strengthened the `async` and `race` laws, in addition to (unfortunately) removing the one which is effectively impossible to write. There are a few more laws I'm thinking about, including backpressure on `cancel`, but it needs thought to ensure that it's actually implementable.

---

Here's a linkable digression on something subtle but significant that I changed:

```scala
  def asyncRightIsSequencedPure[A](a: A, fu: F[Unit]) =
    F.async[A](k => F.delay(k(Right(a))) >> fu.as(None)) <-> (fu >> F.pure(a))

  def asyncLeftIsSequencedRaiseError[A](e: Throwable, fu: F[Unit]) =
    F.async[A](k => F.delay(k(Left(e))) >> fu.as(None)) <-> (fu >> F.raiseError(e))
```

These are the two primary laws governing the behavior of `async`. The essence of what they're saying is that `async` has *linearized queueing* semantics, which is a stronger restriction than any we've imposed. This is directly related to #615, and I recommend looking at that PR for some of the discussion on the question. I do expect that these laws will be controversial, and I am open to being convinced they're a bad idea.

The essence of the problem here is that `async` codifies a race condition between the callback invocation and the registration function. Consider:

```scala
F async { cb =>
  effectA >>
    F.delay(doRegistration(cb)) >>
    effectB
} >> effectC
```

How do you want to order `A`, `B`, and `C`? Remember that `doRegistration` can hit the callback any time starting from when it is called (it may simply be defined as `_(Right(())`, after all) to sometime in the undefinable future. The race here is between `cb.apply` and the completion of `effectB`.

Also remember that `effectB` may be `F.canceled` or `F.raiseError`; what do you do in that case?

There are a few possibilities that leap immediately to the mind:

1. Run `effectC` *as soon* as `cb` is invoked, potentially in parallel with `effectB`
2. Run `effectC` *as soon* as `cb` is invoked, *canceling* `effectB`
3. Allow `effectB` to fully complete, then run `effectC` once `cb` is invoked

All of these are different resolutions to the race, but they have very user-visible consequences. For example, if `effectB` and `effectC` both close over the same mutable state, you can create surprising race conditions. Cancelation helps this a bit, but `effectB` may be uncancelable! They also all have very subtle implications for side-channels.

Consider if `effectB` is `raiseError` *and* `cb` is invoked with `Left`. You now have two errors, simultaneously, and you need to resolve that somehow. The only answer is to report them on a side channel, which fortunately we have in the form of `ExecutionContext`, but still. In semantics 1 and 2, we just have to worry about side-channeling `effectB`'s errors. In semantic 3, we actually might need to side-channel `cb`'s error, or even `cb`'s *result*!

That last one is particularly annoying. So consider the following:

```scala
F.async[A](cb => F.delay(cb(Right(a)) >> F.raiseError(e))
```

In semantic 3, the `raiseError` dominates, which means we suddenly have a value of type `A` which is just like… chilling. This is not at all unlike what happens if you run `race(pure(a), pure(b))`, and in that case, we just memory hole the result.

There's another weird problem here, which is that `effectB` might actually be `F.never`!:

```scala
F.async[A](cb => F.delay(cb(Right(a)) >> F.never)
```

This is, by law, equal to `F.never`.

To be clear, the laws codify semantic 3, because I believe it is the sanest for users. It ensures that there is always a direct linearization of the race condition, and never *any* possibility of the continuation "running ahead" of the registration effect. It also provides a pretty sane mental model: `async` is kind of like a `Promise` which you can only read once, and can only be fulfilled from within the lexical scope of the `async` (or, via mutation, really anywhere, but stick with me).

To my knowledge, no functional effect type other than ce3's `IO` implements this semantic today. It *should* be implementable though using a mechanism like `Deferred`, so this shouldn't outright prevent any effects from participating in the hierarchy even if they prefer a different direct `async` semantic.