### PR TITLE
Unsafe convergent cache for traces

### DIFF
--- a/core/jvm/src/main/java/cats/effect/internals/UnsafeConvergentCache.java
+++ b/core/jvm/src/main/java/cats/effect/internals/UnsafeConvergentCache.java
@@ -120,8 +120,9 @@ public final class UnsafeConvergentCache<K, V> {
                 }
             }
 
-            // This is crucial, array needs to be fully initialized and primed
-            // *before* Buffer is safely initialized.
+            // This is crucial, newArray needs to be fully initialized and primed
+            // *before* Buffer is safely initialized, otherwise the final field
+            // semantics won't be extended to newArray inside Buffer.
             return new Buffer(currentLogSize, newArray);
         }
     }

--- a/core/jvm/src/main/java/cats/effect/internals/UnsafeConvergentCache.java
+++ b/core/jvm/src/main/java/cats/effect/internals/UnsafeConvergentCache.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.internals;
+
+@SuppressWarnings("unchecked")
+public final class UnsafeConvergentCache<K, V> {
+
+    // We need final-field semantics when:
+    // 1) Growing an array and replacing the reference
+    // 2) Inserting a new cache entry
+    private Buffer<K, V> buffer = new Buffer<>(10);
+
+    public void put(K k, V v) {
+        if (buffer.put(k, v) != null) {
+            // A collision occurred, grow the buffer and re-insert
+            // all elements.
+            buffer = buffer.grow();
+        }
+    }
+
+    public V get(K k) {
+        Node<K, V> entry = buffer.get(k);
+        if (entry != null) {
+            return entry.value;
+        } else {
+            return null;
+        }
+    }
+
+    private static final class Node<A, B> {
+        public final A key;
+        public final B value;
+
+        private Node(A key, B value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+
+    private static final class Buffer<K, V> {
+        private final Node<K, V>[] array;
+        private final int logSize;
+        private final int size;
+        private final int mask;
+
+        public Buffer(int logSize) {
+            this.logSize = logSize;
+            this.size = 1 << logSize;
+            this.mask = this.size - 1;
+            this.array = (Node<K,V>[]) new Node<?, ?>[this.size];
+        }
+
+        public Buffer(int logSize, Node<K, V>[] array) {
+            this.logSize = logSize;
+            this.size = 1 << logSize;
+            this.mask = this.size - 1;
+            this.array = array;
+        }
+
+        public Node<K, V> put(K k, V v) {
+            int hash = k.hashCode() & this.mask;
+            Node<K, V> old = this.array[hash];
+            if (old == null) {
+                Node<K, V> newEntry = new Node<>(k, v);
+                this.array[hash] = newEntry;
+            }
+            return old;
+        }
+
+        public Node<K, V> get(K k) {
+            int hash = k.hashCode() & this.mask;
+            return this.array[hash];
+        }
+
+        public Buffer grow() {
+            int currentLogSize = this.logSize + 1;
+            int currentSize = 1 << currentLogSize;
+            int currentMask = currentSize - 1;
+            Node<K, V>[] newArray = (Node<K, V>[]) new Node<?, ?>[currentSize];
+
+            boolean done = false;
+            while (!done) {
+                boolean collided = false;
+                for (int i = 0; i < this.size && !collided; i++) {
+                    Node<K, V> entry = this.array[i];
+                    if (entry != null) {
+                        int hash = entry.key.hashCode() & currentMask;
+                        if (newArray[hash] != null) {
+                            System.out.println("collided at " + hash);
+                            System.out.println(newArray[hash].value);
+                            System.out.println(entry.value);
+                            collided = true;
+                        } else {
+                            newArray[hash] = entry;
+                        }
+                    }
+                }
+
+                if (collided) {
+                    currentLogSize += 1;
+                    currentSize = 1 << currentLogSize;
+                    currentMask = currentSize - 1;
+                    newArray = (Node<K, V>[]) new Node<?, ?>[currentSize];
+                } else {
+                    done = true;
+                }
+            }
+
+            // This is crucial, array needs to be fully initialized and primed
+            // *before* Buffer is safely initialized.
+            return new Buffer(currentLogSize, newArray);
+        }
+    }
+
+}

--- a/core/jvm/src/main/java/cats/effect/internals/UnsafeConvergentCache.java
+++ b/core/jvm/src/main/java/cats/effect/internals/UnsafeConvergentCache.java
@@ -17,7 +17,7 @@
 package cats.effect.internals;
 
 @SuppressWarnings("unchecked")
-public final class UnsafeConvergentCache<K, V> {
+final class UnsafeConvergentCache<K, V> {
 
     // We need final-field semantics when:
     // 1) Growing an array and replacing the reference

--- a/core/shared/src/main/scala/cats/effect/internals/IOTracing.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOTracing.scala
@@ -51,6 +51,6 @@ private[effect] object IOTracing {
    * Global cache for trace frames. Keys are references to lambda classes.
    * Should converge to the working set of traces very quickly for hot code paths.
    */
-  private[this] val frameCache: ConcurrentHashMap[Class[_], IOEvent] = new ConcurrentHashMap()
+  private[this] val frameCache: UnsafeConvergentCache[Class[_], IOEvent] = new UnsafeConvergentCache()
 
 }

--- a/core/shared/src/main/scala/cats/effect/internals/IOTracing.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOTracing.scala
@@ -19,7 +19,6 @@ package cats.effect.internals
 import cats.effect.IO
 import cats.effect.IO.Trace
 import cats.effect.tracing.IOEvent
-import cats.effect.internals.UnsafeConvergentCache
 
 private[effect] object IOTracing {
 

--- a/core/shared/src/main/scala/cats/effect/internals/IOTracing.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOTracing.scala
@@ -16,11 +16,10 @@
 
 package cats.effect.internals
 
-import java.util.concurrent.ConcurrentHashMap
-
 import cats.effect.IO
 import cats.effect.IO.Trace
 import cats.effect.tracing.IOEvent
+import cats.effect.internals.UnsafeConvergentCache
 
 private[effect] object IOTracing {
 

--- a/core/shared/src/main/scala/cats/effect/internals/UnsafeConvergentCache.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/UnsafeConvergentCache.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.internals
+
+private[internals] final class UnsafeConvergentCache[K, V <: AnyRef] {
+
+  private[this] val buffer: Buffer = new Buffer(10)
+
+  def put(k: K, v: V): Unit =
+    buffer.put(k, v)
+
+  def get(k: K): V =
+    buffer.get(k)
+
+  private[this] final class Buffer(logSize: Int) {
+    private[this] val size = 1 << logSize
+    private[this] val mask = size - 1
+    private[this] val array = new Array[AnyRef](size)
+
+    def put(k: K, v: V): Unit = {
+      val hash = k.hashCode() & mask
+      array(hash) = v
+//      if (array(hash) ne null) {
+//        array(hash) = v
+//      } else {
+//        // grow and reset buffer
+//        val newBuffer = new Buffer(logSize + 1)
+//        for (i <- 0 until size) {
+//          val elem = array(i)
+//          if (elem ne null) {
+//
+//          }
+//        }
+//        buffer = newBuffer
+//      }
+    }
+
+    def get(k: K): V = {
+      val hash = k.hashCode() & mask
+      array(hash).asInstanceOf[V]
+    }
+  }
+
+}


### PR DESCRIPTION
This should be the last PR to have tracing ready for 2.2.0. The current version of tracing relies on `ConcurrentHashMap` to keep a cache of traces. As described in #1076, `ConcurrentHashMap` offers thread safety at the cost of synchronization via read barriers on the hot read path. Because the cache will eventually converge to an optimal set, it's OK if we don't have safe publication (different threads may not see the same cache), as long as the objects we *do* see are all safely initialized.  Safe initialization means that an object values initialized in a constructor are visible to threads who observe a shared reference to the object. This property is implicitly guaranteed with the usual synchronization primitives that offer thread safety.

The Java memory model offers another method of achieving safe initialization that is much cheaper than synchronization: final fields. The semantics of final fields dictate that as long as `this` doesn't escape during the constructor of an object and that its final fields are set *before* the constructor completes, then any thread who observes a shared reference of the initialized object will observe fully initialized values for its final fields, and that guarantee extends transitively.

We leverage these semantics to build a thread-unsafe, convergent cache that achieves a higher read throughput than `ConcurrentHashMap`.

TODO:
- [ ] Tests
- [ ] Benchmarks
- [ ] Detailed documentation about the memory model guarantees we are leveraging here
- [ ] Collisions beneath `mask`
- [ ] Max buffer sizes
- [ ] Rewrite the implementation in Scala, verifying field modifiers

Closes #1076.