### PR TITLE
Add cancellation state machine to Dispatcher

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -142,7 +142,7 @@ object Dispatcher {
             def loop(): Unit = {
               val state = cancelState.get()
               state match {
-                case CancelInit() =>
+                case CancelInit =>
                   if (!cancelState.compareAndSet(state, CancelToken(cancelToken))) {
                     loop()
                   }
@@ -150,6 +150,7 @@ object Dispatcher {
                   if (!cancelState.compareAndSet(state, CancelToken(cancelToken))) {
                     loop()
                   } else {
+                    import scala.concurrent.ExecutionContext.Implicits.global
                     cancelToken().onComplete {
                       case Success(_) => promise.success(())
                       case Failure(ex) => promise.failure(ex)
@@ -197,7 +198,7 @@ object Dispatcher {
               def loop(): Future[Unit] = {
                 val state = cancelState.get()
                 state match {
-                  case CancelInit() =>
+                  case CancelInit =>
                     val promise = Promise[Unit]()
                     if (!cancelState.compareAndSet(state, CancelledNoToken(promise))) {
                       loop()

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -25,8 +25,7 @@ import scala.collection.immutable.LongMap
 import scala.concurrent.{Future, Promise}
 
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
-import scala.util.Success
-import scala.util.Failure
+import scala.util.{Failure, Success}
 
 sealed trait Dispatcher[F[_]] extends DispatcherPlatform[F] {
 

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -139,6 +139,7 @@ object Dispatcher {
           def registerCancel(token: F[Unit]): Unit = {
             val cancelToken = () => unsafeToFuture(token)
 
+            @tailrec
             def loop(): Unit = {
               val state = cancelState.get()
               state match {
@@ -195,6 +196,7 @@ object Dispatcher {
             val cancel = { () =>
               dequeue(id)
 
+              @tailrec
               def loop(): Future[Unit] = {
                 val state = cancelState.get()
                 state match {


### PR DESCRIPTION
This PR fixes two bugs:
1. The one described in #1332 where the unsafe cancel token can return before finalization completes.
2. A benign race where a fiber cancel is called twice when the cancel token was only called once

Fixes #1332 