### PR TITLE
Prevent accidental resuming of a done fiber

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -42,4 +42,5 @@ private[effect] object IOFiberConstants {
   val AfterBlockingFailedR: Byte = 4
   val EvalOnR: Byte = 5
   val CedeR: Byte = 6
+  val DoneR: Byte = 7
 }

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -42,4 +42,5 @@ final class IOFiberConstants {
   public static final byte AfterBlockingFailedR = 4;
   public static final byte EvalOnR = 5;
   public static final byte CedeR = 6;
+  public static final byte DoneR = 7;
 }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -227,6 +227,7 @@ private final class IOFiber[A](
     afterBlockingSuccessfulResult = null
     afterBlockingFailedError = null
     evalOnIOA = null
+    resumeTag = DoneR
   }
 
   /*
@@ -755,6 +756,7 @@ private final class IOFiber[A](
       case 4 => afterBlockingFailedR()
       case 5 => evalOnR()
       case 6 => cedeR()
+      case 7 => ()
     }
 
   private[this] def execR(): Unit = {


### PR DESCRIPTION
Also helps to pad out the `resume` switch.