### PR TITLE
Resume fiber before initializing in exec

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -216,15 +216,16 @@ private[effect] final class IOFiber[A](
   }
 
   private[effect] def exec(cur: IO[Any], ec: ExecutionContext): Unit = {
-    conts = new ByteStack(16)
-    pushCont(RunTerminusK)
-
-    ctxs = new ArrayStack[ExecutionContext](2)
-    currentCtx = ec
-    ctxs.push(ec)
-
     if (resume()) {
-//      println(s"$name: starting at ${Thread.currentThread().getName} + ${suspended.get()}")
+      //      println(s"$name: starting at ${Thread.currentThread().getName} + ${suspended.get()}")
+
+      conts = new ByteStack(16)
+      pushCont(RunTerminusK)
+
+      ctxs = new ArrayStack[ExecutionContext](2)
+      currentCtx = ec
+      ctxs.push(ec)
+
       runLoop(cur, 0)
     }
   }

--- a/laws/shared/src/test/scala/cats/effect/FreeSyncSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/FreeSyncSpec.scala
@@ -24,7 +24,7 @@ import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.{eq, MiniInt}; import eq._
 import cats.effect.testkit.{freeEval, FreeSyncGenerators, SyncTypeGenerators}
 import cats.effect.testkit.FreeSyncEq
-import freeEval.{FreeEitherSync, syncForFreeT}
+import freeEval.{syncForFreeT, FreeEitherSync}
 import cats.implicits._
 
 import org.scalacheck.Prop
@@ -35,7 +35,12 @@ import org.specs2.mutable._
 
 import org.typelevel.discipline.specs2.mutable.Discipline
 
-class FreeSyncSpec extends Specification with Discipline with ScalaCheck with BaseSpec with LowPriorityImplicits {
+class FreeSyncSpec
+    extends Specification
+    with Discipline
+    with ScalaCheck
+    with BaseSpec
+    with LowPriorityImplicits {
   import FreeSyncGenerators._
   import SyncTypeGenerators._
 
@@ -48,11 +53,14 @@ class FreeSyncSpec extends Specification with Discipline with ScalaCheck with Ba
   implicit def exec(sbool: FreeEitherSync[Boolean]): Prop =
     run(sbool).fold(Prop.exception(_), b => if (b) Prop.proved else Prop.falsified)
 
-  implicit val scala_2_12_is_buggy: Eq[FreeT[Eval, Either[Throwable, *],Either[Int,Either[Throwable,Int]]]] =
+  implicit val scala_2_12_is_buggy
+      : Eq[FreeT[Eval, Either[Throwable, *], Either[Int, Either[Throwable, Int]]]] =
     eqFreeSync[Either[Throwable, *], Either[Int, Either[Throwable, Int]]]
 
-  implicit val like_really_buggy: Eq[EitherT[FreeT[Eval,Either[Throwable,*],*],Int,Either[Throwable,Int]]] =
-    EitherT.catsDataEqForEitherT[FreeT[Eval, Either[Throwable, *], *], Int, Either[Throwable, Int]]
+  implicit val like_really_buggy
+      : Eq[EitherT[FreeT[Eval, Either[Throwable, *], *], Int, Either[Throwable, Int]]] =
+    EitherT
+      .catsDataEqForEitherT[FreeT[Eval, Either[Throwable, *], *], Int, Either[Throwable, Int]]
 
   checkAll("FreeEitherSync", SyncTests[FreeEitherSync].sync[Int, Int, Int])
   checkAll("OptionT[FreeEitherSync]", SyncTests[OptionT[FreeEitherSync, *]].sync[Int, Int, Int])
@@ -75,6 +83,4 @@ class FreeSyncSpec extends Specification with Discipline with ScalaCheck with Ba
 }
 
 //See the explicitly summoned implicits above - scala 2.12 has weird divergent implicit expansion problems
-trait LowPriorityImplicits extends FreeSyncEq {
-
-}
+trait LowPriorityImplicits extends FreeSyncEq {}


### PR DESCRIPTION
This PR addresses the other half of #1008 , particularly when `ByteStack` operations would throw a `NPE`. The race condition manifests when a fiber starts concurrently with its own cancellation. 

```scala
private[effect] def exec(cur: IO[Any], ec: ExecutionContext): Unit = {
    conts = new ByteStack(16)
    pushCont(RunTerminusK)

    ctxs = new ArrayStack[ExecutionContext](2)
    currentCtx = ec
    ctxs.push(ec)

    if (resume()) {
//      println(s"$name: starting at ${Thread.currentThread().getName} + ${suspended.get()}")
      runLoop(cur, 0)
    }
  }
```

It would initialize `conts` and then push the `RunTerminusK` continuation to it. However, between the execution of these two instructions, the fiber could be cancelled, setting `conts` to `null`. Same memory model rules apply here as in #1012 . We should try to acquire the runloop *before* running any initialization actions.