### PR TITLE
Fix SemigroupK[Resource[F, *]].combineK 

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -561,11 +561,10 @@ abstract private[effect] class ResourceInstances0 {
       def F = F0
     }
 
-  implicit def catsEffectSemigroupKForResource[F[_], A](implicit F0: Monad[F],
-                                                        K0: SemigroupK[F]): ResourceSemigroupK[F] =
-    new ResourceSemigroupK[F] {
-      def F = F0
-      def K = K0
+  implicit def catsEffectSemigroupKForResource[F[_], E](implicit F0: MonadError[F, E]): SemigroupK[Resource[F, *]] =
+    new SemigroupK[Resource[F, *]] {
+      final override def combineK[A](a: Resource[F, A], b: Resource[F, A]): Resource[F, A] =
+        MonadError[Resource[F, *], E].handleErrorWith(a)(_ => b)
     }
 }
 
@@ -638,18 +637,6 @@ abstract private[effect] class ResourceSemigroup[F[_], A] extends Semigroup[Reso
       x <- rx
       y <- ry
     } yield A.combine(x, y)
-}
-
-abstract private[effect] class ResourceSemigroupK[F[_]] extends SemigroupK[Resource[F, *]] {
-  implicit protected def F: Monad[F]
-  implicit protected def K: SemigroupK[F]
-
-  def combineK[A](rx: Resource[F, A], ry: Resource[F, A]): Resource[F, A] =
-    for {
-      x <- rx
-      y <- ry
-      xy <- Resource.liftF(K.combineK(x.pure[F], y.pure[F]))
-    } yield xy
 }
 
 abstract private[effect] class ResourceLiftIO[F[_]] extends LiftIO[Resource[F, *]] {

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -566,6 +566,27 @@ abstract private[effect] class ResourceInstances0 {
       final override def combineK[A](a: Resource[F, A], b: Resource[F, A]): Resource[F, A] =
         MonadError[Resource[F, *], E].handleErrorWith(a)(_ => b)
     }
+
+  // For binary compatibility.
+  @deprecated("Use the new implementaion that behaves like orElse", since = "2.2.0")
+  def catsEffectSemigroupKForResource[F[_], A](implicit F0: Monad[F],
+                                               K0: SemigroupK[F]): ResourceSemigroupK[F] =
+    new ResourceSemigroupK[F] {
+      def F = F0
+      def K = K0
+    }
+}
+
+@deprecated("Use the new implementaion that behaves like orElse", since = "2.2.0")
+abstract private[effect] class ResourceSemigroupK[F[_]] extends SemigroupK[Resource[F, *]] {
+  implicit protected def F: Monad[F]
+  implicit protected def K: SemigroupK[F]
+  def combineK[A](rx: Resource[F, A], ry: Resource[F, A]): Resource[F, A] =
+    for {
+      x <- rx
+      y <- ry
+      xy <- Resource.liftF(K.combineK(x.pure[F], y.pure[F]))
+    } yield xy
 }
 
 abstract private[effect] class ResourceMonadError[F[_], E] extends ResourceMonad[F] with MonadError[Resource[F, *], E] {

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -568,7 +568,7 @@ abstract private[effect] class ResourceInstances0 {
     }
 
   // For binary compatibility.
-  @deprecated("Use the new implementaion that behaves like orElse", since = "2.2.0")
+  @deprecated("Use the new implementaion, catsEffectSemigroupKForResource2, which behaves more like orElse", "2.2.0")
   def catsEffectSemigroupKForResource[F[_], A](implicit F0: Monad[F], K0: SemigroupK[F]): ResourceSemigroupK[F] =
     new ResourceSemigroupK[F] {
       def F = F0
@@ -576,7 +576,7 @@ abstract private[effect] class ResourceInstances0 {
     }
 }
 
-@deprecated("Use the new implementaion that behaves like orElse", since = "2.2.0")
+@deprecated("Use the new implementaion, catsEffectSemigroupKForResource2, which behaves more like orElse", "2.2.0")
 abstract private[effect] class ResourceSemigroupK[F[_]] extends SemigroupK[Resource[F, *]] {
   implicit protected def F: Monad[F]
   implicit protected def K: SemigroupK[F]

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -569,8 +569,7 @@ abstract private[effect] class ResourceInstances0 {
 
   // For binary compatibility.
   @deprecated("Use the new implementaion that behaves like orElse", since = "2.2.0")
-  def catsEffectSemigroupKForResource[F[_], A](implicit F0: Monad[F],
-                                               K0: SemigroupK[F]): ResourceSemigroupK[F] =
+  def catsEffectSemigroupKForResource[F[_], A](implicit F0: Monad[F], K0: SemigroupK[F]): ResourceSemigroupK[F] =
     new ResourceSemigroupK[F] {
       def F = F0
       def K = K0

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -561,7 +561,7 @@ abstract private[effect] class ResourceInstances0 {
       def F = F0
     }
 
-  implicit def catsEffectSemigroupKForResource[F[_], E](implicit F0: MonadError[F, E]): SemigroupK[Resource[F, *]] =
+  implicit def catsEffectSemigroupKForResource2[F[_], E](implicit F0: MonadError[F, E]): SemigroupK[Resource[F, *]] =
     new SemigroupK[Resource[F, *]] {
       final override def combineK[A](a: Resource[F, A], b: Resource[F, A]): Resource[F, A] =
         MonadError[Resource[F, *], E].handleErrorWith(a)(_ => b)

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -568,7 +568,7 @@ abstract private[effect] class ResourceInstances0 {
     }
 
   // For binary compatibility.
-  @deprecated("Use the new implementaion, catsEffectSemigroupKForResource2, which behaves more like orElse", "2.2.0")
+  @deprecated("Use the new implementation, catsEffectSemigroupKForResource2, which behaves more like orElse", "2.2.0")
   def catsEffectSemigroupKForResource[F[_], A](implicit F0: Monad[F], K0: SemigroupK[F]): ResourceSemigroupK[F] =
     new ResourceSemigroupK[F] {
       def F = F0
@@ -576,7 +576,7 @@ abstract private[effect] class ResourceInstances0 {
     }
 }
 
-@deprecated("Use the new implementaion, catsEffectSemigroupKForResource2, which behaves more like orElse", "2.2.0")
+@deprecated("Use the new implementation, catsEffectSemigroupKForResource2, which behaves more like orElse", "2.2.0")
 abstract private[effect] class ResourceSemigroupK[F[_]] extends SemigroupK[Resource[F, *]] {
   implicit protected def F: Monad[F]
   implicit protected def K: SemigroupK[F]

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -334,6 +334,15 @@ class ResourceTests extends BaseTestsSuite {
     suspend.attempt.use(IO.pure).unsafeRunSync() shouldBe Left(exception)
   }
 
+  test("combineK - should behave like orElse") {
+    check { (r1: Resource[IO, Int], r2: Resource[IO, Int]) =>
+      val lhs = (r1 orElse r2).use(IO.pure).attempt.unsafeRunSync()
+      val rhs = (r1 <+> r2).use(IO.pure).attempt.unsafeRunSync()
+
+      lhs <-> rhs
+    }
+  }
+
   testAsync("parZip - releases resources in reverse order of acquisition") { implicit ec =>
     implicit val ctx = ec.contextShift[IO]
 

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -336,7 +336,7 @@ class ResourceTests extends BaseTestsSuite {
 
   test("combineK - should behave like orElse") {
     check { (r1: Resource[IO, Int], r2: Resource[IO, Int]) =>
-      val lhs = (r1 orElse r2).use(IO.pure).attempt.unsafeRunSync()
+      val lhs = r1.orElse(r2).use(IO.pure).attempt.unsafeRunSync()
       val rhs = (r1 <+> r2).use(IO.pure).attempt.unsafeRunSync()
 
       lhs <-> rhs


### PR DESCRIPTION
Changing the behavior of SemigroupK[Resource[F, *]].combineK to be consistent with MonadError[Resource[F, *], E].orElse

Fixes #949

-----

I am surprised I didn't have to change any test _(this is probably a sign that there was no reason for the previous behavior)_.
Should I add some tests for the current behavior?

BTW, I confirmed it worked as expected using the snippet posted in the original issue.