### PR TITLE
Fix race ordering so we check the stored outcome first

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -706,13 +706,13 @@ private final class IOFiber[A](
                           finalizer.set(fiberB.cancel)
                           cb(Right(Left(a)))
                         case Outcome.Canceled() =>
-                        //See if the other side will complete
+                          //See if the other side will complete
                         case Outcome.Errored(e) =>
                           finalizer.set(fiberB.cancel)
                           cb(Left(e))
                       }
                     case Some(Outcome.Canceled()) =>
-                      //We lose and other side was cancelled as well
+                      //We lose but the other side was cancelled
                       oc match {
                         case Outcome.Succeeded(Pure(a)) =>
                           finalizer.set(fiberB.cancel)
@@ -739,13 +739,13 @@ private final class IOFiber[A](
                           finalizer.set(fiberA.cancel)
                           cb(Right(Right(b)))
                         case Outcome.Canceled() =>
-                        //See if the other side will complete
+                          //See if the other side will complete
                         case Outcome.Errored(e) =>
                           finalizer.set(fiberA.cancel)
                           cb(Left(e))
                       }
                     case Some(Outcome.Canceled()) =>
-                      //We lose and other side was cancelled as well
+                      //We lose but the other side was cancelled
                       oc match {
                         case Outcome.Succeeded(Pure(b)) =>
                           finalizer.set(fiberA.cancel)

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -705,8 +705,9 @@ private final class IOFiber[A](
                         case Outcome.Succeeded(Pure(a)) =>
                           finalizer.set(fiberB.cancel)
                           cb(Right(Left(a)))
+                        case Outcome.Succeeded(_) =>
                         case Outcome.Canceled() =>
-                          //See if the other side will complete
+                        //See if the other side will complete
                         case Outcome.Errored(e) =>
                           finalizer.set(fiberB.cancel)
                           cb(Left(e))
@@ -717,6 +718,7 @@ private final class IOFiber[A](
                         case Outcome.Succeeded(Pure(a)) =>
                           finalizer.set(fiberB.cancel)
                           cb(Right(Left(a)))
+                        case Outcome.Succeeded(_) =>
                         case Outcome.Canceled() =>
                           //Both sides cancelled so propagate
                           cb(Left(AsyncPropagateCancelation))
@@ -725,7 +727,7 @@ private final class IOFiber[A](
                           cb(Left(e))
                       }
                     case Some(_) =>
-                    //We lose
+                      //We lose
                   }
                 }
 
@@ -738,8 +740,9 @@ private final class IOFiber[A](
                         case Outcome.Succeeded(Pure(b)) =>
                           finalizer.set(fiberA.cancel)
                           cb(Right(Right(b)))
+                        case Outcome.Succeeded(_) =>
                         case Outcome.Canceled() =>
-                          //See if the other side will complete
+                        //See if the other side will complete
                         case Outcome.Errored(e) =>
                           finalizer.set(fiberA.cancel)
                           cb(Left(e))
@@ -750,6 +753,7 @@ private final class IOFiber[A](
                         case Outcome.Succeeded(Pure(b)) =>
                           finalizer.set(fiberA.cancel)
                           cb(Right(Right(b)))
+                        case Outcome.Succeeded(_) =>
                         case Outcome.Canceled() =>
                           //Both sides cancelled so propagate
                           cb(Left(AsyncPropagateCancelation))
@@ -758,7 +762,7 @@ private final class IOFiber[A](
                           cb(Left(e))
                       }
                     case Some(_) =>
-                    //We lose
+                      //We lose
                   }
                 }
 
@@ -810,6 +814,7 @@ private final class IOFiber[A](
                         //Other fiber already completed
                         case Outcome.Succeeded(Pure(b)) =>
                           cb(Right(a -> b))
+                        case Outcome.Succeeded(_) =>
                         case Outcome.Errored(e) => cb(Left(e.asInstanceOf[Throwable]))
                         //Both fibers have completed so no need for cancellation
                         case Outcome.Canceled() => cb(Left(AsyncPropagateCancelation))
@@ -836,6 +841,7 @@ private final class IOFiber[A](
                         //Other fiber already completed
                         case Outcome.Succeeded(Pure(a)) =>
                           cb(Right(a -> b))
+                        case Outcome.Succeeded(_) =>
                         case Outcome.Errored(e) => cb(Left(e.asInstanceOf[Throwable]))
                         case Outcome.Canceled() => cb(Left(AsyncPropagateCancelation))
                       }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -727,7 +727,7 @@ private final class IOFiber[A](
                           cb(Left(e))
                       }
                     case Some(_) =>
-                      //We lose
+                    //We lose
                   }
                 }
 
@@ -762,7 +762,7 @@ private final class IOFiber[A](
                           cb(Left(e))
                       }
                     case Some(_) =>
-                      //We lose
+                    //We lose
                   }
                 }
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -36,6 +36,6 @@ object Common extends AutoPlugin {
         if (isDotty.value)
           Nil
         else
-          Seq("-Xcheckinit")
+          Seq("-Xcheckinit", "-Ypatmat-exhaust-depth", "off")
       })
 }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -36,6 +36,6 @@ object Common extends AutoPlugin {
         if (isDotty.value)
           Nil
         else
-          Seq("-Xcheckinit", "-Ypatmat-exhaust-depth", "off")
+          Seq("-Xcheckinit")
       })
 }


### PR DESCRIPTION
Currently we blindly invoke the `cb` with the result of a fiber, without checking to see if the other side of the race has already invoked it.