### PR TITLE
Fix generated poms to include scmUrl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,9 +91,9 @@ ThisBuild / Test / jsEnv := {
   }
 }
 
-Global / homepage := Some(url("https://github.com/typelevel/cats-effect"))
+ThisBuild / homepage := Some(url("https://github.com/typelevel/cats-effect"))
 
-Global / scmInfo := Some(
+ThisBuild / scmInfo := Some(
   ScmInfo(
     url("https://github.com/typelevel/cats-effect"),
     "git@github.com:typelevel/cats-effect.git"))


### PR DESCRIPTION
When using the `Global` scope, generated POMs were missing `scmUrl`. No SBT plugins loaded, so not sure why this is different for me than Daniel.

Before this change:

```
sbt:root> show scmInfo
[info] lawsJVM / scmInfo
[info]     None
[info] kernelJVM / scmInfo
[info]     None
…
```

After:

```
sbt:root> show scmInfo
[info] lawsJVM / scmInfo
[info]     Some(ScmInfo(https://github.com/typelevel/cats-effect, git@github.com:typelevel/cats-effect.git, None))
[info] kernelJVM / scmInfo
[info]     Some(ScmInfo(https://github.com/typelevel/cats-effect, git@github.com:typelevel/cats-effect.git, None))
…
```