### PR TITLE
Purge cats implicits import from the codebase

### DIFF
--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/AsyncBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/AsyncBenchmark.scala
@@ -13,13 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package cats.effect.benchmarks
 
-import java.util.concurrent.TimeUnit
 import cats.effect.{ContextShift, IO}
-import cats.implicits._
-import org.openjdk.jmh.annotations._
+import cats.syntax.all._
+
 import scala.concurrent.ExecutionContext.Implicits
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
 
 /**
  * To do comparative benchmarks between versions:

--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/AttemptBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/AttemptBenchmark.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package cats.effect.benchmarks
 
 import java.util.concurrent.TimeUnit

--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/DeepBindBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/DeepBindBenchmark.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package cats.effect.benchmarks
 
 import java.util.concurrent.TimeUnit

--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/ECBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/ECBenchmark.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cats.effect.benchmarks
 
 import java.util.concurrent._

--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/HandleErrorBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/HandleErrorBenchmark.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package cats.effect.benchmarks
 
 import java.util.concurrent.TimeUnit

--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapCallsBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapCallsBenchmark.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package cats.effect.benchmarks
 
 import java.util.concurrent.TimeUnit

--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapStreamBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/MapStreamBenchmark.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package cats.effect.benchmarks
 
 import java.util.concurrent.TimeUnit

--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/ShallowBindBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/ShallowBindBenchmark.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package cats.effect.benchmarks
 
 import java.util.concurrent.TimeUnit

--- a/core/jvm/src/main/scala/cats/effect/internals/ResourcePlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/ResourcePlatform.scala
@@ -31,7 +31,7 @@ private[effect] trait ResourcePlatform {
    * {{{
    *   import java.security.KeyStore.PasswordProtection
    *   import cats.effect._
-   *   import cats.implicits._
+   *   import cats.syntax.all._
    *
    *   def passwordProtection[F[_]](getPassword: F[Array[Char]])(implicit F: Sync[F]): Resource[F, PasswordProtection] =
    *     Resource.fromDestroyable(

--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -524,7 +524,7 @@ object Concurrent {
    * kept in [[cats.effect.concurrent.Ref]] and thus needing `cancelableF`:
    *
    * {{{
-   *   import cats.implicits._
+   *   import cats.syntax.all._
    *   import cats.effect.{CancelToken, Concurrent}
    *   import cats.effect.concurrent.Ref
    *   import scala.collection.immutable.Queue

--- a/core/shared/src/main/scala/cats/effect/IOApp.scala
+++ b/core/shared/src/main/scala/cats/effect/IOApp.scala
@@ -38,7 +38,7 @@ import cats.effect.internals.{IOAppCompanionPlatform, IOAppPlatform}
  *
  * {{{
  * import cats.effect._
- * import cats.implicits._
+ * import cats.syntax.all._
  *
  * object MyApp extends IOApp {
  *   def run(args: List[String]): IO[ExitCode] =

--- a/site/src/main/mdoc/concurrency/deferred.md
+++ b/site/src/main/mdoc/concurrency/deferred.md
@@ -47,7 +47,7 @@ Two processes will try to complete at the same time but only one will succeed, c
 ```scala mdoc:reset:silent
 import cats.effect.IO
 import cats.effect.concurrent.Deferred
-import cats.implicits._
+import cats.syntax.all._
 import scala.concurrent.ExecutionContext
 
 // Needed for `start` or `Concurrent[IO]` and therefore `parSequence`

--- a/site/src/main/mdoc/concurrency/ref.md
+++ b/site/src/main/mdoc/concurrency/ref.md
@@ -44,7 +44,7 @@ The workers will concurrently run and modify the value of the Ref so this is one
 ```scala mdoc:reset:silent
 import cats.effect.{IO, Sync}
 import cats.effect.concurrent.Ref
-import cats.implicits._
+import cats.syntax.all._
 import scala.concurrent.ExecutionContext
 
 // Needed for triggering evaluation in parallel

--- a/site/src/main/mdoc/concurrency/semaphore.md
+++ b/site/src/main/mdoc/concurrency/semaphore.md
@@ -60,7 +60,7 @@ Once `R2` was done `R1` started processing immediately showing no availability. 
 ```scala mdoc:reset:silent
 import cats.effect.{Concurrent, IO, Timer}
 import cats.effect.concurrent.Semaphore
-import cats.implicits._
+import cats.syntax.all._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._

--- a/site/src/main/mdoc/datatypes/clock.md
+++ b/site/src/main/mdoc/datatypes/clock.md
@@ -46,7 +46,7 @@ Example:
 
 ```scala mdoc:reset:silent
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import scala.concurrent.duration.MILLISECONDS
 
 def measure[F[_], A](fa: F[A])

--- a/site/src/main/mdoc/datatypes/contextshift.md
+++ b/site/src/main/mdoc/datatypes/contextshift.md
@@ -45,7 +45,7 @@ something like this:
 
 ```scala mdoc:reset:silent
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 
 def fib[F[_]](n: Int, a: Long = 0, b: Long = 1)
   (implicit F: Sync[F], cs: ContextShift[F]): F[Long] = {

--- a/site/src/main/mdoc/datatypes/io.md
+++ b/site/src/main/mdoc/datatypes/io.md
@@ -1137,7 +1137,7 @@ def fromEither[A](e: Either[Throwable, A]): IO[A] = e.fold(IO.raiseError, IO.pur
 
 ## Error Handling
 
-Since there is an instance of `MonadError[IO, Throwable]` available in Cats Effect, all the error handling is done through it. This means you can use all the operations available for `MonadError` and thus for `ApplicativeError` on `IO` as long as the error type is a `Throwable`. Operations such as `raiseError`, `attempt`, `handleErrorWith`, `recoverWith`, etc. Just make sure you have the syntax import in scope such as `cats.implicits._`.
+Since there is an instance of `MonadError[IO, Throwable]` available in Cats Effect, all the error handling is done through it. This means you can use all the operations available for `MonadError` and thus for `ApplicativeError` on `IO` as long as the error type is a `Throwable`. Operations such as `raiseError`, `attempt`, `handleErrorWith`, `recoverWith`, etc. Just make sure you have the syntax import in scope such as `cats.syntax.all._`.
 
 ### raiseError
 
@@ -1326,7 +1326,7 @@ It has the potential to run an arbitrary number of `IO`s in parallel, and it all
 
 ```scala mdoc:reset:silent
 import cats.effect.{ContextShift, IO}
-import cats.implicits._
+import cats.syntax.all._
 
 import scala.concurrent.ExecutionContext
 
@@ -1350,7 +1350,7 @@ If any of the `IO`s completes with a failure then the result of the whole comput
 
 ```scala mdoc:reset:silent
 import cats.effect.{ContextShift, ExitCase, IO}
-import cats.implicits._
+import cats.syntax.all._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -1378,7 +1378,7 @@ If one of the tasks fails immediately, then the other gets canceled and the comp
 
 ```scala mdoc:reset:silent
 import cats.effect.{ContextShift, Timer, IO}
-import cats.implicits._
+import cats.syntax.all._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._

--- a/site/src/main/mdoc/tracing/index.md
+++ b/site/src/main/mdoc/tracing/index.md
@@ -230,7 +230,7 @@ Here is a sample program that demonstrates tracing in action.
 // -Dcats.effect.stackTracingMode=full
 
 import cats.effect.tracing.PrintingOptions
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.{ExitCode, IO, IOApp}
 
 import scala.util.Random

--- a/site/src/main/mdoc/tutorial/tutorial.md
+++ b/site/src/main/mdoc/tutorial/tutorial.md
@@ -108,7 +108,7 @@ release resources. See this code:
 
 ```scala
 import cats.effect.{IO, Resource}
-import cats.implicits._ 
+import cats.syntax.all._ 
 import java.io._ 
 
 def inputStream(f: File): Resource[IO, FileInputStream] =
@@ -207,7 +207,7 @@ follows:
 
 ```scala
 import cats.effect.IO
-import cats.implicits._ 
+import cats.syntax.all._ 
 import java.io._ 
 
 // function inputOutputStreams not needed
@@ -260,7 +260,7 @@ the main loop, and leave the actual transmission of data to another function
 
 ```scala
 import cats.effect.IO
-import cats.implicits._ 
+import cats.syntax.all._ 
 import java.io._ 
 
 def transmit(origin: InputStream, destination: OutputStream, buffer: Array[Byte], acc: Long): IO[Long] =
@@ -313,7 +313,7 @@ cancellation happens _while_ the streams are being used? This could lead to
 data corruption as a stream where some thread is writing to is at the same time
 being closed by another thread. For more info about this problem see [Gotcha:
 Cancellation is a concurrent
-action](../datatypes/io.html#gotcha-cancellation-is-a-concurrent-action) in
+action](../datatypes/io.md#gotcha-cancellation-is-a-concurrent-action) in
 cats-effect site.
 
 To prevent such data corruption we must use some concurrency control mechanism
@@ -335,7 +335,7 @@ use `.acquire` and then `.release` on the semaphore explicitly, but
 the effect run fails.
 
 ```scala
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.{Concurrent, IO, Resource}
 import cats.effect.concurrent.Semaphore
 import java.io._
@@ -392,7 +392,7 @@ instances returned by `Resource.use`), the `IO` returned by `transfer` is not.
 Trying to cancel it will not have any effect and that `IO` will run until the
 whole file is copied! In real world code you will probably want to make your
 functions cancelable, section [Building cancelable IO
-tasks](../datatypes/io.html#building-cancelable-io-tasks) of `IO` documentation
+tasks](../datatypes/io.md#building-cancelable-io-tasks) of `IO` documentation
 explains how to create such cancelable `IO` instances (besides calling
 `Resource.use`, as we have done for our code).
 
@@ -421,7 +421,7 @@ method can look like this:
 
 ```scala
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import java.io.File
 
 object Main extends IOApp {
@@ -494,7 +494,7 @@ methods of the `Sync[F[_]]` instance!
 ```scala
 import cats.effect.Sync
 import cats.effect.syntax.all._
-import cats.implicits._
+import cats.syntax.all._
 import java.io._
 
 def transmit[F[_]: Sync](origin: InputStream, destination: OutputStream, buffer: Array[Byte], acc: Long): F[Long] =
@@ -517,7 +517,7 @@ instantiation:
 import cats.effect._
 import cats.effect.concurrent.Semaphore
 import cats.effect.syntax.all._
-import cats.implicits._
+import cats.syntax.all._
 import java.io._
 
 def transmit[F[_]: Sync](origin: InputStream, destination: OutputStream, buffer: Array[Byte], acc: Long): F[Long] = ???
@@ -612,7 +612,7 @@ in mind, the code looks like:
 
 ```scala
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import java.io._
 import java.net._
 
@@ -673,7 +673,7 @@ clients:
 import cats.effect._
 import cats.effect.syntax.all._
 import cats.effect.ExitCase._
-import cats.implicits._
+import cats.syntax.all._
 import java.net.{ServerSocket, Socket}
 
 // echoProtocol as defined before
@@ -746,7 +746,7 @@ which we can already do in the `run` method of an `IOApp`:
 
 ```scala
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import java.net.ServerSocket
 
 object Main extends IOApp {
@@ -854,7 +854,7 @@ the cancellation on its own fiber by running `.cancel.start`.
 import cats.effect._
 import cats.effect.syntax.all._
 import cats.effect.concurrent.MVar
-import cats.implicits._
+import cats.syntax.all._
 import java.net.ServerSocket
 
 // serve now requires access to the stopFlag, it will use it to signal the
@@ -876,7 +876,7 @@ We must also modify the main `run` method in `IOApp` so now it calls to `server`
 
 ```scala
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import java.net.ServerSocket
 
 object Main extends IOApp {
@@ -908,7 +908,7 @@ import cats.effect._
 import cats.effect.ExitCase._
 import cats.effect.concurrent.MVar
 import cats.effect.syntax.all._
-import cats.implicits._
+import cats.syntax.all._
 import java.net._
 
 // echoProtocol now requires access to the stopFlag, it will use it to signal the
@@ -945,7 +945,7 @@ signal the server must be stopped, and the function will quit:
 import cats.effect._
 import cats.effect.concurrent.MVar
 import cats.effect.syntax.all._
-import cats.implicits._
+import cats.syntax.all._
 import java.io._
 
 def loop[F[_]:Concurrent](reader: BufferedReader, writer: BufferedWriter, stopFlag: MVar[F, Unit]): F[Unit] =
@@ -1004,7 +1004,7 @@ This is how the `serve` method will look like now with that change:
 import cats.effect._
 import cats.effect.ExitCase._
 import cats.effect.concurrent.MVar
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.syntax.all._
 import java.net._
 
@@ -1044,7 +1044,7 @@ taken; otherwise the error is raised:
 ```scala
 import cats.effect._
 import cats.effect.concurrent.MVar
-import cats.implicits._
+import cats.syntax.all._
 import java.io._
 
 def loop[F[_]: Sync](reader: BufferedReader, writer: BufferedWriter, stopFlag: MVar[F, Unit]): F[Unit] =
@@ -1078,7 +1078,7 @@ it will have a similar effect:
 import cats.effect._
 import cats.effect.ExitCase._
 import cats.effect.concurrent.MVar
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.syntax.all._
 import java.net._
 
@@ -1162,7 +1162,7 @@ task will be run in the default thread pool.
 
 ```scala
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import scala.concurrent.ExecutionContext
 
 def doHeavyStuffInADifferentThreadPool[F[_]: ContextShift: Sync](implicit ec: ExecutionContext): F[Unit] =
@@ -1202,7 +1202,7 @@ shutting down the thread pool when the server finishes:
 import cats.effect._
 import cats.effect.concurrent.MVar
 import cats.effect.syntax.all._
-import cats.implicits._
+import cats.syntax.all._
 import java.net.ServerSocket
 import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
@@ -1249,7 +1249,7 @@ console):
 ```scala
 import cats.effect._
 import cats.effect.syntax.all._
-import cats.implicits._
+import cats.syntax.all._
 import scala.util.Either
 
 def delayed[F[_]: Async]: F[Unit] = for {

--- a/site/src/main/mdoc/typeclasses/liftio.md
+++ b/site/src/main/mdoc/typeclasses/liftio.md
@@ -43,7 +43,6 @@ A more interesting example:
 
 ```scala mdoc:silent
 import cats.data.EitherT
-import cats.implicits._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 


### PR DESCRIPTION
Also fix some documentation links that generated warnings during the build of the site.