### PR TITLE
Fix benchmarks build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -195,6 +195,15 @@ lazy val scalaJSSettings = Seq(
   scalacOptions in (Compile, doc) -= "-Xfatal-warnings"
 )
 
+lazy val sharedSourcesSettings = Seq(
+  unmanagedSourceDirectories in Compile += {
+    baseDirectory.value.getParentFile / "shared" / "src" / "main" / "scala"
+  },
+  unmanagedSourceDirectories in Test += {
+    baseDirectory.value.getParentFile / "shared" / "src" / "test" / "scala"
+  }
+)
+
 lazy val root = project
   .in(file("."))
   .disablePlugins(MimaPlugin)
@@ -272,7 +281,7 @@ lazy val runtimeTests = project
 
 lazy val benchmarksPrev = project
   .in(file("benchmarks/vPrev"))
-  .settings(commonSettings ++ noPublishSettings)
+  .settings(commonSettings ++ noPublishSettings ++ sharedSourcesSettings)
   .settings(libraryDependencies += "org.typelevel" %% "cats-effect" % "2.0.0")
   .settings(scalacOptions ~= (_.filterNot(Set("-Xfatal-warnings", "-Ywarn-unused-import").contains)))
   .enablePlugins(JmhPlugin)
@@ -280,7 +289,7 @@ lazy val benchmarksPrev = project
 lazy val benchmarksNext = project
   .in(file("benchmarks/vNext"))
   .dependsOn(coreJVM)
-  .settings(commonSettings ++ noPublishSettings)
+  .settings(commonSettings ++ noPublishSettings ++ sharedSourcesSettings)
   .settings(scalacOptions ~= (_.filterNot(Set("-Xfatal-warnings", "-Ywarn-unused-import").contains)))
   .enablePlugins(JmhPlugin)
 


### PR DESCRIPTION
#1089 removed those settings which seems to have broken the invocation of benchmarks (#1106)

This is a purely mechanical revert, courtesy of git bisect - I won't be able to explain the connection between this fix and the original error :)

Should there be a small fake benchmark specifically for CI so it can be run on each build to make sure this doesn't happen again?

## Before

```
sbt:root> benchmarksNext/jmh:run -wi 0 -i 1 -f 1 -t 1 cats.effect.benchmarks.DeepBindBenchmark
[info] Compiling 16 Scala sources and 1 Java source to /root/projects/personal/cats-effect/core/jvm/target/scala-2.13/classes ...
[info] Compiling 12 Scala sources to /root/projects/personal/cats-effect/core/jvm/target/scala-2.13/classes ...
Processing 59 classes from /root/projects/personal/cats-effect/benchmarks/vNext/target/scala-2.13/classes with "reflection" generator
Writing out Java source to /root/projects/personal/cats-effect/benchmarks/vNext/target/scala-2.13/src_managed/jmh and resources to /root/projects/personal/cats-effect/benchmarks/vNext/target/scala-2.13/resource_managed/jmh
[error] stack trace is suppressed; run last benchmarksNext / Jmh / generateJmhSourcesAndResources for the full output
[error] (benchmarksNext / Jmh / generateJmhSourcesAndResources) java.lang.NoClassDefFoundError: cats/effect/benchmarks/AttemptBenchmark
[error] Total time: 27 s, completed Aug 23, 2020 2:01:33 PM
```

## After

```
sbt:root> benchmarksNext/jmh:run -wi 0 -i 1 -f 1 -t 1 cats.effect.benchmarks.DeepBindBenchmark
[info] Headers created for 8 files:
[info]   /root/projects/personal/cats-effect/benchmarks/shared/src/main/scala/cats/effect/benchmarks/DeepBindBenchmark.scala
[info]   /root/projects/personal/cats-effect/benchmarks/shared/src/main/scala/cats/effect/benchmarks/AsyncBenchmark.scala
[info]   /root/projects/personal/cats-effect/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapStreamBenchmark.scala
[info]   /root/projects/personal/cats-effect/benchmarks/shared/src/main/scala/cats/effect/benchmarks/AttemptBenchmark.scala
[info]   /root/projects/personal/cats-effect/benchmarks/shared/src/main/scala/cats/effect/benchmarks/ECBenchmark.scala
[info]   /root/projects/personal/cats-effect/benchmarks/shared/src/main/scala/cats/effect/benchmarks/HandleErrorBenchmark.scala
[info]   /root/projects/personal/cats-effect/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapCallsBenchmark.scala
[info]   /root/projects/personal/cats-effect/benchmarks/shared/src/main/scala/cats/effect/benchmarks/ShallowBindBenchmark.scala
[info] Compiling 8 Scala sources to /root/projects/personal/cats-effect/benchmarks/vNext/target/scala-2.13/classes ...
Processing 74 classes from /root/projects/personal/cats-effect/benchmarks/vNext/target/scala-2.13/classes with "reflection" generator
Writing out Java source to /root/projects/personal/cats-effect/benchmarks/vNext/target/scala-2.13/src_managed/jmh and resources to /root/projects/personal/cats-effect/benchmarks/vNext/target/scala-2.13/resource_managed/jmh
[info] Compiling 59 Java sources to /root/projects/personal/cats-effect/benchmarks/vNext/target/scala-2.13/classes ...
[info] running (fork) org.openjdk.jmh.Main -wi 0 -i 1 -f 1 -t 1 cats.effect.benchmarks.DeepBindBenchmark
[info] # JMH version: 1.21
```