### PR TITLE
Concurrent instances for monad transformers

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Clock.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Clock.scala
@@ -94,7 +94,7 @@ object Clock {
       implicit override def L: Monoid[L] = L0
     }
 
-  trait OptionTClock[F[_]] extends Clock[OptionT[F, *]] {
+  private[kernel] trait OptionTClock[F[_]] extends Clock[OptionT[F, *]] {
     implicit protected def F: Clock[F] with Monad[F]
 
     val delegate = OptionT.catsDataMonadForOptionT[F]
@@ -111,7 +111,7 @@ object Clock {
     override def realTime: OptionT[F, FiniteDuration] = OptionT.liftF(F.realTime)
   }
 
-  trait EitherTClock[F[_], E] extends Clock[EitherT[F, E, *]] {
+  private[kernel] trait EitherTClock[F[_], E] extends Clock[EitherT[F, E, *]] {
     implicit protected def F: Clock[F] with Monad[F]
 
     val delegate = EitherT.catsDataMonadErrorForEitherT[F, E]
@@ -128,7 +128,7 @@ object Clock {
     override def realTime: EitherT[F, E, FiniteDuration] = EitherT.liftF(F.realTime)
   }
 
-  trait StateTClock[F[_], S] extends Clock[StateT[F, S, *]] {
+  private[kernel] trait StateTClock[F[_], S] extends Clock[StateT[F, S, *]] {
     implicit protected def F: Clock[F] with Monad[F]
 
     val delegate = IndexedStateT.catsDataMonadForIndexedStateT[F, S]
@@ -146,7 +146,7 @@ object Clock {
       StateT.liftF(F.realTime)
   }
 
-  trait WriterTClock[F[_], S] extends Clock[WriterT[F, S, *]] {
+  private[kernel] trait WriterTClock[F[_], S] extends Clock[WriterT[F, S, *]] {
     implicit protected def F: Clock[F] with Monad[F]
     implicit protected def S: Monoid[S]
 
@@ -164,7 +164,7 @@ object Clock {
     override def realTime: WriterT[F, S, FiniteDuration] = WriterT.liftF(F.realTime)
   }
 
-  trait IorTClock[F[_], L] extends Clock[IorT[F, L, *]] {
+  private[kernel] trait IorTClock[F[_], L] extends Clock[IorT[F, L, *]] {
     implicit protected def F: Clock[F] with Monad[F]
     implicit protected def L: Semigroup[L]
 
@@ -182,7 +182,7 @@ object Clock {
 
   }
 
-  trait KleisliClock[F[_], R] extends Clock[Kleisli[F, R, *]] {
+  private[kernel] trait KleisliClock[F[_], R] extends Clock[Kleisli[F, R, *]] {
     implicit protected def F: Clock[F] with Monad[F]
 
     val delegate = Kleisli.catsDataMonadForKleisli[F, R]
@@ -200,7 +200,7 @@ object Clock {
 
   }
 
-  trait ContTClock[F[_], R] extends Clock[ContT[F, R, *]] {
+  private[kernel] trait ContTClock[F[_], R] extends Clock[ContT[F, R, *]] {
     implicit protected def F: Clock[F] with Monad[F] with Defer[F]
 
     val delegate = ContT.catsDataContTMonad[F, R]
@@ -218,7 +218,7 @@ object Clock {
 
   }
 
-  trait ReaderWriterStateTClock[F[_], R, L, S]
+  private[kernel] trait ReaderWriterStateTClock[F[_], R, L, S]
       extends Clock[ReaderWriterStateT[F, R, L, S, *]] {
     implicit protected def F: Clock[F] with Monad[F]
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
@@ -243,7 +243,7 @@ object Concurrent {
 
     def forceR[A, B](fa: OptionT[F, A])(fb: OptionT[F, B]): OptionT[F, B] =
       OptionT(
-        fa.value.attempt >> fb.value
+        F.forceR(fa.value)(fb.value)
       )
 
     def pure[A](a: A): OptionT[F, A] = delegate.pure(a)
@@ -320,7 +320,7 @@ object Concurrent {
 
     def forceR[A, B](fa: EitherT[F, E0, A])(fb: EitherT[F, E0, B]): EitherT[F, E0, B] =
       EitherT(
-        fa.value.attempt >> fb.value
+        F.forceR(fa.value)(fb.value)
       )
 
     def pure[A](a: A): EitherT[F, E0, A] = delegate.pure(a)
@@ -397,7 +397,7 @@ object Concurrent {
 
     def forceR[A, B](fa: IorT[F, L, A])(fb: IorT[F, L, B]): IorT[F, L, B] =
       IorT(
-        fa.value.attempt >> fb.value
+        F.forceR(fa.value)(fb.value)
       )
 
     def pure[A](a: A): IorT[F, L, A] = delegate.pure(a)
@@ -474,7 +474,7 @@ object Concurrent {
     }
 
     def forceR[A, B](fa: Kleisli[F, R, A])(fb: Kleisli[F, R, B]): Kleisli[F, R, B] =
-      Kleisli(r => fa.run(r).attempt >> fb.run(r))
+      Kleisli(r => F.forceR(fa.run(r))(fb.run(r)))
 
     def pure[A](a: A): Kleisli[F, R, A] = delegate.pure(a)
 
@@ -553,7 +553,7 @@ object Concurrent {
 
     def forceR[A, B](fa: WriterT[F, L, A])(fb: WriterT[F, L, B]): WriterT[F, L, B] =
       WriterT(
-        fa.run.attempt >> fb.run
+        F.forceR(fa.run)(fb.run)
       )
 
     def pure[A](a: A): WriterT[F, L, A] = delegate.pure(a)

--- a/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
@@ -492,7 +492,7 @@ object Concurrent {
     def liftOutcome[A](oc: Outcome[F, E, A]): Outcome[Kleisli[F, R, *], E, A] = {
 
       val nat: F ~> Kleisli[F, R, *] = new ~>[F, Kleisli[F, R, *]] {
-        def apply[A](fa: F[A]) = Kleisli.liftF(fa)
+        def apply[B](fa: F[B]) = Kleisli.liftF(fa)
       }
 
       oc.mapK(nat)

--- a/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
@@ -161,20 +161,7 @@ object Concurrent {
     implicit protected def F: Concurrent[F, E]
 
     def start[A](fa: OptionT[F, A]): OptionT[F, Fiber[OptionT[F, *], E, A]] =
-      OptionT.liftF(F.start(fa.value).map { fib =>
-        new Fiber[OptionT[F, *], E, A] {
-          def cancel: OptionT[F, Unit] = OptionT.liftF(fib.cancel)
-          def join: OptionT[F, Outcome[OptionT[F, *], E, A]] =
-            OptionT.liftF(for {
-              o <- fib.join
-              res: Outcome[OptionT[F, *], E, A] = o match {
-                case Outcome.Canceled() => Outcome.Canceled()
-                case Outcome.Errored(e) => Outcome.Errored(e)
-                case Outcome.Completed(foa) => Outcome.Completed(OptionT(foa))
-              }
-            } yield res)
-        }
-      })
+      OptionT.liftF(F.start(fa.value).map(liftFiber))
 
     def uncancelable[A](
         body: (OptionT[F, *] ~> OptionT[F, *]) => OptionT[F, A]): OptionT[F, A] =
@@ -200,6 +187,25 @@ object Concurrent {
       F,
       Either[
         (Outcome[OptionT[F, *], E, A], Fiber[OptionT[F, *], E, B]),
-        (Fiber[OptionT[F, *], E, A], Outcome[OptionT[F, *], E, B])]] = ???
+        (Fiber[OptionT[F, *], E, A], Outcome[OptionT[F, *], E, B])]] = {
+      OptionT.liftF(F.racePair(fa.value, fb.value).map {
+        case Left((oc, fib)) => Left((liftOutcome(oc), liftFiber(fib)))
+        case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
+      })
+    }
+
+    def liftOutcome[A](oc: Outcome[F, E, Option[A]]): Outcome[OptionT[F, *], E, A] =
+      oc match {
+        case Outcome.Canceled() => Outcome.Canceled()
+        case Outcome.Errored(e) => Outcome.Errored(e)
+        case Outcome.Completed(foa) => Outcome.Completed(OptionT(foa))
+      }
+
+    def liftFiber[A](fib: Fiber[F, E, Option[A]]): Fiber[OptionT[F, *], E, A] =
+      new Fiber[OptionT[F, *], E, A] {
+        def cancel: OptionT[F, Unit] = OptionT.liftF(fib.cancel)
+        def join: OptionT[F, Outcome[OptionT[F, *], E, A]] =
+          OptionT.liftF(fib.join.map(liftOutcome))
+      }
   }
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
@@ -242,7 +242,9 @@ object Concurrent {
     }
 
     def forceR[A, B](fa: OptionT[F, A])(fb: OptionT[F, B]): OptionT[F, B] =
-      fa.attempt >> fb
+      OptionT(
+        fa.value.attempt >> fb.value
+      )
 
     def pure[A](a: A): OptionT[F, A] = delegate.pure(a)
 
@@ -316,7 +318,9 @@ object Concurrent {
     }
 
     def forceR[A, B](fa: EitherT[F, E0, A])(fb: EitherT[F, E0, B]): EitherT[F, E0, B] =
-      fa.attempt >> fb
+      EitherT(
+        fa.value.attempt >> fb.value
+      )
 
     def pure[A](a: A): EitherT[F, E0, A] = delegate.pure(a)
 
@@ -391,7 +395,9 @@ object Concurrent {
     }
 
     def forceR[A, B](fa: IorT[F, L, A])(fb: IorT[F, L, B]): IorT[F, L, B] =
-      fa.attempt >> fb
+      IorT(
+        fa.value.attempt >> fb.value
+      )
 
     def pure[A](a: A): IorT[F, L, A] = delegate.pure(a)
 
@@ -467,7 +473,7 @@ object Concurrent {
     }
 
     def forceR[A, B](fa: Kleisli[F, R, A])(fb: Kleisli[F, R, B]): Kleisli[F, R, B] =
-      fa.attempt >> fb
+      Kleisli(r => fa.run(r).attempt >> fb.run(r))
 
     def pure[A](a: A): Kleisli[F, R, A] = delegate.pure(a)
 
@@ -542,7 +548,9 @@ object Concurrent {
     }
 
     def forceR[A, B](fa: WriterT[F, L, A])(fb: WriterT[F, L, B]): WriterT[F, L, B] =
-      fa.attempt >> fb
+      WriterT(
+        fa.run.attempt >> fb.run
+      )
 
     def pure[A](a: A): WriterT[F, L, A] = delegate.pure(a)
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
@@ -201,7 +201,7 @@ object Concurrent {
       override implicit protected def L: Monoid[L] = L0
     }
 
-  trait OptionTConcurrent[F[_], E] extends Concurrent[OptionT[F, *], E] {
+  private[kernel] trait OptionTConcurrent[F[_], E] extends Concurrent[OptionT[F, *], E] {
 
     implicit protected def F: Concurrent[F, E]
 
@@ -274,7 +274,8 @@ object Concurrent {
       }
   }
 
-  trait EitherTConcurrent[F[_], E0, E] extends Concurrent[EitherT[F, E0, *], E] {
+  private[kernel] trait EitherTConcurrent[F[_], E0, E]
+      extends Concurrent[EitherT[F, E0, *], E] {
 
     implicit protected def F: Concurrent[F, E]
 
@@ -351,7 +352,7 @@ object Concurrent {
       }
   }
 
-  trait IorTConcurrent[F[_], L, E] extends Concurrent[IorT[F, L, *], E] {
+  private[kernel] trait IorTConcurrent[F[_], L, E] extends Concurrent[IorT[F, L, *], E] {
 
     implicit protected def F: Concurrent[F, E]
 
@@ -427,7 +428,7 @@ object Concurrent {
       }
   }
 
-  trait KleisliConcurrent[F[_], R, E] extends Concurrent[Kleisli[F, R, *], E] {
+  private[kernel] trait KleisliConcurrent[F[_], R, E] extends Concurrent[Kleisli[F, R, *], E] {
 
     implicit protected def F: Concurrent[F, E]
 
@@ -488,10 +489,13 @@ object Concurrent {
     def tailRecM[A, B](a: A)(f: A => Kleisli[F, R, Either[A, B]]): Kleisli[F, R, B] =
       delegate.tailRecM(a)(f)
 
-    def liftOutcome[A](oc: Outcome[F, E, A]): Outcome[Kleisli[F, R, *], E, A] = oc.mapK(nat)
+    def liftOutcome[A](oc: Outcome[F, E, A]): Outcome[Kleisli[F, R, *], E, A] = {
 
-    val nat: F ~> Kleisli[F, R, *] = new ~>[F, Kleisli[F, R, *]] {
-      def apply[A](fa: F[A]) = Kleisli.liftF(fa)
+      val nat: F ~> Kleisli[F, R, *] = new ~>[F, Kleisli[F, R, *]] {
+        def apply[A](fa: F[A]) = Kleisli.liftF(fa)
+      }
+
+      oc.mapK(nat)
     }
 
     def liftFiber[A](fib: Fiber[F, E, A]): Fiber[Kleisli[F, R, *], E, A] =
@@ -502,7 +506,7 @@ object Concurrent {
       }
   }
 
-  trait WriterTConcurrent[F[_], L, E] extends Concurrent[WriterT[F, L, *], E] {
+  private[kernel] trait WriterTConcurrent[F[_], L, E] extends Concurrent[WriterT[F, L, *], E] {
 
     implicit protected def F: Concurrent[F, E]
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
@@ -163,18 +163,21 @@ object Concurrent {
   implicit def concurrentForOptionT[F[_], E](
       implicit F0: Concurrent[F, E]): Concurrent[OptionT[F, *], E] =
     new OptionTConcurrent[F, E] {
+
       override implicit protected def F: Concurrent[F, E] = F0
     }
 
   implicit def concurrentForEitherT[F[_], E0, E](
       implicit F0: Concurrent[F, E]): Concurrent[EitherT[F, E0, *], E] =
     new EitherTConcurrent[F, E0, E] {
+
       override implicit protected def F: Concurrent[F, E] = F0
     }
 
   implicit def concurrentForKleisli[F[_], R, E](
       implicit F0: Concurrent[F, E]): Concurrent[Kleisli[F, R, *], E] =
     new KleisliConcurrent[F, R, E] {
+
       override implicit protected def F: Concurrent[F, E] = F0
     }
 
@@ -182,6 +185,7 @@ object Concurrent {
       implicit F0: Concurrent[F, E],
       L0: Semigroup[L]): Concurrent[IorT[F, L, *], E] =
     new IorTConcurrent[F, L, E] {
+
       override implicit protected def F: Concurrent[F, E] = F0
 
       override implicit protected def L: Semigroup[L] = L0
@@ -191,6 +195,7 @@ object Concurrent {
       implicit F0: Concurrent[F, E],
       L0: Monoid[L]): Concurrent[WriterT[F, L, *], E] =
     new WriterTConcurrent[F, L, E] {
+
       override implicit protected def F: Concurrent[F, E] = F0
 
       override implicit protected def L: Monoid[L] = L0
@@ -235,6 +240,9 @@ object Concurrent {
         case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
       })
     }
+
+    def forceR[A, B](fa: OptionT[F, A])(fb: OptionT[F, B]): OptionT[F, B] =
+      fa.attempt >> fb
 
     def pure[A](a: A): OptionT[F, A] = delegate.pure(a)
 
@@ -307,6 +315,9 @@ object Concurrent {
       })
     }
 
+    def forceR[A, B](fa: EitherT[F, E0, A])(fb: EitherT[F, E0, B]): EitherT[F, E0, B] =
+      fa.attempt >> fb
+
     def pure[A](a: A): EitherT[F, E0, A] = delegate.pure(a)
 
     def raiseError[A](e: E): EitherT[F, E0, A] = delegate.raiseError(e)
@@ -378,6 +389,9 @@ object Concurrent {
         case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
       })
     }
+
+    def forceR[A, B](fa: IorT[F, L, A])(fb: IorT[F, L, B]): IorT[F, L, B] =
+      fa.attempt >> fb
 
     def pure[A](a: A): IorT[F, L, A] = delegate.pure(a)
 
@@ -452,6 +466,9 @@ object Concurrent {
       }
     }
 
+    def forceR[A, B](fa: Kleisli[F, R, A])(fb: Kleisli[F, R, B]): Kleisli[F, R, B] =
+      fa.attempt >> fb
+
     def pure[A](a: A): Kleisli[F, R, A] = delegate.pure(a)
 
     def raiseError[A](e: E): Kleisli[F, R, A] = delegate.raiseError(e)
@@ -523,6 +540,9 @@ object Concurrent {
         case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
       })
     }
+
+    def forceR[A, B](fa: WriterT[F, L, A])(fb: WriterT[F, L, B]): WriterT[F, L, B] =
+      fa.attempt >> fb
 
     def pure[A](a: A): WriterT[F, L, A] = delegate.pure(a)
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
@@ -17,6 +17,7 @@
 package cats.effect.kernel
 
 import cats.{~>, MonadError}
+import cats.data.OptionT
 import cats.syntax.all._
 
 trait Fiber[F[_], E, A] {
@@ -154,4 +155,29 @@ trait Concurrent[F[_], E] extends MonadError[F, E] {
 object Concurrent {
   def apply[F[_], E](implicit F: Concurrent[F, E]): F.type = F
   def apply[F[_]](implicit F: Concurrent[F, _], d: DummyImplicit): F.type = F
+
+  trait OptionTConcurrent[F[_], E] extends Concurrent[OptionT[F, *], E] {
+
+    implicit protected def F: Concurrent[F, E]
+
+    def start[A](fa: OptionT[F, A]): OptionT[F, Fiber[OptionT[F, *], E, A]] = ???
+
+    def uncancelable[A](
+        body: (OptionT[F, *] ~> OptionT[F, *]) => OptionT[F, A]): OptionT[F, A] = ???
+
+    def canceled: OptionT[F, Unit] = OptionT.liftF(F.canceled)
+
+    def onCancel[A](fa: OptionT[F, A], fin: OptionT[F, Unit]): OptionT[F, A] =
+      OptionT(F.onCancel(fa.value, fin.value.as(())))
+
+    def never[A]: OptionT[F, A] = OptionT.liftF(F.never)
+
+    def cede: OptionT[F, Unit] = OptionT.liftF(F.cede)
+
+    def racePair[A, B](fa: OptionT[F, A], fb: OptionT[F, B]): OptionT[
+      F,
+      Either[
+        (Outcome[OptionT[F, *], E, A], Fiber[OptionT[F, *], E, B]),
+        (Fiber[OptionT[F, *], E, A], Outcome[OptionT[F, *], E, B])]] = ???
+  }
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
@@ -17,7 +17,8 @@
 package cats.effect.kernel
 
 import cats.{~>, MonadError}
-import cats.data.{OptionT, EitherT}
+import cats.data.{EitherT, Ior, IorT, OptionT}
+import cats.Semigroup
 import cats.syntax.all._
 
 trait Fiber[F[_], E, A] {
@@ -168,6 +169,15 @@ object Concurrent {
       override implicit protected def F: Concurrent[F, E] = F0
     }
 
+  implicit def concurrentForIorT[F[_], L, E](
+      implicit F0: Concurrent[F, E],
+      L0: Semigroup[L]): Concurrent[IorT[F, L, *], E] =
+    new IorTConcurrent[F, L, E] {
+      override implicit protected def F: Concurrent[F, E] = F0
+
+      override implicit protected def L: Semigroup[L] = L0
+    }
+
   trait OptionTConcurrent[F[_], E] extends Concurrent[OptionT[F, *], E] {
 
     implicit protected def F: Concurrent[F, E]
@@ -245,13 +255,15 @@ object Concurrent {
     def start[A](fa: EitherT[F, E0, A]): EitherT[F, E0, Fiber[EitherT[F, E0, *], E, A]] =
       EitherT.liftF(F.start(fa.value).map(liftFiber))
 
-    def uncancelable[A](
-        body: (EitherT[F, E0, *] ~> EitherT[F, E0, *]) => EitherT[F, E0, A]): EitherT[F, E0, A] =
+    def uncancelable[A](body: (EitherT[F, E0, *] ~> EitherT[F, E0, *]) => EitherT[F, E0, A])
+        : EitherT[F, E0, A] =
       EitherT(
         F.uncancelable { nat =>
-          val natT: EitherT[F, E0, *] ~> EitherT[F, E0, *] = new ~>[EitherT[F, E0, *], EitherT[F, E0, *]] {
-            def apply[A](optfa: EitherT[F, E0, A]): EitherT[F, E0, A] = EitherT(nat(optfa.value))
-          }
+          val natT: EitherT[F, E0, *] ~> EitherT[F, E0, *] =
+            new ~>[EitherT[F, E0, *], EitherT[F, E0, *]] {
+              def apply[A](optfa: EitherT[F, E0, A]): EitherT[F, E0, A] =
+                EitherT(nat(optfa.value))
+            }
           body(natT).value
         }
       )
@@ -281,7 +293,8 @@ object Concurrent {
 
     def raiseError[A](e: E): EitherT[F, E0, A] = delegate.raiseError(e)
 
-    def handleErrorWith[A](fa: EitherT[F, E0, A])(f: E => EitherT[F, E0, A]): EitherT[F, E0, A] =
+    def handleErrorWith[A](fa: EitherT[F, E0, A])(
+        f: E => EitherT[F, E0, A]): EitherT[F, E0, A] =
       delegate.handleErrorWith(fa)(f)
 
     def flatMap[A, B](fa: EitherT[F, E0, A])(f: A => EitherT[F, E0, B]): EitherT[F, E0, B] =
@@ -302,6 +315,76 @@ object Concurrent {
         def cancel: EitherT[F, E0, Unit] = EitherT.liftF(fib.cancel)
         def join: EitherT[F, E0, Outcome[EitherT[F, E0, *], E, A]] =
           EitherT.liftF(fib.join.map(liftOutcome))
+      }
+  }
+  trait IorTConcurrent[F[_], L, E] extends Concurrent[IorT[F, L, *], E] {
+
+    implicit protected def F: Concurrent[F, E]
+
+    implicit protected def L: Semigroup[L]
+
+    val delegate = IorT.catsDataMonadErrorFForIorT[F, L, E]
+
+    def start[A](fa: IorT[F, L, A]): IorT[F, L, Fiber[IorT[F, L, *], E, A]] =
+      IorT.liftF(F.start(fa.value).map(liftFiber))
+
+    def uncancelable[A](
+        body: (IorT[F, L, *] ~> IorT[F, L, *]) => IorT[F, L, A]): IorT[F, L, A] =
+      IorT(
+        F.uncancelable { nat =>
+          val natT: IorT[F, L, *] ~> IorT[F, L, *] = new ~>[IorT[F, L, *], IorT[F, L, *]] {
+            def apply[A](optfa: IorT[F, L, A]): IorT[F, L, A] = IorT(nat(optfa.value))
+          }
+          body(natT).value
+        }
+      )
+
+    def canceled: IorT[F, L, Unit] = IorT.liftF(F.canceled)
+
+    def onCancel[A](fa: IorT[F, L, A], fin: IorT[F, L, Unit]): IorT[F, L, A] =
+      IorT(F.onCancel(fa.value, fin.value.as(())))
+
+    def never[A]: IorT[F, L, A] = IorT.liftF(F.never)
+
+    def cede: IorT[F, L, Unit] = IorT.liftF(F.cede)
+
+    def racePair[A, B](fa: IorT[F, L, A], fb: IorT[F, L, B]): IorT[
+      F,
+      L,
+      Either[
+        (Outcome[IorT[F, L, *], E, A], Fiber[IorT[F, L, *], E, B]),
+        (Fiber[IorT[F, L, *], E, A], Outcome[IorT[F, L, *], E, B])]] = {
+      IorT.liftF(F.racePair(fa.value, fb.value).map {
+        case Left((oc, fib)) => Left((liftOutcome(oc), liftFiber(fib)))
+        case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
+      })
+    }
+
+    def pure[A](a: A): IorT[F, L, A] = delegate.pure(a)
+
+    def raiseError[A](e: E): IorT[F, L, A] = delegate.raiseError(e)
+
+    def handleErrorWith[A](fa: IorT[F, L, A])(f: E => IorT[F, L, A]): IorT[F, L, A] =
+      delegate.handleErrorWith(fa)(f)
+
+    def flatMap[A, B](fa: IorT[F, L, A])(f: A => IorT[F, L, B]): IorT[F, L, B] =
+      delegate.flatMap(fa)(f)
+
+    def tailRecM[A, B](a: A)(f: A => IorT[F, L, Either[A, B]]): IorT[F, L, B] =
+      delegate.tailRecM(a)(f)
+
+    def liftOutcome[A](oc: Outcome[F, E, Ior[L, A]]): Outcome[IorT[F, L, *], E, A] =
+      oc match {
+        case Outcome.Canceled() => Outcome.Canceled()
+        case Outcome.Errored(e) => Outcome.Errored(e)
+        case Outcome.Completed(foa) => Outcome.Completed(IorT(foa))
+      }
+
+    def liftFiber[A](fib: Fiber[F, E, Ior[L, A]]): Fiber[IorT[F, L, *], E, A] =
+      new Fiber[IorT[F, L, *], E, A] {
+        def cancel: IorT[F, L, Unit] = IorT.liftF(fib.cancel)
+        def join: IorT[F, L, Outcome[IorT[F, L, *], E, A]] =
+          IorT.liftF(fib.join.map(liftOutcome))
       }
   }
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
@@ -215,7 +215,7 @@ object Concurrent {
       OptionT(
         F.uncancelable { nat =>
           val natT: OptionT[F, *] ~> OptionT[F, *] = new ~>[OptionT[F, *], OptionT[F, *]] {
-            def apply[A](optfa: OptionT[F, A]): OptionT[F, A] = OptionT(nat(optfa.value))
+            def apply[B](optfa: OptionT[F, B]): OptionT[F, B] = OptionT(nat(optfa.value))
           }
           body(natT).value
         }
@@ -289,7 +289,7 @@ object Concurrent {
         F.uncancelable { nat =>
           val natT: EitherT[F, E0, *] ~> EitherT[F, E0, *] =
             new ~>[EitherT[F, E0, *], EitherT[F, E0, *]] {
-              def apply[A](optfa: EitherT[F, E0, A]): EitherT[F, E0, A] =
+              def apply[B](optfa: EitherT[F, E0, B]): EitherT[F, E0, B] =
                 EitherT(nat(optfa.value))
             }
           body(natT).value
@@ -367,7 +367,7 @@ object Concurrent {
       IorT(
         F.uncancelable { nat =>
           val natT: IorT[F, L, *] ~> IorT[F, L, *] = new ~>[IorT[F, L, *], IorT[F, L, *]] {
-            def apply[A](optfa: IorT[F, L, A]): IorT[F, L, A] = IorT(nat(optfa.value))
+            def apply[B](optfa: IorT[F, L, B]): IorT[F, L, B] = IorT(nat(optfa.value))
           }
           body(natT).value
         }
@@ -442,7 +442,7 @@ object Concurrent {
         F.uncancelable { nat =>
           val natT: Kleisli[F, R, *] ~> Kleisli[F, R, *] =
             new ~>[Kleisli[F, R, *], Kleisli[F, R, *]] {
-              def apply[A](stfa: Kleisli[F, R, A]): Kleisli[F, R, A] =
+              def apply[B](stfa: Kleisli[F, R, B]): Kleisli[F, R, B] =
                 Kleisli { r => nat(stfa.run(r)) }
             }
           body(natT).run(r)
@@ -519,7 +519,7 @@ object Concurrent {
         F.uncancelable { nat =>
           val natT: WriterT[F, L, *] ~> WriterT[F, L, *] =
             new ~>[WriterT[F, L, *], WriterT[F, L, *]] {
-              def apply[A](optfa: WriterT[F, L, A]): WriterT[F, L, A] = WriterT(nat(optfa.run))
+              def apply[B](optfa: WriterT[F, L, B]): WriterT[F, L, B] = WriterT(nat(optfa.run))
             }
           body(natT).run
         }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
@@ -158,9 +158,27 @@ object Concurrent {
 
   trait OptionTConcurrent[F[_], E] extends Concurrent[OptionT[F, *], E] {
 
+    val nat: F ~> OptionT[F, *] = new ~>[F, OptionT[F, *]] {
+      def apply[A](fa: F[A]): OptionT[F, A] = OptionT.liftF(fa)
+    }
+
     implicit protected def F: Concurrent[F, E]
 
-    def start[A](fa: OptionT[F, A]): OptionT[F, Fiber[OptionT[F, *], E, A]] = ???
+    def start[A](fa: OptionT[F, A]): OptionT[F, Fiber[OptionT[F, *], E, A]] =
+      OptionT.liftF(F.start(fa.value).map { fib =>
+        new Fiber[OptionT[F, *], E, A] {
+          def cancel: OptionT[F, Unit] = OptionT.liftF(fib.cancel)
+          def join: OptionT[F, Outcome[OptionT[F, *], E, A]] =
+            OptionT.liftF(for {
+              o <- fib.join
+              res: Outcome[OptionT[F, *], E, A] = o match {
+                case Outcome.Canceled() => Outcome.Canceled()
+                case Outcome.Errored(e) => Outcome.Errored(e)
+                case Outcome.Completed(foa) => Outcome.Completed(OptionT(foa))
+              }
+            } yield res)
+        }
+      })
 
     def uncancelable[A](
         body: (OptionT[F, *] ~> OptionT[F, *]) => OptionT[F, A]): OptionT[F, A] = ???

--- a/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
@@ -17,7 +17,7 @@
 package cats.effect.kernel
 
 import cats.{~>, MonadError}
-import cats.data.OptionT
+import cats.data.{OptionT, EitherT}
 import cats.syntax.all._
 
 trait Fiber[F[_], E, A] {
@@ -162,6 +162,12 @@ object Concurrent {
       override implicit protected def F: Concurrent[F, E] = F0
     }
 
+  implicit def concurrentForEitherT[F[_], E0, E](
+      implicit F0: Concurrent[F, E]): Concurrent[EitherT[F, E0, *], E] =
+    new EitherTConcurrent[F, E0, E] {
+      override implicit protected def F: Concurrent[F, E] = F0
+    }
+
   trait OptionTConcurrent[F[_], E] extends Concurrent[OptionT[F, *], E] {
 
     implicit protected def F: Concurrent[F, E]
@@ -227,6 +233,75 @@ object Concurrent {
         def cancel: OptionT[F, Unit] = OptionT.liftF(fib.cancel)
         def join: OptionT[F, Outcome[OptionT[F, *], E, A]] =
           OptionT.liftF(fib.join.map(liftOutcome))
+      }
+  }
+
+  trait EitherTConcurrent[F[_], E0, E] extends Concurrent[EitherT[F, E0, *], E] {
+
+    implicit protected def F: Concurrent[F, E]
+
+    val delegate = EitherT.catsDataMonadErrorFForEitherT[F, E, E0]
+
+    def start[A](fa: EitherT[F, E0, A]): EitherT[F, E0, Fiber[EitherT[F, E0, *], E, A]] =
+      EitherT.liftF(F.start(fa.value).map(liftFiber))
+
+    def uncancelable[A](
+        body: (EitherT[F, E0, *] ~> EitherT[F, E0, *]) => EitherT[F, E0, A]): EitherT[F, E0, A] =
+      EitherT(
+        F.uncancelable { nat =>
+          val natT: EitherT[F, E0, *] ~> EitherT[F, E0, *] = new ~>[EitherT[F, E0, *], EitherT[F, E0, *]] {
+            def apply[A](optfa: EitherT[F, E0, A]): EitherT[F, E0, A] = EitherT(nat(optfa.value))
+          }
+          body(natT).value
+        }
+      )
+
+    def canceled: EitherT[F, E0, Unit] = EitherT.liftF(F.canceled)
+
+    def onCancel[A](fa: EitherT[F, E0, A], fin: EitherT[F, E0, Unit]): EitherT[F, E0, A] =
+      EitherT(F.onCancel(fa.value, fin.value.as(())))
+
+    def never[A]: EitherT[F, E0, A] = EitherT.liftF(F.never)
+
+    def cede: EitherT[F, E0, Unit] = EitherT.liftF(F.cede)
+
+    def racePair[A, B](fa: EitherT[F, E0, A], fb: EitherT[F, E0, B]): EitherT[
+      F,
+      E0,
+      Either[
+        (Outcome[EitherT[F, E0, *], E, A], Fiber[EitherT[F, E0, *], E, B]),
+        (Fiber[EitherT[F, E0, *], E, A], Outcome[EitherT[F, E0, *], E, B])]] = {
+      EitherT.liftF(F.racePair(fa.value, fb.value).map {
+        case Left((oc, fib)) => Left((liftOutcome(oc), liftFiber(fib)))
+        case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
+      })
+    }
+
+    def pure[A](a: A): EitherT[F, E0, A] = delegate.pure(a)
+
+    def raiseError[A](e: E): EitherT[F, E0, A] = delegate.raiseError(e)
+
+    def handleErrorWith[A](fa: EitherT[F, E0, A])(f: E => EitherT[F, E0, A]): EitherT[F, E0, A] =
+      delegate.handleErrorWith(fa)(f)
+
+    def flatMap[A, B](fa: EitherT[F, E0, A])(f: A => EitherT[F, E0, B]): EitherT[F, E0, B] =
+      delegate.flatMap(fa)(f)
+
+    def tailRecM[A, B](a: A)(f: A => EitherT[F, E0, Either[A, B]]): EitherT[F, E0, B] =
+      delegate.tailRecM(a)(f)
+
+    def liftOutcome[A](oc: Outcome[F, E, Either[E0, A]]): Outcome[EitherT[F, E0, *], E, A] =
+      oc match {
+        case Outcome.Canceled() => Outcome.Canceled()
+        case Outcome.Errored(e) => Outcome.Errored(e)
+        case Outcome.Completed(foa) => Outcome.Completed(EitherT(foa))
+      }
+
+    def liftFiber[A](fib: Fiber[F, E, Either[E0, A]]): Fiber[EitherT[F, E0, *], E, A] =
+      new Fiber[EitherT[F, E0, *], E, A] {
+        def cancel: EitherT[F, E0, Unit] = EitherT.liftF(fib.cancel)
+        def join: EitherT[F, E0, Outcome[EitherT[F, E0, *], E, A]] =
+          EitherT.liftF(fib.join.map(liftOutcome))
       }
   }
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
@@ -17,7 +17,7 @@
 package cats.effect.kernel
 
 import cats.{~>, MonadError}
-import cats.data.{EitherT, Ior, IorT, OptionT}
+import cats.data.{EitherT, Ior, IorT, OptionT, Kleisli}
 import cats.Semigroup
 import cats.syntax.all._
 
@@ -169,6 +169,12 @@ object Concurrent {
       override implicit protected def F: Concurrent[F, E] = F0
     }
 
+  implicit def concurrentForKleisli[F[_], R, E](
+      implicit F0: Concurrent[F, E]): Concurrent[Kleisli[F, R, *], E] =
+    new KleisliConcurrent[F, R, E] {
+      override implicit protected def F: Concurrent[F, E] = F0
+    }
+
   implicit def concurrentForIorT[F[_], L, E](
       implicit F0: Concurrent[F, E],
       L0: Semigroup[L]): Concurrent[IorT[F, L, *], E] =
@@ -201,7 +207,7 @@ object Concurrent {
     def canceled: OptionT[F, Unit] = OptionT.liftF(F.canceled)
 
     def onCancel[A](fa: OptionT[F, A], fin: OptionT[F, Unit]): OptionT[F, A] =
-      OptionT(F.onCancel(fa.value, fin.value.as(())))
+      OptionT(F.onCancel(fa.value, fin.value.void))
 
     def never[A]: OptionT[F, A] = OptionT.liftF(F.never)
 
@@ -271,7 +277,7 @@ object Concurrent {
     def canceled: EitherT[F, E0, Unit] = EitherT.liftF(F.canceled)
 
     def onCancel[A](fa: EitherT[F, E0, A], fin: EitherT[F, E0, Unit]): EitherT[F, E0, A] =
-      EitherT(F.onCancel(fa.value, fin.value.as(())))
+      EitherT(F.onCancel(fa.value, fin.value.void))
 
     def never[A]: EitherT[F, E0, A] = EitherT.liftF(F.never)
 
@@ -317,6 +323,7 @@ object Concurrent {
           EitherT.liftF(fib.join.map(liftOutcome))
       }
   }
+
   trait IorTConcurrent[F[_], L, E] extends Concurrent[IorT[F, L, *], E] {
 
     implicit protected def F: Concurrent[F, E]
@@ -342,7 +349,7 @@ object Concurrent {
     def canceled: IorT[F, L, Unit] = IorT.liftF(F.canceled)
 
     def onCancel[A](fa: IorT[F, L, A], fin: IorT[F, L, Unit]): IorT[F, L, A] =
-      IorT(F.onCancel(fa.value, fin.value.as(())))
+      IorT(F.onCancel(fa.value, fin.value.void))
 
     def never[A]: IorT[F, L, A] = IorT.liftF(F.never)
 
@@ -385,6 +392,82 @@ object Concurrent {
         def cancel: IorT[F, L, Unit] = IorT.liftF(fib.cancel)
         def join: IorT[F, L, Outcome[IorT[F, L, *], E, A]] =
           IorT.liftF(fib.join.map(liftOutcome))
+      }
+  }
+
+  trait KleisliConcurrent[F[_], R, E] extends Concurrent[Kleisli[F, R, *], E] {
+
+    implicit protected def F: Concurrent[F, E]
+
+    val delegate = Kleisli.catsDataMonadErrorForKleisli[F, R, E]
+
+    def start[A](fa: Kleisli[F, R, A]): Kleisli[F, R, Fiber[Kleisli[F, R, *], E, A]] =
+      Kleisli { r =>
+        (F.start(fa.run(r)).map(liftFiber))
+      }
+
+    def uncancelable[A](
+        body: (Kleisli[F, R, *] ~> Kleisli[F, R, *]) => Kleisli[F, R, A]): Kleisli[F, R, A] =
+      Kleisli{ r =>
+        F.uncancelable { nat =>
+          val natT: Kleisli[F, R, *] ~> Kleisli[F, R, *] = new ~>[Kleisli[F, R, *], Kleisli[F, R, *]] {
+            def apply[A](stfa: Kleisli[F, R, A]): Kleisli[F, R, A] = Kleisli { r =>
+              nat(stfa.run(r))
+            }
+          }
+          body(natT).run(r)
+        }
+      }
+
+    def canceled: Kleisli[F, R, Unit] = Kleisli.liftF(F.canceled)
+
+    def onCancel[A](fa: Kleisli[F, R, A], fin: Kleisli[F, R, Unit]): Kleisli[F, R, A] =
+      Kleisli{ r =>
+        F.onCancel(fa.run(r), fin.run(r))
+      }
+
+    def never[A]: Kleisli[F, R, A] = Kleisli.liftF(F.never)
+
+    def cede: Kleisli[F, R, Unit] = Kleisli.liftF(F.cede)
+
+    def racePair[A, B](fa: Kleisli[F, R, A], fb: Kleisli[F, R, B]): Kleisli[
+      F,
+      R,
+      Either[
+        (Outcome[Kleisli[F, R, *], E, A], Fiber[Kleisli[F, R, *], E, B]),
+        (Fiber[Kleisli[F, R, *], E, A], Outcome[Kleisli[F, R, *], E, B])]] = {
+      Kleisli { r =>
+        (F.racePair(fa.run(r), fb.run(r)).map {
+        case Left((oc, fib)) => Left((liftOutcome(oc), liftFiber(fib)))
+        case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
+      })
+      }
+    }
+
+    def pure[A](a: A): Kleisli[F, R, A] = delegate.pure(a)
+
+    def raiseError[A](e: E): Kleisli[F, R, A] = delegate.raiseError(e)
+
+    def handleErrorWith[A](fa: Kleisli[F, R, A])(f: E => Kleisli[F, R, A]): Kleisli[F, R, A] =
+      delegate.handleErrorWith(fa)(f)
+
+    def flatMap[A, B](fa: Kleisli[F, R, A])(f: A => Kleisli[F, R, B]): Kleisli[F, R, B] =
+      delegate.flatMap(fa)(f)
+
+    def tailRecM[A, B](a: A)(f: A => Kleisli[F, R, Either[A, B]]): Kleisli[F, R, B] =
+      delegate.tailRecM(a)(f)
+
+    def liftOutcome[A](oc: Outcome[F, E, A]): Outcome[Kleisli[F, R, *], E, A] = oc.mapK(nat)
+
+    val nat: F ~> Kleisli[F, R, *] = new ~>[F, Kleisli[F, R, *]] {
+      def apply[A](fa: F[A]) = Kleisli.liftF(fa)
+    }
+
+    def liftFiber[A](fib: Fiber[F, E, A]): Fiber[Kleisli[F, R, *], E, A] =
+      new Fiber[Kleisli[F, R, *], E, A] {
+        def cancel: Kleisli[F, R, Unit] = Kleisli.liftF(fib.cancel)
+        def join: Kleisli[F, R, Outcome[Kleisli[F, R, *], E, A]] =
+          Kleisli.liftF(fib.join.map(liftOutcome))
       }
   }
 }

--- a/laws/shared/src/test/scala/cats/effect/PureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/PureConcSpec.scala
@@ -17,8 +17,9 @@
 package cats.effect
 
 import cats.Show
+import cats.data.OptionT
 //import cats.laws.discipline.{AlignTests, ParallelTests}
-//import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.arbitrary._
 import cats.implicits._
 //import cats.effect.kernel.ParallelF
 import cats.effect.laws.ConcurrentTests
@@ -43,6 +44,11 @@ class PureConcSpec extends Specification with Discipline with ScalaCheck {
   checkAll(
     "PureConc",
     ConcurrentTests[PureConc[Int, *], Int].concurrent[Int, Int, Int]
+  ) /*(Parameters(seed = Some(Seed.fromBase64("OjD4TDlPxwCr-K-gZb-xyBOGeWMKx210V24VVhsJBLI=").get)))*/
+
+  checkAll(
+    "optionT[PureConc]",
+    ConcurrentTests[OptionT[PureConc[Int, *], *], Int].concurrent[Int, Int, Int]
   ) /*(Parameters(seed = Some(Seed.fromBase64("OjD4TDlPxwCr-K-gZb-xyBOGeWMKx210V24VVhsJBLI=").get)))*/
 
 //  checkAll("PureConc", ParallelTests[PureConc[Int, *]].parallel[Int, Int])

--- a/laws/shared/src/test/scala/cats/effect/PureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/PureConcSpec.scala
@@ -16,10 +16,11 @@
 
 package cats.effect
 
-import cats.Show
-import cats.data.{OptionT, EitherT, IorT}
+import cats.{Show, Eq}
+import cats.data.{OptionT, EitherT, IorT, Kleisli}
 //import cats.laws.discipline.{AlignTests, ParallelTests}
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.{eq, ExhaustiveCheck, MiniInt}; import eq._
 import cats.implicits._
 //import cats.effect.kernel.ParallelF
 import cats.effect.laws.ConcurrentTests
@@ -43,6 +44,10 @@ class PureConcSpec extends Specification with Discipline with ScalaCheck {
   implicit def prettyFromShow[A: Show](a: A): Pretty =
     Pretty.prettyString(a.show)
 
+
+  implicit def kleisliEq[F[_], A, B](implicit ev: Eq[A => F[B]]): Eq[Kleisli[F, A, B]] =
+    Eq.by[Kleisli[F, A, B], A => F[B]](_.run)
+
   checkAll(
     "PureConc",
     ConcurrentTests[PureConc[Int, *], Int].concurrent[Int, Int, Int]
@@ -63,6 +68,12 @@ class PureConcSpec extends Specification with Discipline with ScalaCheck {
   checkAll(
     "IorT[PureConc]",
     ConcurrentTests[IorT[PureConc[Int, *], Int, *], Int].concurrent[Int, Int, Int]
+  // ) (Parameters(seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get)))
+  )
+
+  checkAll(
+    "Kleisli[PureConc]",
+    ConcurrentTests[Kleisli[PureConc[Int, *], MiniInt, *], Int].concurrent[Int, Int, Int]
   // ) (Parameters(seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get)))
   )
 

--- a/laws/shared/src/test/scala/cats/effect/PureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/PureConcSpec.scala
@@ -16,26 +16,24 @@
 
 package cats.effect
 
-import cats.{Show, Eq}
-import cats.data.{OptionT, EitherT, IorT, Kleisli}
+import cats.{Eq, Show}
+import cats.data.{EitherT, IorT, Kleisli, OptionT, WriterT}
 //import cats.laws.discipline.{AlignTests, ParallelTests}
 import cats.laws.discipline.arbitrary._
-import cats.laws.discipline.{eq, ExhaustiveCheck, MiniInt}; import eq._
+import cats.laws.discipline.{eq, MiniInt}; import eq._
 import cats.implicits._
 //import cats.effect.kernel.ParallelF
 import cats.effect.laws.ConcurrentTests
 import cats.effect.testkit.{pure, PureConcGenerators}, pure._
 
-import org.scalacheck.rng.Seed
+// import org.scalacheck.rng.Seed
 import org.scalacheck.util.Pretty
 
 import org.specs2.ScalaCheck
-import org.specs2.scalacheck.Parameters
+// import org.specs2.scalacheck.Parameters
 import org.specs2.mutable._
-import org.scalacheck.Prop
 
 import org.typelevel.discipline.specs2.mutable.Discipline
-import cats.effect.laws.ConcurrentLaws
 
 class PureConcSpec extends Specification with Discipline with ScalaCheck {
   import PureConcGenerators._
@@ -43,7 +41,6 @@ class PureConcSpec extends Specification with Discipline with ScalaCheck {
 
   implicit def prettyFromShow[A: Show](a: A): Pretty =
     Pretty.prettyString(a.show)
-
 
   implicit def kleisliEq[F[_], A, B](implicit ev: Eq[A => F[B]]): Eq[Kleisli[F, A, B]] =
     Eq.by[Kleisli[F, A, B], A => F[B]](_.run)
@@ -56,25 +53,31 @@ class PureConcSpec extends Specification with Discipline with ScalaCheck {
   checkAll(
     "OptionT[PureConc]",
     ConcurrentTests[OptionT[PureConc[Int, *], *], Int].concurrent[Int, Int, Int]
-  // ) (Parameters(seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get)))
+    // ) (Parameters(seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get)))
   )
 
   checkAll(
     "EitherT[PureConc]",
     ConcurrentTests[EitherT[PureConc[Int, *], Int, *], Int].concurrent[Int, Int, Int]
-  // ) (Parameters(seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get)))
+    // ) (Parameters(seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get)))
   )
 
   checkAll(
     "IorT[PureConc]",
     ConcurrentTests[IorT[PureConc[Int, *], Int, *], Int].concurrent[Int, Int, Int]
-  // ) (Parameters(seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get)))
+    // ) (Parameters(seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get)))
   )
 
   checkAll(
     "Kleisli[PureConc]",
     ConcurrentTests[Kleisli[PureConc[Int, *], MiniInt, *], Int].concurrent[Int, Int, Int]
-  // ) (Parameters(seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get)))
+    // ) (Parameters(seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get)))
+  )
+
+  checkAll(
+    "WriterT[PureConc]",
+    ConcurrentTests[WriterT[PureConc[Int, *], Int, *], Int].concurrent[Int, Int, Int]
+    // ) (Parameters(seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get)))
   )
 
 //  checkAll("PureConc", ParallelTests[PureConc[Int, *]].parallel[Int, Int])

--- a/laws/shared/src/test/scala/cats/effect/PureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/PureConcSpec.scala
@@ -17,7 +17,7 @@
 package cats.effect
 
 import cats.Show
-import cats.data.{OptionT, EitherT}
+import cats.data.{OptionT, EitherT, IorT}
 //import cats.laws.discipline.{AlignTests, ParallelTests}
 import cats.laws.discipline.arbitrary._
 import cats.implicits._
@@ -57,6 +57,12 @@ class PureConcSpec extends Specification with Discipline with ScalaCheck {
   checkAll(
     "EitherT[PureConc]",
     ConcurrentTests[EitherT[PureConc[Int, *], Int, *], Int].concurrent[Int, Int, Int]
+  // ) (Parameters(seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get)))
+  )
+
+  checkAll(
+    "IorT[PureConc]",
+    ConcurrentTests[IorT[PureConc[Int, *], Int, *], Int].concurrent[Int, Int, Int]
   // ) (Parameters(seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get)))
   )
 

--- a/laws/shared/src/test/scala/cats/effect/PureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/PureConcSpec.scala
@@ -17,7 +17,7 @@
 package cats.effect
 
 import cats.Show
-import cats.data.OptionT
+import cats.data.{OptionT, EitherT}
 //import cats.laws.discipline.{AlignTests, ParallelTests}
 import cats.laws.discipline.arbitrary._
 import cats.implicits._
@@ -25,14 +25,16 @@ import cats.implicits._
 import cats.effect.laws.ConcurrentTests
 import cats.effect.testkit.{pure, PureConcGenerators}, pure._
 
-// import org.scalacheck.rng.Seed
+import org.scalacheck.rng.Seed
 import org.scalacheck.util.Pretty
 
 import org.specs2.ScalaCheck
-// import org.specs2.scalacheck.Parameters
+import org.specs2.scalacheck.Parameters
 import org.specs2.mutable._
+import org.scalacheck.Prop
 
 import org.typelevel.discipline.specs2.mutable.Discipline
+import cats.effect.laws.ConcurrentLaws
 
 class PureConcSpec extends Specification with Discipline with ScalaCheck {
   import PureConcGenerators._
@@ -47,9 +49,16 @@ class PureConcSpec extends Specification with Discipline with ScalaCheck {
   ) /*(Parameters(seed = Some(Seed.fromBase64("OjD4TDlPxwCr-K-gZb-xyBOGeWMKx210V24VVhsJBLI=").get)))*/
 
   checkAll(
-    "optionT[PureConc]",
+    "OptionT[PureConc]",
     ConcurrentTests[OptionT[PureConc[Int, *], *], Int].concurrent[Int, Int, Int]
-  ) /*(Parameters(seed = Some(Seed.fromBase64("OjD4TDlPxwCr-K-gZb-xyBOGeWMKx210V24VVhsJBLI=").get)))*/
+  // ) (Parameters(seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get)))
+  )
+
+  checkAll(
+    "EitherT[PureConc]",
+    ConcurrentTests[EitherT[PureConc[Int, *], Int, *], Int].concurrent[Int, Int, Int]
+  // ) (Parameters(seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get)))
+  )
 
 //  checkAll("PureConc", ParallelTests[PureConc[Int, *]].parallel[Int, Int])
 


### PR DESCRIPTION
Note that we have not defined instances for `StateT` or `ReaderWriterStateT` as they are fundamentally sequential and `Concurrent` is (oddly enough) fundamentally concurrent.

There's also no instance for `ContT` for the moment as there is currently no `MonadError` instance for it (undecided whether that is fundamental or not)