### PR TITLE
IOFiber Constants Defined in Java (and another minor fix)

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+// defined in Java for the JVM, Scala for ScalaJS (where object field access is faster)
+private[effect] object IOFiberConstants {
+
+  val MaxStackDepth: Int = 512
+
+  // continuation ids (should all be inlined)
+  val MapK: Byte = 0
+  val FlatMapK: Byte = 1
+  val CancelationLoopK: Byte = 2
+  val RunTerminusK: Byte = 3
+  val AsyncK: Byte = 4
+  val EvalOnK: Byte = 5
+  val HandleErrorWithK: Byte = 6
+  val OnCancelK: Byte = 7
+  val UncancelableK: Byte = 8
+  val UnmaskK: Byte = 9
+
+  // resume ids
+  val ExecR: Byte = 0
+  val AsyncContinueR: Byte = 1
+  val BlockingR: Byte = 2
+  val AfterBlockingSuccessfulR: Byte = 3
+  val AfterBlockingFailedR: Byte = 4
+  val EvalOnR: Byte = 5
+  val CedeR: Byte = 6
+}

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect;
+
+// defined in Java since Scala doesn't let us define static fields
+final class IOFiberConstants {
+
+  public static int MaxStackDepth = 512;
+
+  // continuation ids (should all be inlined)
+  public static byte MapK = 0;
+  public static byte FlatMapK = 1;
+  public static byte CancelationLoopK = 2;
+  public static byte RunTerminusK = 3;
+  public static byte AsyncK = 4;
+  public static byte EvalOnK = 5;
+  public static byte HandleErrorWithK = 6;
+  public static byte OnCancelK = 7;
+  public static byte UncancelableK = 8;
+  public static byte UnmaskK = 9;
+
+  // resume ids
+  public static byte ExecR = 0;
+  public static byte AsyncContinueR = 1;
+  public static byte BlockingR = 2;
+  public static byte AfterBlockingSuccessfulR = 3;
+  public static byte AfterBlockingFailedR = 4;
+  public static byte EvalOnR = 5;
+  public static byte CedeR = 6;
+}

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -19,26 +19,26 @@ package cats.effect;
 // defined in Java since Scala doesn't let us define static fields
 final class IOFiberConstants {
 
-  public static int MaxStackDepth = 512;
+  public static final int MaxStackDepth = 512;
 
   // continuation ids (should all be inlined)
-  public static byte MapK = 0;
-  public static byte FlatMapK = 1;
-  public static byte CancelationLoopK = 2;
-  public static byte RunTerminusK = 3;
-  public static byte AsyncK = 4;
-  public static byte EvalOnK = 5;
-  public static byte HandleErrorWithK = 6;
-  public static byte OnCancelK = 7;
-  public static byte UncancelableK = 8;
-  public static byte UnmaskK = 9;
+  public static final byte MapK = 0;
+  public static final byte FlatMapK = 1;
+  public static final byte CancelationLoopK = 2;
+  public static final byte RunTerminusK = 3;
+  public static final byte AsyncK = 4;
+  public static final byte EvalOnK = 5;
+  public static final byte HandleErrorWithK = 6;
+  public static final byte OnCancelK = 7;
+  public static final byte UncancelableK = 8;
+  public static final byte UnmaskK = 9;
 
   // resume ids
-  public static byte ExecR = 0;
-  public static byte AsyncContinueR = 1;
-  public static byte BlockingR = 2;
-  public static byte AfterBlockingSuccessfulR = 3;
-  public static byte AfterBlockingFailedR = 4;
-  public static byte EvalOnR = 5;
-  public static byte CedeR = 6;
+  public static final byte ExecR = 0;
+  public static final byte AsyncContinueR = 1;
+  public static final byte BlockingR = 2;
+  public static final byte AfterBlockingSuccessfulR = 3;
+  public static final byte AfterBlockingFailedR = 4;
+  public static final byte EvalOnR = 5;
+  public static final byte CedeR = 6;
 }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -73,6 +73,7 @@ private final class IOFiber[A](
 
   // I would rather have these on the stack, but we can't because we sometimes need to relocate our runloop to another fiber
   private[this] var conts: ByteStack = _
+  private[this] val objectState = new ArrayStack[AnyRef](16)
 
   // fast-path to head
   private[this] var currentCtx: ExecutionContext = _
@@ -85,7 +86,7 @@ private final class IOFiber[A](
   private[this] val childMask: Int = initMask + 255
 
   private[this] var masks: Int = initMask
-  // TODO reason about whether or not the final finalizers are visible here
+
   private[this] val finalizers = new ArrayStack[IO[Unit]](16)
 
   private[this] val callbacks = new CallbackStack[A](cb)
@@ -95,8 +96,6 @@ private final class IOFiber[A](
 
   @volatile
   private[this] var outcome: OutcomeIO[A] = _
-
-  private[this] val objectState = new ArrayStack[AnyRef](16)
 
   private[this] val childCount = IOFiber.childCount
 


### PR DESCRIPTION
This is a follow-up to #1043 which moves all of the byte constants for `IOFiber` into Java static fields for the JVM, and a Scala `object` for ScalaJS. In this way, we still get the advantages of fast direct access and inlining but without the added cost imposed on `IOFiber` allocation, which is starting to be something we optimize.

In that vein as well, I realized that we can just use a `@volatile` for `outcome`, since we only used `set`/`get` on the `AtomicReference`.