### PR TITLE
Rename Outcome.Completed/ExitCase.Completed to Succeeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The first program produces `42`, exactly as you would expect. The second fails w
 
 This is really difficult to work around in practice. Cancelation is a very frequent element of using Cats Effect in practice, and yet manipulating it directly or even *detecting* it is extremely difficult. As a high-level concrete example, the concept of [supervisor nets](https://erlang.org/doc/man/supervisor.html) makes a great deal of sense when we think about how fibers are `start`ed by a "parent" fiber, which then has the ability to `cancel` or `join` it, and thus one can imagine an implicit directed acyclic graph of dependencies and supervisory capabilities. However, this is impossible since one of the three fundamental outcomes of a fiber, cancelation, cannot be safely observed even by the parent.
 
-One of the major goals of CE3 is to address soundness issues in the hierarchy like the one illustrated here. For example, in CE3, the `join` function produces a value of type `F[Outcome[F, E, A]]`, where `E` is the error type (`Throwable` in the case of `IO`). `Outcome` represents the three possible results explicitly: `Completed`, `Errored`, and `Canceled`, giving callers of `join` the ability to make a decision on the desired semantics.
+One of the major goals of CE3 is to address soundness issues in the hierarchy like the one illustrated here. For example, in CE3, the `join` function produces a value of type `F[Outcome[F, E, A]]`, where `E` is the error type (`Throwable` in the case of `IO`). `Outcome` represents the three possible results explicitly: `Succeeded`, `Errored`, and `Canceled`, giving callers of `join` the ability to make a decision on the desired semantics.
 
 ### Safety
 
@@ -254,7 +254,7 @@ def bracketCase[A, B](
         case e => release(a, Outcome.Errored(e)).attempt.void
       }
 
-      handled.flatTap(b => release(a, Outcome.Completed(pure(b))).attempt)
+      handled.flatTap(b => release(a, Outcome.Succeeded(pure(b))).attempt)
     }
   }
 ```

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -888,7 +888,7 @@ private final class IOFiber[A](
       if (canceled) // this can happen if we don't check the canceled flag before completion
         OutcomeCanceled
       else
-        Outcome.Completed(IO.pure(result.asInstanceOf[A]))
+        Outcome.Succeeded(IO.pure(result.asInstanceOf[A]))
 
     done(outcome)
     IOBlockFiber

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -367,13 +367,13 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
 
         test.flatMap { results =>
           results.traverse { result =>
-            IO(result must beLike { case Outcome.Completed(_) => ok }).flatMap { _ =>
+            IO(result must beLike { case Outcome.Succeeded(_) => ok }).flatMap { _ =>
               result match {
-                case Outcome.Completed(ioa) =>
+                case Outcome.Succeeded(ioa) =>
                   ioa.flatMap { oc =>
-                    IO(result must beLike { case Outcome.Completed(_) => ok }).flatMap { _ =>
+                    IO(result must beLike { case Outcome.Succeeded(_) => ok }).flatMap { _ =>
                       oc match {
-                        case Outcome.Completed(ioa) =>
+                        case Outcome.Succeeded(ioa) =>
                           ioa flatMap { i => IO(i mustEqual 42) }
 
                         case _ => sys.error("nope")
@@ -708,7 +708,7 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
 
         // convenient proxy for an async that returns a cancelToken
         val test = IO.sleep(1.day).onCase {
-          case Outcome.Completed(_) => IO { passed = true }
+          case Outcome.Succeeded(_) => IO { passed = true }
         }
 
         test must completeAs(())

--- a/core/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -133,7 +133,7 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
       def sideEffectyResource: (AtomicBoolean, Resource[IO, Unit]) = {
         val cleanExit = new java.util.concurrent.atomic.AtomicBoolean(false)
         val res = Resource.makeCase(IO.unit) {
-          case (_, Resource.ExitCase.Completed) =>
+          case (_, Resource.ExitCase.Succeeded) =>
             IO {
               cleanExit.set(true)
             }

--- a/core/shared/src/test/scala/cats/effect/Runners.scala
+++ b/core/shared/src/test/scala/cats/effect/Runners.scala
@@ -227,7 +227,7 @@ trait Runners extends SpecificationLike with RunnersPlatform { outer =>
     }
 
   def completeAs[A: Eq: Show](expected: A)(implicit ticker: Ticker): Matcher[IO[A]] =
-    tickTo(Outcome.Completed(Some(expected)))
+    tickTo(Outcome.Succeeded(Some(expected)))
 
   def completeAsSync[A: Eq: Show](expected: A): Matcher[SyncIO[A]] = { (ioa: SyncIO[A]) =>
     val a = ioa.unsafeRunSync()
@@ -247,7 +247,7 @@ trait Runners extends SpecificationLike with RunnersPlatform { outer =>
   }
 
   def nonTerminate(implicit ticker: Ticker): Matcher[IO[Unit]] =
-    tickTo[Unit](Outcome.Completed(None))
+    tickTo[Unit](Outcome.Succeeded(None))
 
   def tickTo[A: Eq: Show](expected: Outcome[Option, Throwable, A])(
       implicit ticker: Ticker): Matcher[IO[A]] = { (ioa: IO[A]) =>
@@ -257,11 +257,11 @@ trait Runners extends SpecificationLike with RunnersPlatform { outer =>
 
   def unsafeRun[A](ioa: IO[A])(implicit ticker: Ticker): Outcome[Option, Throwable, A] =
     try {
-      var results: Outcome[Option, Throwable, A] = Outcome.Completed(None)
+      var results: Outcome[Option, Throwable, A] = Outcome.Succeeded(None)
 
       ioa.unsafeRunAsync {
         case Left(t) => results = Outcome.Errored(t)
-        case Right(a) => results = Outcome.Completed(Some(a))
+        case Right(a) => results = Outcome.Succeeded(Some(a))
       }(unsafe.IORuntime(ticker.ctx, ticker.ctx, scheduler, () => ()))
 
       ticker.ctx.tickAll(3.days)

--- a/core/shared/src/test/scala/cats/effect/concurrent/DeferredSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/DeferredSpec.scala
@@ -76,7 +76,7 @@ class DeferredSpec extends BaseSpec { outer =>
           _ <- (fiber
               .join
               .flatMap {
-                case Outcome.Completed(ioi) => ioi.flatMap(i => r.set(Some(i)))
+                case Outcome.Succeeded(ioi) => ioi.flatMap(i => r.set(Some(i)))
                 case _ => IO.raiseError(new RuntimeException)
               })
             .start

--- a/core/shared/src/test/scala/cats/effect/concurrent/SemaphoreSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/concurrent/SemaphoreSpec.scala
@@ -266,7 +266,7 @@ class SemaphoreSpec extends BaseSpec { outer =>
       }
 
       op.flatMap {
-        case Outcome.Completed(ioa) =>
+        case Outcome.Succeeded(ioa) =>
           ioa.flatMap { res =>
             IO {
               res must beEqualTo(0: Long)

--- a/docs/typeclasses.md
+++ b/docs/typeclasses.md
@@ -280,7 +280,7 @@ The `joinAndEmbedNever` function is a convenience method built on top of `join`,
 
 `Outcome` has the following shape:
 
-- `Completed` (containing a value of type `F[A]`)
+- `Succeeded` (containing a value of type `F[A]`)
 - `Errored` (containing a value of type `E`, usually `Throwable`)
 - `Canceled` (which contains nothing)
 
@@ -288,7 +288,7 @@ These represent the three possible termination states for a fiber, and by produc
 
 ```scala
 fiber.join flatMap {
-  case Outcome.Completed(fa) => 
+  case Outcome.Succeeded(fa) =>
     fa
 
   case Outcome.Errored(e) => 
@@ -316,7 +316,7 @@ There's a subtle issue here though: `canceled` produces an effect of type `F[Uni
 
 ```scala
 fiber.join flatMap {
-  case Outcome.Completed(fa) => // => F[A]
+  case Outcome.Succeeded(fa) => // => F[A]
     fa
 
   case Outcome.Errored(e) => // => F[A]
@@ -340,7 +340,7 @@ This probably works, but it's kind of hacky, and not all `A`s have sane defaults
 import cats.conversions.all._
 
 fiber.join flatMap {
-  case Outcome.Completed(fa) => // => F[Some[A]]
+  case Outcome.Succeeded(fa) => // => F[Some[A]]
     fa.map(Some(_))
 
   case Outcome.Errored(e) => // => F[Option[A]]
@@ -357,7 +357,7 @@ If you are *really* sure that you're `join`ing and you're never, ever going to b
 
 ```scala
 fiber.join flatMap {
-  case Outcome.Completed(fa) => // => F[A]
+  case Outcome.Succeeded(fa) => // => F[A]
     fa
 
   case Outcome.Errored(e) => // => F[A]

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -47,22 +47,22 @@ trait GenSpawn[F[_], E] extends MonadCancel[F, E] {
       flatMap(racePair(fa, fb)) {
         case Left((oc, f)) =>
           oc match {
-            case Outcome.Completed(fa) => productR(f.cancel)(map(fa)(Left(_)))
+            case Outcome.Succeeded(fa) => productR(f.cancel)(map(fa)(Left(_)))
             case Outcome.Errored(ea) => productR(f.cancel)(raiseError(ea))
             case Outcome.Canceled() =>
               flatMap(onCancel(poll(f.join), f.cancel)) {
-                case Outcome.Completed(fb) => map(fb)(Right(_))
+                case Outcome.Succeeded(fb) => map(fb)(Right(_))
                 case Outcome.Errored(eb) => raiseError(eb)
                 case Outcome.Canceled() => productR(canceled)(never)
               }
           }
         case Right((f, oc)) =>
           oc match {
-            case Outcome.Completed(fb) => productR(f.cancel)(map(fb)(Right(_)))
+            case Outcome.Succeeded(fb) => productR(f.cancel)(map(fb)(Right(_)))
             case Outcome.Errored(eb) => productR(f.cancel)(raiseError(eb))
             case Outcome.Canceled() =>
               flatMap(onCancel(poll(f.join), f.cancel)) {
-                case Outcome.Completed(fa) => map(fa)(Left(_))
+                case Outcome.Succeeded(fa) => map(fa)(Left(_))
                 case Outcome.Errored(ea) => raiseError(ea)
                 case Outcome.Canceled() => productR(canceled)(never)
               }
@@ -83,9 +83,9 @@ trait GenSpawn[F[_], E] extends MonadCancel[F, E] {
       flatMap(racePair(fa, fb)) {
         case Left((oc, f)) =>
           oc match {
-            case Outcome.Completed(fa) =>
+            case Outcome.Succeeded(fa) =>
               flatMap(onCancel(poll(f.join), f.cancel)) {
-                case Outcome.Completed(fb) => product(fa, fb)
+                case Outcome.Succeeded(fb) => product(fa, fb)
                 case Outcome.Errored(eb) => raiseError(eb)
                 case Outcome.Canceled() => productR(canceled)(never)
               }
@@ -94,9 +94,9 @@ trait GenSpawn[F[_], E] extends MonadCancel[F, E] {
           }
         case Right((f, oc)) =>
           oc match {
-            case Outcome.Completed(fb) =>
+            case Outcome.Succeeded(fb) =>
               flatMap(onCancel(poll(f.join), f.cancel)) {
-                case Outcome.Completed(fa) => product(fa, fb)
+                case Outcome.Succeeded(fa) => product(fa, fb)
                 case Outcome.Errored(ea) => raiseError(ea)
                 case Outcome.Canceled() => productR(canceled)(never)
               }
@@ -191,7 +191,7 @@ object GenSpawn {
       oc match {
         case Outcome.Canceled() => Outcome.Canceled()
         case Outcome.Errored(e) => Outcome.Errored(e)
-        case Outcome.Completed(foa) => Outcome.Completed(OptionT(foa))
+        case Outcome.Succeeded(foa) => Outcome.Succeeded(OptionT(foa))
       }
 
     def liftFiber[A](fib: Fiber[F, E, Option[A]]): Fiber[OptionT[F, *], E, A] =
@@ -231,7 +231,7 @@ object GenSpawn {
       oc match {
         case Outcome.Canceled() => Outcome.Canceled()
         case Outcome.Errored(e) => Outcome.Errored(e)
-        case Outcome.Completed(foa) => Outcome.Completed(EitherT(foa))
+        case Outcome.Succeeded(foa) => Outcome.Succeeded(EitherT(foa))
       }
 
     def liftFiber[A](fib: Fiber[F, E, Either[E0, A]]): Fiber[EitherT[F, E0, *], E, A] =
@@ -273,7 +273,7 @@ object GenSpawn {
       oc match {
         case Outcome.Canceled() => Outcome.Canceled()
         case Outcome.Errored(e) => Outcome.Errored(e)
-        case Outcome.Completed(foa) => Outcome.Completed(IorT(foa))
+        case Outcome.Succeeded(foa) => Outcome.Succeeded(IorT(foa))
       }
 
     def liftFiber[A](fib: Fiber[F, E, Ior[L, A]]): Fiber[IorT[F, L, *], E, A] =
@@ -359,7 +359,7 @@ object GenSpawn {
       oc match {
         case Outcome.Canceled() => Outcome.Canceled()
         case Outcome.Errored(e) => Outcome.Errored(e)
-        case Outcome.Completed(foa) => Outcome.Completed(WriterT(foa))
+        case Outcome.Succeeded(foa) => Outcome.Succeeded(WriterT(foa))
       }
 
     def liftFiber[A](fib: Fiber[F, E, (L, A)]): Fiber[WriterT[F, L, *], E, A] =

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -40,7 +40,7 @@ import cats.syntax.all._
  * The execution of a fiber of an effect `F[E, A]` produces one of three
  * outcomes, which are encoded by the datatype [[Outcome]]:
  *
- *   1. [[Completed]]: indicates success with a value of type `A`
+ *   1. [[Succeeded]]: indicates success with a value of type `A`
  *   1. [[Errored]]: indicates failure with a value of type `E`
  *   1. [[Canceled]]: indicates abnormal termination
  *
@@ -286,7 +286,7 @@ trait MonadCancel[F[_], E] extends MonadError[F, E] {
         val handled = onError(finalized) {
           case e => void(attempt(release(a, Outcome.Errored(e))))
         }
-        flatMap(handled)(b => as(attempt(release(a, Outcome.Completed(pure(b)))), b))
+        flatMap(handled)(b => as(attempt(release(a, Outcome.Succeeded(pure(b)))), b))
       }
     }
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
@@ -36,33 +36,33 @@ sealed trait Outcome[F[_], E, A] extends Product with Serializable {
     this match {
       case Canceled() => canceled
       case Errored(e) => errored(e)
-      case Completed(fa) => completed(fa)
+      case Succeeded(fa) => completed(fa)
     }
 
   def mapK[G[_]](f: F ~> G): Outcome[G, E, A] =
     this match {
       case Canceled() => Canceled()
       case Errored(e) => Errored(e)
-      case Completed(fa) => Completed(f(fa))
+      case Succeeded(fa) => Succeeded(f(fa))
     }
 }
 
 private[kernel] trait LowPriorityImplicits {
-  import Outcome.{Canceled, Completed, Errored}
+  import Outcome.{Canceled, Errored, Succeeded}
 
   // variant for when F[A] doesn't have a Show (which is, like, most of the time)
   implicit def showUnknown[F[_], E, A](implicit E: Show[E]): Show[Outcome[F, E, A]] =
     Show show {
       case Canceled() => "Canceled"
       case Errored(left) => s"Errored(${left.show})"
-      case Completed(_) => s"Completed(<unknown>)"
+      case Succeeded(_) => s"Succeeded(<unknown>)"
     }
 
   implicit def eq[F[_], E: Eq, A](implicit FA: Eq[F[A]]): Eq[Outcome[F, E, A]] =
     Eq instance {
       case (Canceled(), Canceled()) => true
       case (Errored(left), Errored(right)) => left === right
-      case (Completed(left), Completed(right)) => left === right
+      case (Succeeded(left), Succeeded(right)) => left === right
       case _ => false
     }
 
@@ -74,17 +74,17 @@ private[kernel] trait LowPriorityImplicits {
       extends ApplicativeError[Outcome[F, E, *], E]
       with Bifunctor[Outcome[F, *, *]] {
 
-    def pure[A](x: A): Outcome[F, E, A] = Completed(x.pure[F])
+    def pure[A](x: A): Outcome[F, E, A] = Succeeded(x.pure[F])
 
     def handleErrorWith[A](fa: Outcome[F, E, A])(f: E => Outcome[F, E, A]): Outcome[F, E, A] =
-      fa.fold(Canceled(), f, Completed(_: F[A]))
+      fa.fold(Canceled(), f, Succeeded(_: F[A]))
 
     def raiseError[A](e: E): Outcome[F, E, A] = Errored(e)
 
     def ap[A, B](ff: Outcome[F, E, A => B])(fa: Outcome[F, E, A]): Outcome[F, E, B] =
       (ff, fa) match {
-        case (Completed(cfa), Completed(fa)) =>
-          Completed(cfa.ap(fa))
+        case (Succeeded(cfa), Succeeded(fa)) =>
+          Succeeded(cfa.ap(fa))
 
         case (Errored(e), _) =>
           Errored(e)
@@ -101,7 +101,7 @@ private[kernel] trait LowPriorityImplicits {
 
     def bimap[A, B, C, D](fab: Outcome[F, A, B])(f: A => C, g: B => D): Outcome[F, C, D] =
       fab match {
-        case Completed(fa) => Completed(fa.map(g))
+        case Succeeded(fa) => Succeeded(fa.map(g))
         case Errored(e) => Errored(f(e))
         case Canceled() => Canceled()
       }
@@ -111,7 +111,7 @@ private[kernel] trait LowPriorityImplicits {
 object Outcome extends LowPriorityImplicits {
 
   def completed[F[_], E, A](fa: F[A]): Outcome[F, E, A] =
-    Completed(fa)
+    Succeeded(fa)
 
   def errored[F[_], E, A](e: E): Outcome[F, E, A] =
     Errored(e)
@@ -120,25 +120,25 @@ object Outcome extends LowPriorityImplicits {
     Canceled()
 
   def fromEither[F[_]: Applicative, E, A](either: Either[E, A]): Outcome[F, E, A] =
-    either.fold(Errored(_), a => Completed(a.pure[F]))
+    either.fold(Errored(_), a => Succeeded(a.pure[F]))
 
   implicit def order[F[_], E: Order, A](implicit FA: Order[F[A]]): Order[Outcome[F, E, A]] =
     Order.from {
       case (Canceled(), Canceled()) => 0
       case (Errored(left), Errored(right)) => left.compare(right)
-      case (Completed(lfa), Completed(rfa)) => lfa.compare(rfa)
+      case (Succeeded(lfa), Succeeded(rfa)) => lfa.compare(rfa)
 
       case (Canceled(), _) => -1
       case (_, Canceled()) => 1
-      case (Errored(_), Completed(_)) => -1
-      case (Completed(_), Errored(_)) => 1
+      case (Errored(_), Succeeded(_)) => -1
+      case (Succeeded(_), Errored(_)) => 1
     }
 
   implicit def show[F[_], E, A](implicit FA: Show[F[A]], E: Show[E]): Show[Outcome[F, E, A]] =
     Show show {
       case Canceled() => "Canceled"
       case Errored(left) => s"Errored(${left.show})"
-      case Completed(right) => s"Completed(${right.show})"
+      case Succeeded(right) => s"Succeeded(${right.show})"
     }
 
   implicit def monadError[F[_], E](
@@ -151,9 +151,9 @@ object Outcome extends LowPriorityImplicits {
 
       def flatMap[A, B](fa: Outcome[F, E, A])(f: A => Outcome[F, E, B]): Outcome[F, E, B] =
         fa match {
-          case Completed(ifa) =>
+          case Succeeded(ifa) =>
             Traverse[F].traverse(ifa)(f) match {
-              case Completed(ifaa) => Completed(Monad[F].flatten(ifaa))
+              case Succeeded(ifaa) => Succeeded(Monad[F].flatten(ifaa))
               case Errored(e) => Errored(e)
               case Canceled() => Canceled()
             }
@@ -165,10 +165,10 @@ object Outcome extends LowPriorityImplicits {
       @tailrec
       def tailRecM[A, B](a: A)(f: A => Outcome[F, E, Either[A, B]]): Outcome[F, E, B] =
         f(a) match {
-          case Completed(fa) =>
+          case Succeeded(fa) =>
             Traverse[F].sequence[Either[A, *], B](fa) match { // Dotty can't infer this
               case Left(a) => tailRecM(a)(f)
-              case Right(fb) => Completed(fb)
+              case Right(fb) => Succeeded(fb)
             }
 
           case Errored(e) => Errored(e)
@@ -176,7 +176,7 @@ object Outcome extends LowPriorityImplicits {
         }
     }
 
-  final case class Completed[F[_], E, A](fa: F[A]) extends Outcome[F, E, A]
+  final case class Succeeded[F[_], E, A](fa: F[A]) extends Outcome[F, E, A]
   final case class Errored[F[_], E, A](e: E) extends Outcome[F, E, A]
   final case class Canceled[F[_], E, A]() extends Outcome[F, E, A]
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/GenSpawnLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenSpawnLaws.scala
@@ -30,22 +30,22 @@ trait GenSpawnLaws[F[_], E] extends MonadCancelLaws[F, E] {
       F.flatMap(F.racePair(fa, F.never[B])) {
         case Left((oc, f)) =>
           oc match {
-            case Outcome.Completed(fa) => F.productR(f.cancel)(F.map(fa)(Left(_)))
+            case Outcome.Succeeded(fa) => F.productR(f.cancel)(F.map(fa)(Left(_)))
             case Outcome.Errored(ea) => F.productR(f.cancel)(F.raiseError(ea))
             case Outcome.Canceled() =>
               F.flatMap(F.onCancel(poll(f.join), f.cancel)) {
-                case Outcome.Completed(fb) => F.map(fb)(Right(_))
+                case Outcome.Succeeded(fb) => F.map(fb)(Right(_))
                 case Outcome.Errored(eb) => F.raiseError(eb)
                 case Outcome.Canceled() => F.productR(F.canceled)(F.never)
               }
           }
         case Right((f, oc)) =>
           oc match {
-            case Outcome.Completed(fb) => F.productR(f.cancel)(F.map(fb)(Right(_)))
+            case Outcome.Succeeded(fb) => F.productR(f.cancel)(F.map(fb)(Right(_)))
             case Outcome.Errored(eb) => F.productR(f.cancel)(F.raiseError(eb))
             case Outcome.Canceled() =>
               F.flatMap(F.onCancel(poll(f.join), f.cancel)) {
-                case Outcome.Completed(fa) => F.map(fa)(Left(_))
+                case Outcome.Succeeded(fa) => F.map(fa)(Left(_))
                 case Outcome.Errored(ea) => F.raiseError(ea)
                 case Outcome.Canceled() => F.productR(F.canceled)(F.never)
               }
@@ -61,22 +61,22 @@ trait GenSpawnLaws[F[_], E] extends MonadCancelLaws[F, E] {
       F.flatMap(F.racePair(F.never[A], fb)) {
         case Left((oc, f)) =>
           oc match {
-            case Outcome.Completed(fa) => F.productR(f.cancel)(F.map(fa)(Left(_)))
+            case Outcome.Succeeded(fa) => F.productR(f.cancel)(F.map(fa)(Left(_)))
             case Outcome.Errored(ea) => F.productR(f.cancel)(F.raiseError(ea))
             case Outcome.Canceled() =>
               F.flatMap(F.onCancel(poll(f.join), f.cancel)) {
-                case Outcome.Completed(fb) => F.map(fb)(Right(_))
+                case Outcome.Succeeded(fb) => F.map(fb)(Right(_))
                 case Outcome.Errored(eb) => F.raiseError(eb)
                 case Outcome.Canceled() => F.productR(F.canceled)(F.never)
               }
           }
         case Right((f, oc)) =>
           oc match {
-            case Outcome.Completed(fb) => F.productR(f.cancel)(F.map(fb)(Right(_)))
+            case Outcome.Succeeded(fb) => F.productR(f.cancel)(F.map(fb)(Right(_)))
             case Outcome.Errored(eb) => F.productR(f.cancel)(F.raiseError(eb))
             case Outcome.Canceled() =>
               F.flatMap(F.onCancel(poll(f.join), f.cancel)) {
-                case Outcome.Completed(fa) => F.map(fa)(Left(_))
+                case Outcome.Succeeded(fa) => F.map(fa)(Left(_))
                 case Outcome.Errored(ea) => F.raiseError(ea)
                 case Outcome.Canceled() => F.productR(F.canceled)(F.never)
               }
@@ -107,7 +107,7 @@ trait GenSpawnLaws[F[_], E] extends MonadCancelLaws[F, E] {
     F.race(F.pure(a), F.cede) <-> F.pure(Left(a))*/
 
   def fiberPureIsOutcomeCompletedPure[A](a: A) =
-    F.start(F.pure(a)).flatMap(_.join) <-> F.pure(Outcome.Completed(F.pure(a)))
+    F.start(F.pure(a)).flatMap(_.join) <-> F.pure(Outcome.Succeeded(F.pure(a)))
 
   def fiberErrorIsOutcomeErrored(e: E) =
     F.start(F.raiseError[Unit](e)).flatMap(_.join) <-> F.pure(Outcome.Errored(e))

--- a/laws/shared/src/test/scala/cats/effect/laws/GenTemporalSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/GenTemporalSpec.scala
@@ -43,14 +43,14 @@ class GenTemporalSpec extends Specification { outer =>
       "succeed" in {
         val op = F.timeout(F.pure(true), 10.seconds)
 
-        run(TimeT.run(op)) mustEqual Completed(Some(true))
+        run(TimeT.run(op)) mustEqual Succeeded(Some(true))
       }.pendingUntilFixed
 
       "cancel a loop" in {
         val op: TimeT[F, Either[Throwable, Unit]] = F.timeout(loop, 5.millis).attempt
 
         run(TimeT.run(op)) must beLike {
-          case Completed(Some(Left(e))) => e must haveClass[TimeoutException]
+          case Succeeded(Some(Left(e))) => e must haveClass[TimeoutException]
         }
       }.pendingUntilFixed
     }
@@ -59,13 +59,13 @@ class GenTemporalSpec extends Specification { outer =>
       "succeed" in {
         val op: TimeT[F, Boolean] = F.timeoutTo(F.pure(true), 5.millis, F.raiseError(new RuntimeException))
 
-        run(TimeT.run(op)) mustEqual Completed(Some(true))
+        run(TimeT.run(op)) mustEqual Succeeded(Some(true))
       }.pendingUntilFixed
 
       "use fallback" in {
         val op: TimeT[F, Boolean] = F.timeoutTo(loop >> F.pure(false), 5.millis, F.pure(true))
 
-        run(TimeT.run(op)) mustEqual Completed(Some(true))
+        run(TimeT.run(op)) mustEqual Succeeded(Some(true))
       }.pendingUntilFixed
     }
   }*/

--- a/testkit/shared/src/main/scala/cats/effect/testkit/Generators.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/Generators.scala
@@ -323,7 +323,7 @@ object OutcomeGenerators {
       implicit A: Cogen[F[A]]): Cogen[Outcome[F, E, A]] =
     Cogen[Option[Either[E, F[A]]]].contramap {
       case Outcome.Canceled() => None
-      case Outcome.Completed(fa) => Some(Right(fa))
+      case Outcome.Succeeded(fa) => Some(Right(fa))
       case Outcome.Errored(e) => Some(Left(e))
     }
 }


### PR DESCRIPTION
This removes the ambiguity between "completed" meaning "completed successfully" and meaning "ran to completion". This can be a source of confusion, especially as it's used in the second sense e.g. in `fs2.Stream#onComplete`