### PR TITLE
All things work stealing

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/AsyncBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/AsyncBenchmark.scala
@@ -64,7 +64,7 @@ class AsyncBenchmark {
       if (i < size) evalAsync(i + 1).flatMap(loop)
       else evalAsync(i)
 
-    IO(0).flatMap(loop).unsafeRunSync()
+    IO(0).flatMap(loop).unsafeRunSyncBenchmark()
   }
 
   @Benchmark
@@ -73,7 +73,7 @@ class AsyncBenchmark {
       if (i < size) evalCancelable(i + 1).flatMap(loop)
       else evalCancelable(i)
 
-    IO(0).flatMap(loop).unsafeRunSync()
+    IO(0).flatMap(loop).unsafeRunSyncBenchmark()
   }
 
   // TODO
@@ -125,7 +125,7 @@ class AsyncBenchmark {
       else
         IO.pure(i)
 
-    IO(0).flatMap(loop).unsafeRunSync()
+    IO(0).flatMap(loop).unsafeRunSyncBenchmark()
   }
 
   @Benchmark
@@ -136,6 +136,6 @@ class AsyncBenchmark {
       else
         IO.pure(i)
 
-    IO(0).flatMap(loop).unsafeRunSync()
+    IO(0).flatMap(loop).unsafeRunSyncBenchmark()
   }
 }

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/AttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/AttemptBenchmark.scala
@@ -52,7 +52,7 @@ class AttemptBenchmark {
       if (i < size) IO.pure(i + 1).attempt.flatMap(_.fold(IO.raiseError, loop))
       else IO.pure(i)
 
-    loop(0).unsafeRunSync()
+    loop(0).unsafeRunSyncBenchmark()
   }
 
   @Benchmark
@@ -69,6 +69,6 @@ class AttemptBenchmark {
       else
         IO.pure(i)
 
-    loop(0).unsafeRunSync()
+    loop(0).unsafeRunSyncBenchmark()
   }
 }

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/DeepBindBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/DeepBindBenchmark.scala
@@ -55,7 +55,7 @@ class DeepBindBenchmark {
           loop(j + 1)
       }
 
-    loop(0).unsafeRunSync()
+    loop(0).unsafeRunSyncBenchmark()
   }
 
   @Benchmark
@@ -68,7 +68,7 @@ class DeepBindBenchmark {
           loop(j + 1)
       }
 
-    loop(0).unsafeRunSync()
+    loop(0).unsafeRunSyncBenchmark()
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/HandleErrorBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/HandleErrorBenchmark.scala
@@ -53,7 +53,7 @@ class HandleErrorBenchmark {
       else
         IO.pure(i)
 
-    loop(0).unsafeRunSync()
+    loop(0).unsafeRunSyncBenchmark()
   }
 
   @Benchmark
@@ -69,6 +69,6 @@ class HandleErrorBenchmark {
       else
         IO.pure(i)
 
-    loop(0).unsafeRunSync()
+    loop(0).unsafeRunSyncBenchmark()
   }
 }

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/MapCallsBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/MapCallsBenchmark.scala
@@ -65,7 +65,7 @@ object MapCallsBenchmark {
     var sum = 0L
     var i = 0
     while (i < iterations) {
-      sum += io.unsafeRunSync()
+      sum += io.unsafeRunSyncBenchmark()
       i += 1
     }
     sum

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/MapStreamBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/MapStreamBenchmark.scala
@@ -62,7 +62,7 @@ object MapStreamBenchmark {
       stream = mapStream(addOne)(stream)
       i += 1
     }
-    sum(0)(stream).unsafeRunSync()
+    sum(0)(stream).unsafeRunSyncBenchmark()
   }
 
   final case class Stream(value: Int, next: IO[Option[Stream]])

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/RedeemBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/RedeemBenchmark.scala
@@ -54,7 +54,7 @@ class RedeemBenchmark {
       if (i < size) IO.pure(i + 1).redeem(_ => 0, id).flatMap(loop)
       else IO.pure(i)
 
-    loop(0).unsafeRunSync()
+    loop(0).unsafeRunSyncBenchmark()
   }
 
   @Benchmark
@@ -69,6 +69,6 @@ class RedeemBenchmark {
       else
         IO.pure(i)
 
-    loop(0).unsafeRunSync()
+    loop(0).unsafeRunSyncBenchmark()
   }
 }

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/RedeemWithBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/RedeemWithBenchmark.scala
@@ -54,7 +54,7 @@ class RedeemWithBenchmark {
       if (i < size) IO.pure(i + 1).redeemWith(recover, loop)
       else IO.pure(i)
 
-    loop(0).unsafeRunSync()
+    loop(0).unsafeRunSyncBenchmark()
   }
 
   @Benchmark
@@ -69,6 +69,6 @@ class RedeemWithBenchmark {
       else
         IO.pure(i)
 
-    loop(0).unsafeRunSync()
+    loop(0).unsafeRunSyncBenchmark()
   }
 }

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/ShallowBindBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/ShallowBindBenchmark.scala
@@ -52,7 +52,7 @@ class ShallowBindBenchmark {
       if (i < size) IO.pure(i + 1).flatMap(loop)
       else IO.pure(i)
 
-    IO.pure(0).flatMap(loop).unsafeRunSync()
+    IO.pure(0).flatMap(loop).unsafeRunSyncBenchmark()
   }
 
   @Benchmark
@@ -61,7 +61,7 @@ class ShallowBindBenchmark {
       if (i < size) IO(i + 1).flatMap(loop)
       else IO(i)
 
-    IO(0).flatMap(loop).unsafeRunSync()
+    IO(0).flatMap(loop).unsafeRunSyncBenchmark()
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.benchmarks
+
+import cats.effect.IO
+import cats.effect.unsafe._
+import cats.implicits._
+
+import scala.concurrent.ExecutionContext
+
+import java.util.concurrent.{Executors, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
+import org.openjdk.jmh.annotations._
+
+/**
+ * To do comparative benchmarks between versions:
+ *
+ *     benchmarks/run-benchmark WorkStealingBenchmark
+ *
+ * This will generate results in `benchmarks/results`.
+ *
+ * Or to run the benchmark from within sbt:
+ *
+ *     jmh:run -i 10 -wi 10 -f 2 -t 1 cats.effect.benchmarks.WorkStealingBenchmark
+ *
+ * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+ * Please note that benchmarks should be usually executed at least in
+ * 10 iterations (as a rule of thumb), but more is better.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MINUTES)
+class WorkStealingBenchmark {
+
+  @Param(Array("1000000"))
+  var size: Int = _
+
+  def benchmark(implicit runtime: IORuntime): Int = {
+    def fiber(i: Int): IO[Int] =
+      IO.cede.flatMap { _ =>
+        IO(i).flatMap { j =>
+          IO.cede.flatMap { _ =>
+            if (j > 10000)
+              IO.cede.flatMap(_ => IO.pure(j))
+            else
+              IO.cede.flatMap(_ => fiber(j + 1))
+          }
+        }
+      }
+
+    List
+      .range(0, size)
+      .traverse(fiber(_).start)
+      .flatMap(_.traverse(_.joinAndEmbedNever))
+      .map(_.sum)
+      .unsafeRunSync()
+  }
+
+  @Benchmark
+  def async(): Int = {
+    import cats.effect.unsafe.implicits.global
+    benchmark
+  }
+
+  @Benchmark
+  def asyncTooManyThreads(): Int = {
+    implicit lazy val runtime: IORuntime = {
+      val blocking = {
+        val threadCount = new AtomicInteger(0)
+        val executor = Executors.newCachedThreadPool { (r: Runnable) =>
+          val t = new Thread(r)
+          t.setName(s"io-blocking-${threadCount.getAndIncrement()}")
+          t.setDaemon(true)
+          t
+        }
+        ExecutionContext.fromExecutor(executor)
+      }
+
+      val scheduler = {
+        val executor = Executors.newSingleThreadScheduledExecutor { r =>
+          val t = new Thread(r)
+          t.setName("io-scheduler")
+          t.setDaemon(true)
+          t.setPriority(Thread.MAX_PRIORITY)
+          t
+        }
+        Scheduler.fromScheduledExecutor(executor)
+      }
+
+      val compute = new WorkStealingThreadPool(256, "io-compute", runtime)
+
+      new IORuntime(compute, blocking, scheduler, () => ())
+    }
+
+    benchmark
+  }
+}

--- a/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package unsafe
+
+import scala.concurrent.ExecutionContext
+
+// Can you imagine a thread pool on JS? Have fun trying to extend or instantiate this class.
+// Unfortunately, due to the explicit branching, this type leaks into the shared source code of IOFiber.scala.
+private[effect] sealed abstract class WorkStealingThreadPool private ()
+    extends ExecutionContext {
+  def execute(runnable: Runnable): Unit = ()
+  def reportFailure(cause: Throwable): Unit = ()
+  private[effect] def executeFiber(fiber: IOFiber[_]): Unit = { val _ = fiber }
+  private[effect] def rescheduleFiber(fiber: IOFiber[_]): Unit = { val _ = fiber }
+}

--- a/core/jvm/src/main/java/cats/effect/WorkStealingQueueConstants.java
+++ b/core/jvm/src/main/java/cats/effect/WorkStealingQueueConstants.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.unsafe;
+
+final class WorkStealingQueueConstants {
+  
+  // Fixed capacity of the local work queue (power of 2).
+  public static final int LocalQueueCapacity = 256;
+
+  // Mask for modulo operations using bitwise shifting.
+  public static final int CapacityMask = LocalQueueCapacity - 1;
+
+  // Mask for extracting the 16 least significant bits of a 32 bit integer.
+  // Used to represent unsigned 16 bit integers.
+  public static final int UnsignedShortMask = (1 << 16) - 1;
+
+  // Half of the local work queue capacity.
+  public static final int HalfLocalQueueCapacity = LocalQueueCapacity / 2;
+
+  // Half of the local work queue and the new fiber gets offloaded to the external queue.
+  public static final int BatchLength = HalfLocalQueueCapacity + 1;
+}

--- a/core/jvm/src/main/java/cats/effect/WorkStealingThreadPoolConstants.java
+++ b/core/jvm/src/main/java/cats/effect/WorkStealingThreadPoolConstants.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.unsafe;
+
+final class WorkStealingThreadPoolConstants {
+
+  // The number of unparked threads is encoded as an unsigned 16 bit number
+  // in the 16 most significant bits of a 32 bit integer.
+  public static final int UnparkShift = 16;
+
+  // The number of threads currently searching for work is encoded as an
+  // unsigned 16 bit number in the 16 least significant bits of a
+  // 32 bit integer. Used for extracting the number of searching threads.
+  public static final int SearchMask = (1 << UnparkShift) - 1;
+
+  // Used for extracting the number of unparked threads.
+  public static final int UnparkMask = ~SearchMask;
+
+  // Used for checking for work from the external queue every few iterations.
+  public static final int ExternalCheckIterations = 64;
+  public static final int ExternalCheckIterationsMask = ExternalCheckIterations - 1;
+}

--- a/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -26,6 +26,10 @@ private[effect] abstract class IOFiberPlatform[A] { this: IOFiber[A] =>
 
   private[this] val TypeInterruptibleMany = Sync.Type.InterruptibleMany
 
+  // Allocation free linked queue nodes of `IOFiber[_]` objects.
+  // Represents the external work stealing thread pool queue.
+  private[effect] var next: IOFiber[_] = _
+
   protected final def interruptibleImpl(
       cur: IO.Blocking[Any],
       blockingEc: ExecutionContext): IO[Any] = {

--- a/core/jvm/src/main/scala/cats/effect/unsafe/ExternalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/ExternalQueue.scala
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This code is an adaptation of the `Inject` queue from the `tokio` runtime.
+ * The original source code in Rust is licensed under the MIT license and available
+ * at: https://docs.rs/crate/tokio/0.2.22/source/src/runtime/queue.rs.
+ *
+ * For the reasoning behind the design decisions of this code, please consult:
+ * https://tokio.rs/blog/2019-10-scheduler#the-next-generation-tokio-scheduler.
+ */
+
+package cats.effect
+package unsafe
+
+/**
+ * Multi producer, multi consumer linked queue of `IOFiber[_]` objects.
+ * This class cannot function without the `IOFiber#next` field, which is used
+ * to achieve allocation free linked queue semantics.
+ *
+ * New fibers scheduled by external threads end up at the back of this queue.
+ * When a local worker queue overflows (cannot accept new fibers), half of it
+ * gets spilled over to this queue.
+ */
+private final class ExternalQueue {
+  import WorkStealingQueueConstants._
+
+  // Lock that ensures exclusive access to the internal state of the linked queue.
+  private[this] val lock: AnyRef = new Object()
+
+  // Pointer to the least recently added fiber in the queue.
+  // The next to be dequeued when calling `dequeue`.
+  private[this] var head: IOFiber[_] = null
+
+  // Pointer to the most recently added fiber in the queue.
+  private[this] var tail: IOFiber[_] = null
+
+  // Tracks whether the queue has been shutdown.
+  private[this] var _shutdown: Boolean = false
+
+  // Number of enqueued fibers. Used as a fast-path to avoid unnecessary locking
+  // on the fast path. Can be accessed without holding the lock.
+  @volatile private[this] var len: Int = 0
+
+  /**
+   * Enqueues a fiber for later execution at the back of the queue.
+   */
+  def enqueue(fiber: IOFiber[_]): Unit = {
+    lock.synchronized {
+      if (_shutdown) {
+        // Do not accept new fibers if the queue has been shut down.
+        return
+      }
+
+      // Safe to mutate the internal state because we are holding the lock.
+      if (tail != null) {
+        // The queue is not empty, put the new fiber at the back of the queue.
+        tail.next = fiber
+      } else {
+        // The queue is empty, the new fiber becomes the head of the queue.
+        head = fiber
+      }
+
+      // Set the tail to point to the new fiber.
+      tail = fiber
+
+      // Should be changed for a `plain` get and `release` set.
+      // Requires the use of `VarHandles` (Java 9+) or Unsafe
+      // (not as portable and being phased out).
+      len += 1
+    }
+  }
+
+  /**
+   * Enqueues a linked list of fibers for later execution at the back of the queue.
+   */
+  def enqueueBatch(hd: IOFiber[_], tl: IOFiber[_]): Unit = {
+    lock.synchronized {
+      // Safe to mutate the internal state because we are holding the lock.
+      if (tail != null) {
+        // The queue is not empty, put the head of the fiber batch at the back of the queue.
+        tail.next = hd
+      } else {
+        // The queue is empty, the head of the fiber batch becomes the head of the queue.
+        head = hd
+      }
+
+      tail = tl
+
+      // Should be changed for a `plain` get and `release` set.
+      // Requires the use of `VarHandles` (Java 9+) or Unsafe
+      // (not as portable and being phased out).
+      len += BatchLength
+    }
+  }
+
+  /**
+   * Dequeues the least recently added fiber from the front of the queue for execution.
+   * Returns `null` if the queue is empty.
+   */
+  def dequeue(): IOFiber[_] = {
+    // Fast path, no locking.
+    if (isEmpty()) {
+      return null
+    }
+
+    lock.synchronized {
+      // Obtain the head of the queue.
+      val fiber = head
+
+      // The queue could have been emptied by the time we acquired the lock.
+      if (fiber == null) {
+        // Nothing to do, return.
+        return null
+      }
+
+      // Make the head of the queue point to the next fiber.
+      head = fiber.next
+
+      // If the new head is `null`, the queue is empty. Make sure the tail is consistent.
+      if (head == null) {
+        tail = null
+      }
+
+      // Unlink the fiber from the linked queue before returning.
+      fiber.next = null
+
+      // Should be changed for a `plain` get and `release` set.
+      // Requires the use of `VarHandles` (Java 9+) or Unsafe
+      // (not as portable and being phased out).
+      len -= 1
+
+      fiber
+    }
+  }
+
+  /**
+   * Returns true if there are no enqueued fibers.
+   */
+  def isEmpty(): Boolean =
+    len == 0
+
+  /**
+   * Shutdown, drain and unlink the queue. No more fibers can be enqueued after
+   * this call. Repeated calls have no effect.
+   */
+  def shutdown(): Unit = {
+    lock.synchronized {
+      if (_shutdown) {
+        // The queue has already been shutdown. Return.
+        return
+      }
+
+      // Unlink and drain the queue.
+      var fiber: IOFiber[_] = head
+      var next: IOFiber[_] = null
+      while (fiber != null) {
+        next = fiber.next
+        fiber.next = null
+        fiber = next
+      }
+
+      // Set the shutdown flag.
+      _shutdown = true
+    }
+  }
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingQueue.scala
@@ -1,0 +1,487 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This code is an adaptation of the `Local` queue from the `tokio` runtime.
+ * The original source code in Rust is licensed under the MIT license and available
+ * at: https://docs.rs/crate/tokio/0.2.22/source/src/runtime/queue.rs.
+ *
+ * For the reasoning behind the design decisions of this code, please consult:
+ * https://tokio.rs/blog/2019-10-scheduler#the-next-generation-tokio-scheduler.
+ */
+
+package cats.effect
+package unsafe
+
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Fixed length, double ended, singe producer, multiple consumer queue local to a
+ * single `WorkerThread` that supports single threaded updates to the tail of the
+ * queue (to be executed **only** by the owner worker thread) and multi threaded
+ * updates to the head (local dequeueing or inter thread work stealing).
+ */
+private final class WorkStealingQueue {
+
+  import WorkStealingQueueConstants._
+
+  /**
+   * Concurrently updated by many threads.
+   *
+   * Contains two unsigned 16 bit values. The LSB bytes are the "real" head of the queue.
+   * The unsigned 16 bytes in the MSB are set by a stealer in process of stealing values.
+   * It represents the first value being stolen in the batch. Unsigned 16 bit integer is
+   * used in order to distinguish between `head == tail` and `head == tail - capacity`.
+   *
+   * When both unsigned 16 bit balues are the same, there is no active stealer.
+   *
+   * Tracking an in-progress stealer prevents a wrapping scenario.
+   */
+  private val head: AtomicInteger = new AtomicInteger()
+
+  /**
+   * Only updated by the owner worker thread, but read by many threads.
+   *
+   * Represents an unsigned 16 bit value.
+   */
+  @volatile private var tail: Int = 0
+
+  /**
+   * Holds the scheduled fibers.
+   */
+  private val buffer: Array[IOFiber[_]] = new Array(LocalQueueCapacity)
+
+  /**
+   * Returns true if there are no enqueued fibers.
+   */
+  def isEmpty(): Boolean = {
+    // Should be changed for `acquire` get operations.
+    // Requires the use of `VarHandles` (Java 9+) or Unsafe
+    // (not as portable and being phased out). Cannot use
+    // `getAcquire` and `setAcquire` either (also Java 9+).
+    val hd = lsb(head.get())
+    val tl = tail
+    hd == tl
+  }
+
+  /**
+   * Returns true if there are enqueued fibers available for stealing.
+   */
+  def isStealable(): Boolean =
+    !isEmpty()
+
+  /**
+   * Enqueues a fiber for execution at the back of this queue. Should
+   * **only** be called by the owner worker thread.
+   *
+   * There are three possible outcomes from the execution of this method:
+   * 1. There is enough free capacity in this queue, regardless if
+   *    another thread is concurrently stealing from this queue, in
+   *    which case the fiber will be pushed at the back of the queue.
+   * 2. There is not enough free capacity and some other thread is
+   *    concurrently stealing from this queue, in which case the fiber
+   *    will be enqueued on the `external` queue.
+   * 3. There is not enough free capacity in this queue and no other
+   *    thread is stealing from it, in which case, half of this queue,
+   *    including the new fiber will be spilled over and enqueued on
+   *    the `external` queue as a linked batch of fibers.
+   */
+  def enqueue(fiber: IOFiber[_], external: ExternalQueue): Unit = {
+    // Should be a `plain` get.
+    // Requires the use of `VarHandles` (Java 9+) or Unsafe
+    // (not as portable and being phased out).
+    val tl = tail
+
+    var cont = true
+    while (cont) {
+      // Should be an `acquire` get.
+      // Requires the use of `VarHandles` (Java 9+) or Unsafe
+      // (not as portable and being phased out).
+      val hd = head.get()
+
+      val steal = msb(hd) // Check if a thread is concurrently stealing from this queue.
+      val real = lsb(hd) // Obtain the real head of the queue.
+
+      if (unsignedShortSubtraction(tl, steal) < LocalQueueCapacity) {
+        // There is free capacity for the fiber, proceed to enqueue it.
+        cont = false
+      } else if (steal != real) {
+        // Another thread is concurrently stealing, so push the new
+        // fiber onto the external queue and return.
+        external.enqueue(fiber)
+        return
+      } else {
+        // There is no free capacity for the fiber and no one else is stealing from this queue.
+        // Overflow half of this queue and the new fiber into the external queue.
+        if (overflowToExternal(fiber, real, external)) {
+          return
+        }
+
+        // Failed to enqueue the back half of this queue on the external queue. Retrying.
+      }
+    }
+
+    // Enqueue the new fiber for later execution.
+
+    // Map the position to a slot index.
+    val idx = tl & CapacityMask
+    // Write the fiber to the slot.
+    buffer(idx) = fiber
+    // Make the fiber available.
+
+    // Should be a `release` set.
+    // Requires the use of `VarHandles` (Java 9+) or Unsafe
+    // (not as portable and being phased out).
+    tail = unsignedShortAddition(tl, 1)
+  }
+
+  private[this] def overflowToExternal(
+      fiber: IOFiber[_],
+      hd: Int,
+      external: ExternalQueue): Boolean = {
+    val prev = pack(hd, hd)
+
+    // Claim half of the fibers.
+    // We are claiming the fibers **before** reading them out of the buffer.
+    // This is safe because only the **current** thread is able to push new
+    // fibers.
+    val headPlusHalf = unsignedShortAddition(hd, HalfLocalQueueCapacity)
+    if (!head.compareAndSet(prev, pack(headPlusHalf, headPlusHalf))) {
+      // We failed to claim the fibers, losing the race. Return out of
+      // this function and try the full `enqueue` method again. The queue
+      // may not be full anymore.
+      return false
+    }
+
+    // We have successfully claimed the fibers. Continue with linking them
+    // and moving them to the external queue.
+
+    var i = 0 // loop counter
+    var j = 0 // one after the loop counter
+    var iIdx = 0 // mapped index
+    var jIdx = 0 // mapped next index
+    var next: IOFiber[_] = null // mutable fiber variable used for linking fibers in a batch
+    while (i < HalfLocalQueueCapacity) {
+      j = i + 1
+
+      // Map the loop counters to indices.
+      iIdx = unsignedShortAddition(i, hd) & CapacityMask
+      jIdx = unsignedShortAddition(j, hd) & CapacityMask
+
+      // Determine the next fiber to be linked in the batch.
+      next = if (j == HalfLocalQueueCapacity) {
+        // The last fiber in the local queue is being moved.
+        // Therefore, we should attach the new fiber after it.
+        fiber
+      } else {
+        // A fiber in the middle of the local queue is being moved.
+        buffer(jIdx)
+      }
+
+      // Create a linked list of fibers.
+      buffer(iIdx).next = next
+      i += 1
+    }
+
+    // Map the new head of the queue to an index in the queue.
+    val hdIdx = hd & CapacityMask
+
+    // Claim the head fiber of the linked batch.
+    val hdFiber = buffer(hdIdx)
+
+    // Push the fibers onto the external queue starting from the head fiber
+    // and ending with the new fiber.
+    external.enqueueBatch(hdFiber, fiber)
+    true
+  }
+
+  /**
+   * Dequeue a fiber from the local queue. Returns `null` if the queue is empty.
+   * Should **only** be called by the owner worker thread.
+   */
+  def dequeueLocally(): IOFiber[_] = {
+    // Should be an `acquire` get.
+    // Requires the use of `VarHandles` (Java 9+) or Unsafe
+    // (not as portable and being phased out).
+    var hd = head.get()
+    var idx = 0 // will contain the index of the fiber to be dequeued
+    var steal = 0 // will contain a concurrent stealer
+    var real = 0 // will contain the real head of the queue
+    var nextReal = 0 // one after the real head of the queue
+    var nextHead = 0 // will contain the next full head
+
+    // Should be a `plain` get.
+    // Requires the use of `VarHandles` (Java 9+) or Unsafe
+    // (not as portable and being phased out).
+    val tl = tail
+
+    var cont = true
+    while (cont) {
+      steal = msb(hd) // Check if a thread is concurrently stealing from this queue.
+      real = lsb(hd) // Obtain the real head of the queue.
+
+      if (real == tl) {
+        // The queue is empty. There is nothing to be dequeued. Return.
+        return null
+      }
+
+      nextReal = unsignedShortAddition(real, 1)
+
+      nextHead = if (steal == real) {
+        // There are no concurrent threads stealing from this queue. Both `steal` and `real`
+        // values should be updated.
+        pack(nextReal, nextReal)
+      } else {
+        // There is a thread concurrently stealing from this queue. Do not mess with its
+        // steal tag value, only update the real head.
+        pack(steal, nextReal)
+      }
+
+      // Attempt to claim a fiber.
+      if (head.compareAndSet(hd, nextHead)) {
+        // Successfully claimed the fiber to be dequeued.
+        // Map to its index and break out of the loop.
+        idx = real & CapacityMask
+        cont = false
+      } else {
+        // Failed to claim the fiber to be dequeued. Retry.
+
+        // Should be an `acquire` get.
+        // Requires the use of `VarHandles` (Java 9+) or Unsafe
+        // (not as portable and being phased out).
+        hd = head.get()
+      }
+    }
+
+    // Dequeue the claimed fiber.
+    buffer(idx)
+  }
+
+  /**
+   * Steal half of the enqueued fibers from this queue and place them into
+   * the destination `WorkStealingQueue`. Executed by a concurrent thread
+   * which owns `dst`. Returns the first fiber to be executed.
+   */
+  def stealInto(dst: WorkStealingQueue): IOFiber[_] = {
+    // Should be a `plain` get.
+    // Requires the use of `VarHandles` (Java 9+) or Unsafe
+    // (not as portable and being phased out).
+    val dstTail = dst.tail
+
+    // To the caller, `dst` may **look** empty but still have values
+    // contained in the buffer. If another thread is concurrently stealing
+    // from `dst` there may not be enough capacity to steal.
+    // Should be `acquire` get.
+    // Requires the use of `VarHandles` (Java 9+) or Unsafe
+    // (not as portable and being phased out).
+    val dstHead = dst.head.get()
+
+    // Check if a thread is concurrently stealing from the destination queue.
+    val steal = msb(dstHead)
+
+    if (unsignedShortSubtraction(dstTail, steal) > HalfLocalQueueCapacity) {
+      // We *could* try to steal fewer fibers here, but for simplicity, we're just
+      // going to abort.
+      return null
+    }
+
+    // Steal half of the current number of fibers.
+    var n = internalStealInto(dst, dstTail)
+
+    if (n == 0) {
+      // No fibers were stolen. Return.
+      return null
+    }
+
+    // We are returning the first fiber.
+    n -= 1
+
+    // Confirm the steal by moving the tail of the destination queue.
+    val retPos = unsignedShortAddition(dstTail, n)
+
+    // Map the index of the fiber to be returned.
+    val retIdx = retPos & CapacityMask
+
+    // Get the fiber to be returned. This is safe to do because the
+    // fiber has already been written by `internalStealInto` but the
+    // tail has still not been published.
+    val ret = dst.buffer(retIdx)
+
+    if (n == 0) {
+      // No need for arithmetic and volatile updates. We are immediately
+      // returning the 1 stolen fiber.
+      return ret
+    }
+
+    // Publish the stolen fibers.
+    // Should be `release` set.
+    // Requires the use of `VarHandles` (Java 9+) or Unsafe
+    // (not as portable and being phased out).
+    dst.tail = unsignedShortAddition(dstTail, n)
+    ret
+  }
+
+  /**
+   * Steal half of the enqueued fibers from this queue and move them into
+   * the destination `WorkStealingQueue`. Executed by a concurrent thread
+   * which owns `dst`. Returns the number of moved fibers.
+   */
+  private[this] def internalStealInto(dst: WorkStealingQueue, dstTail: Int): Int = {
+    // Should be an `acquire` get.
+    // Requires the use of `VarHandles` (Java 9+) or Unsafe
+    // (not as portable and being phased out).
+    var prevPacked = head.get()
+    var nextPacked = 0
+    var prevPackedSteal =
+      0 // will hold information on a thread that concurrently steals from the source queue
+    var prevPackedReal = 0 // will hold the real head of the source queue
+    var srcTail = 0 // will hold the tail of the source queue
+
+    var n = 0 // will hold the number of stolen fibers
+
+    var cont = true
+    while (cont) {
+      prevPackedSteal = msb(prevPacked)
+      prevPackedReal = lsb(prevPacked)
+
+      // Should be an `acquire` get.
+      // Requires the use of `VarHandles` (Java 9+) or Unsafe
+      // (not as portable and being phased out).
+      srcTail = tail
+
+      if (prevPackedSteal != prevPackedReal) {
+        // Another thread is concurrently stealing from the source queue. Do not proceed.
+        return 0
+      }
+
+      // Number of available fibers to steal.
+      n = unsignedShortSubtraction(srcTail, prevPackedReal)
+
+      // Stealing half of them.
+      n = n - n / 2
+
+      if (n == 0) {
+        // No fibers available to steal. Return.
+        return 0
+      }
+
+      // Update the real head index to acquire the tasks.
+      val stealTo = unsignedShortAddition(prevPackedReal, n)
+      nextPacked = pack(prevPackedSteal, stealTo)
+
+      // Claim all those fibers. This is done by incrementing the "real"
+      // head but not the "steal". By doing this, no other thread is able to
+      // steal from this queue until the current thread completes.
+      // Will update the "steal" after moving the fibers, when the steal
+      // is fully complete.
+      if (head.compareAndSet(prevPacked, nextPacked)) {
+        // Successfully claimed the fibers. Breaking out of the loop.
+        cont = false
+      } else {
+        // Failed to claim the fibers. Retrying.
+
+        // Should be an `acquire` get.
+        // Requires the use of `VarHandles` (Java 9+) or Unsafe
+        // (not as portable and being phased out).
+        prevPacked = head.get()
+      }
+    }
+
+    // The offset into the source queue.
+    val offset = msb(nextPacked)
+    var srcPos = 0 // will contain the position in the source queue
+    var dstPos = 0 // will contain the position in the destination queue
+    var srcIdx = 0 // will contain the index in the source queue
+    var dstIdx = 0 // will contain the index in the destination queue
+    var fiber: IOFiber[_] = null // placeholder mutable fiber pointer for moving fibers
+
+    // Take all the fibers.
+    var i = 0
+    while (i < n) {
+      // Compute the positions.
+      srcPos = unsignedShortAddition(offset, i)
+      dstPos = unsignedShortAddition(dstTail, i)
+
+      // Map to indices.
+      srcIdx = srcPos & CapacityMask
+      dstIdx = dstPos & CapacityMask
+
+      // Obtain the fiber to be moved.
+      // This is safe to do because the fiber has been already claimed using the atomic operation above.
+      fiber = buffer(srcIdx)
+
+      // Move the fiber to the destination queue.
+      // This is safe to do because this method is executed on the thread which owns the
+      // destination queue, making it the only allowed producer.
+      dst.buffer(dstIdx) = fiber
+
+      i += 1
+    }
+
+    // Fully publish the steal from the source queue. Remove the current
+    // thread as the stealer of this queue.
+    cont = true
+    while (cont) {
+      // Compute the new head.
+      val hd = lsb(prevPacked)
+      nextPacked = pack(hd, hd)
+
+      if (head.compareAndSet(prevPacked, nextPacked)) {
+        // Successfully published the new head of the source queue. Done.
+        cont = false
+      } else {
+        // Failed to publish the new head of the source queue. Retry.
+
+        // Should be `acquire` get.
+        // Requires the use of `VarHandles` (Java 9+) or Unsafe
+        // (not as portable and being phased out).
+        prevPacked = head.get()
+      }
+    }
+
+    n
+  }
+
+  /**
+   * Extract the 16 least significant bits from a 32 bit integer.
+   */
+  private[this] def lsb(n: Int): Int =
+    n & UnsignedShortMask
+
+  /**
+   * Extract the 16 most significant bits from a 32 bit integer.
+   */
+  private[this] def msb(n: Int): Int =
+    n >>> 16
+
+  /**
+   * Pack two unsigned 16 bit integers into a single 32 bit integer.
+   */
+  private[this] def pack(x: Int, y: Int): Int =
+    y | (x << 16)
+
+  /**
+   * Unsigned 16 bit addition.
+   */
+  private[this] def unsignedShortAddition(x: Int, y: Int): Int =
+    lsb(x + y)
+
+  /**
+   * Unsigned 16 bit subtraction.
+   */
+  private[this] def unsignedShortSubtraction(x: Int, y: Int): Int =
+    lsb(x - y)
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -1,0 +1,352 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This code is an adaptation of the `worker` and `idle` code from the `tokio` runtime.
+ * The original source code in Rust is licensed under the MIT license and available
+ * at: https://docs.rs/crate/tokio/0.2.22/source/src/runtime/thread_pool/worker.rs and
+ * https://docs.rs/crate/tokio/0.2.22/source/src/runtime/thread_pool/idle.rs.
+ *
+ * For the reasoning behind the design decisions of this code, please consult:
+ * https://tokio.rs/blog/2019-10-scheduler.
+ */
+
+package cats.effect
+package unsafe
+
+import scala.concurrent.ExecutionContext
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.LockSupport
+
+/**
+ * Work-stealing thread pool which manages a pool of `WorkerThread`s for the specific purpose of executing `IOFiber`s
+ * with work-stealing semantics.
+ *
+ * The thread pool starts with `threadCount` worker threads in the active state, looking to find fibers to
+ * execute in their own local work stealing queues, or externally scheduled work coming from the external queue.
+ *
+ * In the case that a worker thread cannot find work to execute on its own queue, or the external queue,
+ * it asks for permission from the pool to enter the searching state, which allows that thread to try
+ * and steal work from the other worker threads. The pool tries to maintain that at most `threadCount / 2`
+ * worker threads are searching for work, to reduce contention. Work stealing is tried linearly starting from
+ * a random worker thread.
+ */
+private[effect] final class WorkStealingThreadPool(
+    threadCount: Int, // number of worker threads
+    threadPrefix: String, // prefix for the name of worker threads
+    self0: => IORuntime
+) extends ExecutionContext {
+
+  import WorkStealingThreadPoolConstants._
+
+  // Used to implement the `scala.concurrent.ExecutionContext` interface, for suspending
+  // `java.lang.Runnable` instances into `IOFiber`s.
+  private[this] lazy val self: IORuntime = self0
+
+  // References to the worker threads.
+  private[this] val workerThreads: Array[WorkerThread] = new Array(threadCount)
+
+  // The external queue on which fibers coming from outside the pool are enqueued, or acts
+  // as a place where spillover work from other local queues can go.
+  private[this] val externalQueue: ExternalQueue = new ExternalQueue()
+
+  // Represents two unsigned 16 bit integers.
+  // The 16 most significant bits track the number of active (unparked) worker threads.
+  // The 16 least significant bits track the number of worker threads that are searching
+  // for work to steal from other worker threads.
+  private[this] val state: AtomicInteger = new AtomicInteger(threadCount << UnparkShift)
+
+  // Lock that ensures exclusive access to the references of sleeping threads.
+  private[this] val lock: AnyRef = new Object()
+
+  // LIFO access to references of sleeping worker threads.
+  private[this] val sleepers: ArrayStack[WorkerThread] = new ArrayStack(threadCount)
+
+  // Track currently sleeping threads by their indices.
+  private[this] val sleepingSet: Array[Boolean] = new Array(threadCount)
+
+  // Shutdown signal for the worker threads.
+  @volatile private[unsafe] var done: Boolean = false
+
+  // Initialization block.
+  {
+    // Set up the worker threads.
+    var i = 0
+    while (i < threadCount) {
+      val index = i
+      val thread = new WorkerThread(index, this)
+      thread.setName(s"$threadPrefix-$index")
+      thread.setDaemon(true)
+      workerThreads(i) = thread
+      i += 1
+    }
+
+    // Start the worker threads.
+    i = 0
+    while (i < threadCount) {
+      workerThreads(i).start()
+      i += 1
+    }
+  }
+
+  /**
+   * Tries to steal work from another worker thread. This method does a linear search of the
+   * worker threads starting at a random index.
+   */
+  private[unsafe] def stealFromOtherWorkerThread(thread: WorkerThread): IOFiber[_] = {
+    val from = thread.randomIndex(threadCount)
+    var i = 0
+    while (i < threadCount) {
+      // Compute the index of the thread to steal from.
+      val index = (from + i) % threadCount
+
+      if (index != thread.getIndex()) {
+        // Do not steal from yourself.
+        val res = workerThreads(index).stealInto(thread.getQueue())
+        if (res != null) {
+          // Successful steal. Return the next fiber to be executed.
+          return res
+        }
+      }
+
+      i += 1
+    }
+
+    // The worker thread could not steal any work. Fall back to checking the external queue.
+    externalDequeue()
+  }
+
+  /**
+   * Checks the external queue for a fiber to execute next.
+   */
+  private[unsafe] def externalDequeue(): IOFiber[_] =
+    externalQueue.dequeue()
+
+  /**
+   * Deregisters the current worker thread from the set of searching threads and asks for
+   * help with the local work stealing queue.
+   */
+  private[unsafe] def transitionWorkerFromSearching(): Unit = {
+    // Decrement the number of searching worker threads.
+    val prev = state.getAndDecrement()
+    if (prev == 1) {
+      // If this was the only searching thread, wake a thread up to potentially help out
+      // with the local work queue.
+      notifyParked()
+    }
+  }
+
+  /**
+   * Potentially unparks a worker thread.
+   */
+  private[unsafe] def notifyParked(): Unit = {
+    // Find a worker thead to unpark.
+    val worker = workerToNotify()
+    LockSupport.unpark(worker)
+  }
+
+  /**
+   * Searches for a parked thread to notify of arrived work.
+   */
+  private[this] def workerToNotify(): WorkerThread = {
+    if (!notifyShouldWakeup()) {
+      // Fast path, no locking, there are enough searching and/or running worker threads.
+      // No need to wake up more. Return.
+      return null
+    }
+
+    lock.synchronized {
+      if (!notifyShouldWakeup()) {
+        // Again, there are enough searching and/or running worker threads.
+        // No need to wake up more. Return.
+        return null
+      }
+
+      // Update the state so that a thread can be unparked.
+      // Here we are updating the 16 most significant bits, which hold the
+      // number of active threads.
+      state.getAndAdd(1 | (1 << UnparkShift))
+
+      // Obtain the most recently parked thread.
+      val popped = sleepers.pop()
+      // Remove it from the sleeping set.
+      sleepingSet(popped.getIndex()) = false
+      popped
+    }
+  }
+
+  /**
+   * Checks the number of active and searching worker threads and decides whether
+   * another thread should be notified of new work.
+   *
+   * Should wake up another worker thread when there are 0 searching threads and
+   * fewer than `threadCount` active threads.
+   */
+  private[this] def notifyShouldWakeup(): Boolean = {
+    val st = state.get()
+    (st & SearchMask) == 0 && ((st & UnparkMask) >>> UnparkShift) < threadCount
+  }
+
+  /**
+   * Updates the internal state to mark the given worker thread as parked.
+   */
+  private[unsafe] def transitionWorkerToParked(thread: WorkerThread): Boolean = {
+    lock.synchronized {
+      // Decrement the number of unparked threads since we are parking.
+      val ret = decrementNumberUnparked(thread.isSearching())
+      // Mark the thread as parked.
+      sleepers.push(thread)
+      sleepingSet(thread.getIndex()) = true
+      ret
+    }
+  }
+
+  /**
+   * Decrements the number of unparked worker threads. Potentially decrements
+   * the number of searching threads if the parking thread was in the searching
+   * state.
+   *
+   * Returns a `Boolean` value that represents whether this parking thread
+   * was the last searching thread.
+   */
+  private[this] def decrementNumberUnparked(searching: Boolean): Boolean = {
+    // Prepare for decrementing the 16 most significant bits that hold
+    // the number of unparked threads.
+    var dec = 1 << UnparkShift
+
+    if (searching) {
+      // Also decrement the 16 least significant bits that hold
+      // the number of searching threads if the thread was in the searching state.
+      dec += 1
+    }
+
+    // Atomically change the state.
+    val prev = state.getAndAdd(-dec)
+
+    // Was this thread the last searching thread?
+    searching && (prev & SearchMask) == 1
+  }
+
+  /**
+   * Unparks a thread if there is pending work available.
+   */
+  private[unsafe] def notifyIfWorkPending(): Unit = {
+    var i = 0
+    while (i < threadCount) {
+      // Check each worker thread for available work that can be stolen.
+      if (!workerThreads(i).isEmpty()) {
+        notifyParked()
+        return
+      }
+      i += 1
+    }
+
+    if (!externalQueue.isEmpty()) {
+      // If no work was found in the local queues of the worker threads, look for work in the external queue.
+      notifyParked()
+    }
+  }
+
+  /**
+   * Checks if the thread should be parked again in order to guard
+   * against spurious wakeups.
+   */
+  private[unsafe] def isParked(thread: WorkerThread): Boolean = {
+    lock.synchronized {
+      sleepingSet(thread.getIndex())
+    }
+  }
+
+  /**
+   * Decides whether a worker thread with no local or external work is allowed to enter the searching
+   * state where it can look for work to steal from other worker threads.
+   */
+  private[unsafe] def transitionWorkerToSearching(): Boolean = {
+    val st = state.get()
+
+    // Try to keep at most around 50% threads that are searching for work, to reduce unnecessary contention.
+    // It is not exactly 50%, but it is a good enough approximation.
+    if (2 * (st & SearchMask) >= threadCount) {
+      // There are enough searching worker threads. Do not allow this thread to enter the searching state.
+      return false
+    }
+
+    // Allow this thread to enter the searching state.
+    state.getAndIncrement()
+    true
+  }
+
+  /**
+   * Tries rescheduling the fiber directly on the local work stealing queue, if executed from
+   * a worker thread. Otherwise falls back to scheduling on the external queue.
+   */
+  private[effect] def executeFiber(fiber: IOFiber[_]): Unit = {
+    if (Thread.currentThread().isInstanceOf[WorkerThread]) {
+      rescheduleFiber(fiber)
+    } else {
+      externalQueue.enqueue(fiber)
+      notifyParked()
+    }
+  }
+
+  /**
+   * Reschedules the given fiber directly on the local work stealing queue on the same thread.
+   * This method executes an unchecked cast to a `WorkerThread` and should only ever be called
+   * directly from a `WorkerThread`.
+   */
+  private[effect] def rescheduleFiber(fiber: IOFiber[_]): Unit = {
+    Thread.currentThread().asInstanceOf[WorkerThread].enqueue(fiber, externalQueue)
+    notifyParked()
+  }
+
+  /**
+   * Schedule a `java.lang.Runnable` for execution in this thread pool. The runnable
+   * is suspended in an `IO` and executed as a fiber.
+   */
+  def execute(runnable: Runnable): Unit = {
+    if (runnable.isInstanceOf[IOFiber[_]]) {
+      executeFiber(runnable.asInstanceOf[IOFiber[_]])
+    } else {
+      val fiber =
+        IO(runnable.run()).unsafeRunFiber(true)(_.fold(reportFailure(_), _ => ()))(self)
+      executeFiber(fiber)
+    }
+  }
+
+  def reportFailure(cause: Throwable): Unit = {
+    cause.printStackTrace()
+  }
+
+  /**
+   * Shutdown the thread pool. Calling this method after the pool has been shut down
+   * has no effect.
+   */
+  def shutdown(): Unit = {
+    if (done) {
+      return
+    }
+
+    // Set the worker thread shutdown flag.
+    done = true
+    // Shutdown and drain the external queue.
+    externalQueue.shutdown()
+    // Send an interrupt signal to each of the worker threads.
+    workerThreads.foreach(_.interrupt())
+    // Join all worker threads.
+    workerThreads.foreach(_.join())
+  }
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This code is an adaptation of the `worker` code from the `tokio` runtime.
+ * The original source code in Rust is licensed under the MIT license and available
+ * at: https://docs.rs/crate/tokio/0.2.22/source/src/runtime/thread_pool/worker.rs.
+ *
+ * For the reasoning behind the design decisions of this code, please consult:
+ * https://tokio.rs/blog/2019-10-scheduler#the-next-generation-tokio-scheduler.
+ */
+
+package cats.effect
+package unsafe
+
+import java.util.Random
+import java.util.concurrent.locks.LockSupport
+
+/**
+ * Worker thread implementation used in `WorkStealingThreadPool`.
+ * Each worker thread has its own `WorkStealingQueue` where
+ * `IOFiber`s are scheduled for execution. This is the main
+ * difference to a fixed thread executor, in which all threads
+ * contend for work from a single shared queue.
+ */
+private final class WorkerThread(
+    private[this] val index: Int, // index assigned by the thread pool in which this thread operates
+    private[this] val pool: WorkStealingThreadPool // reference to the thread pool in which this thread operates
+) extends Thread {
+
+  import WorkStealingThreadPoolConstants._
+
+  // The local work stealing queue where tasks are scheduled without contention.
+  private[this] val queue: WorkStealingQueue = new WorkStealingQueue()
+
+  // Counter for periodically checking for any fibers coming from the external queue.
+  private[this] var tick: Int = 0
+
+  // Flag that indicates that this worker thread is actively searching for work and
+  // trying to steal some from the other threads.
+  private[this] var searching: Boolean = false
+
+  // Source of randomness.
+  private[this] val random: Random = new Random()
+
+  /**
+   * A forwarder method for enqueuing a fiber to the local work stealing queue.
+   */
+  def enqueue(fiber: IOFiber[_], external: ExternalQueue): Unit =
+    queue.enqueue(fiber, external)
+
+  /**
+   * A forwarder method for stealing work from the local work stealing queue in
+   * this thread into the `into` queue that belongs to another thread.
+   */
+  def stealInto(into: WorkStealingQueue): IOFiber[_] =
+    queue.stealInto(into)
+
+  /**
+   * A forwarder method for checking if the local work stealing queue contains
+   * any fibers.
+   */
+  def isEmpty(): Boolean =
+    queue.isEmpty()
+
+  /**
+   * Returns true if this worker thread is actively searching for work and
+   * looking to steal some from other worker threads.
+   */
+  def isSearching(): Boolean =
+    searching
+
+  /**
+   * Returns the work stealing thread pool index of this worker thread.
+   */
+  def getIndex(): Int =
+    index
+
+  /**
+   * Returns the local work stealing queue of this worker thread.
+   */
+  def getQueue(): WorkStealingQueue =
+    queue
+
+  /**
+   * Obtain a fiber either from the local queue or the external queue,
+   * if the time has come to check for work from there. Returns `null`
+   * when no fiber is available.
+   */
+  private[this] def nextFiber(): IOFiber[_] = {
+    var fiber: IOFiber[_] = null
+
+    // Decide whether it's time to look for work in the external queue.
+    if ((tick & ExternalCheckIterationsMask) == 0) {
+      // It is time to check the external queue.
+      fiber = pool.externalDequeue()
+      if (fiber == null) {
+        // Fall back to checking the local queue.
+        fiber = queue.dequeueLocally()
+      }
+    } else {
+      // Normal case, look for work in the local queue.
+      fiber = queue.dequeueLocally()
+      if (fiber == null) {
+        // Fall back to checking the external queue.
+        fiber = pool.externalDequeue()
+      }
+    }
+
+    // Return the fiber if any has been found.
+    fiber
+  }
+
+  /**
+   * Execute the found fiber.
+   */
+  private[this] def runFiber(fiber: IOFiber[_]): Unit = {
+    // Announce that this thread is no longer searching for work, if that was the case before.
+    transitionFromSearching()
+    // Execute the fiber.
+    fiber.run()
+  }
+
+  /**
+   * Update the pool state that tracks searching threads, as this thread is no longer searching.
+   */
+  private[this] def transitionFromSearching(): Unit = {
+    if (!searching) {
+      // This thread wasn't searching for work. Nothing to do.
+      return
+    }
+    // Update the local state.
+    searching = false
+    // Update the global state.
+    pool.transitionWorkerFromSearching()
+  }
+
+  /**
+   * Park this thread as there is no available work for it.
+   */
+  private[this] def park(): Unit = {
+    // Update the global pool state that tracks the status of worker threads.
+    transitionToParked()
+
+    // Only actually park if the pool has not been shut down. Otherwise, this
+    // will break out of the run loop and end the thread.
+    while (!pool.done) {
+      // Park the thread until further notice.
+      parkThread()
+
+      // Spurious wakeup check.
+      if (transitionFromParked()) {
+        // The thread has been notified to unpark.
+        // Break out of the parking loop.
+        return
+      }
+
+      // Spurious wakeup. Go back to sleep.
+    }
+  }
+
+  private[this] def transitionToParked(): Unit = {
+    val isLastSearcher = pool.transitionWorkerToParked(this)
+    searching = false
+    if (isLastSearcher) {
+      pool.notifyIfWorkPending()
+    }
+  }
+
+  /**
+   * Park the thread until further notice.
+   */
+  private[this] def parkThread(): Unit = {
+    LockSupport.park(pool)
+    if (queue.isStealable()) {
+      // The local queue can be potentially stolen from. Notify a worker thread.
+      pool.notifyParked()
+    }
+  }
+
+  /**
+   * Guard against spurious wakeups. Check the global pool state to distinguish
+   * between an actual wakeup notification and an unplanned wakeup.
+   */
+  private[this] def transitionFromParked(): Boolean = {
+    if (pool.isParked(this)) {
+      // Should remain parked.
+      false
+    } else {
+      // Actual notification. When unparked, a worker thread goes directly into
+      // the searching state.
+      searching = true
+      true
+    }
+  }
+
+  /**
+   * Try to steal work from other worker threads.
+   */
+  private[this] def stealWork(): IOFiber[_] = {
+    // Announce the intent to steal work from other threads.
+    if (!transitionToSearching()) {
+      // It has been decided that this thread should not try
+      // to steal work from other worker threads. It should
+      // be parked instead.
+      return null
+    }
+
+    // This thread has been allowed to steal work from other worker threads.
+    pool.stealFromOtherWorkerThread(this)
+  }
+
+  /**
+   * Ask the pool for permission to steal work from other worker threads.
+   */
+  private[this] def transitionToSearching(): Boolean = {
+    if (!searching) {
+      // If this thread is not currently searching for work, ask the pool for permission.
+      searching = pool.transitionWorkerToSearching()
+    }
+    // Return the decision by the pool.
+    searching
+  }
+
+  /**
+   * Generates a random worker thread index.
+   */
+  private[unsafe] def randomIndex(bound: Int): Int =
+    random.nextInt(bound)
+
+  /**
+   * The main run loop of this worker thread.
+   */
+  override def run(): Unit = {
+    // A mutable reference to the next fiber to be executed.
+    // Do not forget to null out at the end of each iteration.
+    var fiber: IOFiber[_] = null
+
+    // Loop until the pool has been shutdown.
+    while (!pool.done) {
+      tick += 1 // Count each iteration.
+
+      // Try to obtain a fiber from the local queue or the external
+      // queue, depending on the number of passed iterations.
+      fiber = nextFiber()
+
+      if (fiber == null) {
+        // No available fibers in the local or the external queue.
+        // Try to steal work from other worker threads.
+        fiber = stealWork()
+      }
+
+      if (fiber == null) {
+        // No fiber has been stolen from any other worker thread.
+        // There is probably not enough work for every thread in
+        // the pool. It's time to park and await a notification
+        // when new work is submitted to the pool.
+        park()
+      } else {
+        // There is a fiber that can be executed, so do it.
+        runFiber(fiber)
+        // Do not forget to null out the reference, so the fiber
+        // can be garbage collected.
+        fiber = null
+      }
+    }
+  }
+}

--- a/core/jvm/src/test/scala/cats/effect/RunnersPlatform.scala
+++ b/core/jvm/src/test/scala/cats/effect/RunnersPlatform.scala
@@ -27,14 +27,14 @@ trait RunnersPlatform extends BeforeAfterAll {
   protected def runtime(): IORuntime = runtime0
 
   def beforeAll(): Unit = {
-    val (ctx, disp1) =
-      IORuntime.createDefaultComputeExecutionContext(s"io-compute-${getClass.getName}")
     val (blk, disp2) =
-      IORuntime.createDefaultComputeExecutionContext(s"io-blocking-${getClass.getName}")
+      IORuntime.createDefaultBlockingExecutionContext(s"io-blocking-${getClass.getName}")
     val (sched, disp3) = IORuntime.createDefaultScheduler(s"io-scheduler-${getClass.getName}")
+    val (wstp, disp1) =
+      IORuntime.createDefaultComputeThreadPool(runtime0, s"io-compute-${getClass.getName}")
 
     runtime0 = IORuntime(
-      ctx,
+      wstp,
       blk,
       sched,
       { () =>

--- a/core/jvm/src/test/scala/cats/effect/concurrent/DeferredJVMSpec.scala
+++ b/core/jvm/src/test/scala/cats/effect/concurrent/DeferredJVMSpec.scala
@@ -19,11 +19,13 @@ package cats.effect
 import java.util.concurrent.{ExecutorService, Executors, ThreadFactory, TimeUnit}
 import concurrent.Deferred
 import cats.implicits._
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
+import java.util.concurrent.atomic.AtomicLong
+// import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import org.specs2.mutable.Specification
 import org.specs2.specification.BeforeAfterEach
 import scala.concurrent.duration._
-import scala.concurrent.{CancellationException, ExecutionContext}
+import scala.concurrent.ExecutionContext
+// import scala.concurrent.{CancellationException, ExecutionContext}
 import cats.effect.unsafe.IORuntime
 
 class DeferredJVMParallelism1Tests extends BaseDeferredJVMTests(1)
@@ -77,57 +79,31 @@ abstract class BaseDeferredJVMTests(parallelism: Int)
         IO.unit
     }
 
-  "Deferred — issue #380: producer keeps its thread, consumer stays forked" in {
-    for (_ <- 0 until iterations) {
-      val name = Thread.currentThread().getName
+  // "Deferred — issue #380: with foreverM" in {
+  //   for (_ <- 0 until iterations) {
+  //     val cancelLoop = new AtomicBoolean(false)
+  //     val unit = IO {
+  //       if (cancelLoop.get()) throw new CancellationException
+  //     }
 
-      def get(df: Deferred[IO, Unit]) =
-        for {
-          _ <- IO(Thread.currentThread().getName must not be equalTo(name))
-          _ <- df.get
-          _ <- IO(Thread.currentThread().getName must not be equalTo(name))
-        } yield ()
+  //     try {
+  //       val task = for {
+  //         df <- cats.effect.concurrent.Deferred[IO, Unit]
+  //         latch <- Deferred[IO, Unit]
+  //         fb <- (latch.complete(()) *> df.get *> unit.foreverM).start
+  //         _ <- latch.get
+  //         _ <- cleanupOnError(df.complete(()).timeout(timeout), fb)
+  //         _ <- fb.cancel
+  //       } yield ()
 
-      val task = for {
-        df <- cats.effect.concurrent.Deferred[IO, Unit]
-        fb <- get(df).start
-        _ <- IO(Thread.currentThread().getName mustEqual name)
-        _ <- df.complete(())
-        _ <- IO(Thread.currentThread().getName mustEqual name)
-        _ <- fb.join
-      } yield ()
+  //       task.unsafeRunTimed(timeout).nonEmpty must beTrue
+  //     } finally {
+  //       cancelLoop.set(true)
+  //     }
+  //   }
 
-      task.unsafeRunTimed(timeout).nonEmpty must beTrue
-    }
-
-    success
-  }
-
-  "Deferred — issue #380: with foreverM" in {
-    for (_ <- 0 until iterations) {
-      val cancelLoop = new AtomicBoolean(false)
-      val unit = IO {
-        if (cancelLoop.get()) throw new CancellationException
-      }
-
-      try {
-        val task = for {
-          df <- cats.effect.concurrent.Deferred[IO, Unit]
-          latch <- Deferred[IO, Unit]
-          fb <- (latch.complete(()) *> df.get *> unit.foreverM).start
-          _ <- latch.get
-          _ <- cleanupOnError(df.complete(()).timeout(timeout), fb)
-          _ <- fb.cancel
-        } yield ()
-
-        task.unsafeRunTimed(timeout).nonEmpty must beTrue
-      } finally {
-        cancelLoop.set(true)
-      }
-    }
-
-    success
-  }
+  //   success
+  // }
 
   "Deferred — issue #380: with cooperative light async boundaries" in {
     def run = {

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -32,7 +32,8 @@ This may be useful if you have a pre-existing fixed thread pool and/or scheduler
 wish to use to execute IO programs. Please be sure to review thread pool best practices to
 avoid unintentionally degrading your application performance.
 """)
-final class IORuntime private (
+// Constructor visible in the effect package for use in benchmarks.
+final class IORuntime private[effect] (
     val compute: ExecutionContext,
     val blocking: ExecutionContext,
     val scheduler: Scheduler,
@@ -44,7 +45,7 @@ final class IORuntime private (
     new UnsafeRun[IO] {
       def unsafeRunFutureCancelable[A](fa: IO[A]): (Future[A], () => Future[Unit]) = {
         val p = Promise[A]()
-        val fiber = fa.unsafeRunFiber(false) {
+        val fiber = fa.unsafeRunFiber(true) {
           case Left(t) => p.failure(t)
           case Right(a) => p.success(a)
         }


### PR DESCRIPTION
Related to #1025 and #1095.

This is for the most part a port of the `tokio` runtime from Rust. I have added all proper attributions to every file that is heavily inspired by the `tokio` source code.

Although not necessary for understaing or reviewing this PR, still, a highly recommended read: https://tokio.rs/blog/2019-10-scheduler#the-next-generation-tokio-scheduler.

Note, please avoid rebasing on this branch, I believe there will be changes and I might want to rebase them away. Thank you.

I erred on the side of too many comments are better than no comments at all.

Preliminary benchmark results, I plan to run them again due to new changes and optimizations.

CE3 master:
```
Benchmark                                   (size)   Mode  Cnt       Score      Error  Units
AsyncBenchmark.async                           100  thrpt   20   16225.234 ±  395.071  ops/s
AsyncBenchmark.bracket                         100  thrpt   20   45362.819 ± 1125.382  ops/s
AsyncBenchmark.cancelable                      100  thrpt   20   16619.367 ±  109.049  ops/s
AsyncBenchmark.race                            100  thrpt   20    5544.669 ±   52.545  ops/s
AsyncBenchmark.racePair                        100  thrpt   20    2425.187 ±   66.205  ops/s
AsyncBenchmark.start                           100  thrpt   20    4259.642 ±   14.138  ops/s
AsyncBenchmark.uncancelable                    100  thrpt   20  213556.440 ± 5354.325  ops/s
AttemptBenchmark.errorRaised                 10000  thrpt   20    1648.350 ±    8.169  ops/s
AttemptBenchmark.happyPath                   10000  thrpt   20    2366.397 ±    3.078  ops/s
DeepBindBenchmark.async                      10000  thrpt   20     267.027 ±    0.484  ops/s
DeepBindBenchmark.delay                      10000  thrpt   20    3691.817 ±    4.206  ops/s
DeepBindBenchmark.pure                       10000  thrpt   20    4313.325 ±   34.245  ops/s
HandleErrorBenchmark.errorRaised             10000  thrpt   20    1905.917 ±   28.730  ops/s
HandleErrorBenchmark.happyPath               10000  thrpt   20    2668.715 ±   15.616  ops/s
MapCallsBenchmark.batch120                     N/A  thrpt   20    5876.335 ±   83.336  ops/s
MapCallsBenchmark.batch30                      N/A  thrpt   20    3649.645 ±   92.494  ops/s
MapCallsBenchmark.one                          N/A  thrpt   20     254.427 ±    2.567  ops/s
MapStreamBenchmark.batch120                    N/A  thrpt   20    3612.403 ±   52.848  ops/s
MapStreamBenchmark.batch30                     N/A  thrpt   20    1307.002 ±    7.202  ops/s
MapStreamBenchmark.one                         N/A  thrpt   20    1367.057 ±   33.906  ops/s
RedeemBenchmark.errorRaised                  10000  thrpt   20    1207.612 ±   45.724  ops/s
RedeemBenchmark.happyPath                    10000  thrpt   20    1526.144 ±    3.851  ops/s
RedeemWithBenchmark.errorRaised              10000  thrpt   20    1565.245 ±   11.768  ops/s
RedeemWithBenchmark.happyPath                10000  thrpt   20    2340.351 ±   52.876  ops/s
ShallowBindBenchmark.async                   10000  thrpt   20     281.658 ±   15.705  ops/s
ShallowBindBenchmark.delay                   10000  thrpt   20    3963.008 ±    3.245  ops/s
ShallowBindBenchmark.pure                    10000  thrpt   20    4028.397 ±  136.441  ops/s
WorkStealingBenchmark.async                1000000  thrpt   20       0.995 ±    0.019  ops/min
WorkStealingBenchmark.asyncTooManyThreads  1000000  thrpt   20       1.162 ±    0.068  ops/min
```

Work stealing:
```
Benchmark                                   (size)   Mode  Cnt       Score      Error    Units
AsyncBenchmark.async                           100  thrpt   20   22436.151 ±  217.206    ops/s
AsyncBenchmark.bracket                         100  thrpt   20   48127.640 ±  338.857    ops/s
AsyncBenchmark.cancelable                      100  thrpt   20   22838.937 ±  276.638    ops/s
AsyncBenchmark.race                            100  thrpt   20    4607.468 ±   26.697    ops/s
AsyncBenchmark.racePair                        100  thrpt   20   18638.108 ±  271.767    ops/s
AsyncBenchmark.start                           100  thrpt   20    7131.536 ±   56.862    ops/s
AsyncBenchmark.uncancelable                    100  thrpt   20  225983.305 ± 3854.823    ops/s
AttemptBenchmark.errorRaised                 10000  thrpt   20    1706.631 ±   20.437    ops/s
AttemptBenchmark.happyPath                   10000  thrpt   20    2528.153 ±   10.204    ops/s
DeepBindBenchmark.async                      10000  thrpt   20     506.963 ±   28.186    ops/s
DeepBindBenchmark.delay                      10000  thrpt   20    3619.885 ±   19.944    ops/s
DeepBindBenchmark.pure                       10000  thrpt   20    4582.860 ±   82.699    ops/s
HandleErrorBenchmark.errorRaised             10000  thrpt   20    2058.460 ±   18.188    ops/s
HandleErrorBenchmark.happyPath               10000  thrpt   20    2787.462 ±   36.151    ops/s
MapCallsBenchmark.batch120                     N/A  thrpt   20    5585.960 ±   26.981    ops/s
MapCallsBenchmark.batch30                      N/A  thrpt   20    3793.869 ±  181.826    ops/s
MapCallsBenchmark.one                          N/A  thrpt   20     267.421 ±    3.023    ops/s
MapStreamBenchmark.batch120                    N/A  thrpt   20    3630.350 ±   45.796    ops/s
MapStreamBenchmark.batch30                     N/A  thrpt   20    1322.036 ±   22.228    ops/s
MapStreamBenchmark.one                         N/A  thrpt   20    1461.211 ±   46.251    ops/s
RedeemBenchmark.errorRaised                  10000  thrpt   20    1305.533 ±   83.990    ops/s
RedeemBenchmark.happyPath                    10000  thrpt   20    1573.721 ±   15.368    ops/s
RedeemWithBenchmark.errorRaised              10000  thrpt   20    1594.318 ±   27.944    ops/s
RedeemWithBenchmark.happyPath                10000  thrpt   20    2312.903 ±  129.530    ops/s
ShallowBindBenchmark.async                   10000  thrpt   20     502.602 ±   10.863    ops/s
ShallowBindBenchmark.delay                   10000  thrpt   20    4140.454 ±   26.828    ops/s
ShallowBindBenchmark.pure                    10000  thrpt   20    4608.918 ±  335.367    ops/s
WorkStealingBenchmark.async                1000000  thrpt   20       4.883 ±    0.162  ops/min
WorkStealingBenchmark.asyncTooManyThreads  1000000  thrpt   20       7.045 ±    0.450  ops/min
```