### PR TITLE
Remove async done AtomicBoolean

### DIFF
--- a/core/shared/src/main/scala/cats/effect/AsyncState.scala
+++ b/core/shared/src/main/scala/cats/effect/AsyncState.scala
@@ -26,19 +26,20 @@ private[effect] object AsyncState {
   case object Initial extends AsyncState {
     def tag = 0
   }
+
   case object RegisteredNoFinalizer extends AsyncState {
     def tag = 1
   }
+
   case object RegisteredWithFinalizer extends AsyncState {
     def tag = 2
   }
+
   final case class Complete(override val result: Either[Throwable, Any]) extends AsyncState {
     def tag = 3
   }
 
-  // sentinel object used to signal failure during an asynchronous effect
-  // exists to avoid allocation of a `Complete(null)` object
-  case object Failure extends AsyncState {
+  case object Done extends AsyncState {
     def tag = 4
   }
 }

--- a/core/shared/src/main/scala/cats/effect/AsyncState.scala
+++ b/core/shared/src/main/scala/cats/effect/AsyncState.scala
@@ -18,12 +18,27 @@ package cats.effect
 
 sealed abstract private[effect] class AsyncState extends Product with Serializable {
   def result: Either[Throwable, Any] = sys.error("impossible")
+  def tag: Byte
 }
 
 private[effect] object AsyncState {
   // no one completed
-  case object Initial extends AsyncState
-  case object RegisteredNoFinalizer extends AsyncState
-  case object RegisteredWithFinalizer extends AsyncState
-  final case class Complete(override val result: Either[Throwable, Any]) extends AsyncState
+  case object Initial extends AsyncState {
+    def tag = 0
+  }
+  case object RegisteredNoFinalizer extends AsyncState {
+    def tag = 1
+  }
+  case object RegisteredWithFinalizer extends AsyncState {
+    def tag = 2
+  }
+  final case class Complete(override val result: Either[Throwable, Any]) extends AsyncState {
+    def tag = 3
+  }
+
+  // sentinel object used to signal failure during an asynchronous effect
+  // exists to avoid allocation of a `Complete(null)` object
+  case object Failure extends AsyncState {
+    def tag = 4
+  }
 }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -103,6 +103,7 @@ private final class IOFiber[A](
   private[this] val AsyncStateInitial = AsyncState.Initial
   private[this] val AsyncStateRegisteredNoFinalizer = AsyncState.RegisteredNoFinalizer
   private[this] val AsyncStateRegisteredWithFinalizer = AsyncState.RegisteredWithFinalizer
+  private[this] val AsyncStateFailure = AsyncState.Failure
 
   // mutable state for resuming the fiber in different states
   private[this] var resumeTag: Byte = ExecR
@@ -313,8 +314,6 @@ private final class IOFiber[A](
         case 4 =>
           val cur = cur0.asInstanceOf[Async[Any]]
 
-          val done = new AtomicBoolean()
-
           /*
            * The purpose of this buffer is to ensure that registration takes
            * primacy over callbacks in the event that registration produces
@@ -329,60 +328,53 @@ private final class IOFiber[A](
           // remains the same after we re-acquire the runloop
           val wasFinalizing = finalizing
 
-          objectState.push(done)
           objectState.push(state)
 
           val next = cur.k { e =>
-            // println(s"<$name> callback run with $e")
-            if (!done.getAndSet(true)) {
-              val old = state.getAndSet(AsyncState.Complete(e))
+            /*
+             * We *need* to own the runloop when we return, so we CAS loop
+             * on suspended to break the race condition in AsyncK where
+             * `state` is set but suspend() has not yet run. If `state` is
+             * set then `suspend()` should be right behind it *unless* we
+             * have been canceled. If we were canceled, then some other
+             * fiber is taking care of our finalizers and will have
+             * marked suspended as false, meaning that `canceled` will be set
+             * to true. Either way, we won't own the runloop.
+             */
+            @tailrec
+            def loop(old: Byte): Unit = {
+              if (resume()) {
+                state.lazySet(AsyncStateInitial) // avoid leaks
 
-              /*
-               * We *need* to own the runloop when we return, so we CAS loop
-               * on suspended to break the race condition in AsyncK where
-               * `state` is set but suspend() has not yet run. If `state` is
-               * set then `suspend()` should be right behind it *unless* we
-               * have been canceled. If we were canceled, then some other
-               * fiber is taking care of our finalizers and will have
-               * marked suspended as false, meaning that `canceled` will be set
-               * to true. Either way, we won't own the runloop.
-               */
-              @tailrec
-              def loop(): Unit = {
-                if (resume()) {
-                  state.lazySet(AsyncStateInitial) // avoid leaks
-
-                  // Race condition check:
-                  // If finalization occurs and an async finalizer suspends the runloop,
-                  // a window is created where a normal async resumes the runloop.
-                  if (finalizing == wasFinalizing) {
-                    if (!shouldFinalize()) {
-                      if (old == AsyncStateRegisteredWithFinalizer) {
-                        // we completed and were not canceled, so we pop the finalizer
-                        // note that we're safe to do so since we own the runloop
-                        finalizers.pop()
-                      }
-
-                      asyncContinue(e)
-                    } else {
-                      asyncCancel(null)
+                // Race condition check:
+                // If finalization occurs and an async finalizer suspends the runloop,
+                // a window is created where a normal async resumes the runloop.
+                if (finalizing == wasFinalizing) {
+                  if (!shouldFinalize()) {
+                    if (old == 2) {
+                      // AsyncStateRegisteredWithFinalizer
+                      // we completed and were not canceled, so we pop the finalizer
+                      // note that we're safe to do so since we own the runloop
+                      finalizers.pop()
                     }
+
+                    asyncContinue(e)
                   } else {
-                    suspend()
+                    asyncCancel(null)
                   }
-                } else if (!shouldFinalize()) {
-                  loop()
+                } else {
+                  suspend()
                 }
-
-                // If we reach this point, it means that somebody else owns the run-loop
-                // and will handle cancellation.
+              } else if (!shouldFinalize()) {
+                loop(old)
               }
 
-              if (old != AsyncStateInitial) {
-                // registration already completed, we're good to go
-                loop()
-              }
+              // If we reach this point, it means that somebody else owns the run-loop
+              // and will handle cancellation.
             }
+            // println(s"<$name> callback run with $e")
+            val tag = state.getAndSet(AsyncState.Complete(e)).tag
+            if (tag == 1) loop(1) else if (tag == 2) loop(2)
           }
 
           conts.push(AsyncK)
@@ -845,7 +837,6 @@ private final class IOFiber[A](
 
   private[this] def asyncSuccessK(result: Any): IO[Any] = {
     val state = objectState.pop().asInstanceOf[AtomicReference[AsyncState]]
-    objectState.pop()
 
     if (isUnmasked()) {
       result.asInstanceOf[Option[IO[Unit]]] match {
@@ -905,9 +896,9 @@ private final class IOFiber[A](
 
   private[this] def asyncFailureK(t: Throwable, depth: Int): IO[Any] = {
     val state = objectState.pop().asInstanceOf[AtomicReference[AsyncState]]
-    val done = objectState.pop().asInstanceOf[AtomicBoolean]
 
-    if (!done.getAndSet(true)) {
+    val old = state.getAndSet(AsyncStateFailure)
+    if (!old.isInstanceOf[AsyncState.Complete]) {
       // if we get an error before the callback, then propagate
       failed(t, depth + 1)
     } else {


### PR DESCRIPTION
Save an allocation on each `async` and be slightly kinder to the `objectState` stack.