### PR TITLE
Change SemigroupK instance for Resource to lift behaviour from underlying effect

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -561,10 +561,11 @@ abstract private[effect] class ResourceInstances0 {
       def F = F0
     }
 
-  implicit def catsEffectSemigroupKForResource2[F[_], E](implicit F0: MonadError[F, E]): SemigroupK[Resource[F, *]] =
+  implicit def catsEffectSemigroupKForResource2[F[_]](implicit F0: Bracket[F, Throwable],
+                                                      K: SemigroupK[F]): SemigroupK[Resource[F, *]] =
     new SemigroupK[Resource[F, *]] {
       final override def combineK[A](a: Resource[F, A], b: Resource[F, A]): Resource[F, A] =
-        MonadError[Resource[F, *], E].handleErrorWith(a)(_ => b)
+        Resource(K.combineK(a.allocated, b.allocated))
     }
 
   // For binary compatibility.

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -299,6 +299,20 @@ sealed abstract class Resource[+F[_], +A] {
    */
   def evalTap[G[x] >: F[x], B](f: A => G[B])(implicit F: Applicative[G[?]]): Resource[G[?], A] =
     this.evalMap(a => f(a).as(a))
+
+  /**
+   * Combines two `Resource` instances by lifting the behaviour of a
+   * `SemigroupK` instance into the resource context
+   */
+  def combineK[G[x] >: F[x], B >: A](that: Resource[G, B])(implicit F: Sync[G], K: SemigroupK[G]): Resource[G, B] =
+    Resource
+      .make(Ref[G].of(F.unit))(_.get.flatten)
+      .evalMap { finalizers =>
+        def allocate(r: Resource[G, B]): G[B] =
+          r.fold[G, B](_.pure[G], (release: G[Unit]) => finalizers.update(_.guarantee(release)))
+
+        K.combineK(allocate(this), allocate(that))
+      }
 }
 
 object Resource extends ResourceInstances with ResourcePlatform {
@@ -566,14 +580,7 @@ abstract private[effect] class ResourceInstances0 {
     new SemigroupK[Resource[F, *]] {
 
       final override def combineK[A](ra: Resource[F, A], rb: Resource[F, A]): Resource[F, A] =
-        Resource
-          .make(Ref[F].of(Sync[F].unit))(_.get.flatten)
-          .evalMap { finalizers =>
-            def allocate(r: Resource[F, A]): F[A] =
-              r.allocated.flatMap { case (a, release) => finalizers.update(_.guarantee(release)).as(a) }
-
-            K.combineK(allocate(ra), allocate(rb))
-          }
+        ra.combineK(rb)
     }
 
   // For binary compatibility.

--- a/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/ResourceTests.scala
@@ -334,10 +334,20 @@ class ResourceTests extends BaseTestsSuite {
     suspend.attempt.use(IO.pure).unsafeRunSync() shouldBe Left(exception)
   }
 
-  test("combineK - should behave like orElse") {
+  test("combineK - should behave like orElse when underlying effect does") {
     check { (r1: Resource[IO, Int], r2: Resource[IO, Int]) =>
       val lhs = r1.orElse(r2).use(IO.pure).attempt.unsafeRunSync()
       val rhs = (r1 <+> r2).use(IO.pure).attempt.unsafeRunSync()
+
+      lhs <-> rhs
+    }
+  }
+
+  test("combineK - should behave like underlying effect") {
+    import cats.data.OptionT
+    check { (ot1: OptionT[IO, Int], ot2: OptionT[IO, Int]) =>
+      val lhs = Resource.liftF(ot1 <+> ot2).use(OptionT.pure[IO](_)).value.attempt.unsafeRunSync()
+      val rhs = (Resource.liftF(ot1) <+> Resource.liftF(ot2)).use(OptionT.pure[IO](_)).value.attempt.unsafeRunSync()
 
       lhs <-> rhs
     }


### PR DESCRIPTION
Before #949, the `SemigroupK` instance for `Resource` had completely wrong behaviour. It now behaves as expected in the most common cases, but its behaviour is surprising in the case of underlying effects, such as `OptionT[IO, *]`, for which the `SemigroupK` instance behaves like the instance for `Option` (selecting the first non-empty `Option`) rather than the instance for `IO` (selecting the first successful `IO`).

This PR keeps the corrected behaviour from the previous PR, but generalises it by deriving the behaviour from that of the underlying effect.

