### PR TITLE
add clock extension method for creating java.time.Instant

### DIFF
--- a/core/js/src/main/scala/cats/effect/internals/ClockPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/ClockPlatform.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.internals
+
+private[effect] trait ClockPlatform

--- a/core/jvm/src/main/scala/cats/effect/internals/ClockPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/ClockPlatform.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.internals
+
+import java.time.Instant
+
+import cats.Functor
+import cats.effect.Clock
+
+import scala.concurrent.duration.MILLISECONDS
+
+private[effect] trait ClockPlatform {
+  implicit class JvmClockOps[F[_]](val self: Clock[F]) {
+
+    /**
+     * Creates a `java.time.Instant` derived from the clock's `realTime` in milliseconds
+     * for any `F` that has `Functor` defined.
+     */
+    def instantNow(implicit F: Functor[F]): F[Instant] =
+      F.map(self.realTime(MILLISECONDS))(Instant.ofEpochMilli)
+  }
+}

--- a/core/shared/src/main/scala/cats/effect/Clock.scala
+++ b/core/shared/src/main/scala/cats/effect/Clock.scala
@@ -16,8 +16,6 @@
 
 package cats.effect
 
-import java.time.Instant
-
 import cats.{~>, Applicative, Functor, Monoid}
 import cats.data._
 
@@ -126,7 +124,7 @@ trait Clock[F[_]] {
   def monotonic(unit: TimeUnit): F[Long]
 }
 
-object Clock extends LowPriorityImplicits {
+object Clock extends LowPriorityImplicits with ClockPlatform {
   def apply[F[_]](implicit ev: Clock[F]) = ev
 
   /**
@@ -150,13 +148,6 @@ object Clock extends LowPriorityImplicits {
       def realTime(unit: TimeUnit): G[Long] = f(self.realTime(unit))
       def monotonic(unit: TimeUnit): G[Long] = f(self.monotonic(unit))
     }
-
-    /**
-     * Creates a `java.time.Instant` derived from the clock's `realTime` in milliseconds
-     * for any `F` that has `Functor` defined.
-     */
-    def instantNow(implicit F: Functor[F]): F[Instant] =
-      F.map(self.realTime(MILLISECONDS))(Instant.ofEpochMilli)
   }
 }
 

--- a/core/shared/src/main/scala/cats/effect/Clock.scala
+++ b/core/shared/src/main/scala/cats/effect/Clock.scala
@@ -16,6 +16,8 @@
 
 package cats.effect
 
+import cats.effect.internals.ClockPlatform
+
 import cats.{~>, Applicative, Functor, Monoid}
 import cats.data._
 

--- a/core/shared/src/main/scala/cats/effect/Clock.scala
+++ b/core/shared/src/main/scala/cats/effect/Clock.scala
@@ -16,6 +16,8 @@
 
 package cats.effect
 
+import java.time.Instant
+
 import cats.{~>, Applicative, Functor, Monoid}
 import cats.data._
 
@@ -148,6 +150,13 @@ object Clock extends LowPriorityImplicits {
       def realTime(unit: TimeUnit): G[Long] = f(self.realTime(unit))
       def monotonic(unit: TimeUnit): G[Long] = f(self.monotonic(unit))
     }
+
+    /**
+     * Creates a `java.time.Instant` derived from the clock's `realTime` in milliseconds
+     * for any `F` that has `Functor` defined.
+     */
+    def instantNow(implicit F: Functor[F]): F[Instant] =
+      F.map(self.realTime(MILLISECONDS))(Instant.ofEpochMilli)
   }
 }
 


### PR DESCRIPTION
I mainly end up converting clock's realTime to `Instant` and so define this extension method in my projects, so thought it might be useful to add it here if other people deal with `Instant` a lot