### PR TITLE
Hierarchy renaming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [0.26.0, 0.27.0-RC1, 2.12.12, 2.13.3]
+        scala: [0.27.0-RC1, 2.12.12, 2.13.3]
         java:
           - adopt@1.8
           - adopt@11

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ val PrimaryOS = "ubuntu-latest"
 
 val ScalaJSJava = "adopt@1.8"
 
-ThisBuild / crossScalaVersions := Seq("0.26.0", "0.27.0-RC1", "2.12.12", "2.13.3")
+ThisBuild / crossScalaVersions := Seq("0.27.0-RC1", "2.12.12", "2.13.3")
 
 ThisBuild / githubWorkflowTargetBranches := Seq("series/3.x")
 

--- a/concurrent/shared/src/main/scala/cats/effect/concurrent/MVar.scala
+++ b/concurrent/shared/src/main/scala/cats/effect/concurrent/MVar.scala
@@ -213,8 +213,8 @@ object MVar {
    *
    * @see [[of]]and [[empty]]
    */
-  def apply[F[_]](implicit mk: Mk[F]): ApplyBuilders[F] =
-    new ApplyBuilders[F](mk)
+  def apply[F[_]](implicit F: Async[F]): ApplyBuilders[F] =
+    new ApplyBuilders[F](F)
 
   /**
    * Creates a cancelable `MVar` that starts as empty.
@@ -222,8 +222,8 @@ object MVar {
    * @param F is an [[Async]] constraint, needed in order to
    *        describe cancelable operations
    */
-  def empty[F[_], A](implicit mk: Mk[F]): F[MVar[F, A]] =
-    mk.mvarEmpty
+  def empty[F[_], A](implicit F: Async[F]): F[MVar[F, A]] =
+    F.delay(MVarAsync.empty)
 
   /**
    * Creates a cancelable `MVar` that's initialized to an `initial`
@@ -235,56 +235,42 @@ object MVar {
    * @param F is a [[Concurrent]] constraint, needed in order to
    *        describe cancelable operations
    */
-  def of[F[_], A](initial: A)(implicit mk: Mk[F]): F[MVar[F, A]] =
-    mk.mvarOf(initial)
+  def of[F[_], A](initial: A)(implicit F: Async[F]): F[MVar[F, A]] =
+    F.delay(MVarAsync(initial))
 
   /**
    * Like [[of]] but initializes state using another effect constructor
    */
-  def in[F[_], G[_], A](initial: A)(implicit mk: MkIn[F, G]): F[MVar[G, A]] =
-    mk.mvarOf(initial)
+  def in[F[_], G[_], A](initial: A)(implicit F: Sync[F], G: Async[G]): F[MVar[G, A]] =
+    F.delay(MVarAsync(initial))
 
   /**
    * Like [[empty]] but initializes state using another effect constructor
    */
-  def emptyIn[F[_], G[_], A](implicit mk: MkIn[F, G]): F[MVar[G, A]] =
-    mk.mvarEmpty[A]
+  def emptyIn[F[_], G[_], A](implicit F: Sync[F], G: Async[G]): F[MVar[G, A]] =
+    F.delay(MVarAsync.empty)
 
   /**
    * Returned by the [[apply]] builder.
    */
-  final class ApplyBuilders[F[_]](val mk: Mk[F]) extends AnyVal {
+  final class ApplyBuilders[F[_]](val F: Async[F]) extends AnyVal {
 
     /**
      * Builds an `MVar` with an initial value.
      *
      * @see documentation for [[MVar.of]]
      */
-    def of[A](a: A): F[MVar[F, A]] = mk.mvarOf(a)
+    def of[A](a: A): F[MVar[F, A]] =
+      MVar.of(a)(F)
 
     /**
      * Builds an empty `MVar`.
      *
      * @see documentation for [[MVar.empty]]
      */
-    def empty[A]: F[MVar[F, A]] = mk.mvarEmpty[A]
+    def empty[A]: F[MVar[F, A]] =
+      MVar.empty(F)
   }
-
-  trait MkIn[F[_], G[_]] {
-    def mvarOf[A](a: A): F[MVar[G, A]]
-    def mvarEmpty[A]: F[MVar[G, A]]
-  }
-
-  object MkIn {
-    implicit def instance[F[_], G[_]](implicit F: Sync[F], G: Async[G]): MkIn[F, G] =
-      new MkIn[F, G] {
-        override def mvarOf[A](a: A): F[MVar[G, A]] = F.delay(MVarAsync(a))
-
-        override def mvarEmpty[A]: F[MVar[G, A]] = F.delay(MVarAsync.empty)
-      }
-  }
-
-  type Mk[F[_]] = MkIn[F, F]
 
   final private[concurrent] class TransformedMVar[F[_], G[_], A](
       underlying: MVar[F, A],

--- a/concurrent/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
+++ b/concurrent/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
@@ -18,7 +18,7 @@ package cats
 package effect
 package concurrent
 
-import cats.effect.kernel.{Allocate, Concurrent, Outcome}
+import cats.effect.kernel.{Allocate, Outcome, Spawn}
 import cats.effect.concurrent.Semaphore.TransformedSemaphore
 import cats.implicits._
 
@@ -149,7 +149,7 @@ object Semaphore {
   private type State[F[_]] = Either[Queue[(Long, Deferred[F, Unit])], Long]
 
   abstract private class AbstractSemaphore[F[_]](state: Ref[F, State[F]])(
-      implicit F: Concurrent[F, Throwable])
+      implicit F: Spawn[F, Throwable])
       extends Semaphore[F] {
     protected def mkGate: F[Deferred[F, Unit]]
 

--- a/concurrent/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
+++ b/concurrent/shared/src/main/scala/cats/effect/concurrent/Semaphore.scala
@@ -18,7 +18,7 @@ package cats
 package effect
 package concurrent
 
-import cats.effect.kernel.{Allocate, Outcome, Spawn}
+import cats.effect.kernel.{Concurrent, Outcome, Spawn}
 import cats.effect.concurrent.Semaphore.TransformedSemaphore
 import cats.implicits._
 
@@ -110,7 +110,7 @@ object Semaphore {
   /**
    * Creates a new `Semaphore`, initialized with `n` available permits.
    */
-  def apply[F[_]](n: Long)(implicit F: Allocate[F, Throwable]): F[Semaphore[F]] =
+  def apply[F[_]](n: Long)(implicit F: Concurrent[F, Throwable]): F[Semaphore[F]] =
     assertNonNegative[F](n) *>
       F.ref[State[F]](Right(n)).map(stateRef => new AsyncSemaphore[F](stateRef))
 
@@ -129,7 +129,7 @@ object Semaphore {
     implicit def instance[F[_], G[_]](
         implicit mkRef: Ref.MkIn[F, G],
         F: ApplicativeError[F, Throwable],
-        G: Allocate[G, Throwable]): MkIn[F, G] =
+        G: Concurrent[G, Throwable]): MkIn[F, G] =
       new MkIn[F, G] {
         override def semaphore(count: Long): F[Semaphore[G]] =
           assertNonNegative[F](count) *>
@@ -281,7 +281,7 @@ object Semaphore {
   }
 
   final private class AsyncSemaphore[F[_]](state: Ref[F, State[F]])(
-      implicit F: Allocate[F, Throwable])
+      implicit F: Concurrent[F, Throwable])
       extends AbstractSemaphore(state) {
     protected def mkGate: F[Deferred[F, Unit]] = Deferred[F, Unit]
   }

--- a/concurrent/shared/src/test/scala/cats/effect/concurrent/SyntaxSpec.scala
+++ b/concurrent/shared/src/test/scala/cats/effect/concurrent/SyntaxSpec.scala
@@ -16,7 +16,7 @@
 
 package cats.effect.concurrent
 
-import cats.effect.kernel.{Allocate, Async}
+import cats.effect.kernel.{Async, Concurrent}
 import org.specs2.mutable.Specification
 
 class SyntaxSpec extends Specification {
@@ -34,7 +34,7 @@ class SyntaxSpec extends Specification {
   }
 
   def preciseConstraints[F[_]: Ref.Mk: Semaphore.Mk: MVar.Mk](
-      implicit F: Allocate[F, Throwable]) = {
+      implicit F: Concurrent[F, Throwable]) = {
     Ref.of[F, String]("foo")
     Ref[F].of(15)
     Deferred[F, Unit]
@@ -45,6 +45,6 @@ class SyntaxSpec extends Specification {
     MVar.of[F, String]("bar")
   }
 
-  def semaphoreIsDeriveable[F[_]](implicit F: Allocate[F, Throwable]) =
+  def semaphoreIsDeriveable[F[_]](implicit F: Concurrent[F, Throwable]) =
     Semaphore[F](11)
 }

--- a/concurrent/shared/src/test/scala/cats/effect/concurrent/SyntaxSpec.scala
+++ b/concurrent/shared/src/test/scala/cats/effect/concurrent/SyntaxSpec.scala
@@ -16,7 +16,7 @@
 
 package cats.effect.concurrent
 
-import cats.effect.kernel.{Async, Concurrent}
+import cats.effect.kernel.{Async, Concurrent, Sync}
 import org.specs2.mutable.Specification
 
 class SyntaxSpec extends Specification {
@@ -33,16 +33,18 @@ class SyntaxSpec extends Specification {
     MVar.of[F, String]("bar")
   }
 
-  def preciseConstraints[F[_]: Ref.Mk: Semaphore.Mk: MVar.Mk](
-      implicit F: Concurrent[F, Throwable]) = {
+  def concurrent[F[_]](implicit F: Concurrent[F, String]) = {
+    Ref.of[F, Int](0)
+    Deferred[F, Unit]
+  }
+
+  def sync[F[_]](implicit F: Sync[F]) = {
+    Ref.of[F, Int](0)
+  }
+
+  def preciseConstraints[F[_]: Ref.Make] = {
     Ref.of[F, String]("foo")
     Ref[F].of(15)
-    Deferred[F, Unit]
-    Semaphore[F](15)
-    MVar[F].of(1)
-    MVar[F].empty[String]
-    MVar.empty[F, String]
-    MVar.of[F, String]("bar")
   }
 
   def semaphoreIsDeriveable[F[_]](implicit F: Concurrent[F, Throwable]) =

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -623,7 +623,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
   implicit def effectForIO: Effect[IO] = _effectForIO
 
   private[this] val _parallelForIO: Parallel.Aux[IO, ParallelF[IO, *]] =
-    parallelForConcurrent[IO, Throwable]
+    parallelForSpawn[IO, Throwable]
 
   implicit def parallelForIO: Parallel.Aux[IO, ParallelF[IO, *]] = _parallelForIO
 

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -655,7 +655,7 @@ abstract private[effect] class ResourceInstances0 {
   implicit def catsEffectSemigroupKForResource[F[_], A](
       implicit F0: Resource.Bracket[F],
       K0: SemigroupK[F],
-      G0: Ref.Mk[F]): ResourceSemigroupK[F] =
+      G0: Ref.Make[F]): ResourceSemigroupK[F] =
     new ResourceSemigroupK[F] {
       def F = F0
       def K = K0
@@ -760,7 +760,7 @@ abstract private[effect] class ResourceSemigroup[F[_], A] extends Semigroup[Reso
 abstract private[effect] class ResourceSemigroupK[F[_]] extends SemigroupK[Resource[F, *]] {
   implicit protected def F: Resource.Bracket[F]
   implicit protected def K: SemigroupK[F]
-  implicit protected def G: Ref.Mk[F]
+  implicit protected def G: Ref.Make[F]
 
   def combineK[A](ra: Resource[F, A], rb: Resource[F, A]): Resource[F, A] =
     Resource.make(Ref[F].of(F.unit))(_.get.flatten).evalMap { finalizers =>

--- a/core/shared/src/main/scala/cats/effect/Resource.scala
+++ b/core/shared/src/main/scala/cats/effect/Resource.scala
@@ -498,7 +498,7 @@ object Resource extends ResourceInstances with ResourcePlatform {
   }
 
   @annotation.implicitNotFound(
-    "Cannot find an instance for Resource.Bracket. This normally means you need to add implicit evidence of MonadCancel[F, Throwable]")
+    "Cannot find an instance for Resource.Bracket. This normally means you need to add implicit evidence of MonadCancel[${F}, Throwable]")
   trait Bracket[F[_]] extends MonadError[F, Throwable] {
     def bracketCase[A, B](acquire: F[A])(use: A => F[B])(
         release: (A, ExitCase) => F[Unit]): F[B]

--- a/core/shared/src/main/scala/cats/effect/instances/AllInstances.scala
+++ b/core/shared/src/main/scala/cats/effect/instances/AllInstances.scala
@@ -17,4 +17,4 @@
 package cats.effect
 package instances
 
-trait AllInstances extends kernel.instances.ConcurrentInstances
+trait AllInstances extends kernel.instances.SpawnInstances

--- a/core/shared/src/main/scala/cats/effect/instances/package.scala
+++ b/core/shared/src/main/scala/cats/effect/instances/package.scala
@@ -20,5 +20,5 @@ package object instances {
 
   object all extends AllInstances
 
-  object concurrent extends kernel.instances.ConcurrentInstances
+  object concurrent extends kernel.instances.SpawnInstances
 }

--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -32,6 +32,9 @@ package object effect {
   type Fiber[F[_], E, A] = cekernel.Fiber[F, E, A]
   type Poll[F[_]] = cekernel.Poll[F]
 
+  type Concurrent[F[_], E] = cekernel.Concurrent[F, E]
+  val Concurrent = cekernel.Concurrent
+
   type Clock[F[_]] = cekernel.Clock[F]
   val Clock = cekernel.Clock
 
@@ -52,6 +55,7 @@ package object effect {
 
   type MonadCancelThrow[F[_]] = cekernel.MonadCancelThrow[F]
   type SpawnThrow[F[_]] = cekernel.SpawnThrow[F]
+  type ConcurrentThrow[F[_]] = cekernel.ConcurrentThrow[F]
   type TemporalThrow[F[_]] = cekernel.TemporalThrow[F]
 
   type ParallelF[F[_], A] = cekernel.Par.ParallelF[F, A]

--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -26,8 +26,8 @@ package object effect {
   type MonadCancel[F[_], E] = cekernel.MonadCancel[F, E]
   val MonadCancel = cekernel.MonadCancel
 
-  type Concurrent[F[_], E] = cekernel.Concurrent[F, E]
-  val Concurrent = cekernel.Concurrent
+  type Spawn[F[_], E] = cekernel.Spawn[F, E]
+  val Spawn = cekernel.Spawn
 
   type Fiber[F[_], E, A] = cekernel.Fiber[F, E, A]
   type Poll[F[_]] = cekernel.Poll[F]
@@ -51,7 +51,7 @@ package object effect {
   val Effect = cekernel.Effect
 
   type MonadCancelThrow[F[_]] = cekernel.MonadCancelThrow[F]
-  type ConcurrentThrow[F[_]] = cekernel.ConcurrentThrow[F]
+  type SpawnThrow[F[_]] = cekernel.SpawnThrow[F]
   type TemporalThrow[F[_]] = cekernel.TemporalThrow[F]
 
   type ParallelF[F[_], A] = cekernel.Par.ParallelF[F, A]

--- a/core/shared/src/main/scala/cats/effect/syntax/AllSyntax.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/AllSyntax.scala
@@ -18,7 +18,7 @@ package cats.effect
 package syntax
 
 trait AllSyntax
-    extends kernel.syntax.ConcurrentSyntax
+    extends kernel.syntax.SpawnSyntax
     with kernel.syntax.TemporalSyntax
     with kernel.syntax.AsyncSyntax
     with kernel.syntax.SyncEffectSyntax

--- a/core/shared/src/main/scala/cats/effect/syntax/package.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/package.scala
@@ -20,7 +20,7 @@ package object syntax {
 
   object all extends AllSyntax
 
-  object concurrent extends kernel.syntax.ConcurrentSyntax
+  object spawn extends kernel.syntax.SpawnSyntax
   object temporal extends kernel.syntax.TemporalSyntax
   object async extends kernel.syntax.AsyncSyntax
   object syncEffect extends kernel.syntax.SyncEffectSyntax

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Allocate.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Allocate.scala
@@ -19,7 +19,7 @@ package cats.effect.kernel
 import cats.{Monoid, Semigroup}
 import cats.data.{EitherT, IorT, Kleisli, OptionT, WriterT}
 
-trait Allocate[F[_], E] extends Concurrent[F, E] {
+trait Allocate[F[_], E] extends Spawn[F, E] {
 
   def ref[A](a: A): F[Ref[F, A]]
 
@@ -69,7 +69,7 @@ object Allocate {
 
   private[kernel] trait OptionTAllocate[F[_], E]
       extends Allocate[OptionT[F, *], E]
-      with Concurrent.OptionTConcurrent[F, E] {
+      with Spawn.OptionTSpawn[F, E] {
     implicit protected def F: Allocate[F, E]
 
     override def ref[A](a: A): OptionT[F, Ref[OptionT[F, *], A]] =
@@ -81,7 +81,7 @@ object Allocate {
 
   private[kernel] trait EitherTAllocate[F[_], E0, E]
       extends Allocate[EitherT[F, E0, *], E]
-      with Concurrent.EitherTConcurrent[F, E0, E] {
+      with Spawn.EitherTSpawn[F, E0, E] {
     implicit protected def F: Allocate[F, E]
 
     override def ref[A](a: A): EitherT[F, E0, Ref[EitherT[F, E0, *], A]] =
@@ -93,7 +93,7 @@ object Allocate {
 
   private[kernel] trait KleisliAllocate[F[_], R, E]
       extends Allocate[Kleisli[F, R, *], E]
-      with Concurrent.KleisliConcurrent[F, R, E] {
+      with Spawn.KleisliSpawn[F, R, E] {
     implicit protected def F: Allocate[F, E]
 
     override def ref[A](a: A): Kleisli[F, R, Ref[Kleisli[F, R, *], A]] =
@@ -105,7 +105,7 @@ object Allocate {
 
   private[kernel] trait IorTAllocate[F[_], L, E]
       extends Allocate[IorT[F, L, *], E]
-      with Concurrent.IorTConcurrent[F, L, E] {
+      with Spawn.IorTSpawn[F, L, E] {
     implicit protected def F: Allocate[F, E]
 
     implicit protected def L: Semigroup[L]
@@ -119,7 +119,7 @@ object Allocate {
 
   private[kernel] trait WriterTAllocate[F[_], L, E]
       extends Allocate[WriterT[F, L, *], E]
-      with Concurrent.WriterTConcurrent[F, L, E] {
+      with Spawn.WriterTSpawn[F, L, E] {
 
     implicit protected def F: Allocate[F, E]
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Deferred.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Deferred.scala
@@ -86,7 +86,7 @@ object Deferred {
    * If you want to share one, pass it as an argument and `flatMap`
    * once.
    */
-  def apply[F[_], A](implicit F: Allocate[F, _]): F[Deferred[F, A]] =
+  def apply[F[_], A](implicit F: Concurrent[F, _]): F[Deferred[F, A]] =
     F.deferred[A]
 
   /**

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Deferred.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Deferred.scala
@@ -99,23 +99,10 @@ object Deferred {
   def unsafe[F[_]: Async, A]: Deferred[F, A] = new AsyncDeferred[F, A]
 
   /**
-   * Like [[apply]] but initializes state using another effect constructor.
+   * Like [[apply]] but initializes state using another effect constructor
    */
-  def in[F[_], G[_], A](implicit mk: MkIn[F, G]): F[Deferred[G, A]] =
-    mk.deferred[A]
-
-  type Mk[F[_]] = MkIn[F, F]
-
-  trait MkIn[F[_], G[_]] {
-    def deferred[A]: F[Deferred[G, A]]
-  }
-  object MkIn {
-    implicit def instance[F[_], G[_]](implicit F: Sync[F], G: Async[G]): MkIn[F, G] =
-      new MkIn[F, G] {
-        override def deferred[A]: F[Deferred[G, A]] =
-          F.delay(unsafe[G, A])
-      }
-  }
+  def in[F[_], G[_], A](implicit F: Sync[F], G: Async[G]): F[Deferred[G, A]] =
+    F.delay(unsafe[G, A])
 
   sealed abstract private class State[A]
   private object State {

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Fiber.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Fiber.scala
@@ -22,9 +22,9 @@ trait Fiber[F[_], E, A] {
   def cancel: F[Unit]
   def join: F[Outcome[F, E, A]]
 
-  def joinAndEmbed(onCancel: F[A])(implicit F: Concurrent[F, E]): F[A] =
+  def joinAndEmbed(onCancel: F[A])(implicit F: Spawn[F, E]): F[A] =
     join.flatMap(_.fold(onCancel, F.raiseError(_), fa => fa))
 
-  def joinAndEmbedNever(implicit F: Concurrent[F, E]): F[A] =
+  def joinAndEmbedNever(implicit F: Spawn[F, E]): F[A] =
     joinAndEmbed(F.never)
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
@@ -147,7 +147,7 @@ abstract class Ref[F[_], A] {
 object Ref {
 
   @annotation.implicitNotFound(
-    "Cannot find an instance for Ref.Make. Add implicit evidence of Concurrent[F, _], Sync[F] or Async[F] to scope to automatically derive one.")
+    "Cannot find an instance for Ref.Make. Add implicit evidence of Concurrent[${F}, _] or Sync[${F}] to scope to automatically derive one.")
   trait Make[F[_]] {
     def refOf[A](a: A): F[Ref[F, A]]
   }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
@@ -146,6 +146,26 @@ abstract class Ref[F[_], A] {
 
 object Ref {
 
+  trait Make[F[_]] {
+    def refOf[A](a: A): F[Ref[F, A]]
+  }
+
+  object Make extends MakeInstances
+
+  private[kernel] trait MakeInstances extends MakeLowPriorityInstances {
+    implicit def concurrentInstance[F[_]](implicit F: Concurrent[F, _]): Make[F] =
+      new Make[F] {
+        override def refOf[A](a: A): F[Ref[F, A]] = F.ref(a)
+      }
+  }
+
+  private[kernel] trait MakeLowPriorityInstances {
+    implicit def syncInstance[F[_]](implicit F: Sync[F]): Make[F] =
+      new Make[F] {
+        override def refOf[A](a: A): F[Ref[F, A]] = F.delay(unsafe(a))
+      }
+  }
+
   /**
    * Builds a `Ref` value for data types that are [[Sync]]
    *
@@ -159,7 +179,7 @@ object Ref {
    *
    * @see [[of]]
    */
-  def apply[F[_]](implicit mk: Mk[F]): ApplyBuilders[F] = new ApplyBuilders(mk)
+  def apply[F[_]](implicit mk: Make[F]): ApplyBuilders[F] = new ApplyBuilders(mk)
 
   /**
    * Creates an asynchronous, concurrent mutable reference initialized to the supplied value.
@@ -174,26 +194,7 @@ object Ref {
    *   } yield ten
    * }}}
    */
-  def of[F[_], A](a: A)(implicit F: Concurrent[F, _]): F[Ref[F, A]] = F.ref(a)
-
-  /**
-   *  Builds a `Ref` value for data types that are [[Sync]]
-   *  Like [[of]] but initializes state using another effect constructor
-   */
-  def in[F[_], G[_], A](a: A)(implicit mk: MkIn[F, G]): F[Ref[G, A]] = mk.refOf(a)
-
-  trait MkIn[F[_], G[_]] {
-    def refOf[A](a: A): F[Ref[G, A]]
-  }
-
-  object MkIn {
-    implicit def instance[F[_], G[_]](implicit F: Sync[F], G: Sync[G]): MkIn[F, G] =
-      new MkIn[F, G] {
-        override def refOf[A](a: A): F[Ref[G, A]] = F.delay(unsafe(a))
-      }
-  }
-
-  type Mk[F[_]] = MkIn[F, F]
+  def of[F[_], A](a: A)(implicit mk: Make[F]): F[Ref[F, A]] = mk.refOf(a)
 
   /**
    * Like `apply` but returns the newly allocated ref directly instead of wrapping it in `F.delay`.
@@ -239,6 +240,13 @@ object Ref {
     new SyncRef[F, A](new AtomicReference[A](a))
 
   /**
+   *  Builds a `Ref` value for data types that are [[Sync]]
+   *  Like [[of]] but initializes state using another effect constructor
+   */
+  def in[F[_], G[_], A](a: A)(implicit F: Sync[F], G: Sync[G]): F[Ref[G, A]] =
+    F.delay(unsafe(a))
+
+  /**
    * Creates an instance focused on a component of another Ref's value.
    * Delegates every get and modification to underlying Ref, so both instances are always in sync.
    *
@@ -256,14 +264,14 @@ object Ref {
       implicit F: Sync[F]): Ref[F, B] =
     new LensRef[F, A, B](ref)(get, set)
 
-  final class ApplyBuilders[F[_]](val F: Mk[F]) extends AnyVal {
+  final class ApplyBuilders[F[_]](val mk: Make[F]) extends AnyVal {
 
     /**
      * Creates an asynchronous, concurrent mutable reference initialized to the supplied value.
      *
      * @see [[Ref.of]]
      */
-    def of[A](a: A): F[Ref[F, A]] = F.refOf(a)
+    def of[A](a: A): F[Ref[F, A]] = mk.refOf(a)
   }
 
   final private class SyncRef[F[_], A](ar: AtomicReference[A])(implicit F: Sync[F])

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
@@ -174,7 +174,7 @@ object Ref {
    *   } yield ten
    * }}}
    */
-  def of[F[_], A](a: A)(implicit F: Allocate[F, _]): F[Ref[F, A]] = F.ref(a)
+  def of[F[_], A](a: A)(implicit F: Concurrent[F, _]): F[Ref[F, A]] = F.ref(a)
 
   /**
    *  Builds a `Ref` value for data types that are [[Sync]]

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
@@ -146,6 +146,8 @@ abstract class Ref[F[_], A] {
 
 object Ref {
 
+  @annotation.implicitNotFound(
+    "Cannot find an instance for Ref.Make. Add implicit evidence of Concurrent[F, _], Sync[F] or Async[F] to scope to automatically derive one.")
   trait Make[F[_]] {
     def refOf[A](a: A): F[Ref[F, A]]
   }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Temporal.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Temporal.scala
@@ -22,7 +22,7 @@ import cats.data.{EitherT, IorT, Kleisli, OptionT, WriterT}
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration.FiniteDuration
 
-trait Temporal[F[_], E] extends Allocate[F, E] with Clock[F] {
+trait Temporal[F[_], E] extends Concurrent[F, E] with Clock[F] {
   // (sleep(n) *> now) <-> now.map(_ + n + d) forSome { val d: Double }
   def sleep(time: FiniteDuration): F[Unit]
 
@@ -108,7 +108,7 @@ object Temporal {
 
   private[kernel] trait OptionTTemporal[F[_], E]
       extends Temporal[OptionT[F, *], E]
-      with Allocate.OptionTAllocate[F, E]
+      with Concurrent.OptionTConcurrent[F, E]
       with Clock.OptionTClock[F] {
 
     implicit protected def F: Temporal[F, E]
@@ -122,7 +122,7 @@ object Temporal {
 
   private[kernel] trait EitherTTemporal[F[_], E0, E]
       extends Temporal[EitherT[F, E0, *], E]
-      with Allocate.EitherTAllocate[F, E0, E]
+      with Concurrent.EitherTConcurrent[F, E0, E]
       with Clock.EitherTClock[F, E0] {
 
     implicit protected def F: Temporal[F, E]
@@ -135,7 +135,7 @@ object Temporal {
 
   private[kernel] trait IorTTemporal[F[_], L, E]
       extends Temporal[IorT[F, L, *], E]
-      with Allocate.IorTAllocate[F, L, E]
+      with Concurrent.IorTConcurrent[F, L, E]
       with Clock.IorTClock[F, L] {
 
     implicit protected def F: Temporal[F, E]
@@ -148,7 +148,7 @@ object Temporal {
 
   private[kernel] trait WriterTTemporal[F[_], L, E]
       extends Temporal[WriterT[F, L, *], E]
-      with Allocate.WriterTAllocate[F, L, E]
+      with Concurrent.WriterTConcurrent[F, L, E]
       with Clock.WriterTClock[F, L] {
 
     implicit protected def F: Temporal[F, E]
@@ -163,7 +163,7 @@ object Temporal {
 
   private[kernel] trait KleisliTemporal[F[_], R, E]
       extends Temporal[Kleisli[F, R, *], E]
-      with Allocate.KleisliAllocate[F, R, E]
+      with Concurrent.KleisliConcurrent[F, R, E]
       with Clock.KleisliClock[F, R] {
 
     implicit protected def F: Temporal[F, E]

--- a/kernel/shared/src/main/scala/cats/effect/kernel/instances/AllInstances.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/instances/AllInstances.scala
@@ -16,4 +16,4 @@
 
 package cats.effect.kernel.instances
 
-trait AllInstances extends ConcurrentInstances
+trait AllInstances extends SpawnInstances

--- a/kernel/shared/src/main/scala/cats/effect/kernel/instances/SpawnInstances.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/instances/SpawnInstances.scala
@@ -19,12 +19,12 @@ package cats.effect.kernel.instances
 import cats.{~>, Align, Applicative, CommutativeApplicative, Functor, Monad, Parallel}
 import cats.data.Ior
 import cats.implicits._
-import cats.effect.kernel.{Concurrent, ParallelF}
+import cats.effect.kernel.{ParallelF, Spawn}
 
-trait ConcurrentInstances {
+trait SpawnInstances {
 
-  implicit def parallelForConcurrent[M[_], E](
-      implicit M: Concurrent[M, E]): Parallel.Aux[M, ParallelF[M, *]] =
+  implicit def parallelForSpawn[M[_], E](
+      implicit M: Spawn[M, E]): Parallel.Aux[M, ParallelF[M, *]] =
     new Parallel[M] {
       type F[A] = ParallelF[M, A]
 
@@ -45,7 +45,7 @@ trait ConcurrentInstances {
     }
 
   implicit def commutativeApplicativeForParallelF[F[_], E](
-      implicit F: Concurrent[F, E]): CommutativeApplicative[ParallelF[F, *]] =
+      implicit F: Spawn[F, E]): CommutativeApplicative[ParallelF[F, *]] =
     new CommutativeApplicative[ParallelF[F, *]] {
 
       final override def pure[A](a: A): ParallelF[F, A] = ParallelF(F.pure(a))
@@ -74,8 +74,7 @@ trait ConcurrentInstances {
         ParallelF(F.unit)
     }
 
-  implicit def alignForParallelF[F[_], E](
-      implicit F: Concurrent[F, E]): Align[ParallelF[F, *]] =
+  implicit def alignForParallelF[F[_], E](implicit F: Spawn[F, E]): Align[ParallelF[F, *]] =
     new Align[ParallelF[F, *]] {
 
       override def functor: Functor[ParallelF[F, *]] = commutativeApplicativeForParallelF[F, E]

--- a/kernel/shared/src/main/scala/cats/effect/kernel/instances/package.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/instances/package.scala
@@ -20,5 +20,5 @@ package object instances {
 
   object all extends AllInstances
 
-  object concurrent extends ConcurrentInstances
+  object spawn extends SpawnInstances
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
@@ -21,7 +21,7 @@ package object kernel {
   type MonadCancelThrow[F[_]] = MonadCancel[F, Throwable]
   type SpawnThrow[F[_]] = Spawn[F, Throwable]
   type TemporalThrow[F[_]] = Temporal[F, Throwable]
-  type AllocateThrow[F[_]] = Allocate[F, Throwable]
+  type ConcurrentThrow[F[_]] = Concurrent[F, Throwable]
 
   type ParallelF[F[_], A] = Par.ParallelF[F, A]
   val ParallelF = Par.ParallelF

--- a/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
@@ -19,7 +19,7 @@ package cats.effect
 package object kernel {
 
   type MonadCancelThrow[F[_]] = MonadCancel[F, Throwable]
-  type ConcurrentThrow[F[_]] = Concurrent[F, Throwable]
+  type SpawnThrow[F[_]] = Spawn[F, Throwable]
   type TemporalThrow[F[_]] = Temporal[F, Throwable]
   type AllocateThrow[F[_]] = Allocate[F, Throwable]
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AllSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AllSyntax.scala
@@ -17,7 +17,7 @@
 package cats.effect.kernel.syntax
 
 trait AllSyntax
-    extends ConcurrentSyntax
+    extends SpawnSyntax
     with TemporalSyntax
     with AsyncSyntax
     with SyncEffectSyntax

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/SpawnSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/SpawnSyntax.scala
@@ -16,42 +16,42 @@
 
 package cats.effect.kernel.syntax
 
-import cats.effect.kernel.{Concurrent, Fiber, Outcome}
+import cats.effect.kernel.{Fiber, Outcome, Spawn}
 
-trait ConcurrentSyntax {
+trait SpawnSyntax {
 
-  implicit def concurrentOps[F[_], A, E](
+  implicit def spawnOps[F[_], A, E](
       wrapped: F[A]
-  ): ConcurrentOps[F, A, E] =
-    new ConcurrentOps(wrapped)
+  ): SpawnOps[F, A, E] =
+    new SpawnOps(wrapped)
 }
 
-final class ConcurrentOps[F[_], A, E](val wrapped: F[A]) extends AnyVal {
+final class SpawnOps[F[_], A, E](val wrapped: F[A]) extends AnyVal {
 
-  def forceR[B](fb: F[B])(implicit F: Concurrent[F, E]): F[B] =
+  def forceR[B](fb: F[B])(implicit F: Spawn[F, E]): F[B] =
     F.forceR(wrapped)(fb)
 
-  def !>[B](fb: F[B])(implicit F: Concurrent[F, E]): F[B] =
+  def !>[B](fb: F[B])(implicit F: Spawn[F, E]): F[B] =
     forceR(fb)
 
-  def start(implicit F: Concurrent[F, E]): F[Fiber[F, E, A]] = F.start(wrapped)
+  def start(implicit F: Spawn[F, E]): F[Fiber[F, E, A]] = F.start(wrapped)
 
-  def uncancelable(implicit F: Concurrent[F, E]): F[A] =
+  def uncancelable(implicit F: Spawn[F, E]): F[A] =
     F.uncancelable(_ => wrapped)
 
-  def onCancel(fin: F[Unit])(implicit F: Concurrent[F, E]): F[A] =
+  def onCancel(fin: F[Unit])(implicit F: Spawn[F, E]): F[A] =
     F.onCancel(wrapped, fin)
 
-  def guarantee(fin: F[Unit])(implicit F: Concurrent[F, E]): F[A] =
+  def guarantee(fin: F[Unit])(implicit F: Spawn[F, E]): F[A] =
     F.guarantee(wrapped, fin)
 
-  def guaranteeCase(fin: Outcome[F, E, A] => F[Unit])(implicit F: Concurrent[F, E]): F[A] =
+  def guaranteeCase(fin: Outcome[F, E, A] => F[Unit])(implicit F: Spawn[F, E]): F[A] =
     F.guaranteeCase(wrapped)(fin)
 
-  def bracket[B](use: A => F[B])(release: A => F[Unit])(implicit F: Concurrent[F, E]): F[B] =
+  def bracket[B](use: A => F[B])(release: A => F[Unit])(implicit F: Spawn[F, E]): F[B] =
     F.bracket(wrapped)(use)(release)
 
   def bracketCase[B](use: A => F[B])(release: (A, Outcome[F, E, B]) => F[Unit])(
-      implicit F: Concurrent[F, E]): F[B] =
+      implicit F: Spawn[F, E]): F[B] =
     F.bracketCase(wrapped)(use)(release)
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/package.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/package.scala
@@ -20,7 +20,7 @@ package object syntax {
 
   object all extends AllSyntax
 
-  object concurrent extends ConcurrentSyntax
+  object spawn extends SpawnSyntax
   object temporal extends TemporalSyntax
   object async extends AsyncSyntax
   object syncEffect extends SyncEffectSyntax

--- a/kernel/shared/src/test/scala/cats/effect/kernel/SyntaxSpec.scala
+++ b/kernel/shared/src/test/scala/cats/effect/kernel/SyntaxSpec.scala
@@ -25,11 +25,11 @@ class SyntaxSpec extends Specification {
 
   "kernel syntax" >> ok
 
-  def concurrentSyntax[F[_], A, E](target: F[A])(implicit F: Concurrent[F, E]) = {
-    import syntax.concurrent._
+  def spawnSyntax[F[_], A, E](target: F[A])(implicit F: Spawn[F, E]) = {
+    import syntax.spawn._
 
-    Concurrent[F]: F.type
-    Concurrent[F, E]: F.type
+    Spawn[F]: F.type
+    Spawn[F, E]: F.type
 
     {
       val result = target.start

--- a/laws/shared/src/main/scala/cats/effect/laws/SpawnLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SpawnLaws.scala
@@ -17,12 +17,12 @@
 package cats.effect
 package laws
 
-import cats.effect.kernel.{Concurrent, Outcome}
+import cats.effect.kernel.{Outcome, Spawn}
 import cats.syntax.all._
 
-trait ConcurrentLaws[F[_], E] extends MonadCancelLaws[F, E] {
+trait SpawnLaws[F[_], E] extends MonadCancelLaws[F, E] {
 
-  implicit val F: Concurrent[F, E]
+  implicit val F: Spawn[F, E]
 
   // we need to phrase this in terms of never because we can't *evaluate* laws which rely on nondetermnistic substitutability
   def raceDerivesFromRacePairLeft[A, B](fa: F[A]) = {
@@ -150,7 +150,7 @@ trait ConcurrentLaws[F[_], E] extends MonadCancelLaws[F, E] {
     F.forceR(F.never)(fa) <-> F.never
 }
 
-object ConcurrentLaws {
-  def apply[F[_], E](implicit F0: Concurrent[F, E]): ConcurrentLaws[F, E] =
-    new ConcurrentLaws[F, E] { val F = F0 }
+object SpawnLaws {
+  def apply[F[_], E](implicit F0: Spawn[F, E]): SpawnLaws[F, E] =
+    new SpawnLaws[F, E] { val F = F0 }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/SpawnTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SpawnTests.scala
@@ -18,17 +18,17 @@ package cats.effect
 package laws
 
 import cats.Eq
-import cats.effect.kernel.{Concurrent, Outcome}
+import cats.effect.kernel.{Outcome, Spawn}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import org.scalacheck._, Prop.forAll
 import org.scalacheck.util.Pretty
 
-trait ConcurrentTests[F[_], E] extends MonadCancelTests[F, E] {
+trait SpawnTests[F[_], E] extends MonadCancelTests[F, E] {
 
-  val laws: ConcurrentLaws[F, E]
+  val laws: SpawnLaws[F, E]
 
-  def concurrent[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](
+  def spawn[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](
       implicit ArbFA: Arbitrary[F[A]],
       ArbFB: Arbitrary[F[B]],
       ArbFC: Arbitrary[F[C]],
@@ -99,9 +99,9 @@ trait ConcurrentTests[F[_], E] extends MonadCancelTests[F, E] {
   }
 }
 
-object ConcurrentTests {
-  def apply[F[_], E](implicit F0: Concurrent[F, E]): ConcurrentTests[F, E] =
-    new ConcurrentTests[F, E] {
-      val laws = ConcurrentLaws[F, E]
+object SpawnTests {
+  def apply[F[_], E](implicit F0: Spawn[F, E]): SpawnTests[F, E] =
+    new SpawnTests[F, E] {
+      val laws = SpawnLaws[F, E]
     }
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/TemporalLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/TemporalLaws.scala
@@ -22,7 +22,7 @@ import cats.implicits._
 
 import scala.concurrent.duration.FiniteDuration
 
-trait TemporalLaws[F[_], E] extends ConcurrentLaws[F, E] with ClockLaws[F] {
+trait TemporalLaws[F[_], E] extends SpawnLaws[F, E] with ClockLaws[F] {
 
   implicit val F: Temporal[F, E]
 

--- a/laws/shared/src/main/scala/cats/effect/laws/TemporalTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/TemporalTests.scala
@@ -26,7 +26,7 @@ import org.scalacheck.util.Pretty
 
 import scala.concurrent.duration.FiniteDuration
 
-trait TemporalTests[F[_], E] extends ConcurrentTests[F, E] with ClockTests[F] {
+trait TemporalTests[F[_], E] extends SpawnTests[F, E] with ClockTests[F] {
 
   val laws: TemporalLaws[F, E]
 
@@ -77,7 +77,7 @@ trait TemporalTests[F[_], E] extends ConcurrentTests[F, E] with ClockTests[F] {
     new RuleSet {
       val name = "temporal"
       val bases = Nil
-      val parents = Seq(concurrent[A, B, C], clock[A, B, C])
+      val parents = Seq(spawn[A, B, C], clock[A, B, C])
 
       val props = Seq(
         "monotonic sleep sum identity" -> forAll(laws.monotonicSleepSumIdentity _),

--- a/testkit/shared/src/main/scala/cats/effect/testkit/Generators.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/Generators.scala
@@ -194,8 +194,8 @@ trait MonadCancelGenerators[F[_], E] extends MonadErrorGenerators[F, E] {
     } yield F.onCancel(fa, fin)
 }
 
-trait ConcurrentGenerators[F[_], E] extends MonadErrorGenerators[F, E] {
-  implicit val F: Concurrent[F, E]
+trait SpawnGenerators[F[_], E] extends MonadErrorGenerators[F, E] {
+  implicit val F: Spawn[F, E]
 
   override protected def baseGen[A: Arbitrary: Cogen]: List[(String, Gen[F[A]])] =
     List(
@@ -249,7 +249,7 @@ trait ConcurrentGenerators[F[_], E] extends MonadErrorGenerators[F, E] {
     } yield back
 }
 
-trait TemporalGenerators[F[_], E] extends ConcurrentGenerators[F, E] with ClockGenerators[F] {
+trait TemporalGenerators[F[_], E] extends SpawnGenerators[F, E] with ClockGenerators[F] {
   implicit val F: Temporal[F, E]
 
   override protected def baseGen[A: Arbitrary: Cogen] =

--- a/testkit/shared/src/main/scala/cats/effect/testkit/PureConcGenerators.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/PureConcGenerators.scala
@@ -16,7 +16,7 @@
 
 package cats.effect.testkit
 
-import cats.effect.kernel.{Concurrent, Outcome}
+import cats.effect.kernel.{Outcome, Spawn}
 import cats.effect.testkit.pure._
 
 import org.scalacheck.{Arbitrary, Cogen}
@@ -28,13 +28,13 @@ object PureConcGenerators {
     Cogen[Outcome[Option, E, A]].contramap(run(_))
 
   def generators[E: Arbitrary: Cogen] =
-    new ConcurrentGenerators[PureConc[E, *], E] {
+    new SpawnGenerators[PureConc[E, *], E] {
 
       val arbitraryE: Arbitrary[E] = implicitly[Arbitrary[E]]
 
       val cogenE: Cogen[E] = Cogen[E]
 
-      val F: Concurrent[PureConc[E, *], E] = allocateForPureConc[E]
+      val F: Spawn[PureConc[E, *], E] = allocateForPureConc[E]
 
       def cogenCase[A: Cogen]: Cogen[Outcome[PureConc[E, *], E, A]] =
         OutcomeGenerators.cogenOutcome[PureConc[E, *], E, A]

--- a/testkit/shared/src/main/scala/cats/effect/testkit/TimeT.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/TimeT.scala
@@ -19,7 +19,7 @@ package testkit
 
 import cats.{~>, Group, Monad, Monoid, Order}
 import cats.data.Kleisli
-import cats.effect.kernel.{Allocate, Deferred, Fiber, Outcome, Poll, Ref, Temporal}
+import cats.effect.kernel.{Concurrent, Deferred, Fiber, Outcome, Poll, Ref, Temporal}
 import cats.syntax.all._
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 
@@ -87,10 +87,11 @@ object TimeT {
   implicit def orderTimeT[F[_], A](implicit FA: Order[F[A]]): Order[TimeT[F, A]] =
     Order.by(TimeT.run(_))
 
-  implicit def temporalForTimeT[F[_], E](implicit F: Allocate[F, E]): Temporal[TimeT[F, *], E] =
+  implicit def temporalForTimeT[F[_], E](
+      implicit F: Concurrent[F, E]): Temporal[TimeT[F, *], E] =
     new TimeTTemporal[F, E]
 
-  private[this] class TimeTTemporal[F[_], E](implicit F: Allocate[F, E])
+  private[this] class TimeTTemporal[F[_], E](implicit F: Concurrent[F, E])
       extends Temporal[TimeT[F, *], E] {
 
     def pure[A](x: A): TimeT[F, A] =

--- a/testkit/shared/src/main/scala/cats/effect/testkit/pure.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/pure.scala
@@ -171,8 +171,8 @@ object pure {
   implicit def orderForPureConc[E: Order, A: Order]: Order[PureConc[E, A]] =
     Order.by(pure.run(_))
 
-  implicit def allocateForPureConc[E]: Allocate[PureConc[E, *], E] =
-    new Allocate[PureConc[E, *], E] {
+  implicit def allocateForPureConc[E]: Concurrent[PureConc[E, *], E] =
+    new Concurrent[PureConc[E, *], E] {
       private[this] val M: MonadError[PureConc[E, *], E] =
         Kleisli.catsDataMonadErrorForKleisli
 


### PR DESCRIPTION
- [x] Rename `Concurrent` to `Spawn`
- [x] Rename `Allocated` to `Concurrent`
~- [ ] Rename base classes to their `E` variants and add `Throw` aliases which fix the error type to `Throwable`~

I'm opening this PR before the third item is done because it's going to be pretty ugly