### PR TITLE
Special case attempt in IO and SyncIO run loop

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -34,6 +34,7 @@ private[effect] object IOFiberConstants {
   val UnmaskK: Byte = 9
   val AttemptK: Byte = 10
   val RedeemK: Byte = 11
+  val RedeemWithK: Byte = 12
 
   // resume ids
   val ExecR: Byte = 0

--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -33,6 +33,7 @@ private[effect] object IOFiberConstants {
   val UncancelableK: Byte = 8
   val UnmaskK: Byte = 9
   val AttemptK: Byte = 10
+  val RedeemK: Byte = 11
 
   // resume ids
   val ExecR: Byte = 0

--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -33,8 +33,6 @@ private[effect] object IOFiberConstants {
   val UncancelableK: Byte = 8
   val UnmaskK: Byte = 9
   val AttemptK: Byte = 10
-  val RedeemK: Byte = 11
-  val RedeemWithK: Byte = 12
 
   // resume ids
   val ExecR: Byte = 0

--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -32,6 +32,7 @@ private[effect] object IOFiberConstants {
   val OnCancelK: Byte = 7
   val UncancelableK: Byte = 8
   val UnmaskK: Byte = 9
+  val AttemptK: Byte = 10
 
   // resume ids
   val ExecR: Byte = 0

--- a/core/js/src/main/scala/cats/effect/SyncIOConstants.scala
+++ b/core/js/src/main/scala/cats/effect/SyncIOConstants.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+private object SyncIOConstants {
+  val MaxStackDepth = 512
+
+  val MapK: Byte = 0
+  val FlatMapK: Byte = 1
+  val HandleErrorWithK: Byte = 2
+  val RunTerminusK: Byte = 3
+  val AttemptK: Byte = 4
+  val RedeemK: Byte = 5
+  val RedeemWithK: Byte = 6
+}

--- a/core/js/src/main/scala/cats/effect/SyncIOConstants.scala
+++ b/core/js/src/main/scala/cats/effect/SyncIOConstants.scala
@@ -24,6 +24,4 @@ private object SyncIOConstants {
   val HandleErrorWithK: Byte = 2
   val RunTerminusK: Byte = 3
   val AttemptK: Byte = 4
-  val RedeemK: Byte = 5
-  val RedeemWithK: Byte = 6
 }

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -32,6 +32,7 @@ final class IOFiberConstants {
   public static final byte OnCancelK = 7;
   public static final byte UncancelableK = 8;
   public static final byte UnmaskK = 9;
+  public static final byte AttemptK = 10;
 
   // resume ids
   public static final byte ExecR = 0;

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -33,8 +33,6 @@ final class IOFiberConstants {
   public static final byte UncancelableK = 8;
   public static final byte UnmaskK = 9;
   public static final byte AttemptK = 10;
-  public static final byte RedeemK = 11;
-  public static final byte RedeemWithK = 12;
 
   // resume ids
   public static final byte ExecR = 0;

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -33,6 +33,7 @@ final class IOFiberConstants {
   public static final byte UncancelableK = 8;
   public static final byte UnmaskK = 9;
   public static final byte AttemptK = 10;
+  public static final byte RedeemK = 11;
 
   // resume ids
   public static final byte ExecR = 0;

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -34,6 +34,7 @@ final class IOFiberConstants {
   public static final byte UnmaskK = 9;
   public static final byte AttemptK = 10;
   public static final byte RedeemK = 11;
+  public static final byte RedeemWithK = 12;
 
   // resume ids
   public static final byte ExecR = 0;

--- a/core/jvm/src/main/java/cats/effect/SyncIOConstants.java
+++ b/core/jvm/src/main/java/cats/effect/SyncIOConstants.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect;
+
+final class SyncIOConstants {
+
+    public static final int MaxStackDepth = 512;
+
+    public static final byte MapK = 0;
+    public static final byte FlatMapK = 1;
+    public static final byte HandleErrorWithK = 2;
+    public static final byte RunTerminusK = 3;
+    public static final byte AttemptK = 4;
+    public static final byte RedeemK = 5;
+    public static final byte RedeemWithK = 6;
+}

--- a/core/jvm/src/main/java/cats/effect/SyncIOConstants.java
+++ b/core/jvm/src/main/java/cats/effect/SyncIOConstants.java
@@ -25,6 +25,4 @@ final class SyncIOConstants {
   public static final byte HandleErrorWithK = 2;
   public static final byte RunTerminusK = 3;
   public static final byte AttemptK = 4;
-  public static final byte RedeemK = 5;
-  public static final byte RedeemWithK = 6;
 }

--- a/core/jvm/src/main/java/cats/effect/SyncIOConstants.java
+++ b/core/jvm/src/main/java/cats/effect/SyncIOConstants.java
@@ -18,13 +18,13 @@ package cats.effect;
 
 final class SyncIOConstants {
 
-    public static final int MaxStackDepth = 512;
+  public static final int MaxStackDepth = 512;
 
-    public static final byte MapK = 0;
-    public static final byte FlatMapK = 1;
-    public static final byte HandleErrorWithK = 2;
-    public static final byte RunTerminusK = 3;
-    public static final byte AttemptK = 4;
-    public static final byte RedeemK = 5;
-    public static final byte RedeemWithK = 6;
+  public static final byte MapK = 0;
+  public static final byte FlatMapK = 1;
+  public static final byte HandleErrorWithK = 2;
+  public static final byte RunTerminusK = 3;
+  public static final byte AttemptK = 4;
+  public static final byte RedeemK = 5;
+  public static final byte RedeemWithK = 6;
 }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -184,6 +184,9 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
   def redeem[B](recover: Throwable => B, map: A => B): IO[B] =
     IO.Redeem(this, recover, map)
 
+  def redeemWith[B](recover: Throwable => IO[B], bind: A => IO[B]): IO[B] =
+    IO.RedeemWith(this, recover, bind)
+
   def delayBy(duration: FiniteDuration): IO[A] =
     IO.sleep(duration) *> this
 
@@ -551,6 +554,10 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
     override def redeem[A, B](fa: IO[A])(recover: Throwable => B, f: A => B): IO[B] =
       fa.redeem(recover, f)
+
+    override def redeemWith[A, B](
+        fa: IO[A])(recover: Throwable => IO[B], bind: A => IO[B]): IO[B] =
+      fa.redeemWith(recover, bind)
   }
 
   implicit def effectForIO: Effect[IO] = _effectForIO

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -583,7 +583,7 @@ private final class IOFiber[A](
           runLoop(cur.ioa, nextIteration)
 
         case 20 =>
-          val cur = cur0.asInstanceOf[Attempt[A]]
+          val cur = cur0.asInstanceOf[Attempt[Any]]
 
           conts.push(AttemptK)
           runLoop(cur.ioa, nextIteration)

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -581,6 +581,12 @@ private final class IOFiber[A](
           }
 
           runLoop(cur.ioa, nextIteration)
+
+        case 20 =>
+          val cur = cur0.asInstanceOf[Attempt[A]]
+
+          conts.push(AttemptK)
+          runLoop(cur.ioa, nextIteration)
       }
     }
   }
@@ -639,6 +645,7 @@ private final class IOFiber[A](
       case 7 => onCancelSuccessK(result, depth)
       case 8 => uncancelableSuccessK(result, depth)
       case 9 => unmaskSuccessK(result, depth)
+      case 10 => succeeded(Right(result), depth + 1)
     }
 
   private[this] def failed(error: Throwable, depth: Int): IO[Any] = {
@@ -671,6 +678,7 @@ private final class IOFiber[A](
       case 7 => onCancelFailureK(error, depth)
       case 8 => uncancelableFailureK(error, depth)
       case 9 => unmaskFailureK(error, depth)
+      case 10 => succeeded(Left(error), depth + 1)
     }
   }
 

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -587,6 +587,14 @@ private final class IOFiber[A](
 
           conts.push(AttemptK)
           runLoop(cur.ioa, nextIteration)
+
+        case 21 =>
+          val cur = cur0.asInstanceOf[Redeem[Any, Any]]
+
+          objectState.push(cur)
+          conts.push(RedeemK)
+
+          runLoop(cur.ioa, nextIteration)
       }
     }
   }
@@ -646,6 +654,9 @@ private final class IOFiber[A](
       case 8 => uncancelableSuccessK(result, depth)
       case 9 => unmaskSuccessK(result, depth)
       case 10 => succeeded(Right(result), depth + 1)
+      case 11 =>
+        val wrapper = objectState.pop().asInstanceOf[Redeem[Any, Any]]
+        succeeded(wrapper.map(result), depth + 1)
     }
 
   private[this] def failed(error: Throwable, depth: Int): IO[Any] = {
@@ -679,6 +690,9 @@ private final class IOFiber[A](
       case 8 => uncancelableFailureK(error, depth)
       case 9 => unmaskFailureK(error, depth)
       case 10 => succeeded(Left(error), depth + 1)
+      case 11 =>
+        val wrapper = objectState.pop().asInstanceOf[Redeem[Any, Any]]
+        succeeded(wrapper.recover(error), depth + 1)
     }
   }
 

--- a/core/shared/src/main/scala/cats/effect/SyncIO.scala
+++ b/core/shared/src/main/scala/cats/effect/SyncIO.scala
@@ -207,15 +207,7 @@ sealed abstract class SyncIO[+A] private () {
    * @return the result of evaluating this `SyncIO`
    */
   def unsafeRunSync(): A = {
-    val MaxStackDepth = 512
-
-    val MapK: Byte = 0
-    val FlatMapK: Byte = 1
-    val HandleErrorWithK: Byte = 2
-    val RunTerminusK: Byte = 3
-    val AttemptK: Byte = 4
-    val RedeemK: Byte = 5
-    val RedeemWithK: Byte = 6
+    import SyncIOConstants._
 
     val conts = new ByteStack(16)
     val objectState = new ArrayStack[AnyRef](16)

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -89,6 +89,15 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
       IO.raiseError[Unit](TestException).attempt must completeAs(Left(TestException))
     }
 
+    "redeem correctly recovers from errors" in ticked { implicit ticker =>
+      case object TestException extends RuntimeException
+      IO.raiseError[Int](TestException).redeem(_ => 42, _ => 43) must completeAs(42)
+    }
+
+    "redeem maps successful results" in ticked { implicit ticker =>
+      IO.unit.redeem(_ => 41, _ => 42) must completeAs(42)
+    }
+
     "start and join on a successful fiber" in ticked { implicit ticker =>
       IO.pure(42).map(_ + 1).start.flatMap(_.join) must completeAs(
         Outcome.completed[IO, Throwable, Int](IO.pure(43)))

--- a/testkit/shared/src/main/scala/cats/effect/testkit/Generators.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/Generators.scala
@@ -119,7 +119,8 @@ trait ApplicativeErrorGenerators[F[_], E] extends ApplicativeGenerators[F] {
   override protected def recursiveGen[A](
       deeper: GenK[F])(implicit AA: Arbitrary[A], AC: Cogen[A]): List[(String, Gen[F[A]])] =
     List(
-      "handleErrorWith" -> genHandleErrorWith[A](deeper)(AA, AC)
+      "handleErrorWith" -> genHandleErrorWith[A](deeper)(AA, AC),
+      "redeem" -> genRedeem[Int, A](deeper)
     ) ++ super.recursiveGen(deeper)(AA, AC)
 
   private def genRaiseError[A]: Gen[F[A]] =
@@ -130,6 +131,13 @@ trait ApplicativeErrorGenerators[F[_], E] extends ApplicativeGenerators[F] {
       fa <- deeper[A]
       f <- Gen.function1[E, F[A]](deeper[A])
     } yield F.handleErrorWith(fa)(f)
+
+  private def genRedeem[A: Arbitrary: Cogen, B: Arbitrary](deeper: GenK[F]): Gen[F[B]] =
+    for {
+      fa <- deeper[A]
+      recover <- Gen.function1[E, B](arbitrary[B])
+      map <- Gen.function1[A, B](arbitrary[B])
+    } yield F.redeem(fa)(recover, map)
 }
 
 trait MonadErrorGenerators[F[_], E]


### PR DESCRIPTION
Resolves #1055.

I checked the bytecode, we still keep the `tableswitch`. I have included the files as proof.
[iobytecode.txt](https://github.com/typelevel/cats-effect/files/5048251/iobytecode.txt)
[synciobytecode.txt](https://github.com/typelevel/cats-effect/files/5048252/synciobytecode.txt)

