### PR TITLE
Correct the enhancedExceptions property example in the documentation

### DIFF
--- a/site/src/main/mdoc/tracing/index.md
+++ b/site/src/main/mdoc/tracing/index.md
@@ -219,7 +219,7 @@ This feature is controlled by the system property
 `cats.effect.enhancedExceptions`. It is enabled by default.
 
 ```
--Dcats.effect.stackTracingMode=false
+-Dcats.effect.enhancedExceptions=false
 ```
 
 ### Complete example


### PR DESCRIPTION
In the documentation of tracing, the `stackTracingMode` is incorrectly used as in example in the paragraph about the `enhancedExceptions`. This PR corrects it.