### PR TITLE
Add ApplicativeThrow alias

### DIFF
--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -48,6 +48,7 @@ package object effect {
   type Async[F[_]] = cekernel.Async[F]
   val Async = cekernel.Async
 
+  type ApplicativeThrow[F[_]] = cekernel.ApplicativeThrow[F]
   type MonadThrow[F[_]] = cekernel.MonadThrow[F]
   type MonadCancelThrow[F[_]] = cekernel.MonadCancelThrow[F]
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
@@ -16,10 +16,11 @@
 
 package cats.effect
 
-import cats.MonadError
+import cats.{ApplicativeError, MonadError}
 
 package object kernel {
 
+  type ApplicativeThrow[F[_]] = ApplicativeError[F, Throwable]
   type MonadThrow[F[_]] = MonadError[F, Throwable]
   type MonadCancelThrow[F[_]] = MonadCancel[F, Throwable]
 


### PR DESCRIPTION
This adds `ApplicativeThrow` which is an alias for `ApplicativeError[F, Throwable]`. It is not needed in this code base but a convenience for users of the library so that they don't have to define it themselves (like here https://github.com/scala-steward-org/scala-steward/pull/1646/files#diff-70c33485bfc9d88a649c21513414f088R28).