### PR TITLE
Override ref combinators for better performance (with benchmarks)

### DIFF
--- a/benchmarks/run-benchmark
+++ b/benchmarks/run-benchmark
@@ -19,7 +19,7 @@ date = Time.now.strftime("%Y-%m-%d")
 
 exec("mkdir -p benchmarks/results/#{date}")
 exec(
-    "sbt ++2.12.4 " +
+    "sbt ++2.12.12 " +
     "benchmarksPrev/clean benchmarksNext/clean " +
     "'benchmarksPrev/jmh:run -o ../results/#{date}/#{name}-Prev.txt  -i 10 -wi 10 -f 2 -t 1 cats.effect.benchmarks.#{name}' " +
     "'benchmarksNext/jmh:run -o ../results/#{date}/#{name}-Next.txt  -i 10 -wi 10 -f 2 -t 1 cats.effect.benchmarks.#{name}'"

--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/RefBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/RefBenchmark.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2017-2019 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.benchmarks
+
+import cats.effect._
+
+import org.openjdk.jmh.annotations._
+import scala.concurrent.ExecutionContext.global
+
+import java.util.concurrent.TimeUnit
+import cats.effect.concurrent.Ref
+
+/**
+ * To do comparative benchmarks between versions:
+ *
+ *     benchmarks/run-benchmark RefBenchmark
+ *
+ * This will generate results in `benchmarks/results`.
+ *
+ * Or to run the benchmark from within sbt:
+ *
+ *     jmh:run -i 10 -wi 10 -f 2 -t 1 cats.effect.benchmarks.RefBenchmark
+ *
+ * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
+ * Please note that benchmarks should be usually executed at least in
+ * 10 iterations (as a rule of thumb), but more is better.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class RefBenchmark {
+
+  @Benchmark
+  def modify(): Unit = RefBenchmark.modify(10000)
+
+  @Benchmark
+  def getAndUpdate(): Unit = RefBenchmark.getAndUpdate(10000)
+
+}
+
+object RefBenchmark {
+  implicit val cs: ContextShift[IO] = IO.contextShift(global)
+
+  def modify(iterations: Int): Long = {
+    Ref[IO].of(0l).flatMap { ref =>
+      def loop(remaining: Int, acc: Long): IO[Long] = {
+        if (remaining == 0) IO(acc)
+        else ref.modify(n => (n+1, n)).flatMap(prev => loop(remaining - 1, acc + prev))
+      }
+      loop(iterations, 0L)
+    }
+  }.unsafeRunSync()
+
+  def getAndUpdate(iterations: Int): Long = {
+    Ref[IO].of(0l).flatMap { ref =>
+      def loop(remaining: Int, acc: Long): IO[Long] = {
+        if (remaining == 0) IO(acc)
+        else ref.getAndUpdate(_ + 1).flatMap(prev => loop(remaining - 1, acc + prev))
+      }
+      loop(iterations, 0L)
+    }
+  }.unsafeRunSync()
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -339,7 +339,7 @@ lazy val runtimeTests = project
 lazy val benchmarksPrev = project
   .in(file("benchmarks/vPrev"))
   .settings(commonSettings ++ noPublishSettings ++ sharedSourcesSettings)
-  .settings(libraryDependencies += "org.typelevel" %% "cats-effect" % "2.0.0")
+  .settings(libraryDependencies += "org.typelevel" %% "cats-effect" % "2.2.0")
   .settings(scalacOptions ~= (_.filterNot(Set("-Xfatal-warnings", "-Ywarn-unused-import").contains)))
   .enablePlugins(JmhPlugin)
 

--- a/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
@@ -290,12 +290,12 @@ object Ref {
 
     def update(f: A => A): F[Unit] = {
       @tailrec
-      def spin: Unit = {
+      def spin(): Unit = {
         val a = ar.get
         val u = f(a)
-        if (!ar.compareAndSet(a, u)) spin
+        if (!ar.compareAndSet(a, u)) spin()
       }
-      F.delay(spin)
+      F.delay(spin())
     }
 
     override def updateAndGet(f: A => A): F[A] = {

--- a/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala
@@ -267,6 +267,17 @@ object Ref {
       (snapshot, setter)
     }
 
+    override def getAndUpdate(f: A => A): F[A] = {
+      @tailrec
+      def spin: A = {
+        val a = ar.get
+        val u = f(a)
+        if (!ar.compareAndSet(a, u)) spin
+        else a
+      }
+      F.delay(spin)
+    }
+
     def tryUpdate(f: A => A): F[Boolean] =
       F.map(tryModify(a => (f(a), ())))(_.isDefined)
 
@@ -277,8 +288,25 @@ object Ref {
       else None
     }
 
-    def update(f: A => A): F[Unit] = modify { a =>
-      (f(a), ())
+    def update(f: A => A): F[Unit] = {
+      @tailrec
+      def spin: Unit = {
+        val a = ar.get
+        val u = f(a)
+        if (!ar.compareAndSet(a, u)) spin
+      }
+      F.delay(spin)
+    }
+
+    override def updateAndGet(f: A => A): F[A] = {
+      @tailrec
+      def spin: A = {
+        val a = ar.get
+        val u = f(a)
+        if (!ar.compareAndSet(a, u)) spin
+        else u
+      }
+      F.delay(spin)
     }
 
     def modify[B](f: A => (A, B)): F[B] = {


### PR DESCRIPTION
Prompted by the finding that [using Ref combinators in fs2 reduces benchmark performance](https://github.com/typelevel/fs2/pull/2050).

With these changes, `getAndUpdate` has about 6% higher throughput in the benchmark compared to `modify`, whereas in CE 2.2.0 it has about 13% lower throughput.

Benchmark results for this PR:
```
Benchmark                   Mode  Cnt     Score    Error  Units
RefBenchmark.getAndUpdate  thrpt   20  3403.336 ± 77.681  ops/s
RefBenchmark.modify        thrpt   20  3208.759 ± 30.875  ops/s
```

CE 2.2.0:
```
Benchmark                   Mode  Cnt     Score    Error  Units
RefBenchmark.getAndUpdate  thrpt   20  2709.840 ± 25.734  ops/s
RefBenchmark.modify        thrpt   20  3123.585 ± 37.992  ops/s
```

Edit: the differences are far smaller with Scala 2.13, but still there - see comment below