### PR TITLE
Improve inductive race/both combinators

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -208,14 +208,14 @@ object GenSpawn {
       OptionT.liftF(
         F.bothOutcome(fa.value, fb.value).map(_.bimap(liftOutcome(_), liftOutcome(_))))
 
-    def liftOutcome[A](oc: Outcome[F, E, Option[A]]): Outcome[OptionT[F, *], E, A] =
+    private def liftOutcome[A](oc: Outcome[F, E, Option[A]]): Outcome[OptionT[F, *], E, A] =
       oc match {
         case Outcome.Canceled() => Outcome.Canceled()
         case Outcome.Errored(e) => Outcome.Errored(e)
         case Outcome.Completed(foa) => Outcome.Completed(OptionT(foa))
       }
 
-    def liftFiber[A](fib: Fiber[F, E, Option[A]]): Fiber[OptionT[F, *], E, A] =
+    private def liftFiber[A](fib: Fiber[F, E, Option[A]]): Fiber[OptionT[F, *], E, A] =
       new Fiber[OptionT[F, *], E, A] {
         def cancel: OptionT[F, Unit] = OptionT.liftF(fib.cancel)
         def join: OptionT[F, Outcome[OptionT[F, *], E, A]] =
@@ -275,14 +275,14 @@ object GenSpawn {
       EitherT.liftF(
         F.bothOutcome(fa.value, fb.value).map(_.bimap(liftOutcome(_), liftOutcome(_))))
 
-    def liftOutcome[A](oc: Outcome[F, E, Either[E0, A]]): Outcome[EitherT[F, E0, *], E, A] =
+    private def liftOutcome[A](oc: Outcome[F, E, Either[E0, A]]): Outcome[EitherT[F, E0, *], E, A] =
       oc match {
         case Outcome.Canceled() => Outcome.Canceled()
         case Outcome.Errored(e) => Outcome.Errored(e)
         case Outcome.Completed(foa) => Outcome.Completed(EitherT(foa))
       }
 
-    def liftFiber[A](fib: Fiber[F, E, Either[E0, A]]): Fiber[EitherT[F, E0, *], E, A] =
+    private def liftFiber[A](fib: Fiber[F, E, Either[E0, A]]): Fiber[EitherT[F, E0, *], E, A] =
       new Fiber[EitherT[F, E0, *], E, A] {
         def cancel: EitherT[F, E0, Unit] = EitherT.liftF(fib.cancel)
         def join: EitherT[F, E0, Outcome[EitherT[F, E0, *], E, A]] =
@@ -338,14 +338,14 @@ object GenSpawn {
         : IorT[F, L, (Outcome[IorT[F, L, *], E, A], Outcome[IorT[F, L, *], E, B])] =
       IorT.liftF(F.bothOutcome(fa.value, fb.value).map(_.bimap(liftOutcome(_), liftOutcome(_))))
 
-    def liftOutcome[A](oc: Outcome[F, E, Ior[L, A]]): Outcome[IorT[F, L, *], E, A] =
+    private def liftOutcome[A](oc: Outcome[F, E, Ior[L, A]]): Outcome[IorT[F, L, *], E, A] =
       oc match {
         case Outcome.Canceled() => Outcome.Canceled()
         case Outcome.Errored(e) => Outcome.Errored(e)
         case Outcome.Completed(foa) => Outcome.Completed(IorT(foa))
       }
 
-    def liftFiber[A](fib: Fiber[F, E, Ior[L, A]]): Fiber[IorT[F, L, *], E, A] =
+    private def liftFiber[A](fib: Fiber[F, E, Ior[L, A]]): Fiber[IorT[F, L, *], E, A] =
       new Fiber[IorT[F, L, *], E, A] {
         def cancel: IorT[F, L, Unit] = IorT.liftF(fib.cancel)
         def join: IorT[F, L, Outcome[IorT[F, L, *], E, A]] =
@@ -380,7 +380,7 @@ object GenSpawn {
       }
     }
 
-    def liftOutcome[A](oc: Outcome[F, E, A]): Outcome[Kleisli[F, R, *], E, A] = {
+    private def liftOutcome[A](oc: Outcome[F, E, A]): Outcome[Kleisli[F, R, *], E, A] = {
 
       val nat: F ~> Kleisli[F, R, *] = new ~>[F, Kleisli[F, R, *]] {
         def apply[B](fa: F[B]) = Kleisli.liftF(fa)
@@ -389,7 +389,7 @@ object GenSpawn {
       oc.mapK(nat)
     }
 
-    def liftFiber[A](fib: Fiber[F, E, A]): Fiber[Kleisli[F, R, *], E, A] =
+    private def liftFiber[A](fib: Fiber[F, E, A]): Fiber[Kleisli[F, R, *], E, A] =
       new Fiber[Kleisli[F, R, *], E, A] {
         def cancel: Kleisli[F, R, Unit] = Kleisli.liftF(fib.cancel)
         def join: Kleisli[F, R, Outcome[Kleisli[F, R, *], E, A]] =
@@ -424,14 +424,14 @@ object GenSpawn {
       })
     }
 
-    def liftOutcome[A](oc: Outcome[F, E, (L, A)]): Outcome[WriterT[F, L, *], E, A] =
+    private def liftOutcome[A](oc: Outcome[F, E, (L, A)]): Outcome[WriterT[F, L, *], E, A] =
       oc match {
         case Outcome.Canceled() => Outcome.Canceled()
         case Outcome.Errored(e) => Outcome.Errored(e)
         case Outcome.Completed(foa) => Outcome.Completed(WriterT(foa))
       }
 
-    def liftFiber[A](fib: Fiber[F, E, (L, A)]): Fiber[WriterT[F, L, *], E, A] =
+    private def liftFiber[A](fib: Fiber[F, E, (L, A)]): Fiber[WriterT[F, L, *], E, A] =
       new Fiber[WriterT[F, L, *], E, A] {
         def cancel: WriterT[F, L, Unit] = WriterT.liftF(fib.cancel)
         def join: WriterT[F, L, Outcome[WriterT[F, L, *], E, A]] =

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -181,10 +181,11 @@ object GenSpawn {
       Either[
         (Outcome[OptionT[F, *], E, A], Fiber[OptionT[F, *], E, B]),
         (Fiber[OptionT[F, *], E, A], Outcome[OptionT[F, *], E, B])]] = {
-      OptionT.liftF(F.racePair(fa.value, fb.value).map {
-        case Left((oc, fib)) => Left((liftOutcome(oc), liftFiber(fib)))
-        case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
-      })
+      OptionT.liftF(F.uncancelable(poll =>
+        poll(F.racePair(fa.value, fb.value)).map {
+          case Left((oc, fib)) => Left((liftOutcome(oc), liftFiber(fib)))
+          case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
+        }))
     }
 
     override def race[A, B](fa: OptionT[F, A], fb: OptionT[F, B]): OptionT[F, Either[A, B]] =
@@ -242,10 +243,11 @@ object GenSpawn {
       Either[
         (Outcome[EitherT[F, E0, *], E, A], Fiber[EitherT[F, E0, *], E, B]),
         (Fiber[EitherT[F, E0, *], E, A], Outcome[EitherT[F, E0, *], E, B])]] = {
-      EitherT.liftF(F.racePair(fa.value, fb.value).map {
-        case Left((oc, fib)) => Left((liftOutcome(oc), liftFiber(fib)))
-        case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
-      })
+      EitherT.liftF(F.uncancelable(poll =>
+        poll(F.racePair(fa.value, fb.value)).map {
+          case Left((oc, fib)) => Left((liftOutcome(oc), liftFiber(fib)))
+          case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
+        }))
     }
 
     override def race[A, B](
@@ -312,10 +314,11 @@ object GenSpawn {
       Either[
         (Outcome[IorT[F, L, *], E, A], Fiber[IorT[F, L, *], E, B]),
         (Fiber[IorT[F, L, *], E, A], Outcome[IorT[F, L, *], E, B])]] = {
-      IorT.liftF(F.racePair(fa.value, fb.value).map {
-        case Left((oc, fib)) => Left((liftOutcome(oc), liftFiber(fib)))
-        case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
-      })
+      IorT.liftF(F.uncancelable(poll =>
+        poll(F.racePair(fa.value, fb.value)).map {
+          case Left((oc, fib)) => Left((liftOutcome(oc), liftFiber(fib)))
+          case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
+        }))
     }
 
     override def race[A, B](fa: IorT[F, L, A], fb: IorT[F, L, B]): IorT[F, L, Either[A, B]] =
@@ -374,10 +377,11 @@ object GenSpawn {
         (Outcome[Kleisli[F, R, *], E, A], Fiber[Kleisli[F, R, *], E, B]),
         (Fiber[Kleisli[F, R, *], E, A], Outcome[Kleisli[F, R, *], E, B])]] = {
       Kleisli { r =>
-        (F.racePair(fa.run(r), fb.run(r)).map {
-          case Left((oc, fib)) => Left((liftOutcome(oc), liftFiber(fib)))
-          case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
-        })
+        F.uncancelable(poll =>
+          poll((F.racePair(fa.run(r), fb.run(r))).map {
+            case Left((oc, fib)) => Left((liftOutcome(oc), liftFiber(fib)))
+            case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
+          }))
       }
     }
 
@@ -441,10 +445,11 @@ object GenSpawn {
       Either[
         (Outcome[WriterT[F, L, *], E, A], Fiber[WriterT[F, L, *], E, B]),
         (Fiber[WriterT[F, L, *], E, A], Outcome[WriterT[F, L, *], E, B])]] = {
-      WriterT.liftF(F.racePair(fa.run, fb.run).map {
-        case Left((oc, fib)) => Left((liftOutcome(oc), liftFiber(fib)))
-        case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
-      })
+      WriterT.liftF(F.uncancelable(poll =>
+        poll(F.racePair(fa.run, fb.run)).map {
+          case Left((oc, fib)) => Left((liftOutcome(oc), liftFiber(fib)))
+          case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
+        }))
     }
 
     override def race[A, B](

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -438,10 +438,7 @@ object GenSpawn {
     override def race[A, B](
         fa: WriterT[F, L, A],
         fb: WriterT[F, L, B]): WriterT[F, L, Either[A, B]] =
-      WriterT(F.race(fa.run, fb.run).map {
-        case Left((l, a)) => l -> Left(a)
-        case Right((l, b)) => l -> Right(b)
-      })
+      WriterT(F.race(fa.run, fb.run).map(_.bisequence))
 
     override def both[A, B](fa: WriterT[F, L, A], fb: WriterT[F, L, B]): WriterT[F, L, (A, B)] =
       WriterT(F.both(fa.run, fb.run).map {

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -189,12 +189,7 @@ object GenSpawn {
     }
 
     override def race[A, B](fa: OptionT[F, A], fb: OptionT[F, B]): OptionT[F, Either[A, B]] =
-      OptionT(F.race(fa.value, fb.value).map {
-        case Left(Some(a)) => Some(Left(a))
-        case Left(None) => None
-        case Right(Some(b)) => Some(Right(b))
-        case Right(None) => None
-      })
+      OptionT(F.race(fa.value, fb.value).map(_.bisequence))
 
     override def both[A, B](fa: OptionT[F, A], fb: OptionT[F, B]): OptionT[F, (A, B)] =
       OptionT(F.both(fa.value, fb.value).map(_.tupled))
@@ -253,12 +248,7 @@ object GenSpawn {
     override def race[A, B](
         fa: EitherT[F, E0, A],
         fb: EitherT[F, E0, B]): EitherT[F, E0, Either[A, B]] =
-      EitherT(F.race(fa.value, fb.value).map {
-        case Left(Left(e0)) => Left(e0)
-        case Left(Right(a)) => Right(Left(a))
-        case Right(Left(e0)) => Left(e0)
-        case Right(Right(b)) => Right(Right(b))
-      })
+      EitherT(F.race(fa.value, fb.value).map(_.bisequence))
 
     override def both[A, B](
         fa: EitherT[F, E0, A],
@@ -322,14 +312,7 @@ object GenSpawn {
     }
 
     override def race[A, B](fa: IorT[F, L, A], fb: IorT[F, L, B]): IorT[F, L, Either[A, B]] =
-      IorT(F.race(fa.value, fb.value).map {
-        case Left(Ior.Left(l)) => Ior.Left(l)
-        case Left(Ior.Both(l, a)) => Ior.Both(l, Left(a))
-        case Left(Ior.Right(a)) => Ior.Right(Left(a))
-        case Right(Ior.Left(l)) => Ior.left(l)
-        case Right(Ior.Both(l, b)) => Ior.Both(l, Right(b))
-        case Right(Ior.Right(b)) => Ior.Right(Right(b))
-      })
+      IorT(F.race(fa.value, fb.value).map(_.bisequence))
 
     override def both[A, B](fa: IorT[F, L, A], fb: IorT[F, L, B]): IorT[F, L, (A, B)] =
       IorT(F.both(fa.value, fb.value).map(_.tupled))


### PR DESCRIPTION
- Make inductive `racePair` definitions safe via underlying `F.uncancelable`
- Make inductive {race,both}{, Outcome} definitions cancelable by overriding default implementation to delegate to the underlying definition for `F`