### PR TITLE
Add IO.whenA and related convenience methods

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1624,6 +1624,48 @@ object IO extends IOInstances {
       cb(Right(ctx.trace()))
     }
 
+  /**
+   * Returns the given argument if `cond` is true, otherwise `IO.Unit`
+   *
+   * @see [[IO.unlessA]] for the inverse
+   * @see [[IO.raiseWhen]] for conditionally raising an error
+   */
+  def whenA(cond: Boolean)(action: => IO[Unit]): IO[Unit] =
+    Applicative[IO].whenA(cond)(action)
+
+  /**
+   * Returns the given argument if `cond` is false, otherwise `IO.Unit`
+   *
+   * @see [[IO.whenA]] for the inverse
+   * @see [[IO.raiseWhen]] for conditionally raising an error
+   */
+  def unlessA(cond: Boolean)(action: => IO[Unit]): IO[Unit] =
+    Applicative[IO].unlessA(cond)(action)
+
+  /**
+   * Returns `raiseError` when the `cond` is true, otherwise `IO.unit`
+   *
+   * @example {{{
+   * val tooMany = 5
+   * val x: Int = ???
+   * IO.raiseWhen(x >= tooMany)(new IllegalArgumentException("Too many"))
+   * }}}
+   */
+  def raiseWhen(cond: Boolean)(e: => Throwable): IO[Unit] =
+    IO.whenA(cond)(IO.raiseError(e))
+
+  /**
+   * Returns `raiseError` when `cond` is false, otherwise IO.unit
+   *
+   * @example {{{
+   * val tooMany = 5
+   * val x: Int = ???
+   * IO.raiseUnless(x < tooMany)(new IllegalArgumentException("Too many"))
+   * }}}
+   */
+  def raiseUnless(cond: Boolean)(e: => Throwable): IO[Unit] =
+    IO.unlessA(cond)(IO.raiseError(e))
+
   /* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-= */
   /* IO's internal encoding: */
   // In the Bind, Map, and Async constructors, you will notice that traces


### PR DESCRIPTION
Applicative#whenA is a very commonly useful method, but for codebases using
concrete `IO` instead of 'tagless' style, they need to invoke it as
`Applicative[IO].whenA`, which is harder to discover and harder to explain

To make that use case easier, add convenience methods:
- IO.when
- IO.unless
- IO.raiseWhen
- IO.raiseUnless

I chose the names `raiseWhen` and `raiseUnless` to be more discoverable via
autocompletion from `IO.raise<tab>`, as well as for the parallels to the other
methods

A hypothetical application diff for contrast:
```diff
-Applicative[IO].whenA(badThings)(IO.raiseError(new Exception("oh no")))
+IO.raiseWhen(badThings)(new Exception("oh no"))
```