### PR TITLE
Fix unsafe cast to subtype by using Poll in UnmaskTo

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -702,7 +702,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
   }
 
   // Not part of the run loop. Only used in the implementation of IO#to.
-  private[effect] final case class UnmaskTo[F[_], +A](ioa: IO[A], poll: F ~> F) extends IO[A] {
+  private[effect] final case class UnmaskTo[F[_], +A](ioa: IO[A], poll: Poll[F]) extends IO[A] {
     def tag = -1
   }
 }


### PR DESCRIPTION
Not a big deal, we were careful before, just being precise and pedantic.