### PR TITLE
wip: separate typeclasses for creating concurrent data structures

### DIFF
--- a/concurrent/shared/src/main/scala/cats/effect/concurrent/Ref.scala
+++ b/concurrent/shared/src/main/scala/cats/effect/concurrent/Ref.scala
@@ -160,7 +160,7 @@ object Ref {
    *
    * @see [[of]]
    */
-  def apply[F[_]](implicit F: Sync[F]): ApplyBuilders[F] = new ApplyBuilders(F)
+  def apply[F[_]](implicit mk: Mk[F]): ApplyBuilders[F] = new ApplyBuilders(mk)
 
   /**
    * Creates an asynchronous, concurrent mutable reference initialized to the supplied value.
@@ -175,14 +175,26 @@ object Ref {
    *   } yield ten
    * }}}
    */
-  def of[F[_], A](a: A)(implicit F: Sync[F]): F[Ref[F, A]] = F.delay(unsafe(a))
+  def of[F[_], A](a: A)(implicit mk: Mk[F]): F[Ref[F, A]] = mk.refOf(a)
 
   /**
    *  Builds a `Ref` value for data types that are [[Sync]]
    *  Like [[of]] but initializes state using another effect constructor
    */
-  def in[F[_], G[_], A](a: A)(implicit F: Sync[F], G: Sync[G]): F[Ref[G, A]] =
-    F.delay(unsafe(a))
+  def in[F[_], G[_], A](a: A)(implicit mk: MkIn[F, G]): F[Ref[G, A]] = mk.refOf(a)
+
+  trait MkIn[F[_], G[_]] {
+    def refOf[A](a: A): F[Ref[G, A]]
+  }
+
+  object MkIn {
+    implicit def instance[F[_], G[_]](implicit F: Sync[F], G: Sync[G]): MkIn[F, G] =
+      new MkIn[F, G] {
+        override def refOf[A](a: A): F[Ref[G, A]] = F.delay(unsafe(a))
+      }
+  }
+
+  type Mk[F[_]] = MkIn[F, F]
 
   /**
    * Like `apply` but returns the newly allocated ref directly instead of wrapping it in `F.delay`.
@@ -245,14 +257,14 @@ object Ref {
       implicit F: Sync[F]): Ref[F, B] =
     new LensRef[F, A, B](ref)(get, set)
 
-  final class ApplyBuilders[F[_]](val F: Sync[F]) extends AnyVal {
+  final class ApplyBuilders[F[_]](val F: Mk[F]) extends AnyVal {
 
     /**
      * Creates an asynchronous, concurrent mutable reference initialized to the supplied value.
      *
      * @see [[Ref.of]]
      */
-    def of[A](a: A): F[Ref[F, A]] = Ref.of(a)(F)
+    def of[A](a: A): F[Ref[F, A]] = F.refOf(a)
   }
 
   final private class SyncRef[F[_], A](ar: AtomicReference[A])(implicit F: Sync[F])

--- a/concurrent/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
+++ b/concurrent/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
@@ -279,8 +279,9 @@ object Semaphore {
       F.bracket(acquireNInternal(1)) { case (g, _) => g *> t } { case (_, c) => c }
   }
 
-  final private class AsyncSemaphore[F[_]: Concurrent[*[_], Throwable]: Deferred.Mk](
-      state: Ref[F, State[F]])
+  final private class AsyncSemaphore[F[_]](state: Ref[F, State[F]])(
+      implicit F: Concurrent[F, Throwable],
+      mkDeferred: Deferred.Mk[F])
       extends AbstractSemaphore(state) {
     protected def mkGate: F[Deferred[F, Unit]] = Deferred[F, Unit]
   }

--- a/concurrent/shared/src/test/scala/cats/effect/concurrent/SyntaxSpec.scala
+++ b/concurrent/shared/src/test/scala/cats/effect/concurrent/SyntaxSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.concurrent
+
+import cats.effect.kernel.{Async, Concurrent}
+import org.specs2.mutable.Specification
+
+
+class SyntaxSpec extends Specification {
+  "concurrent data structure construction syntax" >> ok
+
+  def async[F[_]: Async] = {
+    Ref.of[F, String]("foo")
+    Ref[F].of(15)
+    Deferred[F, Unit]
+    Semaphore[F](15)
+    MVar[F].of(1)
+    MVar[F].empty[String]
+    MVar.empty[F, String]
+    MVar.of[F, String]("bar")
+  }
+
+  def preciseConstraints[F[_]: Ref.Mk: Deferred.Mk: Semaphore.Mk: MVar.Mk] = {
+    Ref.of[F, String]("foo")
+    Ref[F].of(15)
+    Deferred[F, Unit]
+    Semaphore[F](15)
+    MVar[F].of(1)
+    MVar[F].empty[String]
+    MVar.empty[F, String]
+    MVar.of[F, String]("bar")
+  }
+
+  def semaphoreIsDeriveable[F[_]: Concurrent[*[_], Throwable]: Ref.Mk: Deferred.Mk] =
+    Semaphore[F](11)
+}

--- a/concurrent/shared/src/test/scala/cats/effect/concurrent/SyntaxSpec.scala
+++ b/concurrent/shared/src/test/scala/cats/effect/concurrent/SyntaxSpec.scala
@@ -45,6 +45,6 @@ class SyntaxSpec extends Specification {
     MVar.of[F, String]("bar")
   }
 
-  def semaphoreIsDeriveable[F[_]: Ref.Mk: Deferred.Mk](implicit F: Concurrent[F[_], Throwable]) =
+  def semaphoreIsDeriveable[F[_]: Ref.Mk: Deferred.Mk](implicit F: Concurrent[F, Throwable]) =
     Semaphore[F](11)
 }

--- a/concurrent/shared/src/test/scala/cats/effect/concurrent/SyntaxSpec.scala
+++ b/concurrent/shared/src/test/scala/cats/effect/concurrent/SyntaxSpec.scala
@@ -45,6 +45,6 @@ class SyntaxSpec extends Specification {
     MVar.of[F, String]("bar")
   }
 
-  def semaphoreIsDeriveable[F[_]: Concurrent[*[_], Throwable]: Ref.Mk: Deferred.Mk] =
+  def semaphoreIsDeriveable[F[_]: Ref.Mk: Deferred.Mk](implicit F: Concurrent[F[_], Throwable]) =
     Semaphore[F](11)
 }


### PR DESCRIPTION
Here's my vision for #1017.

This is using a variant with 2 type constructors as a main implementation, where 1-type-constructor is just an alias. That cuts on code duplication and establishes a rule where all (non-unsafe) construction is done only through the typeclass.

I'm experimenting a bit on how practical it's to cake them together if the app wants to avoid huge lists of constraints (e.g. you can do "unofficial" `class Allocated[F[_]](...) extends Ref.Mk[F] with Deferred.Mk[F] with Semaphore.Mk[F]` for your app if it's a common combo you're using together)

Every variant of construction (e.g. empty mvar / full mvar) has its own method. The methods are also named somewhat verbosely for now (I've taken the names from [tofu](https://github.com/TinkoffCreditSystems/tofu) for the most part).

Also I've made it so that Semaphore creation does not require FFI classes directly. Still need to add some docs.

/cc @Odomontois