### PR TITLE
Make the Outcome smart constructors match the regular ones

### DIFF
--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -227,7 +227,7 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
 
       "start and join on a successful fiber" in ticked { implicit ticker =>
         IO.pure(42).map(_ + 1).start.flatMap(_.join) must completeAs(
-          Outcome.completed[IO, Throwable, Int](IO.pure(43)))
+          Outcome.succeeded[IO, Throwable, Int](IO.pure(43)))
       }
 
       "start and join on a failed fiber" in ticked { implicit ticker =>
@@ -278,7 +278,7 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
           oc <- f.join
         } yield oc
 
-        ioa must completeAs(Outcome.completed[IO, Throwable, ExecutionContext](IO.pure(ec)))
+        ioa must completeAs(Outcome.succeeded[IO, Throwable, ExecutionContext](IO.pure(ec)))
       }
 
       "produce Canceled from start of canceled" in ticked { implicit ticker =>
@@ -538,7 +538,7 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
           IO.pure(42)
             .racePair(IO.never: IO[Unit])
             .map(_.left.toOption.map(_._1).get) must completeAs(
-            Outcome.completed[IO, Throwable, Int](IO.pure(42)))
+            Outcome.succeeded[IO, Throwable, Int](IO.pure(42)))
         }
 
       }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
@@ -110,7 +110,7 @@ private[kernel] trait LowPriorityImplicits {
 
 object Outcome extends LowPriorityImplicits {
 
-  def completed[F[_], E, A](fa: F[A]): Outcome[F, E, A] =
+  def succeeded[F[_], E, A](fa: F[A]): Outcome[F, E, A] =
     Succeeded(fa)
 
   def errored[F[_], E, A](e: E): Outcome[F, E, A] =


### PR DESCRIPTION
As commented in #1317 , revise the `Outcome` smart constructors to corresponding ones and also revise tests. 