### PR TITLE
Suppress normal async resumption after async finalizer suspension

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -80,12 +80,12 @@ private final class IOFiber[A](
   private[this] var ctxs: ArrayStack[ExecutionContext] = _
 
   private[this] var canceled: Boolean = false
+  private[this] var masks: Int = initMask
+  private[this] var finalizing: Boolean = false
 
   // allow for 255 masks before conflicting; 255 chosen because it is a familiar bound, and because it's evenly divides UnsignedInt.MaxValue
   // this scheme gives us 16,843,009 (~2^24) potential derived fibers before masks can conflict
   private[this] val childMask: Int = initMask + 255
-
-  private[this] var masks: Int = initMask
 
   private[this] val finalizers = new ArrayStack[IO[Unit]](16)
 
@@ -247,6 +247,8 @@ private final class IOFiber[A](
 
   private[this] def asyncCancel(cb: Either[Throwable, Unit] => Unit): Unit = {
     //       println(s"<$name> running cancelation (finalizers.length = ${finalizers.unsafeIndex()})")
+    finalizing = true
+
     if (!finalizers.isEmpty()) {
       objectState.push(cb)
 
@@ -331,6 +333,10 @@ private final class IOFiber[A](
            */
           val state = new AtomicReference[AsyncState](AsyncStateInitial)
 
+          // Async callbacks may only resume if the finalization state
+          // remains the same after we re-acquire the runloop
+          val wasFinalizing = finalizing
+
           objectState.push(done)
           objectState.push(state)
 
@@ -352,13 +358,20 @@ private final class IOFiber[A](
               @tailrec
               def loop(): Unit = {
                 if (resume()) {
-                  if (old == AsyncStateRegisteredWithFinalizer) {
-                    // we completed and were not canceled, so we pop the finalizer
-                    // note that we're safe to do so since we own the runloop
-                    finalizers.pop()
-                  }
+                  // Race condition check:
+                  // An Async node's callback may resume after finalization begins
+                  // and an async finalizer runs, which suspends the runloop again.
+                  if (finalizing == wasFinalizing) {
+                    if (old == AsyncStateRegisteredWithFinalizer) {
+                      // we completed and were not canceled, so we pop the finalizer
+                      // note that we're safe to do so since we own the runloop
+                      finalizers.pop()
+                    }
 
-                  asyncContinue(state, e)
+                    asyncContinue(state, e)
+                  } else {
+                    suspend()
+                  }
                 } else if (!shouldFinalize()) {
                   loop()
                 }
@@ -571,8 +584,8 @@ private final class IOFiber[A](
     suspended.compareAndSet(false, true)
     // race condition check: we may have been cancelled before we suspended
     if (shouldFinalize()) {
-      // if we can acquire the run-loop, we can run the finalizers
-      // otherwise somebody else picked it up and will run finalizers
+      // if we can re-acquire the run-loop, we can finalize
+      // otherwise somebody else acquired it and will eventually finalize
       if (resume()) {
         asyncCancel(null)
       }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -359,8 +359,8 @@ private final class IOFiber[A](
               def loop(): Unit = {
                 if (resume()) {
                   // Race condition check:
-                  // An Async node's callback may resume after finalization begins
-                  // and an async finalizer runs, which suspends the runloop again.
+                  // If finalization occurs and an async finalizer suspends the runloop,
+                  // a window is created where a normal async resumes the runloop.
                   if (finalizing == wasFinalizing) {
                     if (old == AsyncStateRegisteredWithFinalizer) {
                       // we completed and were not canceled, so we pop the finalizer

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -617,6 +617,29 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
       test should nonTerminate
     }
 
+    "ensure async callback is suppressed during suspension of async finalizers" in ticked { implicit ticker =>
+      var cb: Either[Throwable, Unit] => Unit = null
+
+      val subject = IO.async[Unit] { cb0 =>
+        IO {
+          cb = cb0
+
+          Some(IO.never)
+        }
+      }
+
+      val test = for {
+        f <- subject.start
+        _ <- IO(ticker.ctx.tickAll())   // schedule everything
+        _ <- f.cancel.start
+        _ <- IO(ticker.ctx.tickAll())   // get inside the finalizer suspension
+        _ <- IO(cb(Right(())))
+        _ <- IO(ticker.ctx.tickAll())   // show that the finalizer didn't explode
+      } yield ()
+
+      test must completeAs(())    // ...but not throw an exception
+    }
+
     "temporal" should {
       "timeout" should {
         "succeed" in real {


### PR DESCRIPTION
Fix for another async/finalizer related bug. The race condition here occurs when an normal async callback resumes after finalization begins and suspends because of an async finalizer. @djspiewak summarizes the particular ordering of effects that produces this bug quite concisely in https://github.com/typelevel/cats-effect/issues/1045#issuecomment-670251464 so I won't repeat it here.

My attempt at the fix is to introduce another `IOFiber` non-volatile instance variable `finalizing`  that reflects whether finalization has begun already. After the async callback has been invoked and acquires the runloop, we check if the `finalizing` flag has changed since the `Async` node started. If it didn't, we can continue with the runloop. If it did, we suspend the runloop because it means that an async finalizer hasn't completed yet.

Note that the timely publication and visibility of `finalizing` is guaranteed by read and write barriers on `suspended`. I'm also thinking about whether `finalizing` can or should participate in the `shouldFinalize` invariant. My gut feeling says no since the purpose of `shouldFinalize` is to determine whether or not the conditions for finalization have been met, and *not* whether or not we should run them.

Fixes #1045 .