### PR TITLE
Added Concurrent#forceR and associated laws

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Effect.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Effect.scala
@@ -20,6 +20,10 @@ import cats.~>
 
 trait Effect[F[_]] extends Async[F] {
 
+  // this is implied by parametricity
+  def forceR[A, B](fa: F[A])(fb: F[B]): F[B] =
+    productR(attempt(fa))(fb)
+
   def to[G[_]]: PartiallyApplied[G] =
     new PartiallyApplied[G]
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/concurrent.scala
@@ -32,6 +32,9 @@ trait Fiber[F[_], E, A] {
 
 trait Concurrent[F[_], E] extends MonadError[F, E] {
 
+  // analogous to productR, except discarding short-circuiting (and optionally some effect contexts) except for cancelation
+  def forceR[A, B](fa: F[A])(fb: F[B]): F[B]
+
   def start[A](fa: F[A]): F[Fiber[F, E, A]]
 
   def uncancelable[A](body: (F ~> F) => F[A]): F[A]

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/ConcurrentSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/ConcurrentSyntax.scala
@@ -28,6 +28,12 @@ trait ConcurrentSyntax {
 
 final class ConcurrentOps[F[_], A, E](val wrapped: F[A]) extends AnyVal {
 
+  def forceR[B](fb: F[B])(implicit F: Concurrent[F, E]): F[B] =
+    F.forceR(wrapped)(fb)
+
+  def !>[B](fb: F[B])(implicit F: Concurrent[F, E]): F[B] =
+    forceR(fb)
+
   def start(implicit F: Concurrent[F, E]): F[Fiber[F, E, A]] = F.start(wrapped)
 
   def uncancelable(implicit F: Concurrent[F, E]): F[A] =

--- a/laws/shared/src/main/scala/cats/effect/laws/ConcurrentTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ConcurrentTests.scala
@@ -105,7 +105,11 @@ trait ConcurrentTests[F[_], E] extends MonadErrorTests[F, E] {
           laws.canceledAssociatesLeftOverFlatMap[A] _),
         "canceled sequences onCancel in order" -> forAll(
           laws.canceledSequencesOnCancelInOrder _),
-        "uncancelable eliminates onCancel" -> forAll(laws.uncancelableEliminatesOnCancel[A] _)
+        "uncancelable eliminates onCancel" -> forAll(laws.uncancelableEliminatesOnCancel[A] _),
+        "forceR discards pure" -> forAll(laws.forceRDiscardsPure[A, B] _),
+        "forceR discards error" -> forAll(laws.forceRDiscardsError[A] _),
+        "forceR canceled short-circuits" -> forAll(laws.forceRCanceledShortCircuits[A] _),
+        "forceR never is never" -> forAll(laws.forceRNeverIsNever[A] _)
       )
     }
   }

--- a/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/EffectLaws.scala
@@ -22,6 +22,9 @@ import cats.effect.kernel.Effect
 trait EffectLaws[F[_]] extends AsyncLaws[F] {
   implicit val F: Effect[F]
 
+  def forceRIsProductRAttempt[A, B](fa: F[A], fb: F[B]) =
+    F.forceR(fa)(fb) <-> F.productR(F.attempt(fa))(fb)
+
   def roundTrip[A](fa: F[A]) =
     F.to[F](fa) <-> fa
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/EffectTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/EffectTests.scala
@@ -79,7 +79,9 @@ trait EffectTests[F[_]] extends AsyncTests[F] {
       val bases = Nil
       val parents = Seq(async[A, B, C](tolerance))
 
-      val props = Seq("round trip" -> forAll(laws.roundTrip[A] _))
+      val props = Seq(
+        "forceR is productR . attempt" -> forAll(laws.forceRIsProductRAttempt[A, B] _),
+        "round trip" -> forAll(laws.roundTrip[A] _))
     }
   }
 }

--- a/testkit/shared/src/main/scala/cats/effect/testkit/TimeT.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/TimeT.scala
@@ -128,6 +128,9 @@ object TimeT {
         }
       }
 
+    def forceR[A, B](fa: TimeT[F, A])(fb: TimeT[F, B]): TimeT[F, B] =
+      Kleisli(time => F.forceR(fa.run(time))(fb.run(time)))
+
     def flatMap[A, B](fa: TimeT[F, A])(f: A => TimeT[F, B]): TimeT[F, B] =
       fa.flatMap(f)
 

--- a/testkit/shared/src/main/scala/cats/effect/testkit/freeEval.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/freeEval.scala
@@ -35,7 +35,7 @@ object freeEval {
       implicit F: MonadError[F, Throwable]): Sync[FreeT[Eval, F, *]] =
     new Sync[FreeT[Eval, F, *]] {
       private[this] val M: MonadError[FreeT[Eval, F, *], Throwable] =
-        cats.effect.testkit.pure.catsFreeMonadErrorForFreeT2
+        FreeT.catsFreeMonadErrorForFreeT2
 
       def pure[A](x: A): FreeT[Eval, F, A] =
         M.pure(x)


### PR DESCRIPTION
This is tricky! Basically, `forceR` is almost the same thing as `productR`, except that it only short-circuits for cancelation. This is extremely important for laws, and can also be helpful for generic code that needs to guarantee sequencing even when the parametric monadic context has some internal notion of short-circuiting. An example of where this is relevant from the laws:

```scala
type F[A] = OptionT[IO, A]
val F = Concurrent[F]

F.uncancelable(_ => F.canceled >> OptionT.none) === (OptionT.none >> F.canceled)
```

Unfortunately, this rewrite doesn't work at all, because `none` short-circuits. Thus, we use `forceR` instead (which has been given the `!>` infix syntax):

```scala
F.uncancelable(_ => F.canceled >> OptionT.none) === (OptionT.none !> F.canceled)
```

And now this passes. Note that `forceR` is unconstrained by `productR`/`flatMap` in most cases, and so is also allowed to do things like dropping an effect context (e.g. `StateT.set` inside of an `onCancel`).