### PR TITLE
Remove auto-supervision semantics in joinAndEmbedNever

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Fiber.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Fiber.scala
@@ -26,5 +26,5 @@ trait Fiber[F[_], E, A] {
     join.flatMap(_.fold(onCancel, F.raiseError(_), fa => fa))
 
   def joinAndEmbedNever(implicit F: Concurrent[F, E]): F[A] =
-    joinAndEmbed(F.canceled *> F.never)
+    joinAndEmbed(F.never)
 }


### PR DESCRIPTION
This makes `joinAndEmbedNever` have the same semantics as `join` from CE2