### PR TITLE
Removed racePair from PureConc generators (for the same reason as IO)

### DIFF
--- a/laws/shared/src/test/scala/cats/effect/FreeSyncSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/FreeSyncSpec.scala
@@ -24,7 +24,7 @@ import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.{eq, MiniInt}; import eq._
 import cats.effect.testkit.{freeEval, FreeSyncGenerators, SyncTypeGenerators}
 import cats.effect.testkit.FreeSyncEq
-import freeEval.{FreeEitherSync, syncForFreeT}
+import freeEval.{syncForFreeT, FreeEitherSync}
 import cats.implicits._
 
 import org.scalacheck.Prop
@@ -35,7 +35,12 @@ import org.specs2.mutable._
 
 import org.typelevel.discipline.specs2.mutable.Discipline
 
-class FreeSyncSpec extends Specification with Discipline with ScalaCheck with BaseSpec with LowPriorityImplicits {
+class FreeSyncSpec
+    extends Specification
+    with Discipline
+    with ScalaCheck
+    with BaseSpec
+    with LowPriorityImplicits {
   import FreeSyncGenerators._
   import SyncTypeGenerators._
 
@@ -48,11 +53,14 @@ class FreeSyncSpec extends Specification with Discipline with ScalaCheck with Ba
   implicit def exec(sbool: FreeEitherSync[Boolean]): Prop =
     run(sbool).fold(Prop.exception(_), b => if (b) Prop.proved else Prop.falsified)
 
-  implicit val scala_2_12_is_buggy: Eq[FreeT[Eval, Either[Throwable, *],Either[Int,Either[Throwable,Int]]]] =
+  implicit val scala_2_12_is_buggy
+      : Eq[FreeT[Eval, Either[Throwable, *], Either[Int, Either[Throwable, Int]]]] =
     eqFreeSync[Either[Throwable, *], Either[Int, Either[Throwable, Int]]]
 
-  implicit val like_really_buggy: Eq[EitherT[FreeT[Eval,Either[Throwable,*],*],Int,Either[Throwable,Int]]] =
-    EitherT.catsDataEqForEitherT[FreeT[Eval, Either[Throwable, *], *], Int, Either[Throwable, Int]]
+  implicit val like_really_buggy
+      : Eq[EitherT[FreeT[Eval, Either[Throwable, *], *], Int, Either[Throwable, Int]]] =
+    EitherT
+      .catsDataEqForEitherT[FreeT[Eval, Either[Throwable, *], *], Int, Either[Throwable, Int]]
 
   checkAll("FreeEitherSync", SyncTests[FreeEitherSync].sync[Int, Int, Int])
   checkAll("OptionT[FreeEitherSync]", SyncTests[OptionT[FreeEitherSync, *]].sync[Int, Int, Int])
@@ -75,6 +83,4 @@ class FreeSyncSpec extends Specification with Discipline with ScalaCheck with Ba
 }
 
 //See the explicitly summoned implicits above - scala 2.12 has weird divergent implicit expansion problems
-trait LowPriorityImplicits extends FreeSyncEq {
-
-}
+trait LowPriorityImplicits extends FreeSyncEq {}

--- a/testkit/shared/src/main/scala/cats/effect/testkit/PureConcGenerators.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/PureConcGenerators.scala
@@ -38,6 +38,13 @@ object PureConcGenerators {
 
       def cogenCase[A: Cogen]: Cogen[Outcome[PureConc[E, *], E, A]] =
         OutcomeGenerators.cogenOutcome[PureConc[E, *], E, A]
+
+      override def recursiveGen[B: Arbitrary: Cogen](deeper: GenK[PureConc[E, *]]) =
+        super
+          .recursiveGen[B](deeper)
+          .filterNot(
+            _._1 == "racePair"
+          ) // remove the racePair generator since it reifies nondeterminism, which cannot be law-tested
     }
 
   implicit def arbitraryPureConc[E: Arbitrary: Cogen, A: Arbitrary: Cogen]

--- a/testkit/shared/src/main/scala/cats/effect/testkit/pure.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/pure.scala
@@ -225,17 +225,6 @@ object pure {
           }
       }
 
-      /**
-       * Whereas `start` ignores the cancelability of the parent fiber
-       * when forking off the child, `racePair` inherits cancelability.
-       * Thus, `uncancelable(_ => race(fa, fb)) <-> race(uncancelable(_ => fa), uncancelable(_ => fb))`,
-       * while `uncancelable(_ => start(fa)) <-> start(fa)`.
-       *
-       * race(cede >> raiseError(e1), raiseError(e2)) <-> raiseError(e1)
-       * race(raiseError(e1), cede >> raiseError(e2)) <-> raiseError(e2)
-       * race(canceled, raiseError(e)) <-> raiseError(e)
-       * race(raiseError(e), canceled) <-> raiseError(e)
-       */
       def racePair[A, B](fa: PureConc[E, A], fb: PureConc[E, B]): PureConc[
         E,
         Either[


### PR DESCRIPTION
Fixes #986 

I wrote a long comment on that issue, explaining the problem, but basically `racePair` is a really serious problem in general. It makes it possible to have `F[A]` values which are potentially unequal to themselves. It's not clear to me that this is even rational, but I'm also not sure how to avoid it.