### PR TITLE
Remove call-site constraints from Resource methods

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -107,7 +107,7 @@ trait GenSpawn[F[_], E] extends MonadCancel[F, E] {
     }
 
   def background[A](fa: F[A]): Resource[F, F[Outcome[F, E, A]]] =
-    Resource.make(start(fa))(_.cancel)(this).map(_.join)(this)
+    Resource.make(start(fa))(_.cancel)(this).map(_.join)
 }
 
 object GenSpawn {

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -484,7 +484,8 @@ object Resource extends ResourceInstances with ResourcePlatform {
 
   private[effect] final case class LiftF[F[_], A](fa: F[A]) extends Resource[F, A] {
     def preinterpret[G[x] >: F[x]](implicit F: Applicative[G]): Primitive[G, A] =
-      Suspend(F.map[A, Resource[G, A]](fa)(a => Allocate[G, A]((a, (_: ExitCase) => F.unit).pure[G])))
+      Suspend(
+        F.map[A, Resource[G, A]](fa)(a => Allocate[G, A]((a, (_: ExitCase) => F.unit).pure[G])))
   }
 
   /**

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -216,8 +216,8 @@ sealed abstract class Resource[+F[_], +A] {
    *
    *  This is the standard `Functor.map`.
    */
-  def map[G[x] >: F[x], B](f: A => B): Resource[G, B] =
-    flatMap(a => Resource.pure[G, B](f(a)))
+  def map[B](f: A => B): Resource[F, B] =
+    flatMap(a => Resource.pure[F, B](f(a)))
 
   /**
    * Given a natural transformation from `F` to `G`, transforms this

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -92,7 +92,7 @@ import Resource.ExitCase
  * Normally users don't need to care about these node types, unless conversions
  * from `Resource` into something else is needed (e.g. conversion from `Resource`
  * into a streaming data type).
- * 
+ *
  * Further node types are used internally. To compile a resource down to the
  * above three types, call [[Resource#preinterpret]].
  *
@@ -142,11 +142,11 @@ sealed abstract class Resource[+F[_], +A] {
 
   /**
    * Compiles this down to the three primitive types:
-   * 
+   *
    *  - [[cats.effect.Resource.Allocate Allocate]]
    *  - [[cats.effect.Resource.Suspend Suspend]]
    *  - [[cats.effect.Resource.Bind Bind]]
-   * 
+   *
    * Note that this is done in a "shallow" fashion - when traversing a [[Resource]]
    * recursively, this will need to be done repeatedly.
    */
@@ -158,10 +158,10 @@ sealed abstract class Resource[+F[_], +A] {
         case LiftF(fa) =>
           Suspend(fa.map[Resource[G, A]](a => Allocate((a, (_: ExitCase) => G.unit).pure[G])))
         case MapK(rea, fk0) =>
-           // this would be easier if we could call `rea.preinterpret` but we don't have
-           // the right `Applicative` instance available.
+          // this would be easier if we could call `rea.preinterpret` but we don't have
+          // the right `Applicative` instance available.
           val fk = fk0.asInstanceOf[rea.F0 ~> G] // scala 2 infers this as `Any ~> G`
-           rea.invariant match {
+          rea.invariant match {
             case Allocate(resource) =>
               Allocate(fk(resource).map {
                 case (a, r) => (a, r.andThen(fk(_)))
@@ -509,7 +509,7 @@ object Resource extends ResourceInstances with ResourcePlatform {
   /**
    * Public supertype for the three node types that constitute teh public API
    * for interpreting a [[Resource]].
-   */ 
+   */
   sealed trait Primitive[F[_], +A] extends InvariantResource[F, A]
 
   /**

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -97,9 +97,9 @@ import Resource.ExitCase
  * @tparam A the type of resource
  */
 sealed abstract class Resource[+F[_], +A] {
-  import Resource.{Allocate, Bind, LiftF, MapK, Pure, Suspend}
-
   private[effect] type F0[x] <: F[x]
+
+  import Resource.{Allocate, Bind, LiftF, MapK, Pure, Suspend}
 
   private[effect] def fold[G[x] >: F[x], B](
       onOutput: A => G[B],
@@ -452,16 +452,16 @@ object Resource extends ResourceInstances with ResourcePlatform {
       def apply[A](fa: F[A]): Resource[F, A] = Resource.liftF(fa)
     }
 
+  /**
+   * Like `Resource`, but invariant in `F`. Facilitates pattern matches that Scala 2 cannot
+   * otherwise handle correctly.
+   */
   private[effect] sealed trait InvariantResource[F[_], +A] extends Resource[F, A] {
     type F0[x] = F[x]
     override private[effect] def invariant: InvariantResource[F0, A] = this
     def widen[G[x] >: F[x]: Functor] = this.asInstanceOf[InvariantResource[G, A]]
   }
 
-  /**
-   * Like `Resource`, but invariant in `F`. Facilitates pattern matches that Scala 2 cannot
-   * otherwise handle correctly.
-   */
   sealed trait Primitive[F[_], +A] extends InvariantResource[F, A]
 
   /**

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -143,7 +143,7 @@ sealed abstract class Resource[+F[_], +A] {
         case pr: Resource.Primitive[G, A] => pr
         case Pure(a) => Allocate((a, (_: ExitCase) => G.unit).pure[G])
         case LiftF(fa) =>
-          Suspend(fa.map(a => Allocate((a, (_: ExitCase) => G.unit).pure[G])))
+          Suspend(fa.map[Resource[G, A]](a => Allocate((a, (_: ExitCase) => G.unit).pure[G])))
         case MapK(rea, fk0) =>
           val fk = fk0.asInstanceOf[rea.F0 ~> G]
           rea.invariant match {
@@ -157,7 +157,8 @@ sealed abstract class Resource[+F[_], +A] {
               Suspend(fk(resource).map(_.mapK(fk)))
             case Pure(a) => Allocate((a, (_: ExitCase) => G.unit).pure[G])
             case LiftF(rea) =>
-              Suspend(fk(rea).map(a => Allocate((a, (_: ExitCase) => G.unit).pure[G])))
+              Suspend(fk(rea).map[Resource[G, A]](a =>
+                Allocate((a, (_: ExitCase) => G.unit).pure[G])))
             case MapK(ea0, ek) =>
               loop(ea0.invariant.mapK {
                 new FunctionK[ea0.F0, G] {


### PR DESCRIPTION
Removes typeclass requirements from `map`, `mapK`, `evalMap`, `pure`, `liftF`, `liftK`. Also removes second type parameter from `map`.

This makes a one-off change to the public API. There are extra primitive node types, but they are package-private - to interpret a `Resource` you first call `.preinterpret` to compile it down to the existing three types.

Of course, we could alternatively just add the `Pure`, `LiftF` and `MapK` nodes to the public API. `MapK` is the only one that isn't completely trivial to interpret. My main concern is whether this would be an exhaustive list or if we might want to add more in the future.

Supersedes #1280 if merged.