### PR TITLE
MonadCancel

### DIFF
--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -23,6 +23,9 @@ package object effect {
   type Outcome[F[_], E, A] = cekernel.Outcome[F, E, A]
   val Outcome = cekernel.Outcome
 
+  type MonadCancel[F[_], E] = cekernel.MonadCancel[F, E]
+  val MonadCancel = cekernel.MonadCancel
+
   type Concurrent[F[_], E] = cekernel.Concurrent[F, E]
   val Concurrent = cekernel.Concurrent
 
@@ -47,6 +50,7 @@ package object effect {
   type Effect[F[_]] = cekernel.Effect[F]
   val Effect = cekernel.Effect
 
+  type MonadCancelThrow[F[_]] = cekernel.MonadCancelThrow[F]
   type ConcurrentThrow[F[_]] = cekernel.ConcurrentThrow[F]
   type TemporalThrow[F[_]] = cekernel.TemporalThrow[F]
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Concurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Concurrent.scala
@@ -16,52 +16,14 @@
 
 package cats.effect.kernel
 
-import cats.{~>, MonadError}
+import cats.~>
 import cats.data.{EitherT, Ior, IorT, Kleisli, OptionT, WriterT}
 import cats.{Monoid, Semigroup}
 import cats.syntax.all._
 
-trait Concurrent[F[_], E] extends MonadError[F, E] {
-
-  // analogous to productR, except discarding short-circuiting (and optionally some effect contexts) except for cancelation
-  def forceR[A, B](fa: F[A])(fb: F[B]): F[B]
+trait Concurrent[F[_], E] extends MonadCancel[F, E] {
 
   def start[A](fa: F[A]): F[Fiber[F, E, A]]
-
-  def uncancelable[A](body: Poll[F] => F[A]): F[A]
-
-  // produces an effect which is already canceled (and doesn't introduce an async boundary)
-  // this is effectively a way for a fiber to commit suicide and yield back to its parent
-  // The fallback (unit) value is produced if the effect is sequenced into a block in which
-  // cancelation is suppressed.
-  def canceled: F[Unit]
-
-  def onCancel[A](fa: F[A], fin: F[Unit]): F[A]
-
-  def guarantee[A](fa: F[A], fin: F[Unit]): F[A] =
-    guaranteeCase(fa)(_ => fin)
-
-  def guaranteeCase[A](fa: F[A])(fin: Outcome[F, E, A] => F[Unit]): F[A] =
-    bracketCase(unit)(_ => fa)((_, oc) => fin(oc))
-
-  def bracket[A, B](acquire: F[A])(use: A => F[B])(release: A => F[Unit]): F[B] =
-    bracketCase(acquire)(use)((a, _) => release(a))
-
-  def bracketCase[A, B](acquire: F[A])(use: A => F[B])(
-      release: (A, Outcome[F, E, B]) => F[Unit]): F[B] =
-    bracketFull(_ => acquire)(use)(release)
-
-  def bracketFull[A, B](acquire: Poll[F] => F[A])(use: A => F[B])(
-      release: (A, Outcome[F, E, B]) => F[Unit]): F[B] =
-    uncancelable { poll =>
-      flatMap(acquire(poll)) { a =>
-        val finalized = onCancel(poll(use(a)), release(a, Outcome.Canceled()))
-        val handled = onError(finalized) {
-          case e => void(attempt(release(a, Outcome.Errored(e))))
-        }
-        flatMap(handled)(b => as(attempt(release(a, Outcome.Completed(pure(b)))), b))
-      }
-    }
 
   // produces an effect which never returns
   def never[A]: F[A]

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.kernel
+
+import cats.{~>, MonadError}
+
+trait MonadCancel[F[_], E] extends MonadError[F, E] {
+
+  // analogous to productR, except discarding short-circuiting (and optionally some effect contexts) except for cancelation
+  def forceR[A, B](fa: F[A])(fb: F[B]): F[B]
+
+  def uncancelable[A](body: (F ~> F) => F[A]): F[A]
+
+  // produces an effect which is already canceled (and doesn't introduce an async boundary)
+  // this is effectively a way for a fiber to commit suicide and yield back to its parent
+  // The fallback (unit) value is produced if the effect is sequenced into a block in which
+  // cancelation is suppressed.
+  def canceled: F[Unit]
+
+  def onCancel[A](fa: F[A], fin: F[Unit]): F[A]
+
+  def guarantee[A](fa: F[A], fin: F[Unit]): F[A] =
+    guaranteeCase(fa)(_ => fin)
+
+  def guaranteeCase[A](fa: F[A])(fin: Outcome[F, E, A] => F[Unit]): F[A] =
+    bracketCase(unit)(_ => fa)((_, oc) => fin(oc))
+
+  def bracket[A, B](acquire: F[A])(use: A => F[B])(release: A => F[Unit]): F[B] =
+    bracketCase(acquire)(use)((a, _) => release(a))
+
+  def bracketCase[A, B](acquire: F[A])(use: A => F[B])(
+      release: (A, Outcome[F, E, B]) => F[Unit]): F[B] =
+    bracketFull(_ => acquire)(use)(release)
+
+  def bracketFull[A, B](acquire: (F ~> F) => F[A])(use: A => F[B])(
+      release: (A, Outcome[F, E, B]) => F[Unit]): F[B] =
+    uncancelable { poll =>
+      flatMap(acquire(poll)) { a =>
+        val finalized = onCancel(poll(use(a)), release(a, Outcome.Canceled()))
+        val handled = onError(finalized) {
+          case e => void(attempt(release(a, Outcome.Errored(e))))
+        }
+        flatMap(handled)(b => as(attempt(release(a, Outcome.Completed(pure(b)))), b))
+      }
+    }
+}
+
+object MonadCancel {
+
+  def apply[F[_], E](implicit F: MonadCancel[F, E]): F.type = F
+
+  def apply[F[_]](implicit F: MonadCancel[F, _], d: DummyImplicit): F.type = F
+
+}

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -16,14 +16,16 @@
 
 package cats.effect.kernel
 
-import cats.{~>, MonadError}
+import cats.{MonadError, Monoid, Semigroup}
+import cats.data.{EitherT, IorT, Kleisli, OptionT, WriterT}
+import cats.syntax.all._
 
 trait MonadCancel[F[_], E] extends MonadError[F, E] {
 
   // analogous to productR, except discarding short-circuiting (and optionally some effect contexts) except for cancelation
   def forceR[A, B](fa: F[A])(fb: F[B]): F[B]
 
-  def uncancelable[A](body: (F ~> F) => F[A]): F[A]
+  def uncancelable[A](body: Poll[F] => F[A]): F[A]
 
   // produces an effect which is already canceled (and doesn't introduce an async boundary)
   // this is effectively a way for a fiber to commit suicide and yield back to its parent
@@ -46,7 +48,7 @@ trait MonadCancel[F[_], E] extends MonadError[F, E] {
       release: (A, Outcome[F, E, B]) => F[Unit]): F[B] =
     bracketFull(_ => acquire)(use)(release)
 
-  def bracketFull[A, B](acquire: (F ~> F) => F[A])(use: A => F[B])(
+  def bracketFull[A, B](acquire: Poll[F] => F[A])(use: A => F[B])(
       release: (A, Outcome[F, E, B]) => F[Unit]): F[B] =
     uncancelable { poll =>
       flatMap(acquire(poll)) { a =>
@@ -62,7 +64,262 @@ trait MonadCancel[F[_], E] extends MonadError[F, E] {
 object MonadCancel {
 
   def apply[F[_], E](implicit F: MonadCancel[F, E]): F.type = F
-
   def apply[F[_]](implicit F: MonadCancel[F, _], d: DummyImplicit): F.type = F
 
+  implicit def monadCancelForOptionT[F[_], E](
+      implicit F0: MonadCancel[F, E]): MonadCancel[OptionT[F, *], E] =
+    new OptionTMonadCancel[F, E] {
+
+      override implicit protected def F: MonadCancel[F, E] = F0
+    }
+
+  implicit def monadCancelForEitherT[F[_], E0, E](
+      implicit F0: MonadCancel[F, E]): MonadCancel[EitherT[F, E0, *], E] =
+    new EitherTMonadCancel[F, E0, E] {
+
+      override implicit protected def F: MonadCancel[F, E] = F0
+    }
+
+  implicit def monadCancelForKleisli[F[_], R, E](
+      implicit F0: MonadCancel[F, E]): MonadCancel[Kleisli[F, R, *], E] =
+    new KleisliMonadCancel[F, R, E] {
+
+      override implicit protected def F: MonadCancel[F, E] = F0
+    }
+
+  implicit def monadCancelForIorT[F[_], L, E](
+      implicit F0: MonadCancel[F, E],
+      L0: Semigroup[L]): MonadCancel[IorT[F, L, *], E] =
+    new IorTMonadCancel[F, L, E] {
+
+      override implicit protected def F: MonadCancel[F, E] = F0
+
+      override implicit protected def L: Semigroup[L] = L0
+    }
+
+  implicit def monadCancelForWriterT[F[_], L, E](
+      implicit F0: MonadCancel[F, E],
+      L0: Monoid[L]): MonadCancel[WriterT[F, L, *], E] =
+    new WriterTMonadCancel[F, L, E] {
+
+      override implicit protected def F: MonadCancel[F, E] = F0
+
+      override implicit protected def L: Monoid[L] = L0
+    }
+
+  private[kernel] trait OptionTMonadCancel[F[_], E] extends MonadCancel[OptionT[F, *], E] {
+    implicit protected def F: MonadCancel[F, E]
+
+    protected def delegate: MonadError[OptionT[F, *], E] =
+      OptionT.catsDataMonadErrorForOptionT[F, E]
+
+    def uncancelable[A](body: Poll[OptionT[F, *]] => OptionT[F, A]): OptionT[F, A] =
+      OptionT(
+        F.uncancelable { nat =>
+          val natT = new Poll[OptionT[F, *]] {
+            def apply[B](optfa: OptionT[F, B]): OptionT[F, B] = OptionT(nat(optfa.value))
+          }
+          body(natT).value
+        }
+      )
+
+    def canceled: OptionT[F, Unit] = OptionT.liftF(F.canceled)
+
+    def onCancel[A](fa: OptionT[F, A], fin: OptionT[F, Unit]): OptionT[F, A] =
+      OptionT(F.onCancel(fa.value, fin.value.void))
+
+    def forceR[A, B](fa: OptionT[F, A])(fb: OptionT[F, B]): OptionT[F, B] =
+      OptionT(
+        F.forceR(fa.value)(fb.value)
+      )
+
+    def pure[A](a: A): OptionT[F, A] = delegate.pure(a)
+
+    def raiseError[A](e: E): OptionT[F, A] = delegate.raiseError(e)
+
+    def handleErrorWith[A](fa: OptionT[F, A])(f: E => OptionT[F, A]): OptionT[F, A] =
+      delegate.handleErrorWith(fa)(f)
+
+    def flatMap[A, B](fa: OptionT[F, A])(f: A => OptionT[F, B]): OptionT[F, B] =
+      delegate.flatMap(fa)(f)
+
+    def tailRecM[A, B](a: A)(f: A => OptionT[F, Either[A, B]]): OptionT[F, B] =
+      delegate.tailRecM(a)(f)
+  }
+
+  private[kernel] trait EitherTMonadCancel[F[_], E0, E]
+      extends MonadCancel[EitherT[F, E0, *], E] {
+
+    implicit protected def F: MonadCancel[F, E]
+
+    protected def delegate: MonadError[EitherT[F, E0, *], E] =
+      EitherT.catsDataMonadErrorFForEitherT[F, E, E0]
+
+    def uncancelable[A](body: Poll[EitherT[F, E0, *]] => EitherT[F, E0, A]): EitherT[F, E0, A] =
+      EitherT(
+        F.uncancelable { nat =>
+          val natT =
+            new Poll[EitherT[F, E0, *]] {
+              def apply[B](optfa: EitherT[F, E0, B]): EitherT[F, E0, B] =
+                EitherT(nat(optfa.value))
+            }
+          body(natT).value
+        }
+      )
+
+    def canceled: EitherT[F, E0, Unit] = EitherT.liftF(F.canceled)
+
+    def onCancel[A](fa: EitherT[F, E0, A], fin: EitherT[F, E0, Unit]): EitherT[F, E0, A] =
+      EitherT(F.onCancel(fa.value, fin.value.void))
+
+    def forceR[A, B](fa: EitherT[F, E0, A])(fb: EitherT[F, E0, B]): EitherT[F, E0, B] =
+      EitherT(
+        F.forceR(fa.value)(fb.value)
+      )
+
+    def pure[A](a: A): EitherT[F, E0, A] = delegate.pure(a)
+
+    def raiseError[A](e: E): EitherT[F, E0, A] = delegate.raiseError(e)
+
+    def handleErrorWith[A](fa: EitherT[F, E0, A])(
+        f: E => EitherT[F, E0, A]): EitherT[F, E0, A] =
+      delegate.handleErrorWith(fa)(f)
+
+    def flatMap[A, B](fa: EitherT[F, E0, A])(f: A => EitherT[F, E0, B]): EitherT[F, E0, B] =
+      delegate.flatMap(fa)(f)
+
+    def tailRecM[A, B](a: A)(f: A => EitherT[F, E0, Either[A, B]]): EitherT[F, E0, B] =
+      delegate.tailRecM(a)(f)
+  }
+
+  private[kernel] trait IorTMonadCancel[F[_], L, E] extends MonadCancel[IorT[F, L, *], E] {
+
+    implicit protected def F: MonadCancel[F, E]
+
+    implicit protected def L: Semigroup[L]
+
+    protected def delegate: MonadError[IorT[F, L, *], E] =
+      IorT.catsDataMonadErrorFForIorT[F, L, E]
+
+    def uncancelable[A](body: Poll[IorT[F, L, *]] => IorT[F, L, A]): IorT[F, L, A] =
+      IorT(
+        F.uncancelable { nat =>
+          val natT = new Poll[IorT[F, L, *]] {
+            def apply[B](optfa: IorT[F, L, B]): IorT[F, L, B] = IorT(nat(optfa.value))
+          }
+          body(natT).value
+        }
+      )
+
+    def canceled: IorT[F, L, Unit] = IorT.liftF(F.canceled)
+
+    def onCancel[A](fa: IorT[F, L, A], fin: IorT[F, L, Unit]): IorT[F, L, A] =
+      IorT(F.onCancel(fa.value, fin.value.void))
+
+    def forceR[A, B](fa: IorT[F, L, A])(fb: IorT[F, L, B]): IorT[F, L, B] =
+      IorT(
+        F.forceR(fa.value)(fb.value)
+      )
+
+    def pure[A](a: A): IorT[F, L, A] = delegate.pure(a)
+
+    def raiseError[A](e: E): IorT[F, L, A] = delegate.raiseError(e)
+
+    def handleErrorWith[A](fa: IorT[F, L, A])(f: E => IorT[F, L, A]): IorT[F, L, A] =
+      delegate.handleErrorWith(fa)(f)
+
+    def flatMap[A, B](fa: IorT[F, L, A])(f: A => IorT[F, L, B]): IorT[F, L, B] =
+      delegate.flatMap(fa)(f)
+
+    def tailRecM[A, B](a: A)(f: A => IorT[F, L, Either[A, B]]): IorT[F, L, B] =
+      delegate.tailRecM(a)(f)
+  }
+
+  private[kernel] trait KleisliMonadCancel[F[_], R, E]
+      extends MonadCancel[Kleisli[F, R, *], E] {
+
+    implicit protected def F: MonadCancel[F, E]
+
+    protected def delegate: MonadError[Kleisli[F, R, *], E] =
+      Kleisli.catsDataMonadErrorForKleisli[F, R, E]
+
+    def uncancelable[A](body: Poll[Kleisli[F, R, *]] => Kleisli[F, R, A]): Kleisli[F, R, A] =
+      Kleisli { r =>
+        F.uncancelable { nat =>
+          val natT =
+            new Poll[Kleisli[F, R, *]] {
+              def apply[B](stfa: Kleisli[F, R, B]): Kleisli[F, R, B] =
+                Kleisli { r => nat(stfa.run(r)) }
+            }
+          body(natT).run(r)
+        }
+      }
+
+    def canceled: Kleisli[F, R, Unit] = Kleisli.liftF(F.canceled)
+
+    def onCancel[A](fa: Kleisli[F, R, A], fin: Kleisli[F, R, Unit]): Kleisli[F, R, A] =
+      Kleisli { r => F.onCancel(fa.run(r), fin.run(r)) }
+
+    def forceR[A, B](fa: Kleisli[F, R, A])(fb: Kleisli[F, R, B]): Kleisli[F, R, B] =
+      Kleisli(r => F.forceR(fa.run(r))(fb.run(r)))
+
+    def pure[A](a: A): Kleisli[F, R, A] = delegate.pure(a)
+
+    def raiseError[A](e: E): Kleisli[F, R, A] = delegate.raiseError(e)
+
+    def handleErrorWith[A](fa: Kleisli[F, R, A])(f: E => Kleisli[F, R, A]): Kleisli[F, R, A] =
+      delegate.handleErrorWith(fa)(f)
+
+    def flatMap[A, B](fa: Kleisli[F, R, A])(f: A => Kleisli[F, R, B]): Kleisli[F, R, B] =
+      delegate.flatMap(fa)(f)
+
+    def tailRecM[A, B](a: A)(f: A => Kleisli[F, R, Either[A, B]]): Kleisli[F, R, B] =
+      delegate.tailRecM(a)(f)
+  }
+
+  private[kernel] trait WriterTMonadCancel[F[_], L, E]
+      extends MonadCancel[WriterT[F, L, *], E] {
+
+    implicit protected def F: MonadCancel[F, E]
+
+    implicit protected def L: Monoid[L]
+
+    protected def delegate: MonadError[WriterT[F, L, *], E] =
+      WriterT.catsDataMonadErrorForWriterT[F, L, E]
+
+    def uncancelable[A](body: Poll[WriterT[F, L, *]] => WriterT[F, L, A]): WriterT[F, L, A] =
+      WriterT(
+        F.uncancelable { nat =>
+          val natT =
+            new Poll[WriterT[F, L, *]] {
+              def apply[B](optfa: WriterT[F, L, B]): WriterT[F, L, B] = WriterT(nat(optfa.run))
+            }
+          body(natT).run
+        }
+      )
+
+    def canceled: WriterT[F, L, Unit] = WriterT.liftF(F.canceled)
+
+    //Note that this does not preserve the log from the finalizer
+    def onCancel[A](fa: WriterT[F, L, A], fin: WriterT[F, L, Unit]): WriterT[F, L, A] =
+      WriterT(F.onCancel(fa.run, fin.value.void))
+
+    def forceR[A, B](fa: WriterT[F, L, A])(fb: WriterT[F, L, B]): WriterT[F, L, B] =
+      WriterT(
+        F.forceR(fa.run)(fb.run)
+      )
+
+    def pure[A](a: A): WriterT[F, L, A] = delegate.pure(a)
+
+    def raiseError[A](e: E): WriterT[F, L, A] = delegate.raiseError(e)
+
+    def handleErrorWith[A](fa: WriterT[F, L, A])(f: E => WriterT[F, L, A]): WriterT[F, L, A] =
+      delegate.handleErrorWith(fa)(f)
+
+    def flatMap[A, B](fa: WriterT[F, L, A])(f: A => WriterT[F, L, B]): WriterT[F, L, B] =
+      delegate.flatMap(fa)(f)
+
+    def tailRecM[A, B](a: A)(f: A => WriterT[F, L, Either[A, B]]): WriterT[F, L, B] =
+      delegate.tailRecM(a)(f)
+  }
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
@@ -18,6 +18,7 @@ package cats.effect
 
 package object kernel {
 
+  type MonadCancelThrow[F[_]] = MonadCancel[F, Throwable]
   type ConcurrentThrow[F[_]] = Concurrent[F, Throwable]
   type TemporalThrow[F[_]] = Temporal[F, Throwable]
 

--- a/laws/shared/src/main/scala/cats/effect/laws/ConcurrentTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ConcurrentTests.scala
@@ -19,13 +19,12 @@ package laws
 
 import cats.Eq
 import cats.effect.kernel.{Concurrent, Outcome}
-import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._, Prop.forAll
 import org.scalacheck.util.Pretty
 
-trait ConcurrentTests[F[_], E] extends MonadErrorTests[F, E] {
+trait ConcurrentTests[F[_], E] extends MonadCancelTests[F, E] {
 
   val laws: ConcurrentLaws[F, E]
 
@@ -68,7 +67,7 @@ trait ConcurrentTests[F[_], E] extends MonadErrorTests[F, E] {
     new RuleSet {
       val name = "concurrent"
       val bases = Nil
-      val parents = Seq(monadError[A, B, C])
+      val parents = Seq(monadCancel[A, B, C])
 
       val props = Seq(
         "race derives from racePair (left)" -> forAll(laws.raceDerivesFromRacePairLeft[A, B] _),
@@ -87,11 +86,6 @@ trait ConcurrentTests[F[_], E] extends MonadErrorTests[F, E] {
         "fiber never is never" -> laws.fiberNeverIsNever,
         "fiber start of never is unit" -> laws.fiberStartOfNeverIsUnit,
         "never dominates over flatMap" -> forAll(laws.neverDominatesOverFlatMap[A] _),
-        "uncancelable poll is identity" -> forAll(laws.uncancelablePollIsIdentity[A] _),
-        "uncancelable ignored poll eliminates nesting" -> forAll(
-          laws.uncancelableIgnoredPollEliminatesNesting[A] _),
-        "uncancelable poll inverse nest is uncancelable" -> forAll(
-          laws.uncancelablePollInverseNestIsUncancelable[A] _),
         "uncancelable race displaces canceled" -> laws.uncancelableRaceDisplacesCanceled,
         "uncancelable race poll canceled identity (left)" -> forAll(
           laws.uncancelableRacePollCanceledIdentityLeft[A] _),
@@ -99,16 +93,6 @@ trait ConcurrentTests[F[_], E] extends MonadErrorTests[F, E] {
           laws.uncancelableRacePollCanceledIdentityRight[A] _),
         "uncancelable canceled is canceled" -> laws.uncancelableCancelCancels,
         "uncancelable start is cancelable" -> laws.uncancelableStartIsCancelable,
-        "uncancelable canceled associates right over flatMap" -> forAll(
-          laws.uncancelableCanceledAssociatesRightOverFlatMap[A] _),
-        "canceled associates left over flatMap" -> forAll(
-          laws.canceledAssociatesLeftOverFlatMap[A] _),
-        "canceled sequences onCancel in order" -> forAll(
-          laws.canceledSequencesOnCancelInOrder _),
-        "uncancelable eliminates onCancel" -> forAll(laws.uncancelableEliminatesOnCancel[A] _),
-        "forceR discards pure" -> forAll(laws.forceRDiscardsPure[A, B] _),
-        "forceR discards error" -> forAll(laws.forceRDiscardsError[A] _),
-        "forceR canceled short-circuits" -> forAll(laws.forceRCanceledShortCircuits[A] _),
         "forceR never is never" -> forAll(laws.forceRNeverIsNever[A] _)
       )
     }

--- a/laws/shared/src/main/scala/cats/effect/laws/MonadCancelLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/MonadCancelLaws.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package laws
+
+import cats.effect.kernel.MonadCancel
+import cats.syntax.all._
+import cats.laws.MonadErrorLaws
+
+trait MonadCancelLaws[F[_], E] extends MonadErrorLaws[F, E] {
+
+  implicit val F: MonadCancel[F, E]
+
+  // note that this implies the nested case as well
+  def uncancelablePollIsIdentity[A](fa: F[A]) =
+    F.uncancelable(_(fa)) <-> fa
+
+  def uncancelableIgnoredPollEliminatesNesting[A](fa: F[A]) =
+    F.uncancelable(_ => F.uncancelable(_ => fa)) <-> F.uncancelable(_ => fa)
+
+  // this law shows that inverted polls do not apply
+  def uncancelablePollInverseNestIsUncancelable[A](fa: F[A]) =
+    F.uncancelable(op => F.uncancelable(ip => op(ip(fa)))) <-> F.uncancelable(_ => fa)
+
+  // TODO F.uncancelable(p => F.canceled >> p(fa) >> fb) <-> F.uncancelable(p => p(F.canceled >> fa) >> fb)
+
+  def uncancelableCanceledAssociatesRightOverFlatMap[A](a: A, f: A => F[Unit]) =
+    F.uncancelable(_ => F.canceled.as(a).flatMap(f)) <->
+      F.forceR(F.uncancelable(_ => f(a)))(F.canceled)
+
+  def canceledAssociatesLeftOverFlatMap[A](fa: F[A]) =
+    F.canceled >> fa.void <-> F.canceled
+
+  def canceledSequencesOnCancelInOrder(fin1: F[Unit], fin2: F[Unit]) =
+    F.onCancel(F.onCancel(F.canceled, fin1), fin2) <->
+      F.forceR(F.uncancelable(_ => F.forceR(fin1)(fin2)))(F.canceled)
+
+  def uncancelableEliminatesOnCancel[A](fa: F[A], fin: F[Unit]) =
+    F.uncancelable(_ => F.onCancel(fa, fin)) <-> F.uncancelable(_ => fa)
+
+  def forceRDiscardsPure[A, B](a: A, fa: F[B]) =
+    F.forceR(F.pure(a))(fa) <-> fa
+
+  def forceRDiscardsError[A](e: E, fa: F[A]) =
+    F.forceR(F.raiseError(e))(fa) <-> fa
+
+  def forceRCanceledShortCircuits[A](fa: F[A]) =
+    F.forceR(F.canceled)(fa) <-> F.productR(F.canceled)(fa)
+}
+
+object MonadCancelLaws {
+  def apply[F[_], E](implicit F0: MonadCancel[F, E]): MonadCancelLaws[F, E] =
+    new MonadCancelLaws[F, E] { val F = F0 }
+}

--- a/laws/shared/src/main/scala/cats/effect/laws/MonadCancelTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/MonadCancelTests.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package laws
+
+import cats.Eq
+import cats.effect.kernel.MonadCancel
+import cats.laws.discipline._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
+
+import org.scalacheck._, Prop.forAll
+import org.scalacheck.util.Pretty
+
+trait MonadCancelTests[F[_], E] extends MonadErrorTests[F, E] {
+
+  val laws: MonadCancelLaws[F, E]
+
+  def monadCancel[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](
+      implicit ArbFA: Arbitrary[F[A]],
+      ArbFB: Arbitrary[F[B]],
+      ArbFC: Arbitrary[F[C]],
+      ArbFU: Arbitrary[F[Unit]],
+      ArbFAtoB: Arbitrary[F[A => B]],
+      ArbFBtoC: Arbitrary[F[B => C]],
+      ArbE: Arbitrary[E],
+      CogenA: Cogen[A],
+      CogenB: Cogen[B],
+      CogenC: Cogen[C],
+      CogenE: Cogen[E],
+      EqFA: Eq[F[A]],
+      EqFB: Eq[F[B]],
+      EqFC: Eq[F[C]],
+      EqFU: Eq[F[Unit]],
+      EqE: Eq[E],
+      EqFEitherEU: Eq[F[Either[E, Unit]]],
+      EqFEitherEA: Eq[F[Either[E, A]]],
+      EqFABC: Eq[F[(A, B, C)]],
+      EqFInt: Eq[F[Int]],
+      iso: Isomorphisms[F],
+      faPP: F[A] => Pretty,
+      fuPP: F[Unit] => Pretty,
+      aFUPP: (A => F[Unit]) => Pretty,
+      ePP: E => Pretty): RuleSet = {
+
+    new RuleSet {
+      val name = "monadCancel"
+      val bases = Nil
+      val parents = Seq(monadError[A, B, C])
+
+      val props = Seq(
+        "uncancelable poll is identity" -> forAll(laws.uncancelablePollIsIdentity[A] _),
+        "uncancelable ignored poll eliminates nesting" -> forAll(
+          laws.uncancelableIgnoredPollEliminatesNesting[A] _),
+        "uncancelable poll inverse nest is uncancelable" -> forAll(
+          laws.uncancelablePollInverseNestIsUncancelable[A] _),
+        "uncancelable canceled associates right over flatMap" -> forAll(
+          laws.uncancelableCanceledAssociatesRightOverFlatMap[A] _),
+        "canceled associates left over flatMap" -> forAll(
+          laws.canceledAssociatesLeftOverFlatMap[A] _),
+        "canceled sequences onCancel in order" -> forAll(
+          laws.canceledSequencesOnCancelInOrder _),
+        "uncancelable eliminates onCancel" -> forAll(laws.uncancelableEliminatesOnCancel[A] _),
+        "forceR discards pure" -> forAll(laws.forceRDiscardsPure[A, B] _),
+        "forceR discards error" -> forAll(laws.forceRDiscardsError[A] _),
+        "forceR canceled short-circuits" -> forAll(laws.forceRCanceledShortCircuits[A] _)
+      )
+    }
+  }
+}
+
+object MonadCancelTests {
+  def apply[F[_], E](implicit F0: MonadCancel[F, E]): MonadCancelTests[F, E] =
+    new MonadCancelTests[F, E] {
+      val laws = MonadCancelLaws[F, E]
+    }
+}

--- a/laws/shared/src/test/scala/cats/effect/ReaderWriterStateTPureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/ReaderWriterStateTPureConcSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.{Eq, Monad, Show}
+import cats.data.ReaderWriterStateT
+//import cats.laws.discipline.{AlignTests, ParallelTests}
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.eq._
+import cats.laws.discipline.MiniInt
+import cats.syntax.all._
+//import cats.effect.kernel.ParallelF
+import cats.effect.laws.MonadCancelTests
+import cats.effect.testkit.{pure, PureConcGenerators}, pure._
+
+// import org.scalacheck.rng.Seed
+import org.scalacheck.util.Pretty
+
+import org.specs2.ScalaCheck
+import org.specs2.scalacheck.Parameters
+import org.specs2.mutable._
+
+import org.typelevel.discipline.specs2.mutable.Discipline
+
+class ReaderWriterStateTPureConcSpec extends Specification with Discipline with ScalaCheck {
+  import PureConcGenerators._
+
+  implicit def prettyFromShow[A: Show](a: A): Pretty =
+    Pretty.prettyString(a.show)
+
+  implicit def rwstEq[F[_]: Monad, E, L, S, A](
+      implicit ev: Eq[(E, S) => F[(L, S, A)]]): Eq[ReaderWriterStateT[F, E, L, S, A]] =
+    Eq.by[ReaderWriterStateT[F, E, L, S, A], (E, S) => F[(L, S, A)]](_.run)
+
+  checkAll(
+    "ReaderWriterStateT[PureConc]",
+    MonadCancelTests[ReaderWriterStateT[PureConc[Int, *], MiniInt, Int, MiniInt, *], Int]
+      .monadCancel[Int, Int, Int]
+    // we need to bound this a little tighter because these tests take FOREVER, especially on scalajs
+  )(Parameters(minTestsOk =
+    1 /*, seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get*/ ))
+}

--- a/laws/shared/src/test/scala/cats/effect/StateTPureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/StateTPureConcSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.{Eq, FlatMap, Show}
+import cats.data.StateT
+//import cats.laws.discipline.{AlignTests, ParallelTests}
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.eq._
+import cats.laws.discipline.MiniInt
+import cats.syntax.all._
+//import cats.effect.kernel.ParallelF
+import cats.effect.laws.MonadCancelTests
+import cats.effect.testkit.{pure, PureConcGenerators}, pure._
+
+// import org.scalacheck.rng.Seed
+import org.scalacheck.util.Pretty
+
+import org.specs2.ScalaCheck
+import org.specs2.scalacheck.Parameters
+import org.specs2.mutable._
+
+import org.typelevel.discipline.specs2.mutable.Discipline
+
+class StateTPureConcSpec extends Specification with Discipline with ScalaCheck {
+  import PureConcGenerators._
+
+  implicit def prettyFromShow[A: Show](a: A): Pretty =
+    Pretty.prettyString(a.show)
+
+  implicit def stateTEq[F[_]: FlatMap, S, A](
+      implicit ev: Eq[S => F[(S, A)]]): Eq[StateT[F, S, A]] =
+    Eq.by[StateT[F, S, A], S => F[(S, A)]](_.run)
+
+  checkAll(
+    "StateT[PureConc]",
+    MonadCancelTests[StateT[PureConc[Int, *], MiniInt, *], Int].monadCancel[Int, Int, Int]
+  )(Parameters(minTestsOk =
+    25 /*, seed = Some(Seed.fromBase64("IDF0zP9Be_vlUEA4wfnKjd8gE8RNQ6tj-BvSVAUp86J=").get*/ ))
+}


### PR DESCRIPTION
Conceptually, this is something like a direct replacement for CE2's `Bracket`, and I suspect any upgrade scalafix will assume such. The main difference is that cancelation *as a concept* is extracted from `Concurrent` and moved up into this class. There are two motivations for this change: practical and conceptual.

## Practical Motivation

`StateT` and `ReaderWriterStateT` (and also perhaps `ContT`; I haven't tried yet) form a lawful `MonadCancel`, but neither can form a lawful `Concurrent` (well, *possibly* lawful, but certainly not sane). The fact that they can't form a valid `Concurrent` is quite problematic, because it means that `StateT` cannot *participate* in cancelation-safe code, even when that code itself is fully sequential. This in turn all-but forces people to write unsafe code in areas involving these types, unsafety which would only be exposed when such code is in turn composed with other, `Concurrent`-forming base types.

All in all, it corrupts composability in a very subtle and dangerous way. Thus, feel that the conceptual weight of the added abstraction is justified. As an additional aside, there are many unforeseen third-party types which are isomorphic to `StateT`, and those types would have a similar problem. Thus, presenting this as a full abstraction opens the hierarchy to safe composition with those types, whereas we would otherwise have no options there.

## Conceptual Motivation

There's nothing about cancelation which is *fundamentally* concurrent, given that we have `canceled`. Technically, cancelation probably doesn't have that many practical applications absent concurrency, but that's an argument by lack of imagination. With this change, we can view the (simplified) functor hierarchy through the following lens:

- `Functor` – Contains thing(s) of type `A`
- `Applicative` – Static pairing of `F[A]`s
- `Monad` – Runtime sequentialization of `F[A]`s
- `MonadError` – Recoverable short-circuiting of sequential chains given a sentinel value
- `MonadCancel` – Unrecoverable (but maskable) short-circuiting of sequential chains without a sentinel
- `Concurrent` – Generalize sequential chains to sequential edge-restricted DAGs
- `Allocate` – Generalize chains to arbitrary graphs
- `Async` – Constructor capture of side-effects
- `Effect` – Functional effect type (`IO`-like)

I find this rather pleasing. It simplifies the definition of `Concurrent` down to specifically control-flow, analogous to how `Monad` is itself just a control flow mechanism (characterizing runtime sequentialization).

Fixes #1016