### PR TITLE
Fix tryAcquireN when available permits == acquired permits

### DIFF
--- a/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
@@ -214,7 +214,7 @@ object Semaphore {
           state
             .modify { old =>
               val (newState, result) = old match {
-                case Right(m) if m >= n => (Right(m - n), m != n)
+                case Right(m) if m >= n => (Right(m - n), true)
                 case _                  => (old, false)
               }
               (newState, result)

--- a/core/shared/src/test/scala/cats/effect/concurrent/SemaphoreTests.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/SemaphoreTests.scala
@@ -94,6 +94,18 @@ class SemaphoreTests extends AsyncFunSuite with Matchers with EitherValues {
         .map(_ shouldBe false)
     }
 
+    test(s"$label - tryAcquireN all available permits") {
+      val n = 20
+      sc(20)
+        .flatMap { s =>
+          for {
+            t <- s.tryAcquireN(n.toLong)
+          } yield t
+        }
+        .unsafeToFuture()
+        .map(_ shouldBe true)
+    }
+
     test(s"$label - offsetting acquires/releases - acquires parallel with releases") {
       testOffsettingReleasesAcquires((s, permits) => permits.traverse(s.acquireN).void,
                                      (s, permits) => permits.reverse.traverse(s.releaseN).void)


### PR DESCRIPTION
The `tryAcquireN` implementation would return `false` if a caller attempted to acquire all available permits successfully.

This needs to be ported to `series/3.x` as well.