### PR TITLE
Parameterize Resource error type - WIP

### DIFF
--- a/core/shared/src/main/scala/cats/effect/LiftIO.scala
+++ b/core/shared/src/main/scala/cats/effect/LiftIO.scala
@@ -137,21 +137,21 @@ object LiftIO {
     new LiftIO[IO] { override def liftIO[A](ioa: IO[A]): IO[A] = ioa }
 
   /**
-   * [[LiftIO]] instance for [[Resource]] values.
+   * [[LiftIO]] instance for [[GenResource]] values.
    */
-  implicit def catsEffectLiftIOForResource[F[_], E](
+  implicit def catsEffectLiftIOForGenResource[F[_], E](
       implicit F00: LiftIO[F],
-      F10: Applicative[F]): LiftIO[Resource[F, E, *]] =
-    new ResourceLiftIO[F, E] {
+      F10: Applicative[F]): LiftIO[GenResource[F, E, *]] =
+    new GenResourceLiftIO[F, E] {
       def F0 = F00
       def F1 = F10
     }
 
-  abstract private class ResourceLiftIO[F[_], E] extends LiftIO[Resource[F, E, *]] {
+  abstract private class GenResourceLiftIO[F[_], E] extends LiftIO[GenResource[F, E, *]] {
     implicit protected def F0: LiftIO[F]
     implicit protected def F1: Applicative[F]
 
-    def liftIO[A](ioa: IO[A]): Resource[F, E, A] =
-      Resource.liftF(F0.liftIO(ioa))
+    def liftIO[A](ioa: IO[A]): GenResource[F, E, A] =
+      GenResource.liftF(F0.liftIO(ioa))
   }
 }

--- a/core/shared/src/main/scala/cats/effect/LiftIO.scala
+++ b/core/shared/src/main/scala/cats/effect/LiftIO.scala
@@ -139,19 +139,19 @@ object LiftIO {
   /**
    * [[LiftIO]] instance for [[Resource]] values.
    */
-  implicit def catsEffectLiftIOForResource[F[_]](
+  implicit def catsEffectLiftIOForResource[F[_], E](
       implicit F00: LiftIO[F],
-      F10: Applicative[F]): LiftIO[Resource[F, *]] =
-    new ResourceLiftIO[F] {
+      F10: Applicative[F]): LiftIO[Resource[F, E, *]] =
+    new ResourceLiftIO[F, E] {
       def F0 = F00
       def F1 = F10
     }
 
-  abstract private class ResourceLiftIO[F[_]] extends LiftIO[Resource[F, *]] {
+  abstract private class ResourceLiftIO[F[_], E] extends LiftIO[Resource[F, E, *]] {
     implicit protected def F0: LiftIO[F]
     implicit protected def F1: Applicative[F]
 
-    def liftIO[A](ioa: IO[A]): Resource[F, A] =
+    def liftIO[A](ioa: IO[A]): Resource[F, E, A] =
       Resource.liftF(F0.liftIO(ioa))
   }
 }

--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -62,10 +62,10 @@ package object effect {
   type ParallelF[F[_], A] = cekernel.Par.ParallelF[F, A]
   val ParallelF = cekernel.Par.ParallelF
 
-  type Resource[+F[_], +A] = cekernel.Resource[F, A]
+  type Resource[+F[_], E, +A] = cekernel.Resource[F, E, A]
   val Resource = cekernel.Resource
 
   type OutcomeIO[A] = Outcome[IO, Throwable, A]
   type FiberIO[A] = Fiber[IO, Throwable, A]
-  type ResourceIO[A] = Resource[IO, A]
+  type ResourceIO[A] = Resource[IO, Throwable, A]
 }

--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -41,6 +41,9 @@ package object effect {
   type GenTemporal[F[_], E] = cekernel.GenTemporal[F, E]
   val GenTemporal = cekernel.GenTemporal
 
+  type GenResource[+F[_], E, +A] = cekernel.GenResource[F, E, A]
+  val GenResource = cekernel.GenResource
+
   type Sync[F[_]] = cekernel.Sync[F]
   val Sync = cekernel.Sync
 
@@ -62,10 +65,10 @@ package object effect {
   type ParallelF[F[_], A] = cekernel.Par.ParallelF[F, A]
   val ParallelF = cekernel.Par.ParallelF
 
-  type Resource[+F[_], E, +A] = cekernel.Resource[F, E, A]
+  type Resource[+F[_], +A] = cekernel.Resource[F, A]
   val Resource = cekernel.Resource
 
   type OutcomeIO[A] = Outcome[IO, Throwable, A]
   type FiberIO[A] = Fiber[IO, Throwable, A]
-  type ResourceIO[A] = Resource[IO, Throwable, A]
+  type ResourceIO[A] = Resource[IO, A]
 }

--- a/kernel/jvm/src/main/scala/cats/effect/kernel/ResourcePlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/ResourcePlatform.scala
@@ -45,6 +45,6 @@ private[effect] trait ResourcePlatform {
    * @return a Resource that will automatically destroy after use
    */
   def fromDestroyable[F[_], A <: Destroyable](acquire: F[A])(
-      implicit F: Sync[F]): Resource[F, Throwable, A] =
+      implicit F: Sync[F]): Resource[F, A] =
     Resource.make(acquire)(destroyable => F.delay(destroyable.destroy()))
 }

--- a/kernel/jvm/src/main/scala/cats/effect/kernel/ResourcePlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/ResourcePlatform.scala
@@ -45,6 +45,6 @@ private[effect] trait ResourcePlatform {
    * @return a Resource that will automatically destroy after use
    */
   def fromDestroyable[F[_], A <: Destroyable](acquire: F[A])(
-      implicit F: Sync[F]): Resource[F, A] =
+      implicit F: Sync[F]): Resource[F, Throwable, A] =
     Resource.make(acquire)(destroyable => F.delay(destroyable.destroy()))
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -106,8 +106,8 @@ trait GenSpawn[F[_], E] extends MonadCancel[F, E] {
       }
     }
 
-  def background[A](fa: F[A]): Resource[F, E, F[Outcome[F, E, A]]] =
-    Resource.make(start(fa))(_.cancel)(this).map(_.join)(this)
+  def background[A](fa: F[A]): GenResource[F, E, F[Outcome[F, E, A]]] =
+    GenResource.make(start(fa))(_.cancel)(this).map(_.join)(this)
 }
 
 object GenSpawn {

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -106,7 +106,7 @@ trait GenSpawn[F[_], E] extends MonadCancel[F, E] {
       }
     }
 
-  def background[A](fa: F[A]): Resource[F, F[Outcome[F, E, A]]] =
+  def background[A](fa: F[A]): Resource[F, E, F[Outcome[F, E, A]]] =
     Resource.make(start(fa))(_.cancel)(this).map(_.join)(this)
 }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -648,8 +648,9 @@ abstract private[effect] class ResourceInstances extends ResourceInstances0 {
       def F0 = F
     }
 
-  implicit def catsEffectParallelForResource[F0[_], E](implicit F: GenConcurrent[F0, E])
-      : Parallel.Aux[Resource[F0, E, *], Resource.Par[F0, E, *]] =
+  implicit def catsEffectParallelForResource[F0[_], E](
+      implicit
+      F: GenConcurrent[F0, E]): Parallel.Aux[Resource[F0, E, *], Resource.Par[F0, E, *]] =
     new ResourceParallel[F0, E] {
       def F0 = catsEffectCommutativeApplicativeForResourcePar
       def F1 = catsEffectMonadForResource
@@ -808,15 +809,12 @@ abstract private[effect] class ResourceParCommutativeApplicative[F[_], E]
     par(unwrap(fa).map(f))
   final override def pure[A](x: A): Par[F, E, A] =
     par(Resource.pure[F, E, A](x))
-  final override def product[A, B](
-      fa: Par[F, E, A],
-      fb: Par[F, E, B]): Par[F, E, (A, B)] =
+  final override def product[A, B](fa: Par[F, E, A], fb: Par[F, E, B]): Par[F, E, (A, B)] =
     par(unwrap(fa).parZip(unwrap(fb)))
   final override def map2[A, B, Z](fa: Par[F, E, A], fb: Par[F, E, B])(
       f: (A, B) => Z): Par[F, E, Z] =
     map(product(fa, fb)) { case (a, b) => f(a, b) }
-  final override def ap[A, B](ff: Par[F, E, A => B])(
-      fa: Par[F, E, A]): Par[F, E, B] =
+  final override def ap[A, B](ff: Par[F, E, A => B])(fa: Par[F, E, A]): Par[F, E, B] =
     map(product(ff, fa)) { case (ff, a) => ff(a) }
 }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -641,16 +641,16 @@ abstract private[effect] class ResourceInstances extends ResourceInstances0 {
       def F = F0
     }
 
-  implicit def catsEffectCommutativeApplicativeForResourcePar[F[_]](
-      implicit F: Async[F]
-  ): CommutativeApplicative[Resource.Par[F, Throwable, *]] =
-    new ResourceParCommutativeApplicative[F] {
+  implicit def catsEffectCommutativeApplicativeForResourcePar[F[_], E](
+      implicit F: GenConcurrent[F, E]
+  ): CommutativeApplicative[Resource.Par[F, E, *]] =
+    new ResourceParCommutativeApplicative[F, E] {
       def F0 = F
     }
 
-  implicit def catsEffectParallelForResource[F0[_]: Async]
-      : Parallel.Aux[Resource[F0, Throwable, *], Resource.Par[F0, Throwable, *]] =
-    new ResourceParallel[F0, Throwable] {
+  implicit def catsEffectParallelForResource[F0[_], E](implicit F: GenConcurrent[F0, E])
+      : Parallel.Aux[Resource[F0, E, *], Resource.Par[F0, E, *]] =
+    new ResourceParallel[F0, E] {
       def F0 = catsEffectCommutativeApplicativeForResourcePar
       def F1 = catsEffectMonadForResource
     }
@@ -797,26 +797,26 @@ abstract private[effect] class ResourceSemigroupK[F[_], E]
     }
 }
 
-abstract private[effect] class ResourceParCommutativeApplicative[F[_]]
-    extends CommutativeApplicative[Resource.Par[F, Throwable, *]] {
+abstract private[effect] class ResourceParCommutativeApplicative[F[_], E]
+    extends CommutativeApplicative[Resource.Par[F, E, *]] {
   import Resource.Par
   import Resource.Par.{unwrap, apply => par}
 
-  implicit protected def F0: Async[F]
+  implicit protected def F0: GenConcurrent[F, E]
 
-  final override def map[A, B](fa: Par[F, Throwable, A])(f: A => B): Par[F, Throwable, B] =
+  final override def map[A, B](fa: Par[F, E, A])(f: A => B): Par[F, E, B] =
     par(unwrap(fa).map(f))
-  final override def pure[A](x: A): Par[F, Throwable, A] =
-    par(Resource.pure[F, Throwable, A](x))
+  final override def pure[A](x: A): Par[F, E, A] =
+    par(Resource.pure[F, E, A](x))
   final override def product[A, B](
-      fa: Par[F, Throwable, A],
-      fb: Par[F, Throwable, B]): Par[F, Throwable, (A, B)] =
+      fa: Par[F, E, A],
+      fb: Par[F, E, B]): Par[F, E, (A, B)] =
     par(unwrap(fa).parZip(unwrap(fb)))
-  final override def map2[A, B, Z](fa: Par[F, Throwable, A], fb: Par[F, Throwable, B])(
-      f: (A, B) => Z): Par[F, Throwable, Z] =
+  final override def map2[A, B, Z](fa: Par[F, E, A], fb: Par[F, E, B])(
+      f: (A, B) => Z): Par[F, E, Z] =
     map(product(fa, fb)) { case (a, b) => f(a, b) }
-  final override def ap[A, B](ff: Par[F, Throwable, A => B])(
-      fa: Par[F, Throwable, A]): Par[F, Throwable, B] =
+  final override def ap[A, B](ff: Par[F, E, A => B])(
+      fa: Par[F, E, A]): Par[F, E, B] =
     map(product(ff, fa)) { case (ff, a) => ff(a) }
 }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
@@ -34,4 +34,6 @@ package object kernel {
 
   type ParallelF[F[_], A] = Par.ParallelF[F, A]
   val ParallelF = Par.ParallelF
+
+  type Resource[+F[_], +A] = GenResource[F, Throwable, A]
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenSpawnSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenSpawnSyntax.scala
@@ -16,7 +16,7 @@
 
 package cats.effect.kernel.syntax
 
-import cats.effect.kernel.{Fiber, GenSpawn, Outcome, Resource}
+import cats.effect.kernel.{Fiber, GenResource, GenSpawn, Outcome}
 
 trait GenSpawnSyntax {
 
@@ -30,6 +30,6 @@ final class GenSpawnOps[F[_], A, E](val wrapped: F[A]) extends AnyVal {
 
   def start(implicit F: GenSpawn[F, E]): F[Fiber[F, E, A]] = F.start(wrapped)
 
-  def background(implicit F: GenSpawn[F, E]): Resource[F, E, F[Outcome[F, E, A]]] =
+  def background(implicit F: GenSpawn[F, E]): GenResource[F, E, F[Outcome[F, E, A]]] =
     F.background(wrapped)
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenSpawnSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenSpawnSyntax.scala
@@ -30,6 +30,6 @@ final class GenSpawnOps[F[_], A, E](val wrapped: F[A]) extends AnyVal {
 
   def start(implicit F: GenSpawn[F, E]): F[Fiber[F, E, A]] = F.start(wrapped)
 
-  def background(implicit F: GenSpawn[F, E]): Resource[F, F[Outcome[F, E, A]]] =
+  def background(implicit F: GenSpawn[F, E]): Resource[F, E, F[Outcome[F, E, A]]] =
     F.background(wrapped)
 }

--- a/kernel/shared/src/test/scala/cats/effect/kernel/SyntaxSpec.scala
+++ b/kernel/shared/src/test/scala/cats/effect/kernel/SyntaxSpec.scala
@@ -71,7 +71,7 @@ class SyntaxSpec extends Specification {
 
     {
       val result = target.background
-      result: Resource[F, F[Outcome[F, E, A]]]
+      result: GenResource[F, E, F[Outcome[F, E, A]]]
     }
   }
 


### PR DESCRIPTION
As discussed in #1114 - if the typeclasses are parametric in their error type, `Resource` probably should be too. Initially I'm making the changes in-place to keep the diff readable - the idea is to subsequently rename this to `GenResource` and make `Resource` a special case.