### PR TITLE
Auto yielding

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala
@@ -103,7 +103,7 @@ class WorkStealingBenchmark {
 
       val compute = new WorkStealingThreadPool(256, "io-compute", runtime)
 
-      new IORuntime(compute, blocking, scheduler, () => ())
+      IORuntime(compute, blocking, scheduler, () => ())
     }
 
     benchmark

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -61,5 +61,9 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
       createDefaultComputeThreadPool(global)._1,
       createDefaultBlockingExecutionContext()._1,
       createDefaultScheduler()._1,
-      () => ())
+      () => (),
+      IORuntimeConfig(
+        System.getProperty("cats.effect.cancellation.check.threshold", "512").toInt,
+        System.getProperty("cats.effect.auto.yield.threshold", "2").toInt
+      ))
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -56,14 +56,19 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
     (Scheduler.fromScheduledExecutor(scheduler), { () => scheduler.shutdown() })
   }
 
-  lazy val global: IORuntime =
+  lazy val global: IORuntime = {
+    val cancellationCheckThreshold =
+      System.getProperty("cats.effect.cancellation.check.threshold", "512").toInt
     new IORuntime(
       createDefaultComputeThreadPool(global)._1,
       createDefaultBlockingExecutionContext()._1,
       createDefaultScheduler()._1,
       () => (),
       IORuntimeConfig(
-        System.getProperty("cats.effect.cancellation.check.threshold", "512").toInt,
-        System.getProperty("cats.effect.auto.yield.threshold", "2").toInt
+        cancellationCheckThreshold,
+        System
+          .getProperty("cats.effect.auto.yield.threshold.multiplier", "2")
+          .toInt * cancellationCheckThreshold
       ))
+  }
 }

--- a/core/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/core/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -181,9 +181,9 @@ abstract class IOPlatformSpecification extends Specification with ScalaCheck wit
           _ <- IO.sleep(5.millis)
           //Only hope for the cancellation being run is auto-yielding
           _ <- fiber.cancel
-        } yield ()
+        } yield true
 
-        run.evalOn(ec).map { res => res mustEqual () }
+        run.evalOn(ec).map { res => res mustEqual true }
       }
 
     }

--- a/core/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/core/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -173,7 +173,7 @@ abstract class IOPlatformSpecification extends Specification with ScalaCheck wit
 
         val ec = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
 
-        val run = (for {
+        val run = for {
           //Run in a tight loop on single-threaded ec so only hope of
           //seeing cancellation status is auto-cede
           fiber <- forever.start
@@ -181,9 +181,9 @@ abstract class IOPlatformSpecification extends Specification with ScalaCheck wit
           _ <- IO.sleep(5.millis)
           //Only hope for the cancellation being run is auto-yielding
           _ <- fiber.cancel
-        } yield true).guarantee(IO(ec.shutdown()))
+        } yield true
 
-        run.evalOn(ec).flatMap { res => IO(res must beTrue) }
+        run.evalOn(ec).guarantee(IO(ec.shutdown())).flatMap { res => IO(res must beTrue) }
       }
 
     }

--- a/core/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/core/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -168,6 +168,24 @@ abstract class IOPlatformSpecification extends Specification with ScalaCheck wit
         } yield ok
       }
 
+      "auto-cede" in real {
+        val forever = IO.unit.foreverM
+
+        val ec = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
+
+        val run = for {
+          //Run in a tight loop on single-threaded ec so only hope of
+          //seeing cancellation status is auto-cede
+          fiber <- forever.start
+          //Allow the tight loop to be scheduled
+          _ <- IO.sleep(5.millis)
+          //Only hope for the cancellation being run is auto-yielding
+          _ <- fiber.cancel
+        } yield ()
+
+        run.evalOn(ec).map { res => res mustEqual () }
+      }
+
     }
   }
 }

--- a/core/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/core/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -173,7 +173,7 @@ abstract class IOPlatformSpecification extends Specification with ScalaCheck wit
 
         val ec = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
 
-        val run = for {
+        val run = (for {
           //Run in a tight loop on single-threaded ec so only hope of
           //seeing cancellation status is auto-cede
           fiber <- forever.start
@@ -181,9 +181,9 @@ abstract class IOPlatformSpecification extends Specification with ScalaCheck wit
           _ <- IO.sleep(5.millis)
           //Only hope for the cancellation being run is auto-yielding
           _ <- fiber.cancel
-        } yield true
+        } yield true).guarantee(IO(ec.shutdown()))
 
-        run.evalOn(ec).map { res => res mustEqual true }
+        run.evalOn(ec).flatMap { res => IO(res must beTrue) }
       }
 
     }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -223,7 +223,9 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
       (oc: OutcomeIO[A]) =>
         oc.fold((), e => cb(Left(e)), ioa => cb(Right(ioa.asInstanceOf[IO.Pure[A]].value))),
       this,
-      runtime.compute
+      runtime.compute,
+      runtime.config.cancellationCheckThreshold,
+      runtime.config.autoYieldThreshold
     )
 
     if (shift)

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -224,8 +224,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
         oc.fold((), e => cb(Left(e)), ioa => cb(Right(ioa.asInstanceOf[IO.Pure[A]].value))),
       this,
       runtime.compute,
-      runtime.config.cancellationCheckThreshold,
-      runtime.config.autoYieldThreshold
+      runtime
     )
 
     if (shift)

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -219,7 +219,7 @@ private final class IOFiber[A](
     }
 
     val nextIteration = if (iteration > iterationThreshold) {
-      0
+      1
     } else {
       iteration + 1
     }
@@ -944,7 +944,7 @@ private final class IOFiber[A](
       /* suppress all subsequent cancelation on this fiber */
       masks += 1
       // println(s"$name: Running finalizers on ${Thread.currentThread().getName}")
-      runLoop(finalizers.pop(), 0)
+      runLoop(finalizers.pop(), 1)
     } else {
       if (cb != null)
         cb(RightUnit)
@@ -1105,7 +1105,7 @@ private final class IOFiber[A](
       currentCtx = startEC
       ctxs.push(startEC)
 
-      runLoop(startIO, 0)
+      runLoop(startIO, 1)
     }
   }
 
@@ -1117,7 +1117,7 @@ private final class IOFiber[A](
       case Right(a) => succeeded(a, 0)
     }
 
-    runLoop(next, 0)
+    runLoop(next, 1)
   }
 
   private[this] def blockingR(): Unit = {
@@ -1143,13 +1143,13 @@ private final class IOFiber[A](
   private[this] def afterBlockingSuccessfulR(): Unit = {
     val result = afterBlockingSuccessfulResult
     afterBlockingSuccessfulResult = null
-    runLoop(succeeded(result, 0), 0)
+    runLoop(succeeded(result, 0), 1)
   }
 
   private[this] def afterBlockingFailedR(): Unit = {
     val error = afterBlockingFailedError
     afterBlockingFailedError = null
-    runLoop(failed(error, 0), 0)
+    runLoop(failed(error, 0), 1)
   }
 
   private[this] def evalOnR(): Unit = {
@@ -1159,7 +1159,7 @@ private final class IOFiber[A](
   }
 
   private[this] def cedeR(): Unit = {
-    runLoop(succeeded((), 0), 0)
+    runLoop(succeeded((), 0), 1)
   }
 
   //////////////////////////////////////
@@ -1198,7 +1198,7 @@ private final class IOFiber[A](
   private[this] def cancelationLoopSuccessK(): IO[Any] = {
     if (!finalizers.isEmpty()) {
       conts.push(CancelationLoopK)
-      runLoop(finalizers.pop(), 0)
+      runLoop(finalizers.pop(), 1)
     } else {
       /* resume external canceller */
       val cb = objectState.pop()

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -232,7 +232,9 @@ private final class IOFiber[A](
     if (shouldFinalize()) {
       asyncCancel(null)
     } else if ((nextIteration % autoYieldThreshold) == 0) {
-      runLoop(IO.cede >> _cur0, nextIteration)
+      objectState.push((_: Any) => cur0) //
+      conts.push(FlatMapK)
+      cede()
     } else {
       // println(s"<$name> looping on $cur0")
       /*
@@ -569,8 +571,7 @@ private final class IOFiber[A](
 
         /* Cede */
         case 13 =>
-          resumeTag = CedeR
-          reschedule(currentCtx)(this)
+          cede()
 
         case 14 =>
           val cur = cur0.asInstanceOf[Start[Any]]
@@ -951,6 +952,11 @@ private final class IOFiber[A](
 
       done(OutcomeCanceled)
     }
+  }
+
+  private[this] def cede(): Unit = {
+    resumeTag = CedeR
+    reschedule(currentCtx)(this)
   }
 
   /*

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -221,6 +221,7 @@ private final class IOFiber[A](
     }
 
     if ((nextIteration % cancellationCheckThreshold) == 0) {
+      //Ensure that we see cancellation
       readBarrier()
     }
 

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -134,7 +134,7 @@ private final class IOFiber[A](
   /* similar prefetch for EndFiber */
   private[this] val IOEndFiber = IO.EndFiber
 
-  private[this] val iterationThreshold = autoYieldThreshold * cancellationCheckThreshold
+  private[this] val iterationThreshold = autoYieldThreshold
 
   override def run(): Unit = {
     // insert a read barrier after every async boundary

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -222,9 +222,9 @@ private final class IOFiber[A](
 
     if (shouldFinalize()) {
       asyncCancel(null)
-      return
-    }
-
+    } else if (nextIteration == 100) {
+      runLoop(IO.cede >> _cur0, nextIteration)
+    } else {
     // println(s"<$name> looping on $cur0")
     /*
      * The cases have to use continuous constants to generate a `tableswitch`.

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -16,7 +16,7 @@
 
 package cats.effect
 
-import cats.effect.unsafe.WorkStealingThreadPool
+import cats.effect.unsafe.{IORuntime, WorkStealingThreadPool}
 
 import cats.arrow.FunctionK
 import cats.syntax.all._
@@ -68,8 +68,7 @@ private final class IOFiber[A](
     cb: OutcomeIO[A] => Unit,
     startIO: IO[A],
     startEC: ExecutionContext,
-    cancellationCheckThreshold: Int,
-    autoYieldThreshold: Int)
+    runtime: IORuntime)
     extends IOFiberPlatform[A]
     with FiberIO[A]
     with Runnable {
@@ -134,6 +133,8 @@ private final class IOFiber[A](
   /* similar prefetch for EndFiber */
   private[this] val IOEndFiber = IO.EndFiber
 
+  private[this] val cancellationCheckThreshold = runtime.config.cancellationCheckThreshold
+  private[this] val autoYieldThreshold = runtime.config.autoYieldThreshold
   private[this] val iterationThreshold = autoYieldThreshold
 
   override def run(): Unit = {
@@ -233,636 +234,647 @@ private final class IOFiber[A](
     } else if ((nextIteration % autoYieldThreshold) == 0) {
       runLoop(IO.cede >> _cur0, nextIteration)
     } else {
-    // println(s"<$name> looping on $cur0")
-    /*
-     * The cases have to use continuous constants to generate a `tableswitch`.
-     * Do not name or reorder them.
-     */
-    (cur0.tag: @switch) match {
-      case 0 =>
-        val cur = cur0.asInstanceOf[Pure[Any]]
-        runLoop(succeeded(cur.value, 0), nextIteration)
+      // println(s"<$name> looping on $cur0")
+      /*
+       * The cases have to use continuous constants to generate a `tableswitch`.
+       * Do not name or reorder them.
+       */
+      (cur0.tag: @switch) match {
+        case 0 =>
+          val cur = cur0.asInstanceOf[Pure[Any]]
+          runLoop(succeeded(cur.value, 0), nextIteration)
 
-      case 1 =>
-        val cur = cur0.asInstanceOf[Map[Any, Any]]
+        case 1 =>
+          val cur = cur0.asInstanceOf[Map[Any, Any]]
 
-        objectState.push(cur.f)
-        conts.push(MapK)
+          objectState.push(cur.f)
+          conts.push(MapK)
 
-        runLoop(cur.ioe, nextIteration)
+          runLoop(cur.ioe, nextIteration)
 
-      case 2 =>
-        val cur = cur0.asInstanceOf[FlatMap[Any, Any]]
+        case 2 =>
+          val cur = cur0.asInstanceOf[FlatMap[Any, Any]]
 
-        objectState.push(cur.f)
-        conts.push(FlatMapK)
+          objectState.push(cur.f)
+          conts.push(FlatMapK)
 
-        runLoop(cur.ioe, nextIteration)
+          runLoop(cur.ioe, nextIteration)
 
-      case 3 =>
-        val cur = cur0.asInstanceOf[Error]
-        runLoop(failed(cur.t, 0), nextIteration)
+        case 3 =>
+          val cur = cur0.asInstanceOf[Error]
+          runLoop(failed(cur.t, 0), nextIteration)
 
-      case 4 =>
-        val cur = cur0.asInstanceOf[Attempt[Any]]
+        case 4 =>
+          val cur = cur0.asInstanceOf[Attempt[Any]]
 
-        conts.push(AttemptK)
-        runLoop(cur.ioa, nextIteration)
+          conts.push(AttemptK)
+          runLoop(cur.ioa, nextIteration)
 
-      case 5 =>
-        val cur = cur0.asInstanceOf[HandleErrorWith[Any]]
+        case 5 =>
+          val cur = cur0.asInstanceOf[HandleErrorWith[Any]]
 
-        objectState.push(cur.f)
-        conts.push(HandleErrorWithK)
+          objectState.push(cur.f)
+          conts.push(HandleErrorWithK)
 
-        runLoop(cur.ioa, nextIteration)
+          runLoop(cur.ioa, nextIteration)
 
-      case 6 =>
-        val cur = cur0.asInstanceOf[Delay[Any]]
+        case 6 =>
+          val cur = cur0.asInstanceOf[Delay[Any]]
 
-        var error: Throwable = null
-        val r =
-          try cur.thunk()
-          catch {
-            case NonFatal(t) => error = t
+          var error: Throwable = null
+          val r =
+            try cur.thunk()
+            catch {
+              case NonFatal(t) => error = t
+            }
+
+          val next =
+            if (error == null) succeeded(r, 0)
+            else failed(error, 0)
+
+          runLoop(next, nextIteration)
+
+        /* Canceled */
+        case 7 =>
+          canceled = true
+          if (isUnmasked()) {
+            /* run finalizers immediately */
+            asyncCancel(null)
+          } else {
+            runLoop(succeeded((), 0), nextIteration)
           }
 
-        val next =
-          if (error == null) succeeded(r, 0)
-          else failed(error, 0)
+        case 8 =>
+          val cur = cur0.asInstanceOf[OnCancel[Any]]
 
-        runLoop(next, nextIteration)
+          finalizers.push(EvalOn(cur.fin, currentCtx))
+          // println(s"pushed onto finalizers: length = ${finalizers.unsafeIndex()}")
 
-      /* Canceled */
-      case 7 =>
-        canceled = true
-        if (isUnmasked()) {
-          /* run finalizers immediately */
-          asyncCancel(null)
-        } else {
-          runLoop(succeeded((), 0), nextIteration)
-        }
-
-      case 8 =>
-        val cur = cur0.asInstanceOf[OnCancel[Any]]
-
-        finalizers.push(EvalOn(cur.fin, currentCtx))
-        // println(s"pushed onto finalizers: length = ${finalizers.unsafeIndex()}")
-
-        /*
-         * the OnCancelK marker is used by `succeeded` to remove the
-         * finalizer when `ioa` completes uninterrupted.
-         */
-        conts.push(OnCancelK)
-        runLoop(cur.ioa, nextIteration)
-
-      case 9 =>
-        val cur = cur0.asInstanceOf[Uncancelable[Any]]
-
-        masks += 1
-        val id = masks
-        val poll = new Poll[IO] {
-          def apply[B](ioa: IO[B]) = IO.Uncancelable.UnmaskRunLoop(ioa, id)
-        }
-
-        /*
-         * The uncancelableK marker is used by `succeeded` and `failed`
-         * to unmask once body completes.
-         */
-        conts.push(UncancelableK)
-        runLoop(cur.body(poll), nextIteration)
-
-      case 10 =>
-        val cur = cur0.asInstanceOf[Uncancelable.UnmaskRunLoop[Any]]
-
-        /*
-         * we keep track of nested uncancelable sections.
-         * The outer block wins.
-         */
-        if (masks == cur.id) {
-          masks -= 1
           /*
-           * The UnmaskK marker gets used by `succeeded` and `failed`
-           * to restore masking state after `cur.ioa` has finished
+           * the OnCancelK marker is used by `succeeded` to remove the
+           * finalizer when `ioa` completes uninterrupted.
            */
-          conts.push(UnmaskK)
-        }
+          conts.push(OnCancelK)
+          runLoop(cur.ioa, nextIteration)
 
-        runLoop(cur.ioa, nextIteration)
+        case 9 =>
+          val cur = cur0.asInstanceOf[Uncancelable[Any]]
 
-      case 11 =>
-        val cur = cur0.asInstanceOf[IOCont[Any]]
+          masks += 1
+          val id = masks
+          val poll = new Poll[IO] {
+            def apply[B](ioa: IO[B]) = IO.Uncancelable.UnmaskRunLoop(ioa, id)
+          }
 
-        /*
-         * Takes `cb` (callback) and `get` and returns an IO that
-         * uses them to embed async computations.
-         * This is a CPS'd encoding that uses higher-rank
-         * polymorphism to statically forbid concurrent operations
-         * on `get`, which are unsafe since `get` closes over the
-         * runloop.
-         *
-         */
-        val body = cur.body
-
-        /*
-         *`get` and `cb` (callback) race over the runloop.
-         * If `cb` finishes after `get`, `get` just terminates by
-         * suspending, and `cb` will resume the runloop via
-         * `asyncContinue`.
-         *
-         * If `get` wins, it gets the result from the `state`
-         * `AtomicRef` and it continues, while the callback just
-         * terminates (`stateLoop`, when `tag == 3`)
-         *
-         * The two sides communicate with each other through
-         * `state` to know who should take over, and through
-         * `suspended` (which is manipulated via suspend and
-         * resume), to negotiate ownership of the runloop.
-         *
-         * In case of interruption, neither side will continue,
-         * and they will negotiate ownership with `cancel` to decide who
-         * should run the finalisers (i.e. call `asyncCancel`).
-         *
-         */
-        val state = new AtomicReference[ContState](ContStateInitial)
-        val wasFinalizing = new AtomicBoolean(finalizing)
-
-        val cb: Either[Throwable, Any] => Unit = { e =>
           /*
-           * We *need* to own the runloop when we return, so we CAS loop
-           * on `suspended` (via `resume`) to break the race condition where
-           * `state` has been set by `get, `but `suspend()` has not yet run.
-           * If `state` is set then `suspend()` should be right behind it
-           * *unless* we have been canceled.
+           * The uncancelableK marker is used by `succeeded` and `failed`
+           * to unmask once body completes.
+           */
+          conts.push(UncancelableK)
+          runLoop(cur.body(poll), nextIteration)
+
+        case 10 =>
+          val cur = cur0.asInstanceOf[Uncancelable.UnmaskRunLoop[Any]]
+
+          /*
+           * we keep track of nested uncancelable sections.
+           * The outer block wins.
+           */
+          if (masks == cur.id) {
+            masks -= 1
+            /*
+             * The UnmaskK marker gets used by `succeeded` and `failed`
+             * to restore masking state after `cur.ioa` has finished
+             */
+            conts.push(UnmaskK)
+          }
+
+          runLoop(cur.ioa, nextIteration)
+
+        case 11 =>
+          val cur = cur0.asInstanceOf[IOCont[Any]]
+
+          /*
+           * Takes `cb` (callback) and `get` and returns an IO that
+           * uses them to embed async computations.
+           * This is a CPS'd encoding that uses higher-rank
+           * polymorphism to statically forbid concurrent operations
+           * on `get`, which are unsafe since `get` closes over the
+           * runloop.
            *
-           * If we were canceled, `cb`, `cancel` and `get` are in a 3-way race
-           * to run the finalizers.
            */
-          @tailrec
-          def loop(): Unit = {
-            // println(s"cb loop sees suspended ${suspended.get} on fiber $name")
-            /* try to take ownership of the runloop */
-            if (resume()) {
-              if (finalizing == wasFinalizing.get()) {
-                if (!shouldFinalize()) {
-                  /* we weren't cancelled, so resume the runloop */
-                  asyncContinue(e)
+          val body = cur.body
+
+          /*
+           *`get` and `cb` (callback) race over the runloop.
+           * If `cb` finishes after `get`, `get` just terminates by
+           * suspending, and `cb` will resume the runloop via
+           * `asyncContinue`.
+           *
+           * If `get` wins, it gets the result from the `state`
+           * `AtomicRef` and it continues, while the callback just
+           * terminates (`stateLoop`, when `tag == 3`)
+           *
+           * The two sides communicate with each other through
+           * `state` to know who should take over, and through
+           * `suspended` (which is manipulated via suspend and
+           * resume), to negotiate ownership of the runloop.
+           *
+           * In case of interruption, neither side will continue,
+           * and they will negotiate ownership with `cancel` to decide who
+           * should run the finalisers (i.e. call `asyncCancel`).
+           *
+           */
+          val state = new AtomicReference[ContState](ContStateInitial)
+          val wasFinalizing = new AtomicBoolean(finalizing)
+
+          val cb: Either[Throwable, Any] => Unit = { e =>
+            /*
+             * We *need* to own the runloop when we return, so we CAS loop
+             * on `suspended` (via `resume`) to break the race condition where
+             * `state` has been set by `get, `but `suspend()` has not yet run.
+             * If `state` is set then `suspend()` should be right behind it
+             * *unless* we have been canceled.
+             *
+             * If we were canceled, `cb`, `cancel` and `get` are in a 3-way race
+             * to run the finalizers.
+             */
+            @tailrec
+            def loop(): Unit = {
+              // println(s"cb loop sees suspended ${suspended.get} on fiber $name")
+              /* try to take ownership of the runloop */
+              if (resume()) {
+                if (finalizing == wasFinalizing.get()) {
+                  if (!shouldFinalize()) {
+                    /* we weren't cancelled, so resume the runloop */
+                    asyncContinue(e)
+                  } else {
+                    /*
+                     * we were canceled, but since we have won the race on `suspended`
+                     * via `resume`, `cancel` cannot run the finalisers, and we have to.
+                     */
+                    asyncCancel(null)
+                  }
                 } else {
                   /*
-                   * we were canceled, but since we have won the race on `suspended`
-                   * via `resume`, `cancel` cannot run the finalisers, and we have to.
+                   * we were canceled while suspended, then our finalizer suspended,
+                   * then we hit this line, so we shouldn't own the runloop at all
                    */
-                  asyncCancel(null)
+                  suspend()
                 }
-              } else {
+              } else if (!shouldFinalize()) {
                 /*
-                 * we were canceled while suspended, then our finalizer suspended,
-                 * then we hit this line, so we shouldn't own the runloop at all
+                 * If we aren't canceled, loop on `suspended` to wait
+                 * until `get` has released ownership of the runloop.
                  */
-                suspend()
-              }
-            } else if (!shouldFinalize()) {
-              /*
-               * If we aren't canceled, loop on `suspended` to wait
-               * until `get` has released ownership of the runloop.
+                loop()
+              } /*
+               * If we are canceled, just die off and let `cancel` or `get` win
+               * the race to `resume` and run the finalisers.
                */
-              loop()
-            } /*
-             * If we are canceled, just die off and let `cancel` or `get` win
-             * the race to `resume` and run the finalisers.
+            }
+
+            val resultState = ContStateResult(e)
+
+            /*
+             * CAS loop to update the Cont state machine:
+             * 0 - Initial
+             * 1 - (Get) Waiting
+             * 2 - (Cb) Result
+             *
+             * If state is Initial or Waiting, update the state,
+             * and then if `get` has been flatMapped somewhere already
+             * and is waiting for a result (i.e. it has suspended),
+             * acquire runloop to continue.
+             *
+             * If not, `cb` arrived first, so it just sets the result and die off.
+             *
+             * If `state` is `Result`, the callback has been already invoked, so no-op.
+             * (guards from double calls)
              */
-          }
-
-          val resultState = ContStateResult(e)
-
-          /*
-           * CAS loop to update the Cont state machine:
-           * 0 - Initial
-           * 1 - (Get) Waiting
-           * 2 - (Cb) Result
-           *
-           * If state is Initial or Waiting, update the state,
-           * and then if `get` has been flatMapped somewhere already
-           * and is waiting for a result (i.e. it has suspended),
-           * acquire runloop to continue.
-           *
-           * If not, `cb` arrived first, so it just sets the result and die off.
-           *
-           * If `state` is `Result`, the callback has been already invoked, so no-op.
-           * (guards from double calls)
-           */
-          @tailrec
-          def stateLoop(): Unit = {
-            val old = state.get
-            val tag = old.tag
-            if (tag <= 1) {
-              if (!state.compareAndSet(old, resultState)) stateLoop()
-              else {
-                if (tag == 1) {
-                  /*
-                   * `get` has been sequenced and is waiting
-                   * reacquire runloop to continue
-                   */
-                  loop()
+            @tailrec
+            def stateLoop(): Unit = {
+              val old = state.get
+              val tag = old.tag
+              if (tag <= 1) {
+                if (!state.compareAndSet(old, resultState)) stateLoop()
+                else {
+                  if (tag == 1) {
+                    /*
+                     * `get` has been sequenced and is waiting
+                     * reacquire runloop to continue
+                     */
+                    loop()
+                  }
                 }
               }
             }
+
+            stateLoop()
           }
 
-          stateLoop()
-        }
+          val get: IO[Any] = IOCont
+            .Get(state, wasFinalizing)
+            .onCancel(
+              /*
+               * If get gets canceled but the result hasn't been computed yet,
+               * restore the state to Initial to ensure a subsequent `Get` in
+               * a finalizer still works with the same logic.
+               */
+              IO(state.compareAndSet(ContStateWaiting, ContStateInitial)).void
+            )
 
-        val get: IO[Any] = IOCont
-          .Get(state, wasFinalizing)
-          .onCancel(
+          val next = body[IO].apply(cb, get, FunctionK.id)
+
+          runLoop(next, nextIteration)
+
+        case 12 =>
+          val cur = cur0.asInstanceOf[IOCont.Get[Any]]
+
+          val state = cur.state
+          val wasFinalizing = cur.wasFinalizing
+
+          if (state.compareAndSet(ContStateInitial, ContStateWaiting)) {
             /*
-             * If get gets canceled but the result hasn't been computed yet,
-             * restore the state to Initial to ensure a subsequent `Get` in
-             * a finalizer still works with the same logic.
+             * `state` was Initial, so `get` has arrived before the callback,
+             * it needs to set the state to `Waiting` and suspend: `cb` will
+             * resume with the result once that's ready
              */
-            IO(state.compareAndSet(ContStateWaiting, ContStateInitial)).void
-          )
 
-        val next = body[IO].apply(cb, get, FunctionK.id)
-
-        runLoop(next, nextIteration)
-
-      case 12 =>
-        val cur = cur0.asInstanceOf[IOCont.Get[Any]]
-
-        val state = cur.state
-        val wasFinalizing = cur.wasFinalizing
-
-        if (state.compareAndSet(ContStateInitial, ContStateWaiting)) {
-          /*
-           * `state` was Initial, so `get` has arrived before the callback,
-           * it needs to set the state to `Waiting` and suspend: `cb` will
-           * resume with the result once that's ready
-           */
-
-          /*
-           * we set the finalizing check to the *suspension* point, which may
-           * be in a different finalizer scope than the cont itself
-           */
-          wasFinalizing.set(finalizing)
-
-          /*
-           * This CAS should always succeed since we own the runloop,
-           * but we need it in order to introduce a full memory barrier
-           * which ensures we will always see the most up-to-date value
-           * for `canceled` in `shouldFinalize`, ensuring no finalisation leaks
-           */
-          suspended.compareAndSet(false, true)
-
-          /*
-           * race condition check: we may have been cancelled
-           * after setting the state but before we suspended
-           */
-          if (shouldFinalize()) {
             /*
-             * if we can re-acquire the run-loop, we can finalize,
-             * otherwise somebody else acquired it and will eventually finalize.
+             * we set the finalizing check to the *suspension* point, which may
+             * be in a different finalizer scope than the cont itself
+             */
+            wasFinalizing.set(finalizing)
+
+            /*
+             * This CAS should always succeed since we own the runloop,
+             * but we need it in order to introduce a full memory barrier
+             * which ensures we will always see the most up-to-date value
+             * for `canceled` in `shouldFinalize`, ensuring no finalisation leaks
+             */
+            suspended.compareAndSet(false, true)
+
+            /*
+             * race condition check: we may have been cancelled
+             * after setting the state but before we suspended
+             */
+            if (shouldFinalize()) {
+              /*
+               * if we can re-acquire the run-loop, we can finalize,
+               * otherwise somebody else acquired it and will eventually finalize.
+               *
+               * In this path, `get`, the `cb` callback and `cancel`
+               * all race via `resume` to decide who should run the
+               * finalisers.
+               */
+              if (resume()) {
+                asyncCancel(null)
+              }
+            }
+          } else {
+            /*
+             * state was no longer Initial, so the callback has already been invoked
+             * and the state is Result.
+             * We leave the Result state unmodified so that `get` is idempotent.
              *
-             * In this path, `get`, the `cb` callback and `cancel`
-             * all race via `resume` to decide who should run the
-             * finalisers.
+             * Note that it's impossible for `state` to be `Waiting` here:
+             * - `cont` doesn't allow concurrent calls to `get`, so there can't be
+             *    another `get` in `Waiting` when we execute this.
+             *
+             * - If a previous `get` happened before this code, and we are in a `flatMap`
+             *   or `handleErrorWith`, it means the callback has completed once
+             *   (unblocking the first `get` and letting us execute), and the state is still
+             *   `Result`
+             *
+             * - If a previous `get` has been canceled and we are being called within an
+             *  `onCancel` of that `get`, the finalizer installed on the `Get` node by `Cont`
+             *   has restored the state to `Initial` before the execution of this method,
+             *   which would have been caught by the previous branch unless the `cb` has
+             *   completed and the state is `Result`
              */
-            if (resume()) {
+            val result = state.get().result
+
+            if (!shouldFinalize()) {
+              /* we weren't cancelled, so resume the runloop */
+              asyncContinue(result)
+            } else {
+              /*
+               * we were canceled, but `cancel` cannot run the finalisers
+               * because the runloop was not suspended, so we have to run them
+               */
               asyncCancel(null)
             }
           }
-        } else {
-          /*
-           * state was no longer Initial, so the callback has already been invoked
-           * and the state is Result.
-           * We leave the Result state unmodified so that `get` is idempotent.
-           *
-           * Note that it's impossible for `state` to be `Waiting` here:
-           * - `cont` doesn't allow concurrent calls to `get`, so there can't be
-           *    another `get` in `Waiting` when we execute this.
-           *
-           * - If a previous `get` happened before this code, and we are in a `flatMap`
-           *   or `handleErrorWith`, it means the callback has completed once
-           *   (unblocking the first `get` and letting us execute), and the state is still
-           *   `Result`
-           *
-           * - If a previous `get` has been canceled and we are being called within an
-           *  `onCancel` of that `get`, the finalizer installed on the `Get` node by `Cont`
-           *   has restored the state to `Initial` before the execution of this method,
-           *   which would have been caught by the previous branch unless the `cb` has
-           *   completed and the state is `Result`
-           */
-          val result = state.get().result
 
-          if (!shouldFinalize()) {
-            /* we weren't cancelled, so resume the runloop */
-            asyncContinue(result)
-          } else {
-            /*
-             * we were canceled, but `cancel` cannot run the finalisers
-             * because the runloop was not suspended, so we have to run them
-             */
-            asyncCancel(null)
+        /* Cede */
+        case 13 =>
+          resumeTag = CedeR
+          reschedule(currentCtx)(this)
+
+        case 14 =>
+          val cur = cur0.asInstanceOf[Start[Any]]
+
+          val childName = s"start-${childCount.getAndIncrement()}"
+          val initMask2 = childMask
+
+          val ec = currentCtx
+          val fiber =
+            new IOFiber[Any](
+              childName,
+              scheduler,
+              blockingEc,
+              initMask2,
+              null,
+              cur.ioa,
+              ec,
+              runtime)
+
+          // println(s"<$name> spawning <$childName>")
+
+          reschedule(ec)(fiber)
+
+          runLoop(succeeded(fiber, 0), nextIteration)
+
+        case 15 =>
+          // TODO self-cancelation within a nested poll could result in deadlocks in `both`
+          // example: uncancelable(p => F.both(fa >> p(canceled) >> fc, fd)).
+          // when we check cancelation in the parent fiber, we are using the masking at the point of racePair, rather than just trusting the masking at the point of the poll
+          val cur = cur0.asInstanceOf[RacePair[Any, Any]]
+
+          val next =
+            IO.async[Either[(OutcomeIO[Any], FiberIO[Any]), (FiberIO[Any], OutcomeIO[Any])]] {
+              cb =>
+                IO {
+                  val initMask2 = childMask
+                  val ec = currentCtx
+                  val fiberA = new IOFiber[Any](
+                    s"racePair-left-${childCount.getAndIncrement()}",
+                    scheduler,
+                    blockingEc,
+                    initMask2,
+                    null,
+                    cur.ioa,
+                    ec,
+                    runtime)
+                  val fiberB = new IOFiber[Any](
+                    s"racePair-right-${childCount.getAndIncrement()}",
+                    scheduler,
+                    blockingEc,
+                    initMask2,
+                    null,
+                    cur.iob,
+                    ec,
+                    runtime)
+
+                  fiberA.registerListener(oc => cb(Right(Left((oc, fiberB)))))
+                  fiberB.registerListener(oc => cb(Right(Right((fiberA, oc)))))
+
+                  reschedule(ec)(fiberA)
+                  reschedule(ec)(fiberB)
+
+                  Some(fiberA.cancel.both(fiberB.cancel).void)
+                }
+            }
+
+          runLoop(next, nextIteration)
+
+        case 16 =>
+          val cur = cur0.asInstanceOf[Sleep]
+
+          val next = IO.async[Unit] { cb =>
+            IO {
+              val cancel = scheduler.sleep(cur.delay, () => cb(RightUnit))
+              Some(IO(cancel.run()))
+            }
           }
-        }
 
-      /* Cede */
-      case 13 =>
-        resumeTag = CedeR
-        reschedule(currentCtx)(this)
+          runLoop(next, nextIteration)
 
-      case 14 =>
-        val cur = cur0.asInstanceOf[Start[Any]]
+        /* RealTime */
+        case 17 =>
+          runLoop(succeeded(scheduler.nowMillis().millis, 0), nextIteration)
 
-        val childName = s"start-${childCount.getAndIncrement()}"
-        val initMask2 = childMask
+        /* Monotonic */
+        case 18 =>
+          runLoop(succeeded(scheduler.monotonicNanos().nanos, 0), nextIteration)
 
-        val ec = currentCtx
-        val fiber =
-          new IOFiber[Any](childName, scheduler, blockingEc, initMask2, null, cur.ioa, ec)
+        /* ReadEC */
+        case 19 =>
+          runLoop(succeeded(currentCtx, 0), nextIteration)
 
-        // println(s"<$name> spawning <$childName>")
+        case 20 =>
+          val cur = cur0.asInstanceOf[EvalOn[Any]]
 
-        reschedule(ec)(fiber)
+          /* fast-path when it's an identity transformation */
+          if (cur.ec eq currentCtx) {
+            runLoop(cur.ioa, nextIteration)
+          } else {
+            val ec = cur.ec
+            currentCtx = ec
+            ctxs.push(ec)
+            conts.push(EvalOnK)
 
-        runLoop(succeeded(fiber, 0), nextIteration)
+            resumeTag = EvalOnR
+            evalOnIOA = cur.ioa
+            execute(ec)(this)
+          }
 
-      case 15 =>
-        // TODO self-cancelation within a nested poll could result in deadlocks in `both`
-        // example: uncancelable(p => F.both(fa >> p(canceled) >> fc, fd)).
-        // when we check cancelation in the parent fiber, we are using the masking at the point of racePair, rather than just trusting the masking at the point of the poll
-        val cur = cur0.asInstanceOf[RacePair[Any, Any]]
+        case 21 =>
+          val cur = cur0.asInstanceOf[Blocking[Any]]
+          /* we know we're on the JVM here */
 
-        val next =
-          IO.async[Either[(OutcomeIO[Any], FiberIO[Any]), (FiberIO[Any], OutcomeIO[Any])]] {
-            cb =>
+          if (cur.hint eq TypeBlocking) {
+            resumeTag = BlockingR
+            blockingCur = cur
+            blockingEc.execute(this)
+          } else {
+            runLoop(interruptibleImpl(cur, blockingEc), nextIteration)
+          }
+
+        case 22 =>
+          val cur = cur0.asInstanceOf[Race[Any, Any]]
+
+          val state: AtomicReference[Option[Any]] = new AtomicReference[Option[Any]](None)
+          val finalizer: AtomicReference[IO[Unit]] = new AtomicReference[IO[Unit]](IO.unit)
+
+          val next =
+            IO.async[Either[Any, Any]] { cb =>
               IO {
                 val initMask2 = childMask
                 val ec = currentCtx
                 val fiberA = new IOFiber[Any](
-                  s"racePair-left-${childCount.getAndIncrement()}",
+                  s"race-left-${childCount.getAndIncrement()}",
                   scheduler,
                   blockingEc,
                   initMask2,
                   null,
                   cur.ioa,
                   ec,
-                  cancellationCheckThreshold,
-                  autoYieldThreshold)
+                  runtime)
                 val fiberB = new IOFiber[Any](
-                  s"racePair-right-${childCount.getAndIncrement()}",
+                  s"race-right-${childCount.getAndIncrement()}",
                   scheduler,
                   blockingEc,
                   initMask2,
                   null,
                   cur.iob,
                   ec,
-                  cancellationCheckThreshold,
-                  autoYieldThreshold)
+                  runtime)
 
-                fiberA.registerListener(oc => cb(Right(Left((oc, fiberB)))))
-                fiberB.registerListener(oc => cb(Right(Right((fiberA, oc)))))
+                fiberA registerListener { oc =>
+                  val s = state.getAndSet(Some(oc))
+                  oc match {
+                    case Outcome.Succeeded(Pure(a)) =>
+                      finalizer.set(fiberB.cancel)
+                      cb(Right(Left(a)))
 
-                reschedule(ec)(fiberA)
-                reschedule(ec)(fiberB)
+                    case Outcome.Succeeded(_) =>
+                      throw new AssertionError
+
+                    case Outcome.Canceled() =>
+                      s.fold(()) {
+                        //Other fiber already completed
+                        case Outcome.Succeeded(_) => //cb should have been invoked in other fiber
+                        case Outcome.Canceled() => cb(Left(AsyncPropagateCancelation))
+                        case Outcome.Errored(_) => //cb should have been invoked in other fiber
+                      }
+
+                    case Outcome.Errored(e) =>
+                      finalizer.set(fiberB.cancel)
+                      cb(Left(e))
+                  }
+                }
+
+                fiberB registerListener { oc =>
+                  val s = state.getAndSet(Some(oc))
+                  oc match {
+                    case Outcome.Succeeded(Pure(b)) =>
+                      finalizer.set(fiberA.cancel)
+                      cb(Right(Right(b)))
+
+                    case Outcome.Succeeded(_) =>
+                      throw new AssertionError
+
+                    case Outcome.Canceled() =>
+                      s.fold(()) {
+                        //Other fiber already completed
+                        case Outcome.Succeeded(_) => //cb should have been invoked in other fiber
+                        case Outcome.Canceled() => cb(Left(AsyncPropagateCancelation))
+                        case Outcome.Errored(_) => //cb should have been invoked in other fiber
+                      }
+
+                    case Outcome.Errored(e) =>
+                      finalizer.set(fiberA.cancel)
+                      cb(Left(e))
+                  }
+                }
+
+                execute(ec)(fiberA)
+                execute(ec)(fiberB)
 
                 Some(fiberA.cancel.both(fiberB.cancel).void)
               }
-          }
+            }.handleErrorWith {
+              case AsyncPropagateCancelation => IO.canceled
+              case e => IO.raiseError(e)
+            }.guarantee(IO.defer(finalizer.get()))
 
-        runLoop(next, nextIteration)
+          runLoop(next, nextIteration)
 
-      case 16 =>
-        val cur = cur0.asInstanceOf[Sleep]
+        case 23 =>
+          val cur = cur0.asInstanceOf[Both[Any, Any]]
 
-        val next = IO.async[Unit] { cb =>
-          IO {
-            val cancel = scheduler.sleep(cur.delay, () => cb(RightUnit))
-            Some(IO(cancel.run()))
-          }
-        }
+          val state: AtomicReference[Option[Any]] = new AtomicReference[Option[Any]](None)
+          val finalizer: AtomicReference[IO[Unit]] = new AtomicReference[IO[Unit]](IO.unit)
 
-        runLoop(next, nextIteration)
+          val next =
+            IO.async[(Any, Any)] { cb =>
+              IO {
+                val initMask2 = childMask
+                val ec = currentCtx
+                val fiberA = new IOFiber[Any](
+                  s"both-left-${childCount.getAndIncrement()}",
+                  scheduler,
+                  blockingEc,
+                  initMask2,
+                  null,
+                  cur.ioa,
+                  ec,
+                  runtime)
+                val fiberB = new IOFiber[Any](
+                  s"both-right-${childCount.getAndIncrement()}",
+                  scheduler,
+                  blockingEc,
+                  initMask2,
+                  null,
+                  cur.iob,
+                  ec,
+                  runtime)
 
-      /* RealTime */
-      case 17 =>
-        runLoop(succeeded(scheduler.nowMillis().millis, 0), nextIteration)
+                fiberA registerListener { oc =>
+                  val s = state.getAndSet(Some(oc))
+                  oc match {
+                    case Outcome.Succeeded(Pure(a)) =>
+                      s.fold(()) {
+                        //Other fiber already completed
+                        case Outcome.Succeeded(Pure(b)) =>
+                          cb(Right(a -> b))
+                        case Outcome.Errored(e) => cb(Left(e.asInstanceOf[Throwable]))
+                        //Both fibers have completed so no need for cancellation
+                        case Outcome.Canceled() => cb(Left(AsyncPropagateCancelation))
+                      }
 
-      /* Monotonic */
-      case 18 =>
-        runLoop(succeeded(scheduler.monotonicNanos().nanos, 0), nextIteration)
+                    case Outcome.Succeeded(_) =>
+                      throw new AssertionError
 
-      /* ReadEC */
-      case 19 =>
-        runLoop(succeeded(currentCtx, 0), nextIteration)
+                    case Outcome.Errored(e) =>
+                      finalizer.set(fiberB.cancel)
+                      cb(Left(e))
 
-      case 20 =>
-        val cur = cur0.asInstanceOf[EvalOn[Any]]
-
-        /* fast-path when it's an identity transformation */
-        if (cur.ec eq currentCtx) {
-          runLoop(cur.ioa, nextIteration)
-        } else {
-          val ec = cur.ec
-          currentCtx = ec
-          ctxs.push(ec)
-          conts.push(EvalOnK)
-
-          resumeTag = EvalOnR
-          evalOnIOA = cur.ioa
-          execute(ec)(this)
-        }
-
-      case 21 =>
-        val cur = cur0.asInstanceOf[Blocking[Any]]
-        /* we know we're on the JVM here */
-
-        if (cur.hint eq TypeBlocking) {
-          resumeTag = BlockingR
-          blockingCur = cur
-          blockingEc.execute(this)
-        } else {
-          runLoop(interruptibleImpl(cur, blockingEc), nextIteration)
-        }
-
-      case 22 =>
-        val cur = cur0.asInstanceOf[Race[Any, Any]]
-
-        val state: AtomicReference[Option[Any]] = new AtomicReference[Option[Any]](None)
-        val finalizer: AtomicReference[IO[Unit]] = new AtomicReference[IO[Unit]](IO.unit)
-
-        val next =
-          IO.async[Either[Any, Any]] { cb =>
-            IO {
-              val initMask2 = childMask
-              val ec = currentCtx
-              val fiberA = new IOFiber[Any](
-                s"race-left-${childCount.getAndIncrement()}",
-                scheduler,
-                blockingEc,
-                initMask2,
-                null,
-                cur.ioa,
-                ec)
-              val fiberB = new IOFiber[Any](
-                s"race-right-${childCount.getAndIncrement()}",
-                scheduler,
-                blockingEc,
-                initMask2,
-                null,
-                cur.iob,
-                ec)
-
-              fiberA registerListener { oc =>
-                val s = state.getAndSet(Some(oc))
-                oc match {
-                  case Outcome.Succeeded(Pure(a)) =>
-                    finalizer.set(fiberB.cancel)
-                    cb(Right(Left(a)))
-
-                  case Outcome.Succeeded(_) =>
-                    throw new AssertionError
-
-                  case Outcome.Canceled() =>
-                    s.fold(()) {
-                      //Other fiber already completed
-                      case Outcome.Succeeded(_) => //cb should have been invoked in other fiber
-                      case Outcome.Canceled() => cb(Left(AsyncPropagateCancelation))
-                      case Outcome.Errored(_) => //cb should have been invoked in other fiber
-                    }
-
-                  case Outcome.Errored(e) =>
-                    finalizer.set(fiberB.cancel)
-                    cb(Left(e))
+                    case Outcome.Canceled() =>
+                      finalizer.set(fiberB.cancel)
+                      cb(Left(AsyncPropagateCancelation))
+                  }
                 }
-              }
 
-              fiberB registerListener { oc =>
-                val s = state.getAndSet(Some(oc))
-                oc match {
-                  case Outcome.Succeeded(Pure(b)) =>
-                    finalizer.set(fiberA.cancel)
-                    cb(Right(Right(b)))
+                fiberB registerListener { oc =>
+                  val s = state.getAndSet(Some(oc))
+                  oc match {
+                    case Outcome.Succeeded(Pure(b)) =>
+                      s.fold(()) {
+                        //Other fiber already completed
+                        case Outcome.Succeeded(Pure(a)) =>
+                          cb(Right(a -> b))
+                        case Outcome.Errored(e) => cb(Left(e.asInstanceOf[Throwable]))
+                        case Outcome.Canceled() => cb(Left(AsyncPropagateCancelation))
+                      }
 
-                  case Outcome.Succeeded(_) =>
-                    throw new AssertionError
+                    case Outcome.Succeeded(_) =>
+                      throw new AssertionError
 
-                  case Outcome.Canceled() =>
-                    s.fold(()) {
-                      //Other fiber already completed
-                      case Outcome.Succeeded(_) => //cb should have been invoked in other fiber
-                      case Outcome.Canceled() => cb(Left(AsyncPropagateCancelation))
-                      case Outcome.Errored(_) => //cb should have been invoked in other fiber
-                    }
+                    case Outcome.Errored(e) =>
+                      finalizer.set(fiberA.cancel)
+                      cb(Left(e))
 
-                  case Outcome.Errored(e) =>
-                    finalizer.set(fiberA.cancel)
-                    cb(Left(e))
+                    case Outcome.Canceled() =>
+                      finalizer.set(fiberA.cancel)
+                      cb(Left(AsyncPropagateCancelation))
+                  }
                 }
+
+                execute(ec)(fiberA)
+                execute(ec)(fiberB)
+
+                Some(fiberA.cancel.both(fiberB.cancel).void)
               }
+            }.handleErrorWith {
+              case AsyncPropagateCancelation => IO.canceled
+              case e => IO.raiseError(e)
+            }.guarantee(IO.defer(finalizer.get()))
 
-              execute(ec)(fiberA)
-              execute(ec)(fiberB)
-
-              Some(fiberA.cancel.both(fiberB.cancel).void)
-            }
-          }.handleErrorWith {
-            case AsyncPropagateCancelation => IO.canceled
-            case e => IO.raiseError(e)
-          }.guarantee(IO.defer(finalizer.get()))
-
-        runLoop(next, nextIteration)
-
-      case 23 =>
-        val cur = cur0.asInstanceOf[Both[Any, Any]]
-
-        val state: AtomicReference[Option[Any]] = new AtomicReference[Option[Any]](None)
-        val finalizer: AtomicReference[IO[Unit]] = new AtomicReference[IO[Unit]](IO.unit)
-
-        val next =
-          IO.async[(Any, Any)] { cb =>
-            IO {
-              val initMask2 = childMask
-              val ec = currentCtx
-              val fiberA = new IOFiber[Any](
-                s"both-left-${childCount.getAndIncrement()}",
-                scheduler,
-                blockingEc,
-                initMask2,
-                null,
-                cur.ioa,
-                ec)
-              val fiberB = new IOFiber[Any](
-                s"both-right-${childCount.getAndIncrement()}",
-                scheduler,
-                blockingEc,
-                initMask2,
-                null,
-                cur.iob,
-                ec)
-
-              fiberA registerListener { oc =>
-                val s = state.getAndSet(Some(oc))
-                oc match {
-                  case Outcome.Succeeded(Pure(a)) =>
-                    s.fold(()) {
-                      //Other fiber already completed
-                      case Outcome.Succeeded(Pure(b)) =>
-                        cb(Right(a -> b))
-                      case Outcome.Errored(e) => cb(Left(e.asInstanceOf[Throwable]))
-                      //Both fibers have completed so no need for cancellation
-                      case Outcome.Canceled() => cb(Left(AsyncPropagateCancelation))
-                    }
-
-                  case Outcome.Succeeded(_) =>
-                    throw new AssertionError
-
-                  case Outcome.Errored(e) =>
-                    finalizer.set(fiberB.cancel)
-                    cb(Left(e))
-
-                  case Outcome.Canceled() =>
-                    finalizer.set(fiberB.cancel)
-                    cb(Left(AsyncPropagateCancelation))
-                }
-              }
-
-              fiberB registerListener { oc =>
-                val s = state.getAndSet(Some(oc))
-                oc match {
-                  case Outcome.Succeeded(Pure(b)) =>
-                    s.fold(()) {
-                      //Other fiber already completed
-                      case Outcome.Succeeded(Pure(a)) =>
-                        cb(Right(a -> b))
-                      case Outcome.Errored(e) => cb(Left(e.asInstanceOf[Throwable]))
-                      case Outcome.Canceled() => cb(Left(AsyncPropagateCancelation))
-                    }
-
-                  case Outcome.Succeeded(_) =>
-                    throw new AssertionError
-
-                  case Outcome.Errored(e) =>
-                    finalizer.set(fiberA.cancel)
-                    cb(Left(e))
-
-                  case Outcome.Canceled() =>
-                    finalizer.set(fiberA.cancel)
-                    cb(Left(AsyncPropagateCancelation))
-                }
-              }
-
-              execute(ec)(fiberA)
-              execute(ec)(fiberB)
-
-              Some(fiberA.cancel.both(fiberB.cancel).void)
-            }
-          }.handleErrorWith {
-            case AsyncPropagateCancelation => IO.canceled
-            case e => IO.raiseError(e)
-          }.guarantee(IO.defer(finalizer.get()))
-
-        runLoop(next, nextIteration)
+          runLoop(next, nextIteration)
+      }
     }
   }
 

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -45,18 +45,14 @@ final class IORuntime private[effect] (
 
 final case class IORuntimeConfig private (
     val cancellationCheckThreshold: Int,
-    val autoYieldThreshold: Int
-)
+    val autoYieldThreshold: Int)
 
 object IORuntimeConfig {
   def apply(): IORuntimeConfig = new IORuntimeConfig(512, 1024)
 
   def apply(cancellationCheckThreshold: Int, autoYieldThreshold: Int): IORuntimeConfig = {
     if (autoYieldThreshold % cancellationCheckThreshold == 0)
-      new IORuntimeConfig(
-        cancellationCheckThreshold,
-        autoYieldThreshold
-      )
+      new IORuntimeConfig(cancellationCheckThreshold, autoYieldThreshold)
     else
       throw new AssertionError(
         s"Auto yield threshold $autoYieldThreshold must be a multiple of cancellation check threshold $cancellationCheckThreshold")

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -37,10 +37,17 @@ final class IORuntime private[effect] (
     val compute: ExecutionContext,
     val blocking: ExecutionContext,
     val scheduler: Scheduler,
-    val shutdown: () => Unit) {
+    val shutdown: () => Unit,
+    val config: IORuntimeConfig) {
 
   override def toString: String = s"IORuntime($compute, $scheduler)"
 }
+
+final case class IORuntimeConfig (
+  val cancellationCheckThreshold: Int = 512,
+  //Insert IO.cede every autoYieldThreshold * cancellationCheckThreshold
+  val autoYieldThreshold: Int = 2
+)
 
 object IORuntime extends IORuntimeCompanionPlatform {
   def apply(
@@ -48,5 +55,13 @@ object IORuntime extends IORuntimeCompanionPlatform {
       blocking: ExecutionContext,
       scheduler: Scheduler,
       shutdown: () => Unit): IORuntime =
-    new IORuntime(compute, blocking, scheduler, shutdown)
+    new IORuntime(compute, blocking, scheduler, shutdown, new IORuntimeConfig())
+
+  def apply(
+      compute: ExecutionContext,
+      blocking: ExecutionContext,
+      scheduler: Scheduler,
+      shutdown: () => Unit,
+      config: IORuntimeConfig): IORuntime =
+    new IORuntime(compute, blocking, scheduler, shutdown, config)
 }

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -974,8 +974,10 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
           //Run in a tight loop on single-threaded ec so only hope of
           //seeing cancellation status is auto-cede
           fiber <- forever.start
+          //Allow the tight loop to be scheduled
           _ <- IO.sleep(5.millis)
-          _     <- fiber.cancel
+          //Only hope for the cancellation being run is auto-yielding
+          _ <- fiber.cancel
         } yield ()
 
         run.evalOn(ec).map { res => res mustEqual () }

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -16,8 +16,6 @@
 
 package cats.effect
 
-import java.util.concurrent.Executors
-
 import cats.effect.kernel.Ref
 import cats.kernel.laws.discipline.MonoidTests
 import cats.laws.discipline.SemigroupKTests
@@ -963,24 +961,6 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
             res mustEqual List(1, 2)
           }
         }
-      }
-
-      "auto-cede" in real {
-        val forever = IO.unit.foreverM
-
-        val ec = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
-
-        val run = for {
-          //Run in a tight loop on single-threaded ec so only hope of
-          //seeing cancellation status is auto-cede
-          fiber <- forever.start
-          //Allow the tight loop to be scheduled
-          _ <- IO.sleep(5.millis)
-          //Only hope for the cancellation being run is auto-yielding
-          _ <- fiber.cancel
-        } yield ()
-
-        run.evalOn(ec).map { res => res mustEqual () }
       }
 
     }

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -973,11 +973,12 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
         val run = for {
           //Run in a tight loop on single-threaded ec so only hope of
           //seeing cancellation status is auto-cede
-          fiber <- forever.evalOn(ec).start
-          _ <- fiber.joinAndEmbedNever.timeout(5.seconds)
+          fiber <- forever.start
+          _ <- IO.sleep(5.millis)
+          _     <- fiber.cancel
         } yield ()
 
-        run.map { res => res mustEqual true }
+        run.evalOn(ec).map { res => res mustEqual () }
       }
 
     }


### PR DESCRIPTION
Auto-yield by inserting in `IO.cede` every specified numbere of iterations. The default is to check for cancellation every 512 iterations of the runloop and to auto-yield every 1024 but this is configurable in the `IORuntime`.

The behaviour of `global` is to check for the system properties `cats.effect.cancellation.check.threshold` and `cats.effect.auto.yield.threshold.multiplier` but to default to 512 and 2 respectively. The auto-yield threshold is the product of these.