### PR TITLE
Fix dubious iterations value for MapCallsBenchmark.one

### DIFF
--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapCallsBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapCallsBenchmark.scala
@@ -40,7 +40,7 @@ class MapCallsBenchmark {
   import MapCallsBenchmark.test
 
   @Benchmark
-  def one(): Long = test(1, 1)
+  def one(): Long = test(12000, 1)
 
   @Benchmark
   def batch30(): Long = test(12000 / 30, 30)


### PR DESCRIPTION
This bit me when running benchmarks.