### PR TITLE
Express trace buffer size as a log of 2

### DIFF
--- a/core/js/src/main/scala/cats/effect/internals/TracingPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/internals/TracingPlatform.scala
@@ -23,7 +23,7 @@ object TracingPlatform {
 
   final val isStackTracing: Boolean = isFullStackTracing || isCachedStackTracing
 
-  final val traceBufferSize: Int = 32
+  final val traceBufferLogSize: Int = 4
 
   final val enhancedExceptions: Boolean = false
 }

--- a/core/jvm/src/main/java/cats/effect/internals/TracingPlatform.java
+++ b/core/jvm/src/main/java/cats/effect/internals/TracingPlatform.java
@@ -49,7 +49,7 @@ public final class TracingPlatform {
      * lines are produced, then the oldest trace lines will be discarded.
      * Automatically rounded up to the nearest power of 2.
      */
-    public static final int traceBufferSize = Optional.ofNullable(System.getProperty("cats.effect.traceBufferSize"))
+    public static final int traceBufferLogSize = Optional.ofNullable(System.getProperty("cats.effect.traceBufferLogSize"))
         .filter(x -> !x.isEmpty())
         .flatMap(x -> {
             try {
@@ -58,7 +58,7 @@ public final class TracingPlatform {
                 return Optional.empty();
             }
         })
-        .orElse(16);
+        .orElse(4);
 
     /**
      * Sets the enhanced exceptions flag, which controls whether or not the

--- a/core/shared/src/main/scala/cats/effect/internals/IOContext.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IOContext.scala
@@ -17,7 +17,7 @@
 package cats.effect.internals
 
 import cats.effect.tracing.{IOEvent, IOTrace}
-import cats.effect.internals.TracingPlatform.traceBufferSize
+import cats.effect.internals.TracingPlatform.traceBufferLogSize
 
 /**
  * INTERNAL API — Holds state related to the execution of
@@ -26,7 +26,7 @@ import cats.effect.internals.TracingPlatform.traceBufferSize
  */
 final private[effect] class IOContext() {
 
-  private[this] val events: RingBuffer[IOEvent] = new RingBuffer(traceBufferSize)
+  private[this] val events: RingBuffer[IOEvent] = new RingBuffer(traceBufferLogSize)
   private[this] var captured: Int = 0
   private[this] var omitted: Int = 0
 

--- a/core/shared/src/main/scala/cats/effect/internals/RingBuffer.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/RingBuffer.scala
@@ -21,12 +21,10 @@ package cats.effect.internals
  *
  * INTERNAL API.
  */
-final private[internals] class RingBuffer[A <: AnyRef](size: Int) {
-
-  import RingBuffer._
+final private[internals] class RingBuffer[A <: AnyRef](logSize: Int) {
 
   // These two probably don't need to be allocated every single time, maybe in Java?
-  private[this] val length = nextPowerOfTwo(size)
+  private[this] val length = 1 << logSize
   private[this] val mask = length - 1
 
   private[this] val array: Array[AnyRef] = new Array(length)
@@ -52,19 +50,6 @@ final private[internals] class RingBuffer[A <: AnyRef](size: Int) {
     val end = Math.max(index - length, 0)
     (start to end by -1).toList
       .map(i => array(i & mask).asInstanceOf[A])
-  }
-
-}
-
-private[internals] object RingBuffer {
-
-  // N.B. this can overflow
-  private def nextPowerOfTwo(i: Int): Int = {
-    var n = 1
-    while (n < i) {
-      n *= 2
-    }
-    n
   }
 
 }

--- a/core/shared/src/test/scala/cats/effect/internals/IOContextTests.scala
+++ b/core/shared/src/test/scala/cats/effect/internals/IOContextTests.scala
@@ -22,7 +22,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class IOContextTests extends AnyFunSuite with Matchers {
 
-  val traceBufferSize: Int = cats.effect.internals.TracingPlatform.traceBufferSize
+  val traceBufferSize: Int = 1 << cats.effect.internals.TracingPlatform.traceBufferLogSize
   val stackTrace = new Throwable().getStackTrace.toList
 
   test("push traces") {

--- a/core/shared/src/test/scala/cats/effect/internals/RingBufferTests.scala
+++ b/core/shared/src/test/scala/cats/effect/internals/RingBufferTests.scala
@@ -31,23 +31,14 @@ class RingBufferTests extends AnyFunSuite with Matchers with TestUtils {
     buffer.isEmpty shouldBe false
   }
 
-  test("size is a power of two") {
-    new RingBuffer[Integer](0).capacity shouldBe 1
-    new RingBuffer[Integer](1).capacity shouldBe 1
-    new RingBuffer[Integer](2).capacity shouldBe 2
-    new RingBuffer[Integer](3).capacity shouldBe 4
-    new RingBuffer[Integer](127).capacity shouldBe 128
-    new RingBuffer[Integer](13000).capacity shouldBe 16384
-  }
-
   test("writing elements") {
-    val buffer = new RingBuffer[Integer](4)
+    val buffer = new RingBuffer[Integer](2)
     for (i <- 0 to 3) buffer.push(i)
     buffer.toList shouldBe List(3, 2, 1, 0)
   }
 
   test("overwriting elements") {
-    val buffer = new RingBuffer[Integer](4)
+    val buffer = new RingBuffer[Integer](2)
     for (i <- 0 to 100) buffer.push(i)
     buffer.toList shouldBe List(100, 99, 98, 97)
   }

--- a/site/src/main/mdoc/tracing/index.md
+++ b/site/src/main/mdoc/tracing/index.md
@@ -102,14 +102,14 @@ The stack tracing mode of an application is configured by the system property
 To prevent unbounded memory usage, stack traces for a fiber are accumulated 
 in an internal buffer as execution proceeds. If more traces are collected than
 the buffer can retain, then the older traces will be overwritten. The default
-size for the buffer is 32, but can be changed via the system property 
-`cats.effect.traceBufferSize`. Keep in mind that the buffer size will always
-be rounded up to a power of 2.
+size for the buffer is 16, but can be changed via the system property 
+`cats.effect.traceBufferLogSize`. Note that this property is expressed
+as a logarithm of a power of two!
 
-For example, to enable full stack tracing and a trace buffer size of 1024,
+For example, to enable full stack tracing and a trace buffer size of 32,
 specify the following system properties:
 ```
--Dcats.effect.stackTracingMode=full -Dcats.effect.traceBufferSize=1024
+-Dcats.effect.stackTracingMode=full -Dcats.effect.traceBufferLogSize=5
 ```
 
 #### DISABLED


### PR DESCRIPTION
1. I wonder if `traceBufferLogSize` is confusing? "log" can be ambiguous
2. Should we limit the size of it at all, or just leave it to the user to understand what they're doing? A high value like 30 could cause a heap overflow
3. also, if they pass in something >32, the size is 0, so i'm not sure if that throws an exception or something