### PR TITLE
Generalized Sync to arbitrary suspension hints

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -126,7 +126,7 @@ private[effect] final class IOFiber[A](
   }
 
   var cancel: IO[Unit] = IO uncancelable { _ =>
-    IO suspend {
+    IO defer {
       canceled = true
       cancel = IO.unit
 

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -18,7 +18,7 @@ package cats.effect
 
 import cats.kernel.laws.discipline.MonoidTests
 import cats.effect.laws.EffectTests
-import cats.effect.testkit.TestContext
+import cats.effect.testkit.{SyncTypeGenerators, TestContext}
 import cats.implicits._
 
 import org.scalacheck.Prop, Prop.forAll
@@ -32,6 +32,8 @@ import scala.concurrent.duration._
 
 class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck with BaseSpec {
   outer =>
+
+  import SyncTypeGenerators._
 
   // we just need this because of the laws testing, since the prop runs can interfere with each other
   sequential

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
@@ -22,12 +22,25 @@ import cats.data.OptionT
 import scala.concurrent.duration.FiniteDuration
 
 trait Sync[F[_]] extends MonadError[F, Throwable] with Clock[F] with Defer[F] {
-  def delay[A](thunk: => A): F[A]
+
+  private[this] val Delay = Sync.Type.Delay
+  private[this] val Blocking = Sync.Type.Blocking
+  private[this] val InterruptibleOnce = Sync.Type.InterruptibleOnce
+  private[this] val InterruptibleMany = Sync.Type.InterruptibleMany
+
+  def delay[A](thunk: => A): F[A] =
+    suspend(Delay)(thunk)
 
   def defer[A](thunk: => F[A]): F[A] =
     flatMap(delay(thunk))(x => x)
 
-  def blocking[A](thunk: => A): F[A]
+  def blocking[A](thunk: => A): F[A] =
+    suspend(Blocking)(thunk)
+
+  def interruptible[A](many: Boolean)(thunk: => A): F[A] =
+    suspend(if (many) InterruptibleOnce else InterruptibleMany)(thunk)
+
+  def suspend[A](hint: Sync.Type)(thunk: => A): F[A]
 }
 
 object Sync {
@@ -59,10 +72,16 @@ object Sync {
       def tailRecM[A, B](a: A)(f: A => OptionT[F, Either[A, B]]): OptionT[F, B] =
         delegate.tailRecM(a)(f)
 
-      def delay[A](thunk: => A): OptionT[F, A] =
-        OptionT.liftF(F.delay(thunk))
-
-      def blocking[A](thunk: => A): OptionT[F, A] =
-        OptionT.liftF(F.blocking(thunk))
+      def suspend[A](hint: Type)(thunk: => A): OptionT[F, A] =
+        OptionT.liftF(F.suspend(hint)(thunk))
     }
+
+  sealed trait Type extends Product with Serializable
+
+  object Type {
+    case object Delay extends Type
+    case object Blocking extends Type
+    case object InterruptibleOnce extends Type
+    case object InterruptibleMany extends Type
+  }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
@@ -18,7 +18,7 @@ package cats.effect
 package laws
 
 import cats.{Eq, Group, Order}
-import cats.effect.kernel.{Async, Outcome}
+import cats.effect.kernel.{Async, Outcome, Sync}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._, Prop.forAll
@@ -39,6 +39,7 @@ trait AsyncTests[F[_]] extends TemporalTests[F, Throwable] with SyncTests[F] {
       ArbFAtoB: Arbitrary[F[A => B]],
       ArbFBtoC: Arbitrary[F[B => C]],
       ArbE: Arbitrary[Throwable],
+      ArbST: Arbitrary[Sync.Type],
       ArbFiniteDuration: Arbitrary[FiniteDuration],
       ArbExecutionContext: Arbitrary[ExecutionContext],
       CogenA: Cogen[A],

--- a/laws/shared/src/main/scala/cats/effect/laws/EffectTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/EffectTests.scala
@@ -18,7 +18,7 @@ package cats.effect
 package laws
 
 import cats.{Eq, Group, Order}
-import cats.effect.kernel.{Effect, Outcome}
+import cats.effect.kernel.{Effect, Outcome, Sync}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._, Prop.forAll
@@ -39,6 +39,7 @@ trait EffectTests[F[_]] extends AsyncTests[F] {
       ArbFAtoB: Arbitrary[F[A => B]],
       ArbFBtoC: Arbitrary[F[B => C]],
       ArbE: Arbitrary[Throwable],
+      ArbST: Arbitrary[Sync.Type],
       ArbFiniteDuration: Arbitrary[FiniteDuration],
       ArbExecutionContext: Arbitrary[ExecutionContext],
       CogenA: Cogen[A],

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncEffectTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncEffectTests.scala
@@ -19,7 +19,7 @@ package laws
 
 import cats.Eq
 import cats.data.EitherT
-import cats.effect.kernel.SyncEffect
+import cats.effect.kernel.{Sync, SyncEffect}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._, Prop.forAll
@@ -36,6 +36,7 @@ trait SyncEffectTests[F[_]] extends SyncTests[F] {
       ArbFAtoB: Arbitrary[F[A => B]],
       ArbFBtoC: Arbitrary[F[B => C]],
       ArbE: Arbitrary[Throwable],
+      ArbST: Arbitrary[Sync.Type],
       CogenA: Cogen[A],
       CogenB: Cogen[B],
       CogenC: Cogen[C],

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncTests.scala
@@ -37,6 +37,7 @@ trait SyncTests[F[_]] extends MonadErrorTests[F, Throwable] with ClockTests[F] {
       ArbFAtoB: Arbitrary[F[A => B]],
       ArbFBtoC: Arbitrary[F[B => C]],
       ArbE: Arbitrary[Throwable],
+      ArbST: Arbitrary[Sync.Type],
       CogenA: Cogen[A],
       CogenB: Cogen[B],
       CogenC: Cogen[C],
@@ -59,10 +60,10 @@ trait SyncTests[F[_]] extends MonadErrorTests[F, Throwable] with ClockTests[F] {
       val parents = Seq(monadError[A, B, C], clock[A, B, C])
 
       val props = Seq(
-        "delay value is pure" -> forAll(laws.delayValueIsPure[A] _),
-        "delay throw is raiseError" -> forAll(laws.delayThrowIsRaiseError[A] _),
-        "unsequenced delay is no-op" -> forAll(laws.unsequencedDelayIsNoop[A] _),
-        "repeated delay is not memoized" -> forAll(laws.repeatedDelayNotMemoized[A] _)
+        "suspend value is pure" -> forAll(laws.suspendValueIsPure[A] _),
+        "suspend throw is raiseError" -> forAll(laws.suspendThrowIsRaiseError[A] _),
+        "unsequenced suspend is no-op" -> forAll(laws.unsequencedSuspendIsNoop[A] _),
+        "repeated suspend is not memoized" -> forAll(laws.repeatedSuspendNotMemoized[A] _)
       )
     }
   }

--- a/laws/shared/src/test/scala/cats/effect/FreeSyncSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/FreeSyncSpec.scala
@@ -18,7 +18,7 @@ package cats.effect
 package laws
 
 import cats.{Eq, Show}
-import cats.effect.testkit.{freeEval, FreeSyncGenerators}, freeEval._
+import cats.effect.testkit.{freeEval, FreeSyncGenerators, SyncTypeGenerators}, freeEval._
 import cats.implicits._
 
 import org.scalacheck.Prop
@@ -31,6 +31,7 @@ import org.typelevel.discipline.specs2.mutable.Discipline
 
 class FreeSyncSpec extends Specification with Discipline with ScalaCheck {
   import FreeSyncGenerators._
+  import SyncTypeGenerators._
 
   implicit def prettyFromShow[A: Show](a: A): Pretty =
     Pretty.prettyString(a.show)

--- a/testkit/shared/src/main/scala/cats/effect/testkit/Generators.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/Generators.scala
@@ -310,3 +310,23 @@ object OutcomeGenerators {
       case Outcome.Errored(e) => Some(Left(e))
     }
 }
+
+object SyncTypeGenerators {
+
+  implicit val arbitrarySyncType: Arbitrary[Sync.Type] = {
+    import Sync.Type._
+
+    Arbitrary(Gen.oneOf(Delay, Blocking, InterruptibleOnce, InterruptibleMany))
+  }
+
+  implicit val cogenSyncType: Cogen[Sync.Type] = {
+    import Sync.Type._
+
+    Cogen[Int] contramap {
+      case Delay => 0
+      case Blocking => 1
+      case InterruptibleOnce => 2
+      case InterruptibleMany => 3
+    }
+  }
+}

--- a/testkit/shared/src/main/scala/cats/effect/testkit/freeEval.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/freeEval.scala
@@ -59,7 +59,7 @@ object freeEval {
       def tailRecM[A, B](a: A)(f: A => FreeT[Eval, F, Either[A, B]]): FreeT[Eval, F, B] =
         M.tailRecM(a)(f)
 
-      def delay[A](thunk: => A): FreeT[Eval, F, A] =
+      def suspend[A](hint: Sync.Type)(thunk: => A): FreeT[Eval, F, A] =
         FreeT.roll {
           Eval.always {
             try {
@@ -70,9 +70,6 @@ object freeEval {
             }
           }
         }
-
-      def blocking[A](thunk: => A): FreeT[Eval, F, A] =
-        delay(thunk)
     }
 
   implicit def eqFreeSync[F[_]: Monad, A](implicit F: Eq[F[A]]): Eq[FreeT[Eval, F, A]] =


### PR DESCRIPTION
This is a generalization of what @mpilquist did in #980, particularly restoring lawfulness of `blocking` and all related combinators. Also requesting eyes from @alexandru on this. Note that the semantic of `suspend` is that the `hint` is just that: a hint. Implementations are always free to ignore it, particularly if it is irrelevant to them. (I'll probably actually override the `IO` implementation on ScalaJS to just all point to `delay`, since there's no point in bouncing through `setImmediate` in any of them).

I still haven't implemented `interruptible`, and when I do it will mean some signature changes in `IORuntime`, but I need to think about exactly what that will be.

Fixes #958