### PR TITLE
Queue

### DIFF
--- a/core/shared/src/test/scala/cats/effect/std/QueueSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/QueueSpec.scala
@@ -1,0 +1,342 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * These tests have been inspired by and adapted from `monix-catnap`'s `ConcurrentQueueSuite`, available at
+ * https://github.com/monix/monix/blob/series/3.x/monix-catnap/shared/src/test/scala/monix/catnap/ConcurrentQueueSuite.scala.
+ */
+
+package cats.effect
+package std
+
+import cats.arrow.FunctionK
+import org.specs2.specification.core.Fragments
+
+import scala.collection.immutable.{Queue => ScalaQueue}
+import scala.concurrent.duration._
+
+class BoundedQueueSpec extends BaseSpec with QueueTests {
+  sequential
+
+  "BoundedQueue" should {
+    boundedQueueTests("BoundedQueue", Queue.bounded)
+    boundedQueueTests("BoundedQueue mapK", Queue.bounded[IO, Int](_).map(_.mapK(FunctionK.id)))
+  }
+
+  private def boundedQueueTests(
+      name: String,
+      constructor: Int => IO[Queue[IO, Int]]): Fragments = {
+    s"$name - demonstrate offer and take with zero capacity" in real {
+      for {
+        q <- constructor(0)
+        _ <- q.offer(1).start
+        v1 <- q.take
+        f <- q.take.start
+        _ <- q.offer(2)
+        v2 <- f.joinAndEmbedNever
+        r <- IO((v1 must beEqualTo(1)) and (v2 must beEqualTo(2)))
+      } yield r
+    }
+
+    s"$name - async take with zero capacity" in realWithRuntime { implicit rt =>
+      for {
+        q <- constructor(0)
+        _ <- q.offer(1).start
+        v1 <- q.take
+        _ <- IO(v1 must beEqualTo(1))
+        ff <- IO(q.take.unsafeToFuture()).start
+        f <- ff.joinAndEmbedNever
+        _ <- IO(f.value must beEqualTo(None))
+        _ <- q.offer(2)
+        v2 <- IO.fromFuture(IO.pure(f))
+        r <- IO(v2 must beEqualTo(2))
+      } yield r
+    }
+
+    s"$name - offer/take with zero capacity" in real {
+      val count = 1000
+
+      def producer(q: Queue[IO, Int], n: Int): IO[Unit] =
+        if (n > 0) q.offer(count - n).flatMap(_ => producer(q, n - 1))
+        else IO.unit
+
+      def consumer(
+          q: Queue[IO, Int],
+          n: Int,
+          acc: ScalaQueue[Int] = ScalaQueue.empty
+      ): IO[Long] =
+        if (n > 0)
+          q.take.flatMap { a => consumer(q, n - 1, acc.enqueue(a)) }
+        else
+          IO.pure(acc.foldLeft(0L)(_ + _))
+
+      for {
+        q <- constructor(0)
+        p <- producer(q, count).start
+        c <- consumer(q, count).start
+        _ <- p.join
+        v <- c.joinAndEmbedNever
+        r <- IO(v must beEqualTo(count.toLong * (count - 1) / 2))
+      } yield r
+    }
+
+    negativeCapacityConstructionTests(name, constructor)
+    tryOfferOnFullTests(name, constructor, false)
+    cancelableOfferTests(name, constructor)
+    tryOfferTryTakeTests(name, constructor)
+    commonTests(name, constructor)
+  }
+}
+
+class UnboundedQueueSpec extends BaseSpec with QueueTests {
+  sequential
+
+  "UnboundedQueue" should {
+    unboundedQueueTests("UnboundedQueue", Queue.unbounded)
+    unboundedQueueTests(
+      "UnboundedQueue mapK",
+      Queue.unbounded[IO, Int].map(_.mapK(FunctionK.id)))
+  }
+
+  private def unboundedQueueTests(name: String, constructor: IO[Queue[IO, Int]]): Fragments = {
+    tryOfferOnFullTests(name, _ => constructor, true)
+    tryOfferTryTakeTests(name, _ => constructor)
+    commonTests(name, _ => constructor)
+  }
+}
+
+class DroppingQueueSpec extends BaseSpec with QueueTests {
+  sequential
+
+  "DroppingQueue" should {
+    droppingQueueTests("DroppingQueue", Queue.dropping)
+    droppingQueueTests(
+      "DroppingQueue mapK",
+      Queue.dropping[IO, Int](_).map(_.mapK(FunctionK.id)))
+  }
+
+  private def droppingQueueTests(
+      name: String,
+      constructor: Int => IO[Queue[IO, Int]]
+  ): Fragments = {
+    negativeCapacityConstructionTests(name, constructor)
+    zeroCapacityConstructionTests(name, constructor)
+    tryOfferOnFullTests(name, constructor, false)
+    cancelableOfferTests(name, constructor)
+    tryOfferTryTakeTests(name, constructor)
+    commonTests(name, constructor)
+  }
+}
+
+class CircularBufferQueueSpec extends BaseSpec with QueueTests {
+  sequential
+
+  "CircularBuffer" should {
+    slidingQueueTests("CircularBuffer", Queue.circularBuffer)
+    slidingQueueTests(
+      "CircularBuffer mapK",
+      Queue.circularBuffer[IO, Int](_).map(_.mapK(FunctionK.id)))
+  }
+
+  private def slidingQueueTests(
+      name: String,
+      constructor: Int => IO[Queue[IO, Int]]
+  ): Fragments = {
+    negativeCapacityConstructionTests(name, constructor)
+    zeroCapacityConstructionTests(name, constructor)
+    tryOfferOnFullTests(name, constructor, true)
+    commonTests(name, constructor)
+  }
+}
+
+trait QueueTests { self: BaseSpec =>
+
+  def zeroCapacityConstructionTests(
+      name: String,
+      constructor: Int => IO[Queue[IO, Int]]
+  ): Fragments = {
+    s"$name - raise an exception when constructed with zero capacity" in real {
+      val test = IO.defer(constructor(0)).attempt
+      test.flatMap { res =>
+        IO {
+          res must beLike {
+            case Left(e) => e must haveClass[IllegalArgumentException]
+          }
+        }
+      }
+    }
+  }
+
+  def negativeCapacityConstructionTests(
+      name: String,
+      constructor: Int => IO[Queue[IO, Int]]
+  ): Fragments = {
+    s"$name - raise an exception when constructed with a negative capacity" in real {
+      val test = IO.defer(constructor(-1)).attempt
+      test.flatMap { res =>
+        IO {
+          res must beLike {
+            case Left(e) => e must haveClass[IllegalArgumentException]
+          }
+        }
+      }
+    }
+  }
+
+  def tryOfferOnFullTests(
+      name: String,
+      constructor: Int => IO[Queue[IO, Int]],
+      expected: Boolean): Fragments = {
+    s"$name - return false on tryOffer when the queue is full" in real {
+      for {
+        q <- constructor(1)
+        _ <- q.offer(0)
+        v <- q.tryOffer(1)
+        r <- IO(v must beEqualTo(expected))
+      } yield r
+    }
+  }
+
+  def offerTakeOverCapacityTests(
+      name: String,
+      constructor: Int => IO[Queue[IO, Int]]
+  ): Fragments = {
+    s"$name - offer/take over capacity" in real {
+      val count = 1000
+
+      def producer(q: Queue[IO, Int], n: Int): IO[Unit] =
+        if (n > 0) q.offer(count - n).flatMap(_ => producer(q, n - 1))
+        else IO.unit
+
+      def consumer(
+          q: Queue[IO, Int],
+          n: Int,
+          acc: ScalaQueue[Int] = ScalaQueue.empty
+      ): IO[Long] =
+        if (n > 0)
+          q.take.flatMap { a => consumer(q, n - 1, acc.enqueue(a)) }
+        else
+          IO.pure(acc.foldLeft(0L)(_ + _))
+
+      for {
+        q <- constructor(10)
+        p <- producer(q, count).start
+        c <- consumer(q, count).start
+        _ <- p.join
+        v <- c.joinAndEmbedNever
+        r <- IO(v must beEqualTo(count.toLong * (count - 1) / 2))
+      } yield r
+    }
+  }
+
+  def cancelableOfferTests(name: String, constructor: Int => IO[Queue[IO, Int]]): Fragments = {
+    s"$name - demonstrate cancelable offer" in real {
+      for {
+        q <- constructor(1)
+        _ <- q.offer(1)
+        f <- q.offer(2).start
+        _ <- IO.sleep(10.millis)
+        _ <- f.cancel
+        v1 <- q.take
+        v2 <- q.tryTake
+        r <- IO((v1 must beEqualTo(1)) and (v2 must beEqualTo(None)))
+      } yield r
+    }
+  }
+
+  def tryOfferTryTakeTests(name: String, constructor: Int => IO[Queue[IO, Int]]): Fragments = {
+    s"$name - tryOffer/tryTake" in real {
+      val count = 1000
+
+      def producer(q: Queue[IO, Int], n: Int): IO[Unit] =
+        if (n > 0) q.tryOffer(count - n).flatMap {
+          case true =>
+            producer(q, n - 1)
+          case false =>
+            IO.cede *> producer(q, n)
+        }
+        else IO.unit
+
+      def consumer(
+          q: Queue[IO, Int],
+          n: Int,
+          acc: ScalaQueue[Int] = ScalaQueue.empty
+      ): IO[Long] =
+        if (n > 0)
+          q.tryTake.flatMap {
+            case Some(a) => consumer(q, n - 1, acc.enqueue(a))
+            case None => IO.cede *> consumer(q, n, acc)
+          }
+        else
+          IO.pure(acc.foldLeft(0L)(_ + _))
+
+      for {
+        q <- constructor(10)
+        p <- producer(q, count).start
+        c <- consumer(q, count).start
+        _ <- p.join
+        v <- c.joinAndEmbedNever
+        r <- IO(v must beEqualTo(count.toLong * (count - 1) / 2))
+      } yield r
+    }
+  }
+
+  def commonTests(name: String, constructor: Int => IO[Queue[IO, Int]]): Fragments = {
+    s"$name - return None on tryTake when the queue is empty" in real {
+      for {
+        q <- constructor(1)
+        v <- q.tryTake
+        r <- IO(v must beNone)
+      } yield r
+    }
+
+    s"$name - demonstrate sequential offer and take" in real {
+      for {
+        q <- constructor(1)
+        _ <- q.offer(1)
+        v1 <- q.take
+        _ <- q.offer(2)
+        v2 <- q.take
+        r <- IO((v1 must beEqualTo(1)) and (v2 must beEqualTo(2)))
+      } yield r
+    }
+
+    s"$name - demonstrate cancelable take" in real {
+      for {
+        q <- constructor(1)
+        f <- q.take.start
+        _ <- IO.sleep(10.millis)
+        _ <- f.cancel
+        v <- q.tryOffer(1)
+        r <- IO(v must beTrue)
+      } yield r
+    }
+
+    s"$name - async take" in realWithRuntime { implicit rt =>
+      for {
+        q <- constructor(10)
+        _ <- q.offer(1)
+        v1 <- q.take
+        _ <- IO(v1 must beEqualTo(1))
+        f <- IO(q.take.unsafeToFuture())
+        _ <- IO(f.value must beEqualTo(None))
+        _ <- q.offer(2)
+        v2 <- IO.fromFuture(IO.pure(f))
+        r <- IO(v2 must beEqualTo(2))
+      } yield r
+    }
+  }
+}

--- a/std/shared/src/main/scala/cats/effect/std/Queue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Queue.scala
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.std
+
+import cats.~>
+import cats.effect.kernel.{Concurrent, Deferred, Poll, Ref}
+import cats.effect.kernel.syntax.all._
+import cats.syntax.all._
+
+import scala.collection.immutable.{Queue => ScalaQueue}
+
+/**
+ * A purely functional, concurrent data structure which allows insertion and
+ * retrieval of elements of type `A` in a first-in-first-out (FIFO) manner.
+ *
+ * Depending on the type of queue constructed, the [[Queue#offer]] operation can
+ * block semantically until sufficient capacity in the queue becomes available.
+ *
+ * The [[Queue#take]] operation semantically blocks when the queue is empty.
+ *
+ * The [[Queue#tryOffer]] and [[Queue#tryTake]] allow for usecases which want to
+ * avoid semantically blocking a fiber.
+ */
+abstract class Queue[F[_], A] { self =>
+
+  /**
+   * Enqueues the given element at the back of the queue, possibly semantically
+   * blocking until sufficient capacity becomes available.
+   *
+   * @param a the element to be put at the back of the queue
+   */
+  def offer(a: A): F[Unit]
+
+  /**
+   * Attempts to enqueue the given element at the back of the queue without
+   * semantically blocking.
+   *
+   * @param a the element to be put at the back of the queue
+   * @return an effect that describes whether the enqueuing of the given
+   *         element succeeded without blocking
+   */
+  def tryOffer(a: A): F[Boolean]
+
+  /**
+   * Dequeues an element from the front of the queue, possibly semantically
+   * blocking until an element becomes available.
+   */
+  def take: F[A]
+
+  /**
+   * Attempts to dequeue an element from the front of the queue, if one is
+   * available without semantically blocking.
+   *
+   * @return an effect that describes whether the dequeueing of an element from
+   *         the queue succeeded without blocking, with `None` denoting that no
+   *         element was available
+   */
+  def tryTake: F[Option[A]]
+
+  /**
+   * Modifies the context in which this queue is executed using the natural
+   * transformation `f`.
+   *
+   * @return a queue in the new context obtained by mapping the current one
+   *         using `f`
+   */
+  def mapK[G[_]](f: F ~> G): Queue[G, A] =
+    new Queue[G, A] {
+      def offer(a: A): G[Unit] = f(self.offer(a))
+      def tryOffer(a: A): G[Boolean] = f(self.tryOffer(a))
+      val take: G[A] = f(self.take)
+      val tryTake: G[Option[A]] = f(self.tryTake)
+    }
+}
+
+object Queue {
+
+  /**
+   * Constructs an empty, bounded queue holding up to `capacity` elements for
+   * `F` data types that are [[Concurrent]]. When the queue is full (contains
+   * exactly `capacity` elements), every next [[Queue#offer]] will be
+   * backpressured (i.e. the [[Queue#offer]] blocks semantically).
+   *
+   * @param capacity the maximum capacity of the queue
+   * @return an empty, bounded queue
+   */
+  def bounded[F[_], A](capacity: Int)(implicit F: Concurrent[F]): F[Queue[F, A]] = {
+    assertNonNegative(capacity)
+    F.ref(State.empty[F, A]).map(new BoundedQueue(capacity, _))
+  }
+
+  /**
+   * Constructs a queue through which a single element can pass only in the case
+   * when there are at least one taking fiber and at least one offering fiber
+   * for `F` data types that are [[Concurrent]]. Both [[Queue#offer]] and
+   * [[Queue#take]] semantically block until there is a fiber executing the
+   * opposite action, at which point both fibers are freed.
+   *
+   * @return a synchronous queue
+   */
+  def synchronous[F[_], A](implicit F: Concurrent[F]): F[Queue[F, A]] =
+    bounded(0)
+
+  /**
+   * Constructs an empty, unbounded queue for `F` data types that are
+   * [[Concurrent]]. [[Queue#offer]] never blocks semantically, as there is
+   * always spare capacity in the queue.
+   *
+   * @return an empty, unbounded queue
+   */
+  def unbounded[F[_], A](implicit F: Concurrent[F]): F[Queue[F, A]] =
+    bounded(Int.MaxValue)
+
+  /**
+   * Constructs an empty, bounded, dropping queue holding up to `capacity`
+   * elements for `F` data types that are [[Concurrent]]. When the queue is full
+   * (contains exactly `capacity` elements), every next [[Queue#offer]] will be
+   * ignored, i.e. no other elements can be enqueued until there is sufficient
+   * capacity in the queue, and the offer effect itself will not semantically
+   * block.
+   *
+   * @param capacity the maximum capacity of the queue
+   * @return an empty, bounded, dropping queue
+   */
+  def dropping[F[_], A](capacity: Int)(implicit F: Concurrent[F]): F[Queue[F, A]] = {
+    assertPositive(capacity, "Dropping")
+    F.ref(State.empty[F, A]).map(new DroppingQueue(capacity, _))
+  }
+
+  /**
+   * Constructs an empty, bounded, circular buffer queue holding up to
+   * `capacity` elements for `F` data types that are [[Concurrent]]. The queue
+   * always keeps at most `capacity` number of elements, with the oldest
+   * element in the queue always being dropped in favor of a new elements
+   * arriving in the queue, and the offer effect itself will not semantically
+   * block.
+   *
+   * @param capacity the maximum capacity of the queue
+   * @return an empty, bounded, sliding queue
+   */
+  def circularBuffer[F[_], A](capacity: Int)(implicit F: Concurrent[F]): F[Queue[F, A]] = {
+    assertPositive(capacity, "CircularBuffer")
+    F.ref(State.empty[F, A]).map(new CircularBufferQueue(capacity, _))
+  }
+
+  private def assertNonNegative(capacity: Int): Unit =
+    require(capacity >= 0, s"Bounded queue capacity must be non-negative, was: $capacity")
+
+  private def assertPositive(capacity: Int, name: String): Unit =
+    require(capacity > 0, s"$name queue capacity must be positive, was: $capacity")
+
+  private sealed abstract class AbstractQueue[F[_], A](
+      capacity: Int,
+      state: Ref[F, State[F, A]]
+  )(implicit F: Concurrent[F])
+      extends Queue[F, A] {
+
+    protected def onOfferNoCapacity(
+        s: State[F, A],
+        a: A,
+        offerer: Deferred[F, Unit],
+        poll: Poll[F]
+    ): (State[F, A], F[Unit])
+
+    protected def onTryOfferNoCapacity(s: State[F, A], a: A): (State[F, A], F[Boolean])
+
+    def offer(a: A): F[Unit] =
+      F.deferred[Unit].flatMap { offerer =>
+        F.uncancelable { poll =>
+          state.modify {
+            case State(queue, size, takers, offerers) if takers.nonEmpty =>
+              val (taker, rest) = takers.dequeue
+              State(queue, size, rest, offerers) -> taker.complete(a).void
+
+            case State(queue, size, takers, offerers) if size < capacity =>
+              State(queue.enqueue(a), size + 1, takers, offerers) -> F.unit
+
+            case s =>
+              onOfferNoCapacity(s, a, offerer, poll)
+          }.flatten
+        }
+      }
+
+    def tryOffer(a: A): F[Boolean] =
+      state
+        .modify {
+          case State(queue, size, takers, offerers) if takers.nonEmpty =>
+            val (taker, rest) = takers.dequeue
+            State(queue, size, rest, offerers) -> taker.complete(a).as(true)
+
+          case State(queue, size, takers, offerers) if size < capacity =>
+            State(queue.enqueue(a), size + 1, takers, offerers) -> F.pure(true)
+
+          case s =>
+            onTryOfferNoCapacity(s, a)
+        }
+        .flatten
+        .uncancelable
+
+    val take: F[A] =
+      F.deferred[A].flatMap { taker =>
+        F.uncancelable { poll =>
+          state.modify {
+            case State(queue, size, takers, offerers) if queue.nonEmpty && offerers.isEmpty =>
+              val (a, rest) = queue.dequeue
+              State(rest, size - 1, takers, offerers) -> F.pure(a)
+
+            case State(queue, size, takers, offerers) if queue.nonEmpty =>
+              val (a, rest) = queue.dequeue
+              val ((move, release), tail) = offerers.dequeue
+              State(rest.enqueue(move), size, takers, tail) -> release.complete(()).as(a)
+
+            case State(queue, size, takers, offerers) if offerers.nonEmpty =>
+              val ((a, release), rest) = offerers.dequeue
+              State(queue, size, takers, rest) -> release.complete(()).as(a)
+
+            case State(queue, size, takers, offerers) =>
+              val cleanup = state.update { s => s.copy(takers = s.takers.filter(_ ne taker)) }
+              State(queue, size, takers.enqueue(taker), offerers) ->
+                poll(taker.get).onCancel(cleanup)
+          }.flatten
+        }
+      }
+
+    val tryTake: F[Option[A]] =
+      state
+        .modify {
+          case State(queue, size, takers, offerers) if queue.nonEmpty && offerers.isEmpty =>
+            val (a, rest) = queue.dequeue
+            State(rest, size - 1, takers, offerers) -> F.pure(a.some)
+
+          case State(queue, size, takers, offerers) if queue.nonEmpty =>
+            val (a, rest) = queue.dequeue
+            val ((move, release), tail) = offerers.dequeue
+            State(rest.enqueue(move), size, takers, tail) -> release.complete(()).as(a.some)
+
+          case State(queue, size, takers, offerers) if offerers.nonEmpty =>
+            val ((a, release), rest) = offerers.dequeue
+            State(queue, size, takers, rest) -> release.complete(()).as(a.some)
+
+          case s =>
+            s -> F.pure(none[A])
+        }
+        .flatten
+        .uncancelable
+  }
+
+  private final class BoundedQueue[F[_], A](capacity: Int, state: Ref[F, State[F, A]])(
+      implicit F: Concurrent[F]
+  ) extends AbstractQueue(capacity, state) {
+
+    protected def onOfferNoCapacity(
+        s: State[F, A],
+        a: A,
+        offerer: Deferred[F, Unit],
+        poll: Poll[F]
+    ): (State[F, A], F[Unit]) = {
+      val State(queue, size, takers, offerers) = s
+      val cleanup = state.update { s => s.copy(offerers = s.offerers.filter(_._2 ne offerer)) }
+      State(queue, size, takers, offerers.enqueue(a -> offerer)) -> poll(offerer.get)
+        .onCancel(cleanup)
+    }
+
+    protected def onTryOfferNoCapacity(s: State[F, A], a: A): (State[F, A], F[Boolean]) =
+      s -> F.pure(false)
+  }
+
+  private final class DroppingQueue[F[_], A](capacity: Int, state: Ref[F, State[F, A]])(
+      implicit F: Concurrent[F]
+  ) extends AbstractQueue(capacity, state) {
+
+    protected def onOfferNoCapacity(
+        s: State[F, A],
+        a: A,
+        offerer: Deferred[F, Unit],
+        poll: Poll[F]
+    ): (State[F, A], F[Unit]) =
+      s -> F.unit
+
+    protected def onTryOfferNoCapacity(s: State[F, A], a: A): (State[F, A], F[Boolean]) =
+      s -> F.pure(false)
+  }
+
+  private final class CircularBufferQueue[F[_], A](capacity: Int, state: Ref[F, State[F, A]])(
+      implicit F: Concurrent[F]
+  ) extends AbstractQueue(capacity, state) {
+
+    protected def onOfferNoCapacity(
+        s: State[F, A],
+        a: A,
+        offerer: Deferred[F, Unit],
+        poll: Poll[F]
+    ): (State[F, A], F[Unit]) = {
+      // dotty doesn't like cats map on tuples
+      val (ns, fb) = onTryOfferNoCapacity(s, a)
+      (ns, fb.void)
+    }
+
+    protected def onTryOfferNoCapacity(s: State[F, A], a: A): (State[F, A], F[Boolean]) = {
+      val State(queue, size, takers, offerers) = s
+      val (_, rest) = queue.dequeue
+      State(rest.enqueue(a), size, takers, offerers) -> F.pure(true)
+    }
+  }
+
+  private final case class State[F[_], A](
+      queue: ScalaQueue[A],
+      size: Int,
+      takers: ScalaQueue[Deferred[F, A]],
+      offerers: ScalaQueue[(A, Deferred[F, Unit])]
+  )
+
+  private object State {
+    def empty[F[_], A]: State[F, A] =
+      State(ScalaQueue.empty, 0, ScalaQueue.empty, ScalaQueue.empty)
+  }
+}

--- a/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
@@ -18,13 +18,11 @@ package cats
 package effect
 package std
 
-import cats.effect.kernel.{Concurrent, Deferred, Outcome, Ref, Resource, Spawn}
+import cats.effect.kernel.{Async, Concurrent, Deferred, Outcome, Ref, Resource, Spawn, Sync}
 import cats.effect.std.Semaphore.TransformedSemaphore
 import cats.syntax.all._
 
-import scala.collection.immutable.Queue
-import cats.effect.kernel.Sync
-import cats.effect.kernel.Async
+import scala.collection.immutable.{Queue => ScalaQueue}
 
 /**
  * A purely functional semaphore.
@@ -134,7 +132,7 @@ object Semaphore {
 
   // A semaphore is either empty, and there are number of outstanding acquires (Left)
   // or it is non-empty, and there are n permits available (Right)
-  private type State[F[_]] = Either[Queue[Request[F]], Long]
+  private type State[F[_]] = Either[ScalaQueue[Request[F]], Long]
 
   private final case class Permit[F[_]](await: F[Unit], release: F[Unit])
 
@@ -170,7 +168,7 @@ object Semaphore {
                   if (n <= m) {
                     Right(m - n)
                   } else {
-                    Left(Queue(Request(n - m, gate)))
+                    Left(ScalaQueue(Request(n - m, gate)))
                   }
               }
               .map {


### PR DESCRIPTION
Part of #1217.

WIP. Opening for a sneak peek and early comments on the api direction.

The bounded variant is currently functioning properly and hopefully well tested. I have taken some inspiration from the tests in `monix-catnap` and I have added a proper attribution in the source code.

Nothing here should be considered final and everything is up for change, especially the naming.

This is my first stab at a functional data structure so please take the time to review it properly, there may be bugs or generally things I have misunderstood.

This still needs partially applied and `in` syntax.

Let me know what you think.