### PR TITLE
Read callback once before invoking

### DIFF
--- a/core/shared/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/shared/src/main/scala/cats/effect/CallbackStack.scala
@@ -40,8 +40,9 @@ private[effect] final class CallbackStack[A](private[this] var callback: Outcome
    */
   @tailrec
   def apply(oc: OutcomeIO[A]): Unit = {
-    if (callback != null) {
-      callback(oc)
+    val cb = callback
+    if (cb != null) {
+      cb(oc)
     }
 
     val next = get()


### PR DESCRIPTION
Here's another race condition that addresses half of the issue in #1008. There's a race condition between `join` and any event that completes joiners for a fiber.

In the implementation of `registerListener`, we make a double-check to see if `outcome` has been set. If we see that it has been set, we null the callback inside the `CallbackStack`.

However, observe the implementation of `CallbackStack.apply`:
```scala
@tailrec
  def apply(oc: OutcomeIO[A]): Unit = {
    if (callback != null) {
      callback(oc)
    }

    val next = get()
    if (next != null) {
      next(oc)
    }
  }
```
We read `callback` for the null check, and read it again if the null check passes. The Java memory model doesn't forbid non-volatile variables from being reloaded, so it's completely possible that the value might have changed between those calls. In particular, if in between the null check and the callback invocation, the above `join` behavior occurs, then `callback` will be null inside the `if` even though we passed the check.

The solution here is to read `callback` only once.

Failing test case over millions of iterations would observe a side-channel exception:
```scala
for {
      df <- Deferred[IO, Unit]
      fb <- df.get.start
      _ <- df.complete(())
      _ <- fb.join
    } yield ()
```