### PR TITLE
Remove references to executed fibers

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -334,5 +334,9 @@ private[effect] final class WorkStealingThreadPool(
     workerThreads.foreach(_.interrupt())
     // Join all worker threads.
     workerThreads.foreach(_.join())
+    // Remove the references to the worker threads so that they can be cleaned up, including their worker queues.
+    for (i <- 0 until workerThreads.length) {
+      workerThreads(i) = null
+    }
   }
 }


### PR DESCRIPTION
Fixes #1201.

cc @mpilquist 
https://github.com/typelevel/fs2/pull/2035

Verified by publishing `cats-effect` locally, updating the dependency in `fs2` and running the tests again.
```
sbt:fs2-reactive-streams> testOnly *Unicast*
[info] StreamUnicastPublisherSpec:
[TestNG] Running:
  Command line suite

[info] - optional_spec104_mustSignalOnErrorWhenFails
[info] - optional_spec105_emptyStreamMustTerminateBySignallingOnComplete
[info] - optional_spec111_maySupportMultiSubscribe
[info] - optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfront
[info] - optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected
[info] - optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingOneByOne
[info] - optional_spec111_registeredSubscribersMustReceiveOnNextOrOnCompleteSignals
[info] - optional_spec309_requestNegativeNumberMaySignalIllegalArgumentExceptionWithSpecificMessage
[info] - required_createPublisher1MustProduceAStreamOfExactly1Element
[info] - required_createPublisher3MustProduceAStreamOfExactly3Elements
[info] - required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements
[info] - required_spec102_maySignalLessThanRequestedAndTerminateSubscription
[info] - required_spec105_mustSignalOnCompleteWhenFiniteStreamTerminates
[info] - required_spec107_mustNotEmitFurtherSignalsOnceOnCompleteHasBeenSignalled
[info] - required_spec109_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorAfterOnSubscribe
[info] - required_spec109_mustIssueOnSubscribeForNonNullSubscriber
[info] - required_spec109_subscribeThrowNPEOnNullSubscriber
[info] - required_spec302_mustAllowSynchronousRequestCallsFromOnNextAndOnSubscribe
[info] - required_spec303_mustNotAllowUnboundedRecursion
[info] - required_spec306_afterSubscriptionIsCancelledRequestMustBeNops
[info] - required_spec307_afterSubscriptionIsCancelledAdditionalCancelationsMustBeNops
[info] - required_spec309_requestNegativeNumberMustSignalIllegalArgumentException
[info] - required_spec309_requestZeroMustSignalIllegalArgumentException
[info] - required_spec312_cancelMustMakeThePublisherToEventuallyStopSignaling
[info] - required_spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber
[info] - required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue
[info] - required_spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue
[info] - required_spec317_mustSupportAPendingElementCountUpToLongMaxValue
[info] - required_validate_boundedDepthOfOnNextAndRequestRecursion
[info] - required_validate_maxElementsFromPublisher
[info] - stochastic_spec103_mustSignalOnMethodsSequentially
[info] - untested_spec106_mustConsiderSubscriptionCancelledAfterOnErrorOrOnCompleteHasBeenCalled !!! IGNORED !!!
[info] - untested_spec107_mustNotEmitFurtherSignalsOnceOnErrorHasBeenSignalled !!! IGNORED !!!
[info] - untested_spec108_possiblyCanceledSubscriptionShouldNotReceiveOnErrorOrOnCompleteSignals !!! IGNORED !!!
[info] - untested_spec109_subscribeShouldNotThrowNonFatalThrowable !!! IGNORED !!!
[info] - untested_spec110_rejectASubscriptionRequestIfTheSameSubscriberSubscribesTwice !!! IGNORED !!!
[info] - untested_spec304_requestShouldNotPerformHeavyComputations !!! IGNORED !!!
[info] - untested_spec305_cancelMustNotSynchronouslyPerformHeavyComputation !!! IGNORED !!!

===============================================
Command line suite
Total tests run: 38, Failures: 0, Skips: 7
===============================================
  | => reactiveStreams / Test / testOnly 22s
[info] ScalaTest
[info] Run completed in 22 seconds, 497 milliseconds.
[info] Total number of tests run: 31
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 31, failed 0, canceled 0, ignored 7, pending 0
[info] All tests passed.
[info] Passed: Total 31, Failed 0, Errors 0, Passed 31, Ignored 7
[success] Total time: 24 s, completed Sep 17, 2020, 1:34:30 PM
```