### PR TITLE
Remove Resource.Bracket in favor of MonadCancel

### DIFF
--- a/core/js/src/main/scala/cats/effect/SyncIOConstants.scala
+++ b/core/js/src/main/scala/cats/effect/SyncIOConstants.scala
@@ -24,4 +24,8 @@ private object SyncIOConstants {
   val HandleErrorWithK: Byte = 2
   val RunTerminusK: Byte = 3
   val AttemptK: Byte = 4
+  val CancelationLoopK: Byte = 5
+  val OnCancelK: Byte = 6
+  val UncancelableK: Byte = 7
+  val UnmaskK: Byte = 8
 }

--- a/core/jvm/src/main/java/cats/effect/SyncIOConstants.java
+++ b/core/jvm/src/main/java/cats/effect/SyncIOConstants.java
@@ -25,4 +25,8 @@ final class SyncIOConstants {
   public static final byte HandleErrorWithK = 2;
   public static final byte RunTerminusK = 3;
   public static final byte AttemptK = 4;
+  public static final byte CancelationLoopK = 5;
+  public static final byte OnCancelK = 6;
+  public static final byte UncancelableK = 7;
+  public static final byte UnmaskK = 8;
 }

--- a/core/shared/src/main/scala/cats/effect/SyncIO.scala
+++ b/core/shared/src/main/scala/cats/effect/SyncIO.scala
@@ -534,10 +534,10 @@ object SyncIO extends SyncIOLowPriorityImplicits {
       def canceled: SyncIO[Unit] = unit
 
       def forceR[A, B](fa: SyncIO[A])(fb: SyncIO[B]): SyncIO[B] =
-        productR(fa)(fb)
+        productR(fa.attempt)(fb)
 
       def onCancel[A](fa: SyncIO[A], fin: SyncIO[Unit]): SyncIO[A] =
-        fa <* fin
+        fa
 
       def uncancelable[A](body: Poll[SyncIO] => SyncIO[A]): SyncIO[A] =
         body(new Poll[SyncIO] { def apply[X](fx: SyncIO[X]) = fx })

--- a/core/shared/src/main/scala/cats/effect/SyncIO.scala
+++ b/core/shared/src/main/scala/cats/effect/SyncIO.scala
@@ -20,6 +20,7 @@ import cats.{Eval, Now, Show, StackSafeMonad}
 import cats.kernel.{Monoid, Semigroup}
 
 import scala.annotation.{switch, tailrec}
+import scala.concurrent.CancellationException
 import scala.concurrent.duration._
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -132,6 +133,9 @@ sealed abstract class SyncIO[+A] private () {
   def map[B](f: A => B): SyncIO[B] =
     SyncIO.Map(this, f)
 
+  def onCancel(fin: SyncIO[Unit]): SyncIO[A] =
+    SyncIO.OnCancel(this, fin)
+
   /**
    * Executes `that` only for the side effects.
    *
@@ -184,13 +188,21 @@ sealed abstract class SyncIO[+A] private () {
   def unsafeRunSync(): A = {
     import SyncIOConstants._
 
-    val conts = new ByteStack(16)
+    var conts = new ByteStack(16)
     val objectState = new ArrayStack[AnyRef](16)
+    val initMask = 0
+    var masks = initMask
+    val finalizers = new ArrayStack[SyncIO[Unit]](16)
+    var canceled = false
 
     conts.push(RunTerminusK)
 
     @tailrec
-    def runLoop(cur0: SyncIO[Any]): A =
+    def runLoop(cur0: SyncIO[Any]): A = {
+      if (shouldFinalize()) {
+        syncCancel()
+      }
+
       (cur0.tag: @switch) match {
         case 0 =>
           val cur = cur0.asInstanceOf[SyncIO.Pure[Any]]
@@ -253,7 +265,63 @@ sealed abstract class SyncIO[+A] private () {
 
           conts.push(AttemptK)
           runLoop(cur.ioa)
+
+        case 9 =>
+          canceled = true
+          if (isUnmasked()) {
+            syncCancel()
+          } else {
+            runLoop(succeeded((), 0))
+          }
+
+        case 10 =>
+          val cur = cur0.asInstanceOf[SyncIO.OnCancel[Any]]
+
+          finalizers.push(cur.fin)
+          conts.push(OnCancelK)
+          runLoop(cur.ioa)
+
+        case 11 =>
+          val cur = cur0.asInstanceOf[SyncIO.Uncancelable[Any]]
+
+          masks += 1
+          val id = masks
+          val poll = new Poll[SyncIO] {
+            def apply[B](ioa: SyncIO[B]) =
+              SyncIO.Uncancelable.UnmaskRunLoop(ioa, id)
+          }
+
+          conts.push(UncancelableK)
+          runLoop(cur.body(poll))
+
+        case 12 =>
+          val cur = cur0.asInstanceOf[SyncIO.Uncancelable.UnmaskRunLoop[Any]]
+
+          if (masks == cur.id) {
+            masks -= 1
+            conts.push(UnmaskK)
+          }
+
+          runLoop(cur.ioa)
       }
+    }
+
+    def shouldFinalize(): Boolean =
+      canceled && isUnmasked()
+
+    def isUnmasked(): Boolean =
+      masks == initMask
+
+    def syncCancel(): A = {
+      if (!finalizers.isEmpty()) {
+        conts = new ByteStack(16)
+        conts.push(CancelationLoopK)
+        masks += 1
+        runLoop(finalizers.pop())
+      } else {
+        throw new CancellationException()
+      }
+    }
 
     @tailrec
     def succeeded(result: Any, depth: Int): SyncIO[Any] =
@@ -267,6 +335,10 @@ sealed abstract class SyncIO[+A] private () {
           succeeded(result, depth)
         case 3 => SyncIO.Success(result)
         case 4 => succeeded(Right(result), depth + 1)
+        case 5 => cancelationLoopSuccessK()
+        case 6 => onCancelSuccessK(result, depth)
+        case 7 => uncancelableSuccessK(result, depth)
+        case 8 => unmaskSuccessK(result, depth)
       }
 
     def failed(error: Throwable, depth: Int): SyncIO[Any] = {
@@ -290,6 +362,10 @@ sealed abstract class SyncIO[+A] private () {
         case 2 => handleErrorWithK(error, depth)
         case 3 => SyncIO.Failure(error)
         case 4 => succeeded(Left(error), depth + 1)
+        case 5 => cancelationLoopFailureK(error)
+        case 6 => onCancelFailureK(error, depth)
+        case 7 => uncancelableFailureK(error, depth)
+        case 8 => unmaskFailureK(error, depth)
       }
     }
 
@@ -328,6 +404,50 @@ sealed abstract class SyncIO[+A] private () {
       catch {
         case NonFatal(t) => failed(t, depth + 1)
       }
+    }
+
+    def cancelationLoopSuccessK(): SyncIO[Any] = {
+      if (!finalizers.isEmpty()) {
+        conts.push(CancelationLoopK)
+        finalizers.pop()
+      } else {
+        throw new CancellationException()
+      }
+    }
+
+    def cancelationLoopFailureK(t: Throwable): SyncIO[Any] = {
+      t.printStackTrace()
+      cancelationLoopSuccessK()
+    }
+
+    def onCancelSuccessK(result: Any, depth: Int): SyncIO[Any] = {
+      finalizers.pop()
+      succeeded(result, depth + 1)
+    }
+
+    def onCancelFailureK(t: Throwable, depth: Int): SyncIO[Any] = {
+      finalizers.pop()
+      failed(t, depth + 1)
+    }
+
+    def uncancelableSuccessK(result: Any, depth: Int): SyncIO[Any] = {
+      masks -= 1
+      succeeded(result, depth + 1)
+    }
+
+    def uncancelableFailureK(t: Throwable, depth: Int): SyncIO[Any] = {
+      masks -= 1
+      failed(t, depth + 1)
+    }
+
+    def unmaskSuccessK(result: Any, depth: Int): SyncIO[Any] = {
+      masks += 1
+      succeeded(result, depth + 1)
+    }
+
+    def unmaskFailureK(t: Throwable, depth: Int): SyncIO[Any] = {
+      masks += 1
+      failed(t, depth + 1)
     }
 
     runLoop(this)
@@ -531,16 +651,16 @@ object SyncIO extends SyncIOLowPriorityImplicits {
           fa: SyncIO[A])(recover: Throwable => SyncIO[B], bind: A => SyncIO[B]): SyncIO[B] =
         fa.redeemWith(recover, bind)
 
-      def canceled: SyncIO[Unit] = unit
+      def canceled: SyncIO[Unit] = Canceled
 
       def forceR[A, B](fa: SyncIO[A])(fb: SyncIO[B]): SyncIO[B] =
-        productR(fa.attempt)(fb)
+        fa.attempt.productR(fb)
 
       def onCancel[A](fa: SyncIO[A], fin: SyncIO[Unit]): SyncIO[A] =
-        fa
+        fa.onCancel(fin)
 
       def uncancelable[A](body: Poll[SyncIO] => SyncIO[A]): SyncIO[A] =
-        body(new Poll[SyncIO] { def apply[X](fx: SyncIO[X]) = fx })
+        Uncancelable(body)
     }
 
   implicit def syncForSyncIO: Sync[SyncIO] with MonadCancel[SyncIO, Throwable] = _syncForSyncIO
@@ -587,5 +707,25 @@ object SyncIO extends SyncIOLowPriorityImplicits {
   private[effect] final case class Attempt[+A](ioa: SyncIO[A])
       extends SyncIO[Either[Throwable, A]] {
     def tag = 8
+  }
+
+  private[effect] case object Canceled extends SyncIO[Unit] {
+    def tag = 9
+  }
+
+  private[effect] final case class OnCancel[+A](ioa: SyncIO[A], fin: SyncIO[Unit])
+      extends SyncIO[A] {
+    def tag = 10
+  }
+
+  private[effect] final case class Uncancelable[+A](body: Poll[SyncIO] => SyncIO[A])
+      extends SyncIO[A] {
+    def tag = 11
+  }
+
+  private[effect] object Uncancelable {
+    final case class UnmaskRunLoop[+A](ioa: SyncIO[A], id: Int) extends SyncIO[A] {
+      def tag = 12
+    }
   }
 }

--- a/core/shared/src/test/scala/cats/effect/Runners.scala
+++ b/core/shared/src/test/scala/cats/effect/Runners.scala
@@ -294,7 +294,7 @@ trait Runners extends SpecificationLike with RunnersPlatform { outer =>
     }
 
   def unsafeRunSync[A](ioa: SyncIO[A]): Outcome[Id, Throwable, A] =
-    try Outcome.completed[Id, Throwable, A](ioa.unsafeRunSync())
+    try Outcome.succeeded[Id, Throwable, A](ioa.unsafeRunSync())
     catch {
       case _: CancellationException => Outcome.canceled
       case t: Throwable => Outcome.errored(t)

--- a/core/shared/src/test/scala/cats/effect/Runners.scala
+++ b/core/shared/src/test/scala/cats/effect/Runners.scala
@@ -197,7 +197,7 @@ trait Runners extends SpecificationLike with RunnersPlatform { outer =>
    */
   implicit def eqResource[F[_], A](
       implicit E: Eq[F[A]],
-      F: Resource.Bracket[F]): Eq[Resource[F, A]] =
+      F: MonadCancel[F, Throwable]): Eq[Resource[F, A]] =
     new Eq[Resource[F, A]] {
       def eqv(x: Resource[F, A], y: Resource[F, A]): Boolean =
         E.eqv(x.use(F.pure), y.use(F.pure))

--- a/core/shared/src/test/scala/cats/effect/Runners.scala
+++ b/core/shared/src/test/scala/cats/effect/Runners.scala
@@ -16,7 +16,7 @@
 
 package cats.effect
 
-import cats.{Applicative, Eq, Order, Show}
+import cats.{Applicative, Eq, Id, Order, Show}
 import cats.effect.testkit.{
   AsyncGenerators,
   GenK,
@@ -35,7 +35,13 @@ import org.specs2.mutable.SpecificationLike
 import org.specs2.specification.core.Execution
 
 import scala.annotation.implicitNotFound
-import scala.concurrent.{ExecutionContext, Future, Promise, TimeoutException}
+import scala.concurrent.{
+  CancellationException,
+  ExecutionContext,
+  Future,
+  Promise,
+  TimeoutException
+}
 import scala.concurrent.duration._
 import scala.util.Try
 
@@ -219,9 +225,7 @@ trait Runners extends SpecificationLike with RunnersPlatform { outer =>
     Try(io.unsafeRunSync()).toEither
 
   implicit def eqSyncIOA[A: Eq]: Eq[SyncIO[A]] =
-    Eq.instance { (left, right) =>
-      unsafeRunSyncIOEither(left) === unsafeRunSyncIOEither(right)
-    }
+    Eq.by(unsafeRunSync)
 
   // feel the rhythm, feel the rhyme...
   implicit def boolRunnings(iob: IO[Boolean])(implicit ticker: Ticker): Prop =
@@ -258,6 +262,9 @@ trait Runners extends SpecificationLike with RunnersPlatform { outer =>
   def nonTerminate(implicit ticker: Ticker): Matcher[IO[Unit]] =
     tickTo[Unit](Outcome.Succeeded(None))
 
+  def beCanceledSync: Matcher[SyncIO[Unit]] =
+    (ioa: SyncIO[Unit]) => unsafeRunSync(ioa) eqv Outcome.canceled
+
   def tickTo[A: Eq: Show](expected: Outcome[Option, Throwable, A])(
       implicit ticker: Ticker): Matcher[IO[A]] = { (ioa: IO[A]) =>
     val oc = unsafeRun(ioa)
@@ -284,6 +291,13 @@ trait Runners extends SpecificationLike with RunnersPlatform { outer =>
       case t: Throwable =>
         t.printStackTrace()
         throw t
+    }
+
+  def unsafeRunSync[A](ioa: SyncIO[A]): Outcome[Id, Throwable, A] =
+    try Outcome.completed[Id, Throwable, A](ioa.unsafeRunSync())
+    catch {
+      case _: CancellationException => Outcome.canceled
+      case t: Throwable => Outcome.errored(t)
     }
 
   implicit def materializeRuntime(implicit ticker: Ticker): unsafe.IORuntime =

--- a/core/shared/src/test/scala/cats/effect/SyncIOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/SyncIOSpec.scala
@@ -196,6 +196,68 @@ class SyncIOSpec extends IOPlatformSpecification with Discipline with ScalaCheck
         .handleErrorWith(_ => (throw TestException): SyncIO[Unit])
         .attempt must completeAsSync(Left(TestException))
     }
+
+    "preserve monad right identity on uncancelable" in {
+      val fa = MonadCancel[SyncIO].uncancelable(_ => MonadCancel[SyncIO].canceled)
+      fa.flatMap(SyncIO.pure(_)) must beCanceledSync
+      fa must beCanceledSync
+    }
+
+    "cancel flatMap continuations following a canceled uncancelable block" in {
+      MonadCancel[SyncIO]
+        .uncancelable(_ => MonadCancel[SyncIO].canceled)
+        .flatMap(_ => SyncIO.pure(())) must beCanceledSync
+    }
+
+    "cancel map continuations following a canceled uncancelable block" in {
+      MonadCancel[SyncIO]
+        .uncancelable(_ => MonadCancel[SyncIO].canceled)
+        .map(_ => ()) must beCanceledSync
+    }
+
+    "sequence onCancel when canceled before registration" in {
+      var passed = false
+      val test = MonadCancel[SyncIO].uncancelable { poll =>
+        MonadCancel[SyncIO].canceled >> poll(SyncIO.unit).onCancel(SyncIO { passed = true })
+      }
+
+      test must beCanceledSync
+      passed must beTrue
+    }
+
+    "break out of uncancelable when canceled before poll" in {
+      var passed = true
+      val test = MonadCancel[SyncIO].uncancelable { poll =>
+        MonadCancel[SyncIO].canceled >> poll(SyncIO.unit) >> SyncIO { passed = false }
+      }
+
+      test must beCanceledSync
+      passed must beTrue
+    }
+
+    "not invoke onCancel when previously canceled within uncancelable" in {
+      var failed = false
+      MonadCancel[SyncIO].uncancelable(_ =>
+        MonadCancel[SyncIO].canceled >> SyncIO
+          .unit
+          .onCancel(SyncIO { failed = true })) must beCanceledSync
+      failed must beFalse
+    }
+
+    "ignore repeated polls" in {
+      var passed = true
+
+      val test = MonadCancel[SyncIO].uncancelable { poll =>
+        poll(poll(SyncIO.unit) >> MonadCancel[SyncIO].canceled) >> SyncIO { passed = false }
+      }
+
+      test must beCanceledSync
+      passed must beTrue
+    }
+
+    "mapping something with a finalizer should complete" in {
+      SyncIO.pure(42).onCancel(SyncIO.unit).as(()) must completeAsSync(())
+    }
   }
 
   {

--- a/core/shared/src/test/scala/cats/effect/SyncIOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/SyncIOSpec.scala
@@ -17,7 +17,7 @@
 package cats.effect
 
 import cats.kernel.laws.discipline.MonoidTests
-import cats.effect.laws.SyncTests
+import cats.effect.laws.{MonadCancelTests, SyncTests}
 import cats.effect.testkit.SyncTypeGenerators
 import cats.syntax.all._
 
@@ -212,4 +212,10 @@ class SyncIOSpec extends IOPlatformSpecification with Discipline with ScalaCheck
     )
   }
 
+  {
+    checkAll(
+      "SyncIO MonadCancel",
+      MonadCancelTests[SyncIO, Throwable].monadCancel[Int, Int, Int]
+    )
+  }
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -40,8 +40,7 @@ import cats.data.Kleisli
  *     })
  * }}}
  *
- * Usage is done via [[Resource!.use use]] and note that resource usage nests,
- * because its implementation is specified in terms of [[Bracket]]:
+ * Usage is done via [[Resource!.use use]] and note that resource usage nests.
  *
  * {{{
  *   open(file1).use { in1 =>
@@ -108,7 +107,7 @@ sealed abstract class Resource[+F[_], +A] {
   private[effect] def fold[G[x] >: F[x], B](
       onOutput: A => G[B],
       onRelease: G[Unit] => G[Unit]
-  )(implicit G: Resource.Bracket[G]): G[B] = {
+  )(implicit G: MonadCancel[G, Throwable]): G[B] = {
     sealed trait Stack[AA]
     case object Nil extends Stack[A]
     final case class Frame[AA, BB](head: AA => Resource[G, BB], tail: Stack[BB])
@@ -130,8 +129,8 @@ sealed abstract class Resource[+F[_], +A] {
                 case Frame(head, tail) => continue(head(a), tail)
               }
           } {
-            case ((_, release), ec) =>
-              onRelease(release(ec))
+            case ((_, release), outcome) =>
+              onRelease(release(ExitCase.fromOutcome(outcome)))
           }
         case Bind(source, fs) =>
           loop(source, Frame(fs, stack))
@@ -203,7 +202,7 @@ sealed abstract class Resource[+F[_], +A] {
    * @param f the function to apply to the allocated resource
    * @return the result of applying [F] to
    */
-  def use[G[x] >: F[x], B](f: A => G[B])(implicit G: Resource.Bracket[G]): G[B] =
+  def use[G[x] >: F[x], B](f: A => G[B])(implicit G: MonadCancel[G, Throwable]): G[B] =
     fold[G, B](f, identity)
 
   /**
@@ -268,7 +267,7 @@ sealed abstract class Resource[+F[_], +A] {
     def allocate[C](r: Resource[G, C], storeFinalizer: Update): G[C] =
       r.fold[G, C](
         _.pure[G],
-        release => storeFinalizer(Resource.Bracket[G].guarantee(_)(release))
+        release => storeFinalizer(MonadCancel[G, Throwable].guarantee(_, release))
       )
 
     val bothFinalizers = Ref.of(().pure[G] -> ().pure[G])
@@ -348,7 +347,7 @@ sealed abstract class Resource[+F[_], +A] {
    * code that needs to modify or move the finalizer for an existing
    * resource.
    */
-  def allocated[G[x] >: F[x], B >: A](implicit G: Resource.Bracket[G]): G[(B, G[Unit])] = {
+  def allocated[G[x] >: F[x], B >: A](implicit G: MonadCancel[G, Throwable]): G[(B, G[Unit])] = {
     sealed trait Stack[AA]
     case object Nil extends Stack[B]
     final case class Frame[AA, BB](head: AA => Resource[G, BB], tail: Stack[BB])
@@ -373,15 +372,15 @@ sealed abstract class Resource[+F[_], +A] {
             case (a, rel) =>
               stack match {
                 case Nil =>
-                  G.pure((a: B) -> G.guarantee(rel(ExitCase.Succeeded))(release))
+                  G.pure((a: B) -> G.guarantee(rel(ExitCase.Succeeded), release))
                 case Frame(head, tail) =>
-                  continue(head(a), tail, G.guarantee(rel(ExitCase.Succeeded))(release))
+                  continue(head(a), tail, G.guarantee(rel(ExitCase.Succeeded), release))
               }
           } {
-            case (_, ExitCase.Succeeded) =>
+            case (_, Outcome.Succeeded(_)) =>
               G.unit
-            case ((_, release), ec) =>
-              release(ec)
+            case ((_, release), outcome) =>
+              release(ExitCase.fromOutcome(outcome))
           }
         case Bind(source, fs) =>
           loop(source, Frame(fs, stack), release)
@@ -464,8 +463,6 @@ object Resource extends ResourceInstances with ResourcePlatform {
   /**
    * Creates a resource from an acquiring effect and a release function.
    *
-   * This builder mirrors the signature of [[Bracket.bracket]].
-   *
    * @tparam F the effect type in which the resource is acquired and released
    * @tparam A the type of the resource
    * @param acquire a function to effectfully acquire a resource
@@ -478,8 +475,6 @@ object Resource extends ResourceInstances with ResourcePlatform {
   /**
    * Creates a resource from an acquiring effect and a release function that can
    * discriminate between different [[ExitCase exit cases]].
-   *
-   * This builder mirrors the signature of [[Bracket.bracketCase]].
    *
    * @tparam F the effect type in which the resource is acquired and released
    * @tparam A the type of the resource
@@ -632,7 +627,8 @@ object Resource extends ResourceInstances with ResourcePlatform {
      * An [[ExitCase]] that signals successful completion.
      *
      * Note that "successful" is from the type of view of the
-     * `MonadError` type that's implementing [[Bracket]].
+     * `MonadCancel` type.
+     * 
      * When combining such a type with `EitherT` or `OptionT` for
      * example, this exit condition might not signal a successful
      * outcome for the user, but it does for the purposes of the
@@ -651,85 +647,15 @@ object Resource extends ResourceInstances with ResourcePlatform {
      * As an example this can happen when we have a cancelable data type,
      * like [[IO]] and the task yielded by `bracket` gets canceled
      * when it's at its `use` phase.
-     *
-     * Thus [[Bracket]] allows you to observe interruption conditions
-     * and act on them.
      */
     case object Canceled extends ExitCase
-  }
 
-  @annotation.implicitNotFound(
-    "Cannot find an instance for Resource.Bracket. This normally means you need to add implicit evidence of MonadCancel[${F}, Throwable]")
-  trait Bracket[F[_]] extends MonadThrow[F] {
-    def bracketCase[A, B](acquire: F[A])(use: A => F[B])(
-        release: (A, ExitCase) => F[Unit]): F[B]
-
-    def bracket[A, B](acquire: F[A])(use: A => F[B])(release: A => F[Unit]): F[B] =
-      bracketCase(acquire)(use)((a, _) => release(a))
-
-    def guarantee[A](fa: F[A])(finalizer: F[Unit]): F[A] =
-      bracket(unit)(_ => fa)(_ => finalizer)
-
-    def guaranteeCase[A](fa: F[A])(finalizer: ExitCase => F[Unit]): F[A] =
-      bracketCase(unit)(_ => fa)((_, e) => finalizer(e))
-  }
-
-  trait Bracket0 {
-    implicit def catsEffectResourceBracketForSync[F[_]](implicit F0: Sync[F]): Bracket[F] =
-      new SyncBracket[F] {
-        implicit protected def F: Sync[F] = F0
+    def fromOutcome[F[_], A](outcome: Outcome[F, Throwable, A]): ExitCase =
+      outcome match {
+        case Outcome.Succeeded(_) => Succeeded
+        case Outcome.Errored(t) => Errored(t)
+        case Outcome.Canceled() => Canceled
       }
-
-    trait SyncBracket[F[_]] extends Bracket[F] {
-      implicit protected def F: Sync[F]
-
-      def bracketCase[A, B](acquire: F[A])(use: A => F[B])(
-          release: (A, ExitCase) => F[Unit]): F[B] =
-        flatMap(acquire) { a =>
-          val handled = onError(use(a)) {
-            case e => void(attempt(release(a, ExitCase.Errored(e))))
-          }
-          flatMap(handled)(b => as(attempt(release(a, ExitCase.Succeeded)), b))
-        }
-
-      def pure[A](x: A): F[A] = F.pure(x)
-      def handleErrorWith[A](fa: F[A])(f: Throwable => F[A]): F[A] = F.handleErrorWith(fa)(f)
-      def raiseError[A](e: Throwable): F[A] = F.raiseError(e)
-      def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B] = F.flatMap(fa)(f)
-      def tailRecM[A, B](a: A)(f: A => F[Either[A, B]]): F[B] = F.tailRecM(a)(f)
-    }
-  }
-
-  object Bracket extends Bracket0 {
-    def apply[F[_]](implicit F: Bracket[F]): F.type = F
-
-    implicit def bracketMonadCancel[F[_]](
-        implicit F0: MonadCancel[F, Throwable]
-    ): Bracket[F] =
-      new MonadCancelBracket[F] {
-        implicit protected def F: MonadCancel[F, Throwable] = F0
-      }
-
-    trait MonadCancelBracket[F[_]] extends Bracket[F] {
-      implicit protected def F: MonadCancel[F, Throwable]
-
-      def bracketCase[A, B](acquire: F[A])(use: A => F[B])(
-          release: (A, ExitCase) => F[Unit]): F[B] =
-        F.uncancelable { poll =>
-          flatMap(acquire) { a =>
-            val finalized = F.onCancel(poll(use(a)), release(a, ExitCase.Canceled))
-            val handled = onError(finalized) {
-              case e => void(attempt(release(a, ExitCase.Errored(e))))
-            }
-            flatMap(handled)(b => as(attempt(release(a, ExitCase.Succeeded)), b))
-          }
-        }
-      def pure[A](x: A): F[A] = F.pure(x)
-      def handleErrorWith[A](fa: F[A])(f: Throwable => F[A]): F[A] = F.handleErrorWith(fa)(f)
-      def raiseError[A](e: Throwable): F[A] = F.raiseError(e)
-      def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B] = F.flatMap(fa)(f)
-      def tailRecM[A, B](a: A)(f: A => F[Either[A, B]]): F[B] = F.tailRecM(a)(f)
-    }
   }
 
   /**
@@ -805,7 +731,7 @@ abstract private[effect] class ResourceInstances0 {
     }
 
   implicit def catsEffectSemigroupKForResource[F[_], A](
-      implicit F0: Resource.Bracket[F],
+      implicit F0: MonadCancel[F, Throwable],
       K0: SemigroupK[F],
       G0: Ref.Make[F]): ResourceSemigroupK[F] =
     new ResourceSemigroupK[F] {
@@ -913,7 +839,7 @@ abstract private[effect] class ResourceSemigroup[F[_], A] extends Semigroup[Reso
 }
 
 abstract private[effect] class ResourceSemigroupK[F[_]] extends SemigroupK[Resource[F, *]] {
-  implicit protected def F: Resource.Bracket[F]
+  implicit protected def F: MonadCancel[F, Throwable]
   implicit protected def K: SemigroupK[F]
   implicit protected def G: Ref.Make[F]
 
@@ -922,7 +848,7 @@ abstract private[effect] class ResourceSemigroupK[F[_]] extends SemigroupK[Resou
       def allocate(r: Resource[F, A]): F[A] =
         r.fold(
           _.pure[F],
-          (release: F[Unit]) => finalizers.update(Resource.Bracket[F].guarantee(_)(release)))
+          (release: F[Unit]) => finalizers.update(MonadCancel[F, Throwable].guarantee(_, release)))
 
       K.combineK(allocate(ra), allocate(rb))
     }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -347,7 +347,8 @@ sealed abstract class Resource[+F[_], +A] {
    * code that needs to modify or move the finalizer for an existing
    * resource.
    */
-  def allocated[G[x] >: F[x], B >: A](implicit G: MonadCancel[G, Throwable]): G[(B, G[Unit])] = {
+  def allocated[G[x] >: F[x], B >: A](
+      implicit G: MonadCancel[G, Throwable]): G[(B, G[Unit])] = {
     sealed trait Stack[AA]
     case object Nil extends Stack[B]
     final case class Frame[AA, BB](head: AA => Resource[G, BB], tail: Stack[BB])
@@ -628,7 +629,7 @@ object Resource extends ResourceInstances with ResourcePlatform {
      *
      * Note that "successful" is from the type of view of the
      * `MonadCancel` type.
-     * 
+     *
      * When combining such a type with `EitherT` or `OptionT` for
      * example, this exit condition might not signal a successful
      * outcome for the user, but it does for the purposes of the
@@ -848,7 +849,8 @@ abstract private[effect] class ResourceSemigroupK[F[_]] extends SemigroupK[Resou
       def allocate(r: Resource[F, A]): F[A] =
         r.fold(
           _.pure[F],
-          (release: F[Unit]) => finalizers.update(MonadCancel[F, Throwable].guarantee(_, release)))
+          (release: F[Unit]) =>
+            finalizers.update(MonadCancel[F, Throwable].guarantee(_, release)))
 
       K.combineK(allocate(ra), allocate(rb))
     }


### PR DESCRIPTION
This also defines a "no-op" `MonadCancel[SyncIO, Throwable]` instance, allowing `Resource[SyncIO, X]` instances despite `SyncIO` not supporting cancelation.