### PR TITLE
Port Hotswap from Fs2

### DIFF
--- a/core/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package std
+
+import cats.effect.kernel.Ref
+
+class HotswapSpec extends BaseSpec { outer =>
+
+  sequential
+
+  def log(state: Ref[IO, List[String]], message: String): IO[Unit] =
+    state.update(_ :: message)
+
+  def resource(state: Ref[IO, List[String]], name: String): IO[Unit] =
+    Resource.make(log(state, s"open $name"))(_ => log(state, s"close $name"))
+
+  "Hotswap" should {
+    "run finalizer of target run when hotswap is finalized" in real {
+      val op = for {
+        state <- Ref.of[IO, Int](0)
+        _ <- Hotswap[IO, Unit](Resource.make(IO.unit)(_ => state.set(1))).use(_ => IO.unit)
+        value <- state.get
+      } yield value
+
+      op.flatMap { res =>
+        IO {
+          res must beEqualTo(1)
+        }
+      }
+    }
+
+    "acquire new resource and finalize old resource on swap" in real {
+      val op = for {
+        state <- Ref.of[IO, List[String]](0)
+        _ <- Hotswap[IO, Unit](resource(state, "a")).use { hotswap =>
+          hotswap.swap(resource(state, "b"))
+        }
+        log <- state.get
+      } yield value
+
+      op.flatMap { res =>
+        IO {
+          res must beEqualTo(List("open a", "open b", "close a", "close b"))
+        }
+      }
+    }
+
+    "finalize old resource on clear" in real {
+      val op = for {
+        state <- Ref.of[IO, List[String]](0)
+        _ <- Hotswap[IO, Unit](resource(state, "a")).use { hotswap =>
+          hotswap.clear *> hotswap.swap(resource(state, "b"))
+        }
+        log <- state.get
+      } yield value
+
+      op.flatMap { res =>
+        IO {
+          res must beEqualTo(List("open a", "close a", "open b", "close b"))
+        }
+      }
+    }
+  }
+
+}

--- a/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
@@ -116,8 +116,8 @@ object Hotswap {
       new Hotswap[F, R] {
 
         override def swap(next: Resource[F, R]): F[R] =
-          F.uncancelable { _ =>
-            next.allocated[F, R].flatMap {
+          F.uncancelable { poll =>
+            poll(next.allocated[F, R]).flatMap {
               case (r, finalizer) =>
                 swapFinalizer(finalizer).as(r)
             }

--- a/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
@@ -117,7 +117,7 @@ object Hotswap {
 
         override def swap(next: Resource[F, R]): F[R] =
           F.uncancelable { _ =>
-            next.allocated.flatMap {
+            next.allocated[F, R].flatMap {
               case (r, finalizer) =>
                 swapFinalizer(finalizer).as(r)
             }
@@ -129,7 +129,7 @@ object Hotswap {
         private def swapFinalizer(next: F[Unit]): F[Unit] =
           state.modify {
             case Some(previous) =>
-              Some(next) -> previous.attempt.void
+              Some(next) -> previous
             case None =>
               None -> (next *> raise("Cannot swap after finalization"))
           }.flatten

--- a/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.std
+
+import cats.syntax.all._
+import cats.effect.kernel.syntax.all._
+import cats.effect.kernel.{Concurrent, Ref, Resource}
+
+sealed trait Hotswap[F[_], R] {
+
+  def swap(next: Resource[F, R]): F[R]
+
+  def clear: F[Unit]
+
+}
+
+object Hotswap {
+
+  def create[F[_], R](implicit F: Concurrent[F]): Resource[F, Hotswap[F, R]] = {
+    type State = Option[F[Unit]]
+
+    def initialize: F[Ref[F, State]] =
+      F.ref(Some(F.pure(())))
+
+    def finalize(state: Ref[F, State]): F[Unit] =
+      state.getAndSet(None).flatMap {
+        case Some(finalizer) => finalizer
+        case None => raise("Hotswap already finalized")
+      }
+
+    def raise(message: String): F[Unit] =
+      F.raiseError[Unit](new RuntimeException(message))
+
+    Resource.make(initialize)(finalize).map { state =>
+      new Hotswap[F, R] {
+
+        override def swap(next: Resource[F, R]): F[R] =
+          F.uncancelable { _ =>
+            next.allocated.flatMap {
+              case (r, finalizer) =>
+                swapFinalizer(finalizer).as(r)
+            }
+          }
+
+        override def clear: F[Unit] =
+          swapFinalizer(F.unit).uncancelable
+
+        private def swapFinalizer(next: F[Unit]): F[Unit] =
+          state.modify {
+            case Some(previous) =>
+              Some(next) -> previous.attempt.void
+            case None =>
+              None -> (next *> raise("Cannot swap after finalization"))
+          }.flatten
+
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Ported from https://github.com/typelevel/fs2/blob/60b57c242d5a1628826b9f14fcb92d60a47fccc2/core/shared/src/main/scala/fs2/Hotswap.scala .

Closes #1325