### PR TITLE
Correct Parallel tests for Resource in the 2.x series

### DIFF
--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -47,7 +47,7 @@ class ResourceTests extends BaseTestsSuite {
       implicit val cs = ec.contextShift[IO]
 
       // do NOT inline this val; it causes the 2.13.0 compiler to crash for... reasons (see: scala/bug#11732)
-      val module = ParallelTests[IO]
+      val module = ParallelTests[Resource[IO, *]]
       module.parallel[Int, Int]
     }
   )


### PR DESCRIPTION
This went undetected for some time 