### PR TITLE
Add CE3 redeem benchmarks

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/RedeemBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/RedeemBenchmark.scala
@@ -18,7 +18,6 @@ package cats.effect.benchmarks
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
-import cats.implicits._
 
 import org.openjdk.jmh.annotations._
 

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/RedeemBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/RedeemBenchmark.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.benchmarks
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.implicits._
+
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * To do comparative benchmarks between versions:
+ *
+ *     benchmarks/run-benchmark RedeemBenchmark
+ *
+ * This will generate results in `benchmarks/results`.
+ *
+ * Or to run the benchmark from within sbt:
+ *
+ *     jmh:run -i 10 -wi 10 -f 2 -t 1 cats.effect.benchmarks.RedeemBenchmark
+ *
+ * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+ * Please note that benchmarks should be usually executed at least in
+ * 10 iterations (as a rule of thumb), but more is better.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class RedeemBenchmark {
+
+  @Param(Array("10000"))
+  var size: Int = _
+
+  @Benchmark
+  def happyPath(): Int = {
+    val id = identity[Int] _
+
+    def loop(i: Int): IO[Int] =
+      if (i < size) IO.pure(i + 1).redeem(_ => 0, id).flatMap(loop)
+      else IO.pure(i)
+
+    loop(0).unsafeRunSync()
+  }
+
+  @Benchmark
+  def errorRaised(): Int = {
+    val dummy = new RuntimeException("dummy")
+    val ioIncrement: Int => IO[Int] = x => IO.pure(x + 1)
+    val id = identity[Int] _
+
+    def loop(i: Int): IO[Int] =
+      if (i < size)
+        IO.raiseError[Int](dummy).flatMap(ioIncrement).redeem(_ => i + 1, id).flatMap(loop)
+      else
+        IO.pure(i)
+
+    loop(0).unsafeRunSync()
+  }
+}

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/RedeemWithBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/RedeemWithBenchmark.scala
@@ -18,7 +18,6 @@ package cats.effect.benchmarks
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
-import cats.implicits._
 
 import org.openjdk.jmh.annotations._
 

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/RedeemWithBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/RedeemWithBenchmark.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.benchmarks
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.implicits._
+
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * To do comparative benchmarks between versions:
+ *
+ *     benchmarks/run-benchmark RedeemWithBenchmark
+ *
+ * This will generate results in `benchmarks/results`.
+ *
+ * Or to run the benchmark from within sbt:
+ *
+ *     jmh:run -i 10 -wi 10 -f 2 -t 1 cats.effect.benchmarks.RedeemWithBenchmark
+ *
+ * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+ * Please note that benchmarks should be usually executed at least in
+ * 10 iterations (as a rule of thumb), but more is better.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class RedeemWithBenchmark {
+
+  @Param(Array("10000"))
+  var size: Int = _
+
+  @Benchmark
+  def happyPath(): Int = {
+    val recover: Throwable => IO[Int] = _ => IO.pure(0)
+
+    def loop(i: Int): IO[Int] =
+      if (i < size) IO.pure(i + 1).redeemWith(recover, loop)
+      else IO.pure(i)
+
+    loop(0).unsafeRunSync()
+  }
+
+  @Benchmark
+  def errorRaised(): Int = {
+    val dummy = new RuntimeException("dummy")
+    val ioIncrement: Int => IO[Int] = x => IO.pure(x + 1)
+    val id = IO.pure[Int] _
+
+    def loop(i: Int): IO[Int] =
+      if (i < size)
+        IO.raiseError[Int](dummy).flatMap(ioIncrement).redeemWith(_ => loop(i + 1), id)
+      else
+        IO.pure(i)
+
+    loop(0).unsafeRunSync()
+  }
+}


### PR DESCRIPTION
Opening for posterity. Will post baseline scores, without any special cases.

CE3 master:
```
Benchmark                        (size)   Mode  Cnt     Score    Error  Units
AttemptBenchmark.errorRaised      10000  thrpt   20  1176.175 ± 19.742  ops/s
AttemptBenchmark.happyPath        10000  thrpt   20  1533.906 ± 31.811  ops/s
RedeemBenchmark.errorRaised       10000  thrpt   20  1005.665 ± 17.223  ops/s
RedeemBenchmark.happyPath         10000  thrpt   20  1403.133 ± 20.596  ops/s
RedeemWithBenchmark.errorRaised   10000  thrpt   20  1112.423 ±  3.353  ops/s
RedeemWithBenchmark.happyPath     10000  thrpt   20  1460.951 ±  2.383  ops/s
```

CE3 with `redeemWith` specialized in the run loop and `redeem` and `attempt` implemented in terms of it:
```
Benchmark                        (size)   Mode  Cnt     Score    Error  Units
AttemptBenchmark.errorRaised      10000  thrpt   20  1398.482 ± 45.226  ops/s
AttemptBenchmark.happyPath        10000  thrpt   20  1715.366 ± 13.471  ops/s
RedeemBenchmark.errorRaised       10000  thrpt   20  1263.061 ±  1.180  ops/s
RedeemBenchmark.happyPath         10000  thrpt   20  1664.181 ±  1.777  ops/s
RedeemWithBenchmark.errorRaised   10000  thrpt   20  2198.608 ± 11.373  ops/s
RedeemWithBenchmark.happyPath     10000  thrpt   20  3638.704 ± 56.893  ops/s
```

Further specializing `attempt`, `redeemWith` remains identical, `redeem` is still implemented in terms of `redeemWith`:
```
Benchmark                        (size)   Mode  Cnt     Score    Error  Units
AttemptBenchmark.errorRaised      10000  thrpt   20  1608.404 ± 33.204  ops/s
AttemptBenchmark.happyPath        10000  thrpt   20  2293.181 ± 91.073  ops/s
RedeemBenchmark.errorRaised       10000  thrpt   20  1324.089 ±  8.704  ops/s
RedeemBenchmark.happyPath         10000  thrpt   20  1648.077 ±  6.450  ops/s
RedeemWithBenchmark.errorRaised   10000  thrpt   20  2230.361 ± 28.927  ops/s
RedeemWithBenchmark.happyPath     10000  thrpt   20  3815.468 ± 68.948  ops/s
```

And finally, the super specialized version from #1069, where `attempt`, `redeem` and `redeemWith` are all part of the runloop:
```
Benchmark                        (size)   Mode  Cnt     Score    Error  Units
AttemptBenchmark.errorRaised      10000  thrpt   20  1651.755 ± 22.416  ops/s
AttemptBenchmark.happyPath        10000  thrpt   20  2385.165 ± 23.389  ops/s
RedeemBenchmark.errorRaised       10000  thrpt   20  1489.859 ±  4.968  ops/s
RedeemBenchmark.happyPath         10000  thrpt   20  1734.115 ± 24.102  ops/s
RedeemWithBenchmark.errorRaised   10000  thrpt   20  2261.896 ±  8.064  ops/s
RedeemWithBenchmark.happyPath     10000  thrpt   20  3631.001 ± 46.834  ops/s
```

IMO, the sweetspot is: specialized `attempt` and specialized `redeemWith`, with `redeem` being implemented in terms of `redeemWith`.