### PR TITLE
Rename Poll to Demask

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Laws are more than just a [TCK](https://en.wikipedia.org/wiki/Technology_Compati
 
 Notice how the laws are written in terms of the `<->` "rewrite" operator. This operator simply turns into a ScalaCheck property in practice, but in *theory* it should be read as something much more powerful: an equational substitution.
 
-The first law is saying that any time we see a program which contains the pattern `F.uncancelable(poll => poll(...))` for *any* value of the `...` subexpression, we can rewrite it as just the `...` subexpression itself. This kind of step-wise evaluation semantic is the foundation of all formal computational calculi, including Scala itself (as of Dotty, via the DOT calculus).
+The first law is saying that any time we see a program which contains the pattern `F.uncancelable(demask => demask(...))` for *any* value of the `...` subexpression, we can rewrite it as just the `...` subexpression itself. This kind of step-wise evaluation semantic is the foundation of all formal computational calculi, including Scala itself (as of Dotty, via the DOT calculus).
 
 Unfortunately, due to expressiveness limitations, not *all* programs can be reduced to a simple composition of these evaluation rules (laws). However, significantly more such programs can be reduced now than was possible with the laws framework in ce2, in which a single law very frequently reduced to a rewrite asserting one side was equal to `F.pure(...)` of some value, which is a rewrite of very limited applicability.
 
@@ -247,9 +247,9 @@ def bracketCase[A, B](
     release: (A, Outcome[F, E, B]) => F[Unit])(
     implicit F: Concurrent[F, E])
     : F[B] =
-  F uncancelable { poll =>
+  F uncancelable { demask =>
     acquire flatMap { a =>
-      val finalized = poll(use(a)).onCancel(release(a, Outcome.Canceled()))
+      val finalized = demask(use(a)).onCancel(release(a, Outcome.Canceled()))
       val handled = finalized onError {
         case e => release(a, Outcome.Errored(e)).attempt.void
       }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -307,7 +307,7 @@ private final class IOFiber[A](
 
           masks += 1
           val id = masks
-          val poll = new Poll[IO] {
+          val demask = new Demask[IO] {
             def apply[B](ioa: IO[B]) = IO.Uncancelable.UnmaskRunLoop(ioa, id)
           }
 
@@ -316,7 +316,7 @@ private final class IOFiber[A](
            * to unmask once body completes.
            */
           conts.push(UncancelableK)
-          runLoop(cur.body(poll), nextIteration)
+          runLoop(cur.body(demask), nextIteration)
 
         case 10 =>
           val cur = cur0.asInstanceOf[Uncancelable.UnmaskRunLoop[Any]]
@@ -574,9 +574,9 @@ private final class IOFiber[A](
           runLoop(succeeded(fiber, 0), nextIteration)
 
         case 15 =>
-          // TODO self-cancelation within a nested poll could result in deadlocks in `both`
+          // TODO self-cancelation within a nested demask could result in deadlocks in `both`
           // example: uncancelable(p => F.both(fa >> p(canceled) >> fc, fd)).
-          // when we check cancelation in the parent fiber, we are using the masking at the point of racePair, rather than just trusting the masking at the point of the poll
+          // when we check cancelation in the parent fiber, we are using the masking at the point of racePair, rather than just trusting the masking at the point of the demask
           val cur = cur0.asInstanceOf[RacePair[Any, Any]]
 
           val next =

--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -30,7 +30,7 @@ package object effect {
   val GenSpawn = cekernel.GenSpawn
 
   type Fiber[F[_], E, A] = cekernel.Fiber[F, E, A]
-  type Poll[F[_]] = cekernel.Poll[F]
+  type Demask[F[_]] = cekernel.Demask[F]
   type Cont[F[_], A] = cekernel.Cont[F, A]
 
   type GenConcurrent[F[_], E] = cekernel.GenConcurrent[F, E]

--- a/docs/typeclasses.md
+++ b/docs/typeclasses.md
@@ -49,38 +49,38 @@ def guarded[F[_], R, A, E](
     release: R => F[Unit])(
     implicit F: MonadCancel[F, E])
     : F[A] =
-  F uncancelable { poll =>
+  F uncancelable { demask =>
     for {
       r <- alloc
 
-      _ <- poll(s.acquire).onCancel(release(r))
+      _ <- demask(s.acquire).onCancel(release(r))
       releaseAll = s.release >> release(r)
 
-      a <- poll(use(r)).guarantee(releaseAll)
+      a <- demask(use(r)).guarantee(releaseAll)
     } yield a
   }
 ```
 
-The above looks intimidating, but it's actually just another flavor of `bracket`, the operation we saw earlier! The whole thing is wrapped in `uncancelable`, which means we don't need to worry about other fibers interrupting us in the middle of each of these actions. In particular, the very *first* action we perform is `alloc`, which allocates a value of type `R`. Once this has completed successfully, we attempt to acquire the `Semaphore`. If some other fiber has already acquired the lock, this may end up blocking for quite a while. We *want* other fibers to be able to interrupt this blocking, so we wrap the acquisition in `poll`.
+The above looks intimidating, but it's actually just another flavor of `bracket`, the operation we saw earlier! The whole thing is wrapped in `uncancelable`, which means we don't need to worry about other fibers interrupting us in the middle of each of these actions. In particular, the very *first* action we perform is `alloc`, which allocates a value of type `R`. Once this has completed successfully, we attempt to acquire the `Semaphore`. If some other fiber has already acquired the lock, this may end up blocking for quite a while. We *want* other fibers to be able to interrupt this blocking, so we wrap the acquisition in `demask`.
 
-You can think of `poll` like a "cancelable" block: it re-enables cancellation for whatever is inside of it, but *only* if that's possible. There's a reason it's not just called `cancelable`! We'll come back to this a little bit later.
+You can think of `demask` like a "cancelable" block: it re-enables cancellation for whatever is inside of it, but *only* if that's possible. There's a reason it's not just called `cancelable`! We'll come back to this a little bit later.
 
 If the semaphore acquisition is canceled, we want to make sure we still release the resource, `r`, so we use `onCancel` to achieve this. From that moment forward, if and when we're ready to release our resource, we want to *also* release the semaphore, so we create an effect which merges these two things together.
 
-Finally we move on to invoking the `use(r)` action, which again we need to wrap in `poll` to ensure that it can be interrupted by an external fiber. This `use(r)` action may take quite a long time and have a lot of complicated internal workings, and the last thing we want to do is suppress cancellation for its entire duration. It's likely safe to cancel `use`, because the resource management is already handled (by us!).
+Finally we move on to invoking the `use(r)` action, which again we need to wrap in `demask` to ensure that it can be interrupted by an external fiber. This `use(r)` action may take quite a long time and have a lot of complicated internal workings, and the last thing we want to do is suppress cancellation for its entire duration. It's likely safe to cancel `use`, because the resource management is already handled (by us!).
 
 Finally, once `use(r)` is done, we run `releaseAll`. The `guarantee` method does exactly what it sounds like it does: ensures that `releaseAll` is run regardless of whether `use(r)` completes naturally, raises an error, or is canceled.
 
-As mentioned earlier, `poll` is *not* the same as a function hypothetically named `cancelable`. If we had something like `cancelable`, then we would need to answer an impossible question: what does `uncancelable` mean if someone can always contradict you with `cancelable`? Additionally, whatever answer you come up with to *that* question has to be applied to weird and complicated things such as `uncancelable(uncancelable(cancelable(...)))`, which is unpleasant and hard to define.
+As mentioned earlier, `demask` is *not* the same as a function hypothetically named `cancelable`. If we had something like `cancelable`, then we would need to answer an impossible question: what does `uncancelable` mean if someone can always contradict you with `cancelable`? Additionally, whatever answer you come up with to *that* question has to be applied to weird and complicated things such as `uncancelable(uncancelable(cancelable(...)))`, which is unpleasant and hard to define.
 
-At the end of the day, the better option is to simply add `poll` to `uncancelable` after the fashion we have done. The *meaning* of `poll` is that it "undoes" the effect of its origin `uncancelable`. So in other words:
+At the end of the day, the better option is to simply add `demask` to `uncancelable` after the fashion we have done. The *meaning* of `demask` is that it "undoes" the effect of its origin `uncancelable`. So in other words:
 
 ```scala
 val fa: F[A] = ???
-MonadCancel[F].uncancelable(poll => poll(fa))  // => fa
+MonadCancel[F].uncancelable(demask => demask(fa))  // => fa
 ```
 
-The `poll` wrapped around the `fa` effectively *eliminates* the `uncancelable`, so the above is equivalent to just writing `fa`. This significance of this "elimination" semantic becomes apparent when you consider what happens when multiple `uncancelable`s are nested within each other:
+The `demask` wrapped around the `fa` effectively *eliminates* the `uncancelable`, so the above is equivalent to just writing `fa`. This significance of this "elimination" semantic becomes apparent when you consider what happens when multiple `uncancelable`s are nested within each other:
 
 ```scala
 MonadCancel[F] uncancelable { outer =>
@@ -90,7 +90,7 @@ MonadCancel[F] uncancelable { outer =>
 }
 ```
 
-The `inner` poll eliminates the inner `uncancelable`, but the *outer* `uncancelable` still applies, meaning that this whole thing is equivalent to `MonadCancel[F].uncancelable(_ => fa)`.
+The `inner` demask eliminates the inner `uncancelable`, but the *outer* `uncancelable` still applies, meaning that this whole thing is equivalent to `MonadCancel[F].uncancelable(_ => fa)`.
 
 Note that polling for an *outer* block within an inner one has no effect whatsoever. For example:
 
@@ -112,7 +112,7 @@ MonadCancel[F] uncancelable { _ =>
 }
 ```
 
-The use of the `outer` poll within the inner `uncancelable` is simply ignored unless we have already stripped off the inner `uncancelable` using *its* `poll`. For example:
+The use of the `outer` demask within the inner `uncancelable` is simply ignored unless we have already stripped off the inner `uncancelable` using *its* `demask`. For example:
 
 ```scala
 MonadCancel[F] uncancelable { outer =>
@@ -122,7 +122,7 @@ MonadCancel[F] uncancelable { outer =>
 }
 ```
 
-This is simply equivalent to writing `fa`. Which is to say, `poll` composes in the way you would expect.
+This is simply equivalent to writing `fa`. Which is to say, `demask` composes in the way you would expect.
 
 ### Self-Cancelation
 
@@ -136,7 +136,7 @@ The above will result in a canceled evaluation, and `fa` will never be run, *pro
 
 Self-cancellation is somewhat similar to raising an error with `raiseError` in that it will short-circuit evaluation and begin "popping" back up the stack until it hits a handler. Just as `raiseError` can be observed using the `onError` method, `canceled` can be observed using `onCancel`.
 
-The primary differences between self-cancellation and `raiseError` are two-fold. First, `uncancelable` suppresses `canceled` within its body (unless `poll`ed!), turning it into something equivalent to just `().pure[F]`. There is no analogue for this kind of functionality with errors. Second, if you sequence an error with `raiseError`, it's always possible to use `attempt` or `handleError` to *handle* the error and resume normal execution. No such functionality is available for cancellation.
+The primary differences between self-cancellation and `raiseError` are two-fold. First, `uncancelable` suppresses `canceled` within its body (unless `demask`ed!), turning it into something equivalent to just `().pure[F]`. There is no analogue for this kind of functionality with errors. Second, if you sequence an error with `raiseError`, it's always possible to use `attempt` or `handleError` to *handle* the error and resume normal execution. No such functionality is available for cancellation.
 
 In other words, cancellation is effective; it cannot be undone. It can be suppressed, but once it is observed, it must be respected by the canceled fiber. This feature is exceptionally important for ensuring deterministic evaluation and avoiding deadlocks.
 
@@ -179,8 +179,8 @@ def endpoint[F[_]: Spawn](
       _ <- conn.write(response)
     } yield ()
 
-  val handler = MonadCancel[F] uncancelable { poll =>
-    poll(server.accept) flatMap { conn =>
+  val handler = MonadCancel[F] uncancelable { demask =>
+    demask(server.accept) flatMap { conn =>
       handle(conn).guarantee(conn.close).start
     }
   }
@@ -198,8 +198,8 @@ handler.foreverM
 Alright, so whatever `handler` happens to be, we're going to keep doing it *indefinitely*. This already seems to imply that `handler` is probably "the thing that handles a single request". Let's look at `handler` and see if that intuition is born out:
 
 ```scala
-val handler = MonadCancel[F] uncancelable { poll =>
-  poll(server.accept) flatMap { conn =>
+val handler = MonadCancel[F] uncancelable { demask =>
+  demask(server.accept) flatMap { conn =>
     handle(conn).guarantee(conn.close).start
   }
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -30,10 +30,10 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
   def async[A](k: (Either[Throwable, A] => Unit) => F[Option[F[Unit]]]): F[A] = {
     val body = new Cont[F, A] {
       def apply[G[_]](implicit G: MonadCancel[G, Throwable]) = { (resume, get, lift) =>
-        G.uncancelable { poll =>
+        G.uncancelable { demask =>
           lift(k(resume)) flatMap {
-            case Some(fin) => G.onCancel(poll(get), lift(fin))
-            case None => poll(get)
+            case Some(fin) => G.onCancel(demask(get), lift(fin))
+            case None => demask(get)
           }
         }
       }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Demask.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Demask.scala
@@ -18,4 +18,4 @@ package cats.effect.kernel
 
 import cats.~>
 
-trait Poll[F[_]] extends (F ~> F)
+trait Demask[F[_]] extends (F ~> F)

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -579,9 +579,9 @@ object Resource extends ResourceInstances with ResourcePlatform {
 
       def bracketCase[A, B](acquire: F[A])(use: A => F[B])(
           release: (A, ExitCase) => F[Unit]): F[B] =
-        F.uncancelable { poll =>
+        F.uncancelable { demask =>
           flatMap(acquire) { a =>
-            val finalized = F.onCancel(poll(use(a)), release(a, ExitCase.Canceled))
+            val finalized = F.onCancel(demask(use(a)), release(a, ExitCase.Canceled))
             val handled = onError(finalized) {
               case e => void(attempt(release(a, ExitCase.Errored(e))))
             }

--- a/laws/shared/src/main/scala/cats/effect/laws/GenSpawnTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenSpawnTests.scala
@@ -87,9 +87,9 @@ trait GenSpawnTests[F[_], E] extends MonadCancelTests[F, E] {
         "fiber start of never is unit" -> laws.fiberStartOfNeverIsUnit,
         "never dominates over flatMap" -> forAll(laws.neverDominatesOverFlatMap[A] _),
         "uncancelable race displaces canceled" -> laws.uncancelableRaceDisplacesCanceled,
-        "uncancelable race poll canceled identity (left)" -> forAll(
+        "uncancelable race demask canceled identity (left)" -> forAll(
           laws.uncancelableRacePollCanceledIdentityLeft[A] _),
-        "uncancelable race poll canceled identity (right)" -> forAll(
+        "uncancelable race demask canceled identity (right)" -> forAll(
           laws.uncancelableRacePollCanceledIdentityRight[A] _),
         "uncancelable canceled is canceled" -> laws.uncancelableCancelCancels,
         "uncancelable start is cancelable" -> laws.uncancelableStartIsCancelable,

--- a/laws/shared/src/main/scala/cats/effect/laws/MonadCancelTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/MonadCancelTests.scala
@@ -62,10 +62,10 @@ trait MonadCancelTests[F[_], E] extends MonadErrorTests[F, E] {
       val parents = Seq(monadError[A, B, C])
 
       val props = Seq(
-        "uncancelable poll is identity" -> forAll(laws.uncancelablePollIsIdentity[A] _),
-        "uncancelable ignored poll eliminates nesting" -> forAll(
+        "uncancelable demask is identity" -> forAll(laws.uncancelablePollIsIdentity[A] _),
+        "uncancelable ignored demask eliminates nesting" -> forAll(
           laws.uncancelableIgnoredPollEliminatesNesting[A] _),
-        "uncancelable poll inverse nest is uncancelable" -> forAll(
+        "uncancelable demask inverse nest is uncancelable" -> forAll(
           laws.uncancelablePollInverseNestIsUncancelable[A] _),
         "uncancelable canceled associates right over flatMap" -> forAll(
           laws.uncancelableCanceledAssociatesRightOverFlatMap[A] _),

--- a/testkit/shared/src/main/scala/cats/effect/testkit/Generators.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/Generators.scala
@@ -183,7 +183,7 @@ trait MonadCancelGenerators[F[_], E] extends MonadErrorGenerators[F, E] {
       right <- deeper[A]
     } yield F.forceR(left)(right)
 
-  // TODO we can't really use poll :-( since we can't Cogen FunctionK
+  // TODO we can't really use demask :-( since we can't Cogen FunctionK
   private def genUncancelable[A: Arbitrary: Cogen](deeper: GenK[F]): Gen[F[A]] =
     deeper[A].map(pc => F.uncancelable(_ => pc))
 


### PR DESCRIPTION
`Poll` is a pretty opaque name. My first thought was that it should be called `Unmask`, but that carries the obvious ambiguity between "remove a mask" (which it does) and "render maskless" (which it may or may not do). I think `Demask` avoids that ambiguity. 