### PR TITLE
Concurrent.memoize

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -221,7 +221,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
     IO.Start(this)
 
   def memoize: IO[IO[A]] =
-    Concurrent.memoize(this)
+    Concurrent[IO].memoize(this)
 
   def to[F[_]](implicit F: Effect[F]): F[A @uncheckedVariance] =
     // re-comment this fast-path to test the implementation with IO itself

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -220,6 +220,9 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
   def start: IO[FiberIO[A @uncheckedVariance]] =
     IO.Start(this)
 
+  def memoize: IO[IO[A]] =
+    Concurrent.memoize(this)
+
   def to[F[_]](implicit F: Effect[F]): F[A @uncheckedVariance] =
     // re-comment this fast-path to test the implementation with IO itself
     if (F eq IO.effectForIO) {

--- a/core/shared/src/main/scala/cats/effect/syntax/AllSyntax.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/AllSyntax.scala
@@ -19,6 +19,7 @@ package syntax
 
 trait AllSyntax
     extends kernel.syntax.GenSpawnSyntax
+    with kernel.syntax.GenConcurrentSyntax
     with kernel.syntax.GenTemporalSyntax
     with kernel.syntax.AsyncSyntax
     with kernel.syntax.SyncEffectSyntax

--- a/core/shared/src/main/scala/cats/effect/syntax/package.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/package.scala
@@ -22,6 +22,7 @@ package object syntax {
 
   object spawn extends kernel.syntax.GenSpawnSyntax
   object temporal extends kernel.syntax.GenTemporalSyntax
+  object concurrent extends kernel.syntax.GenConcurrentSyntax
   object async extends kernel.syntax.AsyncSyntax
   object syncEffect extends kernel.syntax.SyncEffectSyntax
   object effect extends kernel.syntax.EffectSyntax

--- a/core/shared/src/test/scala/cats/effect/MemoizeSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/MemoizeSpec.scala
@@ -38,7 +38,7 @@ class MemoizeSpec extends BaseSpec with Discipline with ScalaCheck {
       val op = for {
         ref <- Ref.of[IO, Int](0)
         action = ref.update(_ + 1)
-        _ <- Concurrent.memoize(action)
+        _ <- Concurrent[IO].memoize(action)
         _ <- IO.sleep(100.millis)
         v <- ref.get
       } yield v
@@ -57,7 +57,7 @@ class MemoizeSpec extends BaseSpec with Discipline with ScalaCheck {
           val ns = s + 1
           ns -> ns
         }
-        memoized <- Concurrent.memoize(action)
+        memoized <- Concurrent[IO].memoize(action)
         x <- memoized
         y <- memoized
         v <- ref.get
@@ -77,7 +77,7 @@ class MemoizeSpec extends BaseSpec with Discipline with ScalaCheck {
           val ns = s + 1
           ns -> ns
         }
-        memoized <- Concurrent.memoize(action)
+        memoized <- Concurrent[IO].memoize(action)
         _ <- memoized.start
         x <- memoized
         _ <- IO.sleep(100.millis)
@@ -92,14 +92,14 @@ class MemoizeSpec extends BaseSpec with Discipline with ScalaCheck {
     }
 
     "Concurrent.memoize and then flatten is identity" in ticked { implicit ticker =>
-      forAll { (fa: IO[Int]) => Concurrent.memoize(fa).flatten eqv fa }
+      forAll { (fa: IO[Int]) => Concurrent[IO].memoize(fa).flatten eqv fa }
     }
 
     "Memoized effects can be canceled when there are no other active subscribers (1)" in real {
       val op = for {
         completed <- Ref[IO].of(false)
         action = IO.sleep(200.millis) >> completed.set(true)
-        memoized <- Concurrent.memoize(action)
+        memoized <- Concurrent[IO].memoize(action)
         fiber <- memoized.start
         _ <- IO.sleep(100.millis)
         _ <- fiber.cancel
@@ -118,7 +118,7 @@ class MemoizeSpec extends BaseSpec with Discipline with ScalaCheck {
       val op = for {
         completed <- Ref[IO].of(false)
         action = IO.sleep(300.millis) >> completed.set(true)
-        memoized <- Concurrent.memoize(action)
+        memoized <- Concurrent[IO].memoize(action)
         fiber1 <- memoized.start
         _ <- IO.sleep(100.millis)
         fiber2 <- memoized.start
@@ -140,7 +140,7 @@ class MemoizeSpec extends BaseSpec with Discipline with ScalaCheck {
       val op = for {
         completed <- Ref[IO].of(false)
         action = IO.sleep(300.millis) >> completed.set(true)
-        memoized <- Concurrent.memoize(action)
+        memoized <- Concurrent[IO].memoize(action)
         fiber1 <- memoized.start
         _ <- IO.sleep(100.millis)
         fiber2 <- memoized.start
@@ -163,7 +163,7 @@ class MemoizeSpec extends BaseSpec with Discipline with ScalaCheck {
         started <- Ref[IO].of(0)
         completed <- Ref[IO].of(0)
         action = started.update(_ + 1) >> IO.sleep(200.millis) >> completed.update(_ + 1)
-        memoized <- Concurrent.memoize(action)
+        memoized <- Concurrent[IO].memoize(action)
         fiber <- memoized.start
         _ <- IO.sleep(100.millis)
         _ <- fiber.cancel
@@ -183,7 +183,7 @@ class MemoizeSpec extends BaseSpec with Discipline with ScalaCheck {
       val op = for {
         condition <- Deferred[IO, Unit]
         action = IO.sleep(200.millis) >> condition.complete(())
-        memoized <- Concurrent.memoize(action)
+        memoized <- Concurrent[IO].memoize(action)
         fiber1 <- memoized.start
         _ <- IO.sleep(50.millis)
         fiber2 <- memoized.start

--- a/core/shared/src/test/scala/cats/effect/MemoizeSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/MemoizeSpec.scala
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+
+import cats.effect.concurrent.{Deferred, Ref}
+import cats.syntax.all._
+
+import org.scalacheck.Prop, Prop.forAll
+
+import org.specs2.ScalaCheck
+
+import org.typelevel.discipline.specs2.mutable.Discipline
+
+import scala.concurrent.duration._
+
+class MemoizeSpec extends BaseSpec with Discipline with ScalaCheck {
+
+  sequential
+
+  "Concurrent.memoize" >> {
+
+    "Concurrent.memoize does not evaluates the effect if the inner `F[A]` isn't bound" in real {
+      val op = for {
+        ref <- Ref.of[IO, Int](0)
+        action = ref.update(_ + 1)
+        _ <- Concurrent.memoize(action)
+        _ <- IO.sleep(100.millis)
+        v <- ref.get
+      } yield v
+
+      op.flatMap { res =>
+        IO {
+          res must beEqualTo(0)
+        }
+      }
+    }
+
+    "Concurrent.memoize evalutes effect once if inner `F[A]` is bound twice" in real {
+      val op = for {
+        ref <- Ref.of[IO, Int](0)
+        action = ref.modify { s =>
+          val ns = s + 1
+          ns -> ns
+        }
+        memoized <- Concurrent.memoize(action)
+        x <- memoized
+        y <- memoized
+        v <- ref.get
+      } yield (x, y, v)
+
+      op.flatMap { res =>
+        IO {
+          res must beEqualTo((1, 1, 1))
+        }
+      }
+    }
+
+    "Concurrent.memoize effect evaluates effect once if the inner `F[A]` is bound twice (race)" in real {
+      val op = for {
+        ref <- Ref.of[IO, Int](0)
+        action = ref.modify { s =>
+          val ns = s + 1
+          ns -> ns
+        }
+        memoized <- Concurrent.memoize(action)
+        _ <- memoized.start
+        x <- memoized
+        _ <- IO.sleep(100.millis)
+        v <- ref.get
+      } yield x -> v
+
+      op.flatMap { res =>
+        IO {
+          res must beEqualTo((1, 1))
+        }
+      }
+    }
+
+    "Concurrent.memoize and then flatten is identity" in ticked { implicit ticker =>
+      forAll { (fa: IO[Int]) => Concurrent.memoize(fa).flatten eqv fa }
+    }
+
+    "Memoized effects can be canceled when there are no other active subscribers (1)" in real {
+      val op = for {
+        completed <- Ref[IO].of(false)
+        action = IO.sleep(200.millis) >> completed.set(true)
+        memoized <- Concurrent.memoize(action)
+        fiber <- memoized.start
+        _ <- IO.sleep(100.millis)
+        _ <- fiber.cancel
+        _ <- IO.sleep(300.millis)
+        res <- completed.get
+      } yield res
+
+      op.flatMap { res =>
+        IO {
+          res must beEqualTo(false)
+        }
+      }
+    }
+
+    "Memoized effects can be canceled when there are no other active subscribers (2)" in real {
+      val op = for {
+        completed <- Ref[IO].of(false)
+        action = IO.sleep(300.millis) >> completed.set(true)
+        memoized <- Concurrent.memoize(action)
+        fiber1 <- memoized.start
+        _ <- IO.sleep(100.millis)
+        fiber2 <- memoized.start
+        _ <- IO.sleep(100.millis)
+        _ <- fiber2.cancel
+        _ <- fiber1.cancel
+        _ <- IO.sleep(400.millis)
+        res <- completed.get
+      } yield res
+
+      op.flatMap { res =>
+        IO {
+          res must beEqualTo(false)
+        }
+      }
+    }
+
+    "Memoized effects can be canceled when there are no other active subscribers (3)" in real {
+      val op = for {
+        completed <- Ref[IO].of(false)
+        action = IO.sleep(300.millis) >> completed.set(true)
+        memoized <- Concurrent.memoize(action)
+        fiber1 <- memoized.start
+        _ <- IO.sleep(100.millis)
+        fiber2 <- memoized.start
+        _ <- IO.sleep(100.millis)
+        _ <- fiber1.cancel
+        _ <- fiber2.cancel
+        _ <- IO.sleep(400.millis)
+        res <- completed.get
+      } yield res
+
+      op.flatMap { res =>
+        IO {
+          res must beEqualTo(false)
+        }
+      }
+    }
+
+    "Running a memoized effect after it was previously canceled reruns it" in real {
+      val op = for {
+        started <- Ref[IO].of(0)
+        completed <- Ref[IO].of(0)
+        action = started.update(_ + 1) >> IO.sleep(200.millis) >> completed.update(_ + 1)
+        memoized <- Concurrent.memoize(action)
+        fiber <- memoized.start
+        _ <- IO.sleep(100.millis)
+        _ <- fiber.cancel
+        _ <- memoized.timeout(1.second)
+        v1 <- started.get
+        v2 <- completed.get
+      } yield v1 -> v2
+
+      op.flatMap { res =>
+        IO {
+          res must beEqualTo((2, 1))
+        }
+      }
+    }
+
+    "Attempting to cancel a memoized effect with active subscribers is a no-op" in real {
+      val op = for {
+        condition <- Deferred[IO, Unit]
+        action = IO.sleep(200.millis) >> condition.complete(())
+        memoized <- Concurrent.memoize(action)
+        fiber1 <- memoized.start
+        _ <- IO.sleep(50.millis)
+        fiber2 <- memoized.start
+        _ <- IO.sleep(50.millis)
+        _ <- fiber1.cancel
+        _ <- fiber2.join // Make sure no exceptions are swallowed by start
+        v <- condition.get.timeout(1.second).as(true)
+      } yield v
+
+      op.flatMap { res =>
+        IO {
+          res must beEqualTo(true)
+        }
+      }
+    }
+
+  }
+
+}

--- a/core/shared/src/test/scala/cats/effect/MemoizeSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/MemoizeSpec.scala
@@ -62,12 +62,12 @@ class MemoizeSpec extends BaseSpec with Discipline with ScalaCheck {
           x <- memoized
           y <- memoized
           v <- ref.get
-        } yield (x, y, v) == (1, 1, 1)
+        } yield (x, y, v)
 
         val result = op.unsafeToFuture()
         ticker.ctx.tickAll()
 
-        result.value mustEqual Some(Success(true))
+        result.value mustEqual Some(Success((1, 1, 1)))
     }
 
     "Concurrent.memoize effect evaluates effect once if the inner `F[A]` is bound twice (race)" in ticked {
@@ -109,7 +109,7 @@ class MemoizeSpec extends BaseSpec with Discipline with ScalaCheck {
         } yield res
 
         val result = op.unsafeToFuture()
-        ticker.ctx.tick(500.millis)
+        ticker.ctx.tickAll(500.millis)
 
         result.value mustEqual Some(Success(false))
     }
@@ -131,7 +131,7 @@ class MemoizeSpec extends BaseSpec with Discipline with ScalaCheck {
         } yield res
 
         val result = op.unsafeToFuture()
-        ticker.ctx.tick(600.millis)
+        ticker.ctx.tickAll(600.millis)
 
         result.value mustEqual Some(Success(false))
     }
@@ -153,7 +153,7 @@ class MemoizeSpec extends BaseSpec with Discipline with ScalaCheck {
         } yield res
 
         val result = op.unsafeToFuture()
-        ticker.ctx.tick(600.millis)
+        ticker.ctx.tickAll(600.millis)
 
         result.value mustEqual Some(Success(false))
     }
@@ -174,7 +174,7 @@ class MemoizeSpec extends BaseSpec with Discipline with ScalaCheck {
         } yield v1 -> v2
 
         val result = op.unsafeToFuture()
-        ticker.ctx.tick(500.millis)
+        ticker.ctx.tickAll(500.millis)
 
         result.value mustEqual Some(Success((2, 1)))
     }
@@ -195,7 +195,7 @@ class MemoizeSpec extends BaseSpec with Discipline with ScalaCheck {
         } yield v
 
         val result = op.unsafeToFuture()
-        ticker.ctx.tick(500.millis)
+        ticker.ctx.tickAll(500.millis)
 
         result.value mustEqual Some(Success(true))
     }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -59,12 +59,12 @@ object GenConcurrent {
           def fetch: F[Either[E, A]] =
             F.uncancelable { poll =>
               for {
-                result <- poll(fa).attempt
+                result0 <- poll(fa).attempt
                 // in some interleavings, there may be several racing fetches.
                 // always respect the first completion.
-                _ <- state.update {
-                  case st @ Done(_) => st
-                  case _ => Done(result)
+                result <- state.modify {
+                  case st @ Done(result) => st -> result
+                  case _ => Done(result0) -> result0
                 }
                 _ <- value.complete(result)
               } yield result

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AllSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AllSyntax.scala
@@ -19,6 +19,7 @@ package cats.effect.kernel.syntax
 trait AllSyntax
     extends GenSpawnSyntax
     with GenTemporalSyntax
+    with GenConcurrentSyntax
     with AsyncSyntax
     with SyncEffectSyntax
     with EffectSyntax

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenConcurrentSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenConcurrentSyntax.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.kernel.syntax
+
+import cats.effect.kernel.GenConcurrent
+
+trait GenConcurrentSyntax {
+  implicit def genConcurrentOps[F[_], E, A](wrapped: F[A]): GenConcurrentOps[F, E, A] =
+    new GenConcurrentOps(wrapped)
+}
+
+final class GenConcurrentOps[F[_], E, A](val wrapped: F[A]) extends AnyVal {
+  def memoize(implicit F: GenConcurrent[F, E]): F[F[A]] =
+    F.memoize(wrapped)
+}

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/package.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/package.scala
@@ -21,6 +21,7 @@ package object syntax {
   object all extends AllSyntax
 
   object spawn extends GenSpawnSyntax
+  object concurrent extends GenConcurrentSyntax
   object temporal extends GenTemporalSyntax
   object async extends AsyncSyntax
   object syncEffect extends SyncEffectSyntax


### PR DESCRIPTION
I took the liberty to refactor the CE2 `Concurrent.memoize` to simplify implementation and eliminate a correctness bug, and also ported over the existing tests.

The bug in CE2 may appear in some interleavings [here](https://github.com/typelevel/cats-effect/blob/series/2.x/core/shared/src/main/scala/cats/effect/Concurrent.scala#L497). There is an invariant that the effect returned by the `modify` is evaluated after a state change. Cancellation can occur at the `flatten`, which creates an inconsistent state: either we have the wrong subscriber count, or the supplied effect never runs, indefinitely blocking subscribers.

Closes #1111. 