### PR TITLE
Add Semaphore#permit returning Resource

### DIFF
--- a/core/shared/src/test/scala/cats/effect/std/SemaphoreSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/SemaphoreSpec.scala
@@ -47,7 +47,7 @@ class SemaphoreSpec extends BaseSpec { outer =>
 
       op.flatMap { res =>
         IO {
-          res must beEqualTo(2: Long)
+          res must beEqualTo(2L)
         }
       }
     }
@@ -64,7 +64,7 @@ class SemaphoreSpec extends BaseSpec { outer =>
 
       op.flatMap { res =>
         IO {
-          res must beEqualTo(1: Long)
+          res must beEqualTo(1L)
         }
       }
     }
@@ -78,7 +78,7 @@ class SemaphoreSpec extends BaseSpec { outer =>
 
       op.flatMap { res =>
         IO {
-          res must beEqualTo(1: Long)
+          res must beEqualTo(1L)
         }
       }
     }
@@ -112,7 +112,7 @@ class SemaphoreSpec extends BaseSpec { outer =>
 
       op.flatMap { res =>
         IO {
-          res must beEqualTo(0: Long)
+          res must beEqualTo(0L)
         }
       }
     }
@@ -216,7 +216,7 @@ class SemaphoreSpec extends BaseSpec { outer =>
 
       op.flatMap { res =>
         IO {
-          res must beEqualTo(1: Long)
+          res must beEqualTo(1L)
         }
       }
     }
@@ -231,7 +231,7 @@ class SemaphoreSpec extends BaseSpec { outer =>
 
       op.flatMap { res =>
         IO {
-          res must beEqualTo(0: Long)
+          res must beEqualTo(0L)
         }
       }
     }
@@ -282,7 +282,7 @@ class SemaphoreSpec extends BaseSpec { outer =>
         case Outcome.Succeeded(ioa) =>
           ioa.flatMap { res =>
             IO {
-              res must beEqualTo(0: Long)
+              res must beEqualTo(0L)
             }
           }
         case _ => IO.pure(false must beTrue) //Is there a not a `const failure` matcher?
@@ -301,7 +301,7 @@ class SemaphoreSpec extends BaseSpec { outer =>
   //       (acquires(s, permits), releases(s, permits)).parTupled *> s.count
   //     }
 
-  //   op must completeAs(0: Long)
+  //   op must completeAs(0L)
   // }
 
 }

--- a/core/shared/src/test/scala/cats/effect/std/SemaphoreSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/SemaphoreSpec.scala
@@ -55,23 +55,9 @@ class SemaphoreSpec extends BaseSpec { outer =>
     "permit.use does not leak fibers or permits upon cancelation" in real {
       val op = Semaphore[IO](0L).flatMap { s =>
         // The inner s.release should never be run b/c the timeout will be reached before a permit
-        // is available. After the timeout and hence cancelation of s.withPermit(...), we release
-        // a permit and then sleep a bit, then check the permit count. If withPermit doesn't properly
+        // is available. After the timeout and hence cancelation of s.permit.use(_ => ...), we release
+        // a permit and then sleep a bit, then check the permit count. If permit.use doesn't properly
         // cancel, the permit count will be 2, otherwise 1
-        s.permit.use(_ => s.release).timeout(1.milli).attempt *> s.release *> IO.sleep(
-          10.millis) *> s.count
-      }
-
-      op.flatMap { res =>
-        IO {
-          res must beEqualTo(1L)
-        }
-      }
-    }
-
-    "permit.use does not leak fibers or permits upon cancelation" in real {
-      val op = Semaphore[IO](0L).flatMap { s =>
-        // Same as for `withPermit`
         s.permit.use(_ => s.release).timeout(1.milli).attempt *> s.release *> IO.sleep(
           10.millis) *> s.count
       }

--- a/core/shared/src/test/scala/cats/effect/std/SemaphoreSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/SemaphoreSpec.scala
@@ -34,7 +34,7 @@ class SemaphoreSpec extends BaseSpec { outer =>
 
     tests("async", n => Semaphore[IO](n))
     tests("async in", n => Semaphore.in[IO, IO](n))
-    tests("async imapK", n => Semaphore[IO](n).map(_.imapK[IO](FunctionK.id, FunctionK.id)))
+    tests("async mapK", n => Semaphore[IO](n).map(_.mapK[IO](FunctionK.id)))
 
     "acquire does not leak permits upon cancelation" in real {
       val op = Semaphore[IO](1L).flatMap { s =>
@@ -52,13 +52,13 @@ class SemaphoreSpec extends BaseSpec { outer =>
       }
     }
 
-    "withPermit does not leak fibers or permits upon cancelation" in real {
+    "permit.use does not leak fibers or permits upon cancelation" in real {
       val op = Semaphore[IO](0L).flatMap { s =>
         // The inner s.release should never be run b/c the timeout will be reached before a permit
         // is available. After the timeout and hence cancelation of s.withPermit(...), we release
         // a permit and then sleep a bit, then check the permit count. If withPermit doesn't properly
         // cancel, the permit count will be 2, otherwise 1
-        s.withPermit(s.release).timeout(1.milli).attempt *> s.release *> IO.sleep(
+        s.permit.use(_ => s.release).timeout(1.milli).attempt *> s.release *> IO.sleep(
           10.millis) *> s.count
       }
 

--- a/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
@@ -18,7 +18,8 @@ package cats
 package effect
 package std
 
-import cats.effect.kernel.{Concurrent, Deferred, Outcome, Ref, Spawn}
+import cats.Defer
+import cats.effect.kernel.{Concurrent, Deferred, Outcome, Ref, Resource, Spawn}
 import cats.effect.std.Semaphore.TransformedSemaphore
 import cats.syntax.all._
 
@@ -96,14 +97,21 @@ abstract class Semaphore[F[_]] {
   def release: F[Unit] = releaseN(1)
 
   /**
+   * Returns a [[Resource]] that acquires a permit, holds it for the lifetime of the resource, then
+   * releases the permit.
+   */
+  def permit: Resource[F, Unit]
+
+  /**
    * Returns an effect that acquires a permit, runs the supplied effect, and then releases the permit.
+   * Equivalent to permit.use(_ => t)
    */
   def withPermit[A](t: F[A]): F[A]
 
   /**
    * Modify the context `F` using natural isomorphism  `f` with `g`.
    */
-  def imapK[G[_]](f: F ~> G, g: G ~> F): Semaphore[G] =
+  def imapK[G[_]: Applicative](f: F ~> G, g: G ~> F): Semaphore[G] =
     new TransformedSemaphore(this, f, g)
 }
 
@@ -249,6 +257,9 @@ object Semaphore {
         case Right(n) => n
       }
 
+    val permit: Resource[F, Unit] =
+      Resource.make(acquireNInternal(1))(_.release).evalMap(_.await)
+
     def withPermit[A](t: F[A]): F[A] =
       F.bracket(acquireNInternal(1))(_.await *> t)(_.release)
   }
@@ -258,7 +269,7 @@ object Semaphore {
     protected def mkGate: F[Deferred[F, Unit]] = Deferred[F, Unit]
   }
 
-  final private[std] class TransformedSemaphore[F[_], G[_]](
+  final private[std] class TransformedSemaphore[F[_], G[_]: Applicative](
       underlying: Semaphore[F],
       trans: F ~> G,
       inverse: G ~> F
@@ -268,6 +279,7 @@ object Semaphore {
     override def acquireN(n: Long): G[Unit] = trans(underlying.acquireN(n))
     override def tryAcquireN(n: Long): G[Boolean] = trans(underlying.tryAcquireN(n))
     override def releaseN(n: Long): G[Unit] = trans(underlying.releaseN(n))
+    override def permit: Resource[G, Unit] = underlying.permit.mapK(trans)
     override def withPermit[A](t: G[A]): G[A] = trans(underlying.withPermit(inverse(t)))
   }
 }

--- a/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
@@ -18,7 +18,6 @@ package cats
 package effect
 package std
 
-import cats.Defer
 import cats.effect.kernel.{Concurrent, Deferred, Outcome, Ref, Resource, Spawn}
 import cats.effect.std.Semaphore.TransformedSemaphore
 import cats.syntax.all._


### PR DESCRIPTION
Depends on #1280.

This adds an `Applicative` constraint to `imapK` but I can't see that being a problem.