### PR TITLE
Enhanced exceptions

### DIFF
--- a/core/js/src/main/scala/cats/effect/internals/TracingPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/TracingPlatform.scala
@@ -25,5 +25,5 @@ object TracingPlatform {
 
   final val traceBufferSize: Int = 32
 
-  final val contextualExceptions: Boolean = false
+  final val enhancedExceptions: Boolean = false
 }

--- a/core/js/src/main/scala/cats/effect/internals/TracingPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/TracingPlatform.scala
@@ -24,4 +24,6 @@ object TracingPlatform {
   final val isStackTracing: Boolean = isFullStackTracing || isCachedStackTracing
 
   final val traceBufferSize: Int = 32
+
+  final val contextualExceptions: Boolean = false
 }

--- a/core/jvm/src/main/java/cats/effect/internals/TracingPlatform.java
+++ b/core/jvm/src/main/java/cats/effect/internals/TracingPlatform.java
@@ -36,7 +36,7 @@ public final class TracingPlatform {
      */
     private static final String stackTracingMode = Optional.ofNullable(System.getProperty("cats.effect.stackTracingMode"))
             .filter(x -> !x.isEmpty())
-            .orElse("cached");
+            .orElse("full");
 
     public static final boolean isCachedStackTracing = stackTracingMode.equalsIgnoreCase("cached");
 
@@ -59,5 +59,15 @@ public final class TracingPlatform {
             }
         })
         .orElse(16);
+
+    /**
+     * Sets the contextual exceptions flag, which controls whether or not the
+     * stack traces of IO exceptions are augmented to include async stack trace information.
+     * Stack tracing must be enabled in order to use this feature.
+     * This flag is enabled by default.
+     */
+    public static final boolean contextualExceptions = Optional.ofNullable(System.getProperty("cats.effect.contextualExceptions"))
+            .map(x -> Boolean.valueOf(x))
+            .orElse(true);
 
 }

--- a/core/jvm/src/main/java/cats/effect/internals/TracingPlatform.java
+++ b/core/jvm/src/main/java/cats/effect/internals/TracingPlatform.java
@@ -36,7 +36,7 @@ public final class TracingPlatform {
      */
     private static final String stackTracingMode = Optional.ofNullable(System.getProperty("cats.effect.stackTracingMode"))
             .filter(x -> !x.isEmpty())
-            .orElse("full");
+            .orElse("cached");
 
     public static final boolean isCachedStackTracing = stackTracingMode.equalsIgnoreCase("cached");
 

--- a/core/jvm/src/main/java/cats/effect/internals/TracingPlatform.java
+++ b/core/jvm/src/main/java/cats/effect/internals/TracingPlatform.java
@@ -58,6 +58,6 @@ public final class TracingPlatform {
                 return Optional.empty();
             }
         })
-        .orElse(128);
+        .orElse(16);
 
 }

--- a/core/jvm/src/main/java/cats/effect/internals/TracingPlatform.java
+++ b/core/jvm/src/main/java/cats/effect/internals/TracingPlatform.java
@@ -61,12 +61,12 @@ public final class TracingPlatform {
         .orElse(16);
 
     /**
-     * Sets the contextual exceptions flag, which controls whether or not the
+     * Sets the enhanced exceptions flag, which controls whether or not the
      * stack traces of IO exceptions are augmented to include async stack trace information.
      * Stack tracing must be enabled in order to use this feature.
      * This flag is enabled by default.
      */
-    public static final boolean contextualExceptions = Optional.ofNullable(System.getProperty("cats.effect.contextualExceptions"))
+    public static final boolean enhancedExceptions = Optional.ofNullable(System.getProperty("cats.effect.enhancedExceptions"))
             .map(x -> Boolean.valueOf(x))
             .orElse(true);
 

--- a/core/shared/src/main/scala/cats/effect/internals/IOContext.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOContext.scala
@@ -38,7 +38,7 @@ final private[effect] class IOContext() {
   def trace(): IOTrace =
     IOTrace(events.toList, captured, omitted)
 
-  def getStackTraces(): List[Throwable] =
-    events.toList.collect { case IOEvent.StackTrace(throwable) => throwable }
+  def getStackTraces(): List[IOEvent.StackTrace] =
+    events.toList.collect { case ev: IOEvent.StackTrace => ev }
 
 }

--- a/core/shared/src/main/scala/cats/effect/internals/IOContext.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOContext.scala
@@ -38,4 +38,7 @@ final private[effect] class IOContext() {
   def trace(): IOTrace =
     IOTrace(events.toList, captured, omitted)
 
+  def getStackTraces(): List[Throwable] =
+    events.toList.collect { case IOEvent.StackTrace(throwable) => throwable }
+
 }

--- a/core/shared/src/main/scala/cats/effect/internals/IORunLoop.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IORunLoop.scala
@@ -114,7 +114,7 @@ private[effect] object IORunLoop {
             catch { case NonFatal(ex) => RaiseError(ex) }
 
         case RaiseError(ex) =>
-          if (isStackTracing && enhancedExceptions) {
+          if (isStackTracing && enhancedExceptions && ctx != null) {
             augmentException(ex, ctx)
           }
           findErrorHandler(bFirst, bRest) match {
@@ -247,7 +247,7 @@ private[effect] object IORunLoop {
             } catch { case NonFatal(ex) => RaiseError(ex) }
 
         case RaiseError(ex) =>
-          if (isStackTracing && enhancedExceptions) {
+          if (isStackTracing && enhancedExceptions && ctx != null) {
             augmentException(ex, ctx)
           }
           findErrorHandler(bFirst, bRest) match {

--- a/core/shared/src/main/scala/cats/effect/internals/IORunLoop.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IORunLoop.scala
@@ -134,12 +134,18 @@ private[effect] object IORunLoop {
               }
           }
 
-          val prefix = ex.getStackTrace.takeWhile(ste => ste.getClassName != "cats.effect.internals.IORunLoop$" && ste.getClassName != "scala.runtime.java8.JFunction0$mcV$sp")
-          val asyncTrace = ctx.getStackTraces()
+          val prefix = ex.getStackTrace.takeWhile(ste =>
+            ste.getClassName != "cats.effect.internals.IORunLoop$" && ste.getClassName != "scala.runtime.java8.JFunction0$mcV$sp"
+          )
+          val asyncTrace = ctx
+            .getStackTraces()
             .flatMap(t => getOpAndCallSite(t.getStackTrace.toList))
             .map {
               case (methodSite, callSite) =>
-                new StackTraceElement(methodSite.getMethodName + " @ " + callSite.getClassName, callSite.getMethodName, callSite.getFileName, callSite.getLineNumber)
+                new StackTraceElement(methodSite.getMethodName + " @ " + callSite.getClassName,
+                                      callSite.getMethodName,
+                                      callSite.getFileName,
+                                      callSite.getLineNumber)
             }
           val suffix = asyncTrace
           ex.setStackTrace(prefix ++ suffix.reverse)

--- a/core/shared/src/main/scala/cats/effect/internals/IOTracing.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOTracing.scala
@@ -45,7 +45,7 @@ private[effect] object IOTracing {
   }
 
   private def buildFrame(): IOEvent =
-    IOEvent.StackTrace(new Throwable())
+    IOEvent.StackTrace(new Throwable().getStackTrace.toList)
 
   /**
    * Global cache for trace frames. Keys are references to lambda classes.

--- a/core/shared/src/main/scala/cats/effect/internals/RingBuffer.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/RingBuffer.scala
@@ -46,10 +46,11 @@ final private[internals] class RingBuffer[A <: AnyRef](size: Int) {
   def capacity: Int =
     length
 
+  // returns a list in reverse order of insertion
   def toList: List[A] = {
-    val end = index
-    val start = Math.max(end - length, 0)
-    (start until end).toList
+    val start = index - 1
+    val end = Math.max(start - length, 0)
+    (start to end by -1).toList
       .map(i => array(i & mask).asInstanceOf[A])
   }
 

--- a/core/shared/src/main/scala/cats/effect/internals/RingBuffer.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/RingBuffer.scala
@@ -49,7 +49,7 @@ final private[internals] class RingBuffer[A <: AnyRef](size: Int) {
   // returns a list in reverse order of insertion
   def toList: List[A] = {
     val start = index - 1
-    val end = Math.max(start - length, 0)
+    val end = Math.max(index - length, 0)
     (start to end by -1).toList
       .map(i => array(i & mask).asInstanceOf[A])
   }

--- a/core/shared/src/main/scala/cats/effect/tracing/IOEvent.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/IOEvent.scala
@@ -20,9 +20,6 @@ sealed abstract class IOEvent
 
 object IOEvent {
 
-  final case class StackTrace(throwable: Throwable) extends IOEvent {
-    def stackTrace: List[StackTraceElement] =
-      throwable.getStackTrace().toList
-  }
+  final case class StackTrace(stackTrace: List[StackTraceElement]) extends IOEvent
 
 }

--- a/core/shared/src/main/scala/cats/effect/tracing/IOTrace.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/IOTrace.scala
@@ -109,9 +109,6 @@ private[effect] object IOTrace {
         case (_, callSite) => !stackTraceFilter.exists(callSite.getClassName.startsWith(_))
       }
 
-  def dropRunLoopSuffix(frames: List[StackTraceElement]): List[StackTraceElement] =
-    frames.takeWhile(ste => !contextualFilter.exists(ste.getClassName.startsWith(_)))
-
   private def renderStackTraceElement(ste: StackTraceElement): String = {
     val methodName = demangleMethod(ste.getMethodName)
     s"${ste.getClassName}.$methodName (${ste.getFileName}:${ste.getLineNumber})"
@@ -131,11 +128,6 @@ private[effect] object IOTrace {
     "sbt.",
     "java.",
     "sun.",
-    "scala."
-  )
-
-  private[this] val contextualFilter = List(
-    "cats.effect.",
     "scala."
   )
 }

--- a/core/shared/src/main/scala/cats/effect/tracing/IOTrace.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/IOTrace.scala
@@ -33,11 +33,11 @@ final case class IOTrace(events: List[IOEvent], captured: Int, omitted: Int) {
     val Junction = "├"
     val Line = "│"
 
+    val acc0 = s"IOTrace: $captured frames captured, $omitted omitted\n"
     if (options.showFullStackTraces) {
       val stackTraces = events.collect { case e: IOEvent.StackTrace => e }
 
-      val header = s"IOTrace: $captured frames captured, $omitted omitted\n"
-      val body = stackTraces.zipWithIndex
+      val acc1 = stackTraces.zipWithIndex
         .map {
           case (st, index) =>
             val tag = getOpAndCallSite(st.stackTrace)
@@ -62,9 +62,8 @@ final case class IOTrace(events: List[IOEvent], captured: Int, omitted: Int) {
         }
         .mkString("\n")
 
-      header + body
+      acc0 + acc1
     } else {
-      val acc0 = s"IOTrace: $captured frames captured, $omitted omitted\n"
       val acc1 = events.zipWithIndex
         .map {
           case (event, index) =>

--- a/core/shared/src/test/scala/cats/effect/internals/IOContextTests.scala
+++ b/core/shared/src/test/scala/cats/effect/internals/IOContextTests.scala
@@ -23,13 +23,13 @@ import org.scalatest.funsuite.AnyFunSuite
 class IOContextTests extends AnyFunSuite with Matchers {
 
   val traceBufferSize: Int = cats.effect.internals.TracingPlatform.traceBufferSize
-  val throwable = new Throwable()
+  val stackTrace = new Throwable().getStackTrace.toList
 
   test("push traces") {
     val ctx = new IOContext()
 
-    val t1 = IOEvent.StackTrace(throwable)
-    val t2 = IOEvent.StackTrace(throwable)
+    val t1 = IOEvent.StackTrace(stackTrace)
+    val t2 = IOEvent.StackTrace(stackTrace)
 
     ctx.pushEvent(t1)
     ctx.pushEvent(t2)
@@ -44,7 +44,7 @@ class IOContextTests extends AnyFunSuite with Matchers {
     val ctx = new IOContext()
 
     for (_ <- 0 until (traceBufferSize + 10)) {
-      ctx.pushEvent(IOEvent.StackTrace(throwable))
+      ctx.pushEvent(IOEvent.StackTrace(stackTrace))
     }
 
     val trace = ctx.trace()

--- a/core/shared/src/test/scala/cats/effect/internals/RingBufferTests.scala
+++ b/core/shared/src/test/scala/cats/effect/internals/RingBufferTests.scala
@@ -43,12 +43,12 @@ class RingBufferTests extends AnyFunSuite with Matchers with TestUtils {
   test("writing elements") {
     val buffer = new RingBuffer[Integer](4)
     for (i <- 0 to 3) buffer.push(i)
-    buffer.toList shouldBe List(0, 1, 2, 3)
+    buffer.toList shouldBe List(3, 2, 1, 0)
   }
 
   test("overwriting elements") {
     val buffer = new RingBuffer[Integer](4)
     for (i <- 0 to 100) buffer.push(i)
-    buffer.toList shouldBe List(97, 98, 99, 100)
+    buffer.toList shouldBe List(100, 99, 98, 97)
   }
 }

--- a/site/src/main/mdoc/tracing/index.md
+++ b/site/src/main/mdoc/tracing/index.md
@@ -26,20 +26,25 @@ coherent view of the fiber's execution path. For example, here is a trace of a
 sample program that is running in cached stack tracing mode:
 
 ```
-IOTrace: 13 frames captured, 0 omitted
- ├ flatMap at org.simpleapp.example.Example.run (Example.scala:67)
- ├ flatMap at org.simpleapp.example.Example.program (Example.scala:57)
- ├ flatMap at org.simpleapp.example.Example.program (Example.scala:58)
- ├ flatMap at org.simpleapp.example.Example.program (Example.scala:59)
- ├ flatMap at org.simpleapp.example.Example.program (Example.scala:60)
- ├ async at org.simpleapp.example.Example.program (Example.scala:60)
- ├ flatMap at org.simpleapp.example.Example.program (Example.scala:61)
- ├ flatMap at org.simpleapp.example.Example.program (Example.scala:60)
- ├ flatMap at org.simpleapp.example.Example.program2 (Example.scala:51)
- ├ map at org.simpleapp.example.Example.program2 (Example.scala:52)
- ├ map at org.simpleapp.example.Example.program (Example.scala:60)
- ├ map at org.simpleapp.example.Example.program (Example.scala:62)
- ╰ flatMap at org.simpleapp.example.Example.run (Example.scala:67)
+IOTrace: 19 frames captured
+ ├ flatMap @ org.simpleapp.examples.Main$.program (Main.scala:53)
+ ├ map @ org.simpleapp.examples.Main$.foo (Main.scala:46)
+ ├ flatMap @ org.simpleapp.examples.Main$.foo (Main.scala:45)
+ ├ flatMap @ org.simpleapp.examples.Main$.foo (Main.scala:44)
+ ├ flatMap @ org.simpleapp.examples.Main$.foo (Main.scala:43)
+ ├ flatMap @ org.simpleapp.examples.Main$.foo (Main.scala:42)
+ ├ flatMap @ org.simpleapp.examples.Main$.foo (Main.scala:41)
+ ├ flatMap @ org.simpleapp.examples.Main$.foo (Main.scala:40)
+ ├ flatMap @ org.simpleapp.examples.Main$.foo (Main.scala:39)
+ ├ flatMap @ org.simpleapp.examples.Main$.foo (Main.scala:38)
+ ├ flatMap @ org.simpleapp.examples.Main$.foo (Main.scala:37)
+ ├ flatMap @ org.simpleapp.examples.Main$.foo (Main.scala:36)
+ ├ flatMap @ org.simpleapp.examples.Main$.foo (Main.scala:35)
+ ├ flatMap @ org.simpleapp.examples.Main$.foo (Main.scala:34)
+ ├ flatMap @ org.simpleapp.examples.Main$.foo (Main.scala:33)
+ ├ flatMap @ org.simpleapp.examples.Main$.foo (Main.scala:32)
+ ├ flatMap @ org.simpleapp.examples.Main$.program (Main.scala:53)
+ ╰ ... (3 frames omitted)
 ```
 
 However, fiber tracing isn't limited to collecting stack traces. Tracing 
@@ -54,32 +59,34 @@ fiber.
 combinator was actually called by user code. For example, `void` and `as` are 
 combinators that are derived from `map`, and should appear in the fiber trace
 rather than `map`.
-3. Intermediate values. The intermediate values that an `IO` program encounters
+3. **Contextual exceptions**. Exceptions captured by the `IO` runtime can be
+augmented with async stack traces to produce more relevant stack traces.
+4. Intermediate values. The intermediate values that an `IO` program encounters
 can be converted to a string to render. This can aid in understanding the
 actions that a program takes.
-4. Thread tracking. A fiber is scheduled on potentially many threads throughout
+5. Thread tracking. A fiber is scheduled on potentially many threads throughout
 its lifetime. Knowing what thread a fiber is running on, and when it shifts
 threads is a powerful tool for understanding and debugging the concurrency of 
 an application.
-5. Tree rendering. By collecting a trace of all `IO` operations, a pretty tree
+6. Tree rendering. By collecting a trace of all `IO` operations, a pretty tree
 or graph can be rendered to visualize fiber execution.
-6. Fiber identity. Fibers, like threads, are unique and can therefore assume an
+7. Fiber identity. Fibers, like threads, are unique and can therefore assume an
 identity. If user code can observe fiber identity, powerful observability tools
 can be built on top of it. For example, another shortcoming of asynchronous
 code is that it becomes tedious to correlate log messages across asynchronous
 boundaries (thread IDs aren't very useful). With fiber identity, log messages
 produced by a single fiber can be associated with a unique, stable identifier.
-7. Fiber ancestry graph. If fibers can assume an identity, an ancestry graph 
+8. Fiber ancestry graph. If fibers can assume an identity, an ancestry graph 
 can be formed, where nodes are fibers and edges represent a fork/join
 relationship.
-8. Asynchronous deadlock detection. Even when working with asynchronously
+9. Asynchronous deadlock detection. Even when working with asynchronously
 blocking code, fiber deadlocks aren't impossible. Being able to detect
 deadlocks or infer when a deadlock can happen makes writing concurrent code
 much easier.
-9. Live fiber trace dumps. Similar to JVM thread dumps, the execution status 
+10. Live fiber trace dumps. Similar to JVM thread dumps, the execution status 
 and trace information of all fibers in an application can be extracted for 
 debugging purposes.
-10. Monad transformer analysis.
+11. Monad transformer analysis.
 
 As note of caution, fiber tracing generally introduces overhead to
 applications in the form of higher CPU usage, memory and GC pressure. 
@@ -95,7 +102,7 @@ The stack tracing mode of an application is configured by the system property
 To prevent unbounded memory usage, stack traces for a fiber are accumulated 
 in an internal buffer as execution proceeds. If more traces are collected than
 the buffer can retain, then the older traces will be overwritten. The default
-size for the buffer is 128, but can be changed via the system property 
+size for the buffer is 32, but can be changed via the system property 
 `cats.effect.traceBufferSize`. Keep in mind that the buffer size will always
 be rounded up to a power of 2.
 
@@ -162,6 +169,58 @@ def program: IO[Unit] =
 
 Keep in mind that the scope and amount of information that traces hold will
 change over time as additional fiber tracing features are merged into master.
+
+## Contextual exceptions
+The stack trace of an exception caught by the IO runloop looks similar to the
+following output:
+```
+java.lang.Throwable: A runtime exception has occurred
+	at org.simpleapp.examples.Main$.b(Main.scala:28)
+	at org.simpleapp.examples.Main$.a(Main.scala:25)
+	at org.simpleapp.examples.Main$.$anonfun$foo$11(Main.scala:37)
+	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
+	at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:103)
+	at cats.effect.internals.IORunLoop$RestartCallback.signal(IORunLoop.scala:440)
+	at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:461)
+	at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:399)
+	at cats.effect.internals.IOShift$Tick.run(IOShift.scala:36)
+	at cats.effect.internals.PoolUtils$$anon$2$$anon$3.run(PoolUtils.scala:52)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+	at java.lang.Thread.run(Thread.java:748)
+```
+
+It includes stack frames that are part of the IO runloop, which are generally
+not of interest to users of the library. When asynchronous stack tracing is
+enabled, the IO runloop is capable of augmenting the stack traces of caught
+exceptions to include frames from the asynchronous stack traces. For example,
+the augmented version of the above stack trace looks like the following:
+```
+java.lang.Throwable: A runtime exception has occurred
+	at org.simpleapp.examples.Main$.b(Main.scala:28)
+	at org.simpleapp.examples.Main$.a(Main.scala:25)
+	at org.simpleapp.examples.Main$.$anonfun$foo$11(Main.scala:37)
+	at map @ org.simpleapp.examples.Main$.$anonfun$foo$10(Main.scala:37)
+	at flatMap @ org.simpleapp.examples.Main$.$anonfun$foo$8(Main.scala:36)
+	at flatMap @ org.simpleapp.examples.Main$.$anonfun$foo$6(Main.scala:35)
+	at flatMap @ org.simpleapp.examples.Main$.$anonfun$foo$4(Main.scala:34)
+	at flatMap @ org.simpleapp.examples.Main$.$anonfun$foo$2(Main.scala:33)
+	at flatMap @ org.simpleapp.examples.Main$.foo(Main.scala:32)
+	at flatMap @ org.simpleapp.examples.Main$.program(Main.scala:42)
+	at as @ org.simpleapp.examples.Main$.run(Main.scala:48)
+	at main$ @ org.simpleapp.examples.Main$.main(Main.scala:22)
+```
+
+Note that the relevant stack frames from the call-site of the user code
+is preserved, but all IO-related stack frames are replaced with async
+stack trace frames.
+
+This feature is controlled by the system property 
+`cats.effect.contextualExceptions`. It is enabled by default.
+
+```
+-Dcats.effect.stackTracingMode=false
+```
 
 ### Complete example
 Here is a sample program that demonstrates tracing in action.

--- a/site/src/main/mdoc/tracing/index.md
+++ b/site/src/main/mdoc/tracing/index.md
@@ -59,7 +59,7 @@ fiber.
 combinator was actually called by user code. For example, `void` and `as` are 
 combinators that are derived from `map`, and should appear in the fiber trace
 rather than `map`.
-3. **Contextual exceptions**. Exceptions captured by the `IO` runtime can be
+3. **Enhanced exceptions**. Exceptions captured by the `IO` runtime can be
 augmented with async stack traces to produce more relevant stack traces.
 4. Intermediate values. The intermediate values that an `IO` program encounters
 can be converted to a string to render. This can aid in understanding the
@@ -170,7 +170,7 @@ def program: IO[Unit] =
 Keep in mind that the scope and amount of information that traces hold will
 change over time as additional fiber tracing features are merged into master.
 
-## Contextual exceptions
+## Enhanced exceptions
 The stack trace of an exception caught by the IO runloop looks similar to the
 following output:
 ```
@@ -216,7 +216,7 @@ is preserved, but all IO-related stack frames are replaced with async
 stack trace frames.
 
 This feature is controlled by the system property 
-`cats.effect.contextualExceptions`. It is enabled by default.
+`cats.effect.enhancedExceptions`. It is enabled by default.
 
 ```
 -Dcats.effect.stackTracingMode=false


### PR DESCRIPTION
With asynchronous stack tracing implemented, we have the ability to make exceptions caught by the IO runloop much more useful and relevant than they were before. This PR introduces *enhanced exceptions*, which is a feature that augments stack traces of caught exceptions with information from an accumulated fiber trace. The feature is controlled by a system property `cats.effect.enhancedExceptions`, which is enabled by default and also requires asynchronous stack tracing to be enabled.

Stack traces before:
```
java.lang.Throwable: A runtime exception has occurred
	at org.simpleapp.examples.Main$.b(Main.scala:28)
	at org.simpleapp.examples.Main$.a(Main.scala:25)
	at org.simpleapp.examples.Main$.$anonfun$foo$11(Main.scala:37)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:103)
	at cats.effect.internals.IORunLoop$RestartCallback.signal(IORunLoop.scala:440)
	at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:461)
	at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:399)
	at cats.effect.internals.IOShift$Tick.run(IOShift.scala:36)
	at cats.effect.internals.PoolUtils$$anon$2$$anon$3.run(PoolUtils.scala:52)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

Stack traces after:
```
java.lang.Throwable: A runtime exception has occurred
	at org.simpleapp.examples.Main$.b(Main.scala:28)
	at org.simpleapp.examples.Main$.a(Main.scala:25)
	at org.simpleapp.examples.Main$.$anonfun$foo$11(Main.scala:37)
	at map @ org.simpleapp.examples.Main$.$anonfun$foo$10(Main.scala:37)
	at flatMap @ org.simpleapp.examples.Main$.$anonfun$foo$8(Main.scala:36)
	at flatMap @ org.simpleapp.examples.Main$.$anonfun$foo$6(Main.scala:35)
	at flatMap @ org.simpleapp.examples.Main$.$anonfun$foo$4(Main.scala:34)
	at flatMap @ org.simpleapp.examples.Main$.$anonfun$foo$2(Main.scala:33)
	at flatMap @ org.simpleapp.examples.Main$.foo(Main.scala:32)
	at flatMap @ org.simpleapp.examples.Main$.program(Main.scala:42)
	at as @ org.simpleapp.examples.Main$.run(Main.scala:48)
	at main$ @ org.simpleapp.examples.Main$.main(Main.scala:22)
```

The original idea for this feature called for a `TracedException` wrapper, but there were quite a few problems with that approach, one of which was deciding where to wrap exceptions. 

Relevant Gitter discussion: https://gitter.im/typelevel/cats-effect-dev?at=5f31e511e20413052e7c556e

TODO:
- [x] All my review comments
- [x] Benchmarks
- [ ] Should we sanitize the augmented stack traces like we do for `printFiberTrace`?