### PR TITLE
1096 fix warnings

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -274,7 +274,7 @@ sealed abstract class Resource[+F[_], +A] {
         stack: List[Any => Resource[G, Any]],
         release: G[Unit]): G[(Any, G[Unit])] =
       current match {
-        case a@Allocate(_) => {
+        case a @ Allocate(_) => {
           val cur = a.asInstanceOf[Allocate[G, Any]]
           G.bracketCase(cur.resource) {
             case (a, rel) =>
@@ -290,11 +290,11 @@ sealed abstract class Resource[+F[_], +A] {
               release(ec)
           }
         }
-        case b@Bind(_, _) => {
+        case b @ Bind(_, _) => {
           val cur = b.asInstanceOf[Bind[G, Any, Any]]
           loop(cur.source, cur.fs.asInstanceOf[Any => Resource[G, Any]] :: stack, release)
         }
-        case s@Suspend(_) => {
+        case s @ Suspend(_) => {
           val cur = s.asInstanceOf[Suspend[G, Any]]
           cur.resource.flatMap(continue(_, stack, release))
         }
@@ -738,7 +738,7 @@ abstract private[effect] class ResourceMonad[F[_]] extends Monad[Resource[F, *]]
   def tailRecM[A, B](a: A)(f: A => Resource[F, Either[A, B]]): Resource[F, B] = {
     def continue(r: Resource[F, Either[A, B]]): Resource[F, B] =
       r match {
-        case a@Allocate(_) => {
+        case a @ Allocate(_) => {
           val cur = a.asInstanceOf[Allocate[F, Either[A, B]]]
           Suspend(cur.resource.flatMap[Resource[F, B]] {
             case (Left(a), release) =>
@@ -747,11 +747,11 @@ abstract private[effect] class ResourceMonad[F[_]] extends Monad[Resource[F, *]]
               F.pure(Allocate[F, B](F.pure((b, release))))
           })
         }
-        case s@Suspend(_) => {
+        case s @ Suspend(_) => {
           val cur = s.asInstanceOf[Suspend[F, Either[A, B]]]
           Suspend(cur.resource.map(continue))
         }
-        case b@Bind(_, _) => {
+        case b @ Bind(_, _) => {
           val cur = b.asInstanceOf[Bind[F, Any, Either[A, B]]]
           Bind(cur.source, AndThen(cur.fs).andThen(continue))
         }

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -22,8 +22,6 @@ import cats.effect.concurrent.Ref
 import cats.implicits._
 import cats.effect.implicits._
 
-import scala.annotation.tailrec
-
 import Resource.ExitCase
 
 /**
@@ -109,7 +107,8 @@ sealed abstract class Resource[+F[_], +A] {
 
     // Interpreter that knows how to evaluate a Resource data structure;
     // Maintains its own stack for dealing with Bind chains
-    @tailrec def loop(current: Resource[G, Any], stack: List[Any => Resource[G, Any]]): G[Any] =
+    //@tailrec scala 2.13  thinks this isn't tail recursive ¯\_(ツ)_/
+    def loop(current: Resource[G, Any], stack: List[Any => Resource[G, Any]]): G[Any] =
       current match {
         case a @ Allocate(_) => {
           val cur = a.asInstanceOf[Allocate[G, Any]]
@@ -269,7 +268,8 @@ sealed abstract class Resource[+F[_], +A] {
 
     // Interpreter that knows how to evaluate a Resource data structure;
     // Maintains its own stack for dealing with Bind chains
-    @tailrec def loop(
+    //@tailrec scala 2.13  thinks this isn't tail recursive ¯\_(ツ)_/
+    def loop(
         current: Resource[G, Any],
         stack: List[Any => Resource[G, Any]],
         release: G[Unit]): G[(Any, G[Unit])] =


### PR DESCRIPTION
Fix runtime typecheck warnings.

Unfortunately this requires us to remove the tailrec annotations as 2.13 is buggy and thinks that it isn't tail-recursive. I've checked the bytecode and it looks ok though.