### PR TITLE
It...works?

### DIFF
--- a/laws/shared/src/test/scala/cats/effect/FreeSyncSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/FreeSyncSpec.scala
@@ -24,7 +24,7 @@ import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.{eq, MiniInt}; import eq._
 import cats.effect.testkit.{freeEval, FreeSyncGenerators, SyncTypeGenerators}
 import cats.effect.testkit.FreeSyncEq
-import freeEval.{FreeEitherSync, syncForFreeT}
+import freeEval.{syncForFreeT, FreeEitherSync}
 import cats.implicits._
 
 import org.scalacheck.Prop
@@ -35,7 +35,12 @@ import org.specs2.mutable._
 
 import org.typelevel.discipline.specs2.mutable.Discipline
 
-class FreeSyncSpec extends Specification with Discipline with ScalaCheck with BaseSpec with LowPriorityImplicits {
+class FreeSyncSpec
+    extends Specification
+    with Discipline
+    with ScalaCheck
+    with BaseSpec
+    with LowPriorityImplicits {
   import FreeSyncGenerators._
   import SyncTypeGenerators._
 
@@ -48,11 +53,14 @@ class FreeSyncSpec extends Specification with Discipline with ScalaCheck with Ba
   implicit def exec(sbool: FreeEitherSync[Boolean]): Prop =
     run(sbool).fold(Prop.exception(_), b => if (b) Prop.proved else Prop.falsified)
 
-  implicit val scala_2_12_is_buggy: Eq[FreeT[Eval, Either[Throwable, *],Either[Int,Either[Throwable,Int]]]] =
+  implicit val scala_2_12_is_buggy
+      : Eq[FreeT[Eval, Either[Throwable, *], Either[Int, Either[Throwable, Int]]]] =
     eqFreeSync[Either[Throwable, *], Either[Int, Either[Throwable, Int]]]
 
-  implicit val like_really_buggy: Eq[EitherT[FreeT[Eval,Either[Throwable,*],*],Int,Either[Throwable,Int]]] =
-    EitherT.catsDataEqForEitherT[FreeT[Eval, Either[Throwable, *], *], Int, Either[Throwable, Int]]
+  implicit val like_really_buggy
+      : Eq[EitherT[FreeT[Eval, Either[Throwable, *], *], Int, Either[Throwable, Int]]] =
+    EitherT
+      .catsDataEqForEitherT[FreeT[Eval, Either[Throwable, *], *], Int, Either[Throwable, Int]]
 
   checkAll("FreeEitherSync", SyncTests[FreeEitherSync].sync[Int, Int, Int])
   checkAll("OptionT[FreeEitherSync]", SyncTests[OptionT[FreeEitherSync, *]].sync[Int, Int, Int])
@@ -75,6 +83,4 @@ class FreeSyncSpec extends Specification with Discipline with ScalaCheck with Ba
 }
 
 //See the explicitly summoned implicits above - scala 2.12 has weird divergent implicit expansion problems
-trait LowPriorityImplicits extends FreeSyncEq {
-
-}
+trait LowPriorityImplicits extends FreeSyncEq {}

--- a/laws/shared/src/test/scala/cats/effect/TimeTSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/TimeTSpec.scala
@@ -18,12 +18,11 @@ package cats.effect.testkit
 
 import cats.{Eq, Order}
 import cats.data.Kleisli
-// import cats.effect.laws.TemporalBracketTests
-import cats.implicits._
-// import cats.laws.discipline.arbitrary._
+import cats.effect.laws.TemporalTests
+import cats.laws.discipline.arbitrary._
 
 import pure.PureConc
-// import TimeT._
+import TimeT._
 
 import org.specs2.ScalaCheck
 import org.specs2.mutable._
@@ -47,13 +46,12 @@ class TimeTSpec
     with Discipline
     with ScalaCheck
     with LowPriorityInstances {
-  // import OutcomeGenerators._
-  // import PureConcGenerators._
 
-  // TODO reenable when race in TimeT's Concurrent is fixed
-  /*checkAll(
+  import PureConcGenerators._
+
+  checkAll(
     "TimeT[PureConc, *]",
-    TemporalBracketTests[TimeT[PureConc[Int, *], *], Int].temporalBracket[Int, Int, Int](0.millis))*/
+    TemporalTests[TimeT[PureConc[Int, *], *], Int].temporal[Int, Int, Int](0.millis))
 
   implicit def exec(fb: TimeT[PureConc[Int, *], Boolean]): Prop =
     Prop(pure.run(TimeT.run(fb)).fold(false, _ => false, _.getOrElse(false)))


### PR DESCRIPTION
This reenables the `TimeT` law tests, which apparently just straight up run. I didn't touch the timeout stuff yet; just wanted to get this in. I don't understand why this is working, given that I didn't really fix `racePair`.