### PR TITLE
Reset cancel effect at done

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -142,7 +142,6 @@ private[effect] final class IOFiber[A](
   var cancel: IO[Unit] = IO uncancelable { _ =>
     IO defer {
       canceled = true
-      cancel = IO.unit
 
 //      println(s"${name}: attempting cancellation")
 
@@ -241,6 +240,7 @@ private[effect] final class IOFiber[A](
   private[this] def done(oc: OutcomeIO[A]): Unit = {
 //     println(s"<$name> invoking done($oc); callback = ${callback.get()}")
     join = IO.pure(oc)
+    cancel = IO.unit
 
     outcome.set(oc)
 


### PR DESCRIPTION
The intended semantics for cancellation dictate that the first canceller of a fiber should backpressure subsequent cancellers until finalization is complete. The `cancel` effect was previously reset right at the beginning of `cancel`, so if that write was propagated to another thread before it attempted cancellation, they would return immediately.