### PR TITLE
Use a pattern-bound type variable instead of `Any`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -665,11 +665,11 @@ abstract private[effect] class ResourceMonadError[F[_], E]
           case Left(error) => (Left(error), (_: ExitCase) => F.unit)
           case Right((a, release)) => (Right(a), release)
         })
-      case Bind(source: Resource[F, Any], fs: (Any => Resource[F, A])) =>
+      case Bind(source: Resource[F, s], fs) =>
         Suspend(F.pure(source).map[Resource[F, Either[E, A]]] { source =>
           Bind(
             attempt(source),
-            (r: Either[E, Any]) =>
+            (r: Either[E, s]) =>
               r match {
                 case Left(error) => Resource.pure[F, Either[E, A]](Left(error))
                 case Right(s) => attempt(fs(s))


### PR DESCRIPTION
`Bind` has an extra type parameter `S` which does not exist in
`Resource`, so when pattern matching on `Bind`, that type parameter is
replaced by a skolem (that is, a fresh abstract type whose bounds are
those of `S` in `Bind`). This skolem doesn't have an accessible name,
so to get a reference to it we need to use a pattern-bound type variable
(here called `s`), this allows us to type the lambda parameter `r`
correctly. Before this commit, `Any` was used instead of a type
variable, this is unsound since `S` appears contravariantly in `fs` but
didn't lead to any issue since it only appeared in the expression
`fs(s)` (but if someone had accidentally written `fs(0)`, the compiler
wouldn't have detected the error).

This issue was identified by Dotty (though it somewhat confusingly
reported that `Bind(_, _)` was missing from the match instead of
reporting the use of an unchecked type test, I've minimized that and
opened https://github.com/lampepfl/dotty/issues/9682), the remaining
Dotty warnings are all unchecked type tests and they all seem like
legitimate warnings to me.

It's also worth noting that if we didn't have to cross-compile with
Scala 2, we could just omit the type of the lambda parameter and Dotty
would figure it out, so no explicit pattern-bound type variable would be
needed at all :).

I haven't tried it but this change should be backportable as-is to
`series/2.x`.