### PR TITLE
Std Priority Queue

### DIFF
--- a/core/shared/src/test/scala/cats/effect/std/PQueueSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/PQueueSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * These tests have been inspired by and adapted from `monix-catnap`'s `ConcurrentQueueSuite`, available at
+ * https://github.com/monix/monix/blob/series/3.x/monix-catnap/shared/src/test/scala/monix/catnap/ConcurrentQueueSuite.scala.
+ */
+
+package cats.effect
+package std
+
+import cats.implicits._
+import cats.Order
+import cats.arrow.FunctionK
+import org.specs2.specification.core.Fragments
+
+import scala.collection.immutable.{Queue => ScalaQueue}
+import scala.concurrent.duration._
+
+class PQueueSpec extends BaseSpec {
+
+  implicit val orderForInt: Order[Int] = Order.fromLessThan((x, y) => x < y)
+
+  "PQueue" should {
+    boundedPQueueTests("PQueue", PQueue.bounded)
+    boundedPQueueTests("PQueue mapK", PQueue.bounded[IO, Int](_).map(_.mapK(FunctionK.id)))
+  }
+
+  private def boundedPQueueTests(
+      name: String,
+      constructor: Int => IO[PQueue[IO, Int]]): Fragments = {
+
+    s"$name - take when empty" in real {
+      for {
+        q <- constructor(0)
+        _ <- q.offer(1).start
+        v1 <- q.take
+        f <- q.take.start
+        _ <- q.offer(2)
+        v2 <- f.joinAndEmbedNever
+        r <- IO((v1 must beEqualTo(1)) and (v2 must beEqualTo(2)))
+      } yield r
+    }
+
+    s"$name - simple order check" in real {
+      for {
+        q <- constructor(10)
+        _ <- List(1, 3, 4, 2, 5).traverse(q.offer(_))
+        res <- List.fill(5)(q.take).sequence
+        r <- IO(res must beEqualTo(List(1, 2, 3, 4, 5)))
+      } yield r
+    }
+
+  }
+}

--- a/core/shared/src/test/scala/cats/effect/std/PQueueSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/PQueueSpec.scala
@@ -30,7 +30,8 @@ import org.specs2.specification.core.Fragments
 import scala.collection.immutable.{Queue => ScalaQueue}
 import scala.concurrent.duration._
 
-class PQueueSpec extends BaseSpec {
+class BoundedPQueueSpec extends BaseSpec with PQueueTests {
+  sequential
 
   implicit val orderForInt: Order[Int] = Order.fromLessThan((x, y) => x < y)
 
@@ -43,7 +44,7 @@ class PQueueSpec extends BaseSpec {
       name: String,
       constructor: Int => IO[PQueue[IO, Int]]): Fragments = {
 
-    s"$name - take when empty" in real {
+    s"$name - demonstrate offer and take with zero capacity" in real {
       for {
         q <- constructor(0)
         _ <- q.offer(1).start
@@ -55,6 +56,54 @@ class PQueueSpec extends BaseSpec {
       } yield r
     }
 
+    s"$name - async take with zero capacity" in realWithRuntime { implicit rt =>
+      for {
+        q <- constructor(0)
+        _ <- q.offer(1).start
+        v1 <- q.take
+        _ <- IO(v1 must beEqualTo(1))
+        ff <- IO(q.take.unsafeToFuture()).start
+        f <- ff.joinAndEmbedNever
+        _ <- IO(f.value must beEqualTo(None))
+        _ <- q.offer(2)
+        v2 <- IO.fromFuture(IO.pure(f))
+        r <- IO(v2 must beEqualTo(2))
+      } yield r
+    }
+
+    s"$name - offer/take with zero capacity" in real {
+      val count = 1000
+
+      def producer(q: PQueue[IO, Int], n: Int): IO[Unit] =
+        if (n > 0) q.offer(count - n).flatMap(_ => producer(q, n - 1))
+        else IO.unit
+
+      def consumer(
+          q: PQueue[IO, Int],
+          n: Int,
+          acc: ScalaQueue[Int] = ScalaQueue.empty
+      ): IO[Long] =
+        if (n > 0)
+          q.take.flatMap { a => consumer(q, n - 1, acc.enqueue(a)) }
+        else
+          IO.pure(acc.foldLeft(0L)(_ + _))
+
+      for {
+        q <- constructor(0)
+        p <- producer(q, count).start
+        c <- consumer(q, count).start
+        _ <- p.join
+        v <- c.joinAndEmbedNever
+        r <- IO(v must beEqualTo(count.toLong * (count - 1) / 2))
+      } yield r
+    }
+
+    negativeCapacityConstructionTests(name, constructor)
+    tryOfferOnFullTests(name, constructor, false)
+    cancelableOfferTests(name, constructor)
+    tryOfferTryTakeTests(name, constructor)
+    commonTests(name, constructor)
+
     s"$name - simple order check" in real {
       for {
         q <- constructor(10)
@@ -64,5 +113,205 @@ class PQueueSpec extends BaseSpec {
       } yield r
     }
 
+  }
+}
+
+class UnboundedPQueueSpec extends BaseSpec with PQueueTests {
+  sequential
+
+  implicit val orderForInt: Order[Int] = Order.fromLessThan((x, y) => x < y)
+
+  "UnboundedPQueue" should {
+    unboundedPQueueTests("UnboundedPQueue", PQueue.unbounded)
+    unboundedPQueueTests(
+      "UnboundedPQueue mapK",
+      PQueue.unbounded[IO, Int].map(_.mapK(FunctionK.id)))
+  }
+
+  private def unboundedPQueueTests(
+      name: String,
+      constructor: IO[PQueue[IO, Int]]): Fragments = {
+    tryOfferOnFullTests(name, _ => constructor, true)
+    tryOfferTryTakeTests(name, _ => constructor)
+    commonTests(name, _ => constructor)
+  }
+}
+
+trait PQueueTests { self: BaseSpec =>
+
+  def zeroCapacityConstructionTests(
+      name: String,
+      constructor: Int => IO[PQueue[IO, Int]]
+  ): Fragments = {
+    s"$name - raise an exception when constructed with zero capacity" in real {
+      val test = IO.defer(constructor(0)).attempt
+      test.flatMap { res =>
+        IO {
+          res must beLike {
+            case Left(e) => e must haveClass[IllegalArgumentException]
+          }
+        }
+      }
+    }
+  }
+
+  def negativeCapacityConstructionTests(
+      name: String,
+      constructor: Int => IO[PQueue[IO, Int]]
+  ): Fragments = {
+    s"$name - raise an exception when constructed with a negative capacity" in real {
+      val test = IO.defer(constructor(-1)).attempt
+      test.flatMap { res =>
+        IO {
+          res must beLike {
+            case Left(e) => e must haveClass[IllegalArgumentException]
+          }
+        }
+      }
+    }
+  }
+
+  def tryOfferOnFullTests(
+      name: String,
+      constructor: Int => IO[PQueue[IO, Int]],
+      expected: Boolean): Fragments = {
+    s"$name - return false on tryOffer when the queue is full" in real {
+      for {
+        q <- constructor(1)
+        _ <- q.offer(0)
+        v <- q.tryOffer(1)
+        r <- IO(v must beEqualTo(expected))
+      } yield r
+    }
+  }
+
+  def offerTakeOverCapacityTests(
+      name: String,
+      constructor: Int => IO[PQueue[IO, Int]]
+  ): Fragments = {
+    s"$name - offer/take over capacity" in real {
+      val count = 1000
+
+      def producer(q: PQueue[IO, Int], n: Int): IO[Unit] =
+        if (n > 0) q.offer(count - n).flatMap(_ => producer(q, n - 1))
+        else IO.unit
+
+      def consumer(
+          q: PQueue[IO, Int],
+          n: Int,
+          acc: ScalaQueue[Int] = ScalaQueue.empty
+      ): IO[Long] =
+        if (n > 0)
+          q.take.flatMap { a => consumer(q, n - 1, acc.enqueue(a)) }
+        else
+          IO.pure(acc.foldLeft(0L)(_ + _))
+
+      for {
+        q <- constructor(10)
+        p <- producer(q, count).start
+        c <- consumer(q, count).start
+        _ <- p.join
+        v <- c.joinAndEmbedNever
+        r <- IO(v must beEqualTo(count.toLong * (count - 1) / 2))
+      } yield r
+    }
+  }
+
+  def cancelableOfferTests(name: String, constructor: Int => IO[PQueue[IO, Int]]): Fragments = {
+    s"$name - demonstrate cancelable offer" in real {
+      for {
+        q <- constructor(1)
+        _ <- q.offer(1)
+        f <- q.offer(2).start
+        _ <- IO.sleep(10.millis)
+        _ <- f.cancel
+        v1 <- q.take
+        v2 <- q.tryTake
+        r <- IO((v1 must beEqualTo(1)) and (v2 must beEqualTo(None)))
+      } yield r
+    }
+  }
+
+  def tryOfferTryTakeTests(name: String, constructor: Int => IO[PQueue[IO, Int]]): Fragments = {
+    s"$name - tryOffer/tryTake" in real {
+      val count = 1000
+
+      def producer(q: PQueue[IO, Int], n: Int): IO[Unit] =
+        if (n > 0) q.tryOffer(count - n).flatMap {
+          case true =>
+            producer(q, n - 1)
+          case false =>
+            IO.cede *> producer(q, n)
+        }
+        else IO.unit
+
+      def consumer(
+          q: PQueue[IO, Int],
+          n: Int,
+          acc: ScalaQueue[Int] = ScalaQueue.empty
+      ): IO[Long] =
+        if (n > 0)
+          q.tryTake.flatMap {
+            case Some(a) => consumer(q, n - 1, acc.enqueue(a))
+            case None => IO.cede *> consumer(q, n, acc)
+          }
+        else
+          IO.pure(acc.foldLeft(0L)(_ + _))
+
+      for {
+        q <- constructor(10)
+        p <- producer(q, count).start
+        c <- consumer(q, count).start
+        _ <- p.join
+        v <- c.joinAndEmbedNever
+        r <- IO(v must beEqualTo(count.toLong * (count - 1) / 2))
+      } yield r
+    }
+  }
+
+  def commonTests(name: String, constructor: Int => IO[PQueue[IO, Int]]): Fragments = {
+    s"$name - return None on tryTake when the queue is empty" in real {
+      for {
+        q <- constructor(1)
+        v <- q.tryTake
+        r <- IO(v must beNone)
+      } yield r
+    }
+
+    s"$name - demonstrate sequential offer and take" in real {
+      for {
+        q <- constructor(1)
+        _ <- q.offer(1)
+        v1 <- q.take
+        _ <- q.offer(2)
+        v2 <- q.take
+        r <- IO((v1 must beEqualTo(1)) and (v2 must beEqualTo(2)))
+      } yield r
+    }
+
+    s"$name - demonstrate cancelable take" in real {
+      for {
+        q <- constructor(1)
+        f <- q.take.start
+        _ <- IO.sleep(10.millis)
+        _ <- f.cancel
+        v <- q.tryOffer(1)
+        r <- IO(v must beTrue)
+      } yield r
+    }
+
+    s"$name - async take" in realWithRuntime { implicit rt =>
+      for {
+        q <- constructor(10)
+        _ <- q.offer(1)
+        v1 <- q.take
+        _ <- IO(v1 must beEqualTo(1))
+        f <- IO(q.take.unsafeToFuture())
+        _ <- IO(f.value must beEqualTo(None))
+        _ <- q.offer(2)
+        v2 <- IO.fromFuture(IO.pure(f))
+        r <- IO(v2 must beEqualTo(2))
+      } yield r
+    }
   }
 }

--- a/core/shared/src/test/scala/cats/effect/std/internal/BinomialHeapSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/internal/BinomialHeapSpec.scala
@@ -38,6 +38,10 @@ class BinomialHeapSpec extends Specification with ScalaCheck {
       toList(heap) must beEqualTo(elems.sorted)
     }
 
+    /**
+     * The root of a heap must be <= any of its children and all of its children
+     * must also be heaps
+     */
     "maintain the heap property" in prop { elems: List[Int] =>
       val heap = buildHeap(elems)
 

--- a/core/shared/src/test/scala/cats/effect/std/internal/BinomialHeapSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/internal/BinomialHeapSpec.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * These tests have been inspired by and adapted from `monix-catnap`'s `ConcurrentQueueSuite`, available at
+ * https://github.com/monix/monix/blob/series/3.x/monix-catnap/shared/src/test/scala/monix/catnap/ConcurrentQueueSuite.scala.
+ */
+
+package cats.effect.std.internal
+
+import cats.Order
+
+import org.specs2.mutable.Specification
+import org.specs2.ScalaCheck
+
+class BinomialHeapSpec extends Specification with ScalaCheck {
+
+  implicit val orderForInt: Order[Int] = Order.fromLessThan((x, y) => x < y)
+
+  "Binomial heap" should {
+
+    "dequeue by priority" in prop { elems: List[Int] =>
+      val heap = buildHeap(elems)
+
+      toList(heap) must beEqualTo(elems.sorted)
+    }
+
+    "maintain the heap property" in prop { elems: List[Int] =>
+      val heap = buildHeap(elems)
+
+      heap.trees.forall(validHeap(_)) must beTrue
+    }
+
+    /**
+     * The rank of the top-level trees should be strictly monotonically increasing.
+     * There is one binomial tree for each nonzero bit in the binary representation
+     * of the number of elements n
+     *
+     * The children of a top-level tree of rank i
+     * should be trees of monotonically decreasing rank
+     * i-1, i-2, ..., 1
+     */
+    "maintain correct subtree ranks" in prop { elems: List[Int] =>
+      val heap = buildHeap(elems)
+
+      var currentRank = 0
+      heap.trees.forall { t =>
+        val r = rank(t)
+        r must beGreaterThan(currentRank)
+        currentRank = r
+        checkRank(r, t)
+      }
+    }
+
+  }
+
+  /**
+   * The root of a heap must be <= any of its children and all of its children
+   * must also be heaps
+   */
+  private def validHeap[A: Order](tree: BinomialTree[A]): Boolean = {
+    def validHeap[A](parent: A, tree: BinomialTree[A])(implicit Ord: Order[A]): Boolean =
+      Ord.lteqv(parent, tree.value) && tree.children.forall(validHeap(tree.value, _))
+
+    tree.children match {
+      case Nil => true
+      case cs => cs.forall(validHeap(tree.value, _))
+    }
+  }
+
+  private def buildHeap[A: Order](elems: List[A]): BinomialHeap[A] =
+    elems.foldLeft(BinomialHeap.empty[A]) { (heap, e) => heap.insert(e) }
+
+  private def toList[A](heap: BinomialHeap[A]): List[A] =
+    heap.tryTake match {
+      case (rest, Some(a)) => a :: toList(rest)
+      case _ => Nil
+    }
+
+  private def rank[A](tree: BinomialTree[A]): Int =
+    tree.children match {
+      case Nil => 1
+      case h :: _ => 1 + rank(h)
+    }
+
+  /**
+   * A tree of rank i should have children of rank i-1, i-2, ..., 1
+   * in that order
+   */
+  private def checkRank[A](rank: Int, tree: BinomialTree[A]): Boolean =
+    tree.children match {
+      case Nil => rank == 1
+      case cs =>
+        List.range(0, rank).reverse.zip(cs).forall {
+          case (r, t) => checkRank(r, t)
+        }
+    }
+
+}

--- a/core/shared/src/test/scala/cats/effect/std/internal/BinomialHeapSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/internal/BinomialHeapSpec.scala
@@ -71,8 +71,8 @@ class BinomialHeapSpec extends Specification with ScalaCheck {
    * The root of a heap must be <= any of its children and all of its children
    * must also be heaps
    */
-  private def validHeap[A: Order](tree: BinomialTree[A]): Boolean = {
-    def validHeap[A](parent: A, tree: BinomialTree[A])(implicit Ord: Order[A]): Boolean =
+  private def validHeap[A](tree: BinomialTree[A])(implicit Ord: Order[A]): Boolean = {
+    def validHeap(parent: A, tree: BinomialTree[A]): Boolean =
       Ord.lteqv(parent, tree.value) && tree.children.forall(validHeap(tree.value, _))
 
     tree.children match {

--- a/std/shared/src/main/scala/cats/effect/std/PQueue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/PQueue.scala
@@ -26,6 +26,8 @@ import scala.collection.immutable.{Queue => ScalaQueue}
 /**
  * A purely functional Priority Queue implementation based
  * on a binomial heap (Okasaki)
+ *
+ * Assumes an `Order` instance is in scope for `A`
  */
 
 abstract class PQueue[F[_], A] { self =>
@@ -34,7 +36,9 @@ abstract class PQueue[F[_], A] { self =>
    * Enqueues the given element, possibly semantically
    * blocking until sufficient capacity becomes available.
    *
-   * @param a the element to be put at the back of the queue
+   * O(log(n))
+   *
+   * @param a the element to be put in the queue
    */
   def offer(a: A): F[Unit]
 
@@ -42,21 +46,27 @@ abstract class PQueue[F[_], A] { self =>
    * Attempts to enqueue the given element without
    * semantically blocking.
    *
-   * @param a the element to be put at the back of the queue
+   * O(log(n))
+   *
+   * @param a the element to be put in the queue
    * @return an effect that describes whether the enqueuing of the given
    *         element succeeded without blocking
    */
   def tryOffer(a: A): F[Boolean]
 
   /**
-   * Dequeues an element from the front of the queue, possibly semantically
+   * Dequeues the least element from the queue, possibly semantically
    * blocking until an element becomes available.
+   *
+   * O(log(n))
    */
   def take: F[A]
 
   /**
-   * Attempts to dequeue an element from the front of the queue, if one is
+   * Attempts to dequeue the least element from the queue, if one is
    * available without semantically blocking.
+   *
+   * O(log(n))
    *
    * @return an effect that describes whether the dequeueing of an element from
    *         the queue succeeded without blocking, with `None` denoting that no
@@ -67,6 +77,8 @@ abstract class PQueue[F[_], A] { self =>
   /**
    * Modifies the context in which this queue is executed using the natural
    * transformation `f`.
+   *
+   * O(1)
    *
    * @return a queue in the new context obtained by mapping the current one
    *         using `f`
@@ -111,8 +123,10 @@ object PQueue {
       })
 
     //TODO semantic blocking
+    //TODO keep pointer to head to make this O(1)
     def take: F[A] = ???
 
+    //TODO keep pointer to head to make this O(1)
     def tryTake: F[Option[A]] =
       ref.modify(s => {
         if (s.size == 0) {

--- a/std/shared/src/main/scala/cats/effect/std/PQueue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/PQueue.scala
@@ -19,7 +19,7 @@ package cats.effect.std
 import cats.{~>, Order}
 import cats.implicits._
 import cats.effect.kernel.syntax.all._
-import cats.effect.kernel.{Concurrent, Deferred, Poll, Ref}
+import cats.effect.kernel.{Concurrent, Deferred, Ref}
 import scala.annotation.tailrec
 
 import scala.collection.immutable.{Queue => ScalaQueue}
@@ -238,8 +238,6 @@ object PQueue {
 
     def insert(a: A): BinomialHeap[A] = insert(Tree(0, a, Nil))
 
-    def peek: Option[A] = BinomialHeap.peek(trees)
-
     def take: (BinomialHeap[A], A) = tryTake.map(_.get)
 
     def tryTake: (BinomialHeap[A], Option[A]) = {
@@ -281,16 +279,6 @@ object PQueue {
           if (t1.rank < t2.rank) t1 :: merge(ts1, l2)
           else if (t2.rank < t1.rank) t2 :: merge(l1, ts2)
           else insert(t1.link(t2), merge(ts1, ts2))
-      }
-
-    def peek[A](trees: List[Tree[A]])(implicit Ord: Order[A]): Option[A] =
-      trees match {
-        case Nil => None
-        case h :: t =>
-          peek(t) match {
-            case None => Some(h.value)
-            case Some(v) => Some(Ord.min(h.value, v))
-          }
       }
 
     def take[A](trees: List[Tree[A]])(implicit Ord: Order[A]): (List[Tree[A]], Option[A]) = {

--- a/std/shared/src/main/scala/cats/effect/std/PQueue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/PQueue.scala
@@ -213,6 +213,18 @@ object PQueue {
       )
   }
 
+  /**
+   * A binomial heap is a list of trees maintaining the following invariants:
+   * - The list is strictly monotonically increasing in the rank of the trees
+   *   In fact, a binomial heap built from n elements has is a tree of rank i
+   *   iff there is a 1 in the ith digit of the binary representation of n
+   *   Consequently, the length of the list is <= 1 + log(n)
+   * - Each tree satisfies the heap property (the value at any node is greater
+   *   than that of its parent). This means that the smallest element of the
+   *   heap is found at one of the roots of the trees
+   * - The ranks of the children of a node are strictly monotonically decreasing
+   *   (in fact the rank of the ith child is r - i)
+   */
   private[std] abstract case class BinomialHeap[A](trees: List[Tree[A]]) { self =>
 
     //Allows us to fix this on construction, ensuring some safety from

--- a/std/shared/src/main/scala/cats/effect/std/PQueue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/PQueue.scala
@@ -39,7 +39,7 @@ abstract class PQueue[F[_], A] { self =>
    *
    * O(log(n))
    *
-   * @param a the element to be put in the queue
+   * @param a the element to be put in the PQueue
    */
   def offer(a: A): F[Unit]
 
@@ -49,14 +49,14 @@ abstract class PQueue[F[_], A] { self =>
    *
    * O(log(n))
    *
-   * @param a the element to be put in the queue
+   * @param a the element to be put in the PQueue
    * @return an effect that describes whether the enqueuing of the given
    *         element succeeded without blocking
    */
   def tryOffer(a: A): F[Boolean]
 
   /**
-   * Dequeues the least element from the queue, possibly semantically
+   * Dequeues the least element from the PQueue, possibly semantically
    * blocking until an element becomes available.
    *
    * O(log(n))
@@ -64,24 +64,24 @@ abstract class PQueue[F[_], A] { self =>
   def take: F[A]
 
   /**
-   * Attempts to dequeue the least element from the queue, if one is
+   * Attempts to dequeue the least element from the PQueue, if one is
    * available without semantically blocking.
    *
    * O(log(n))
    *
    * @return an effect that describes whether the dequeueing of an element from
-   *         the queue succeeded without blocking, with `None` denoting that no
+   *         the PQueue succeeded without blocking, with `None` denoting that no
    *         element was available
    */
   def tryTake: F[Option[A]]
 
   /**
-   * Modifies the context in which this queue is executed using the natural
+   * Modifies the context in which this PQueue is executed using the natural
    * transformation `f`.
    *
    * O(1)
    *
-   * @return a queue in the new context obtained by mapping the current one
+   * @return a PQueue in the new context obtained by mapping the current one
    *         using `f`
    */
   def mapK[G[_]](f: F ~> G): PQueue[G, A] =
@@ -259,7 +259,7 @@ object PQueue {
       }
 
     /**
-     * Assumes trees is monotonically increasing in rank
+     * Assumes trees is strictly monotonically increasing in rank
      */
     @tailrec
     def insert[A: Order](tree: Tree[A], trees: List[Tree[A]]): List[Tree[A]] =
@@ -272,7 +272,7 @@ object PQueue {
       }
 
     /**
-     * Assumes each list is monotonically increasing in rank
+     * Assumes each list is strictly monotonically increasing in rank
      */
     def merge[A: Order](lhs: List[Tree[A]], rhs: List[Tree[A]]): List[Tree[A]] =
       (lhs, rhs) match {

--- a/std/shared/src/main/scala/cats/effect/std/PQueue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/PQueue.scala
@@ -149,7 +149,6 @@ object PQueue {
         .flatten
         .uncancelable
 
-    //TODO keep pointer to head to make this O(1)
     def take: F[A] =
       F.deferred[A].flatMap { taker =>
         F.uncancelable { poll =>
@@ -175,7 +174,6 @@ object PQueue {
         }
       }
 
-    //TODO keep pointer to head to make this O(1)
     def tryTake: F[Option[A]] =
       ref
         .modify {
@@ -273,7 +271,6 @@ object PQueue {
           else insert(t1.link(t2), merge(ts1, ts2))
       }
 
-    //TODO we can make this O(1) by storing a pointer to the smallest root instead
     def peek[A](trees: List[Tree[A]])(implicit Ord: Order[A]): Option[A] =
       trees match {
         case Nil => None

--- a/std/shared/src/main/scala/cats/effect/std/PQueue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/PQueue.scala
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.std
+
+import cats.{~>, Monad, Order}
+import cats.implicits._
+import cats.effect.kernel.{Concurrent, Deferred, Poll, Ref}
+import scala.annotation.tailrec
+
+/**
+ * A purely functional Priority Queue implementation based
+ * on a binomial heap (Okasaki)
+ */
+
+abstract class PQueue[F[_], A] { self =>
+
+  /**
+   * Enqueues the given element at the back of the queue, possibly semantically
+   * blocking until sufficient capacity becomes available.
+   *
+   * @param a the element to be put at the back of the queue
+   */
+  def offer(a: A): F[Unit]
+
+  /**
+   * Dequeues an element from the front of the queue, possibly semantically
+   * blocking until an element becomes available.
+   */
+  def take: F[A]
+
+  /**
+   * Attempts to dequeue an element from the front of the queue, if one is
+   * available without semantically blocking.
+   *
+   * @return an effect that describes whether the dequeueing of an element from
+   *         the queue succeeded without blocking, with `None` denoting that no
+   *         element was available
+   */
+  def tryTake: F[Option[A]]
+
+  /**
+   * Modifies the context in which this queue is executed using the natural
+   * transformation `f`.
+   *
+   * @return a queue in the new context obtained by mapping the current one
+   *         using `f`
+   */
+  def mapK[G[_]](f: F ~> G): PQueue[G, A] =
+    new PQueue[G, A] {
+      def offer(a: A): G[Unit] = f(self.offer(a))
+      val take: G[A] = f(self.take)
+      val tryTake: G[Option[A]] = f(self.tryTake)
+    }
+
+}
+
+object PQueue {
+
+  def empty[F[_], A](implicit F: Concurrent[F], O: Order[A]): F[PQueue[F, A]] =
+    F.ref(BinomialHeap.empty[A]).map { ref =>
+      new PQueueImpl[F, A](ref) {
+        implicit val Ord = O
+      }
+    }
+
+  private[std] abstract class PQueueImpl[F[_], A](ref: Ref[F, BinomialHeap[A]])
+      extends PQueue[F, A] {
+    implicit val Ord: Order[A]
+
+    def offer(a: A): F[Unit] = ref.update(_.insert(a))
+
+    def take: F[A] = ???
+
+    def tryTake: F[Option[A]] = ref.modify(_.take)
+  }
+
+  private[std] abstract case class BinomialHeap[A](trees: List[Tree[A]]) { self =>
+
+    //Allows us to fix this on construction, ensuring some safety from
+    //different Ord instances for A
+    implicit val Ord: Order[A]
+
+    def insert(tree: Tree[A]): BinomialHeap[A] =
+      BinomialHeap[A](BinomialHeap.insert(tree, trees))
+
+    def insert(a: A): BinomialHeap[A] = insert(Tree(0, a, Nil))
+
+    def peek: Option[A] = BinomialHeap.peek(trees)
+
+    def take: (BinomialHeap[A], Option[A]) = {
+      val (ts, head) = BinomialHeap.take(trees)
+      BinomialHeap(ts) -> head
+    }
+  }
+
+  private[std] object BinomialHeap {
+
+    def empty[A: Order]: BinomialHeap[A] = BinomialHeap(Nil)
+
+    def apply[A](trees: List[Tree[A]])(implicit ord: Order[A]) =
+      new BinomialHeap[A](trees) {
+        implicit val Ord = ord
+      }
+
+    /**
+     * Assumes trees is monotonically increasing in rank
+     */
+    @tailrec
+    def insert[A: Order](tree: Tree[A], trees: List[Tree[A]]): List[Tree[A]] =
+      trees match {
+        case Nil => List(tree)
+        case l @ (t :: ts) =>
+          if (tree.rank < t.rank)
+            (tree :: l)
+          else insert(tree.link(t), ts)
+      }
+
+    /**
+     * Assumes each list is monotonically increasing in rank
+     */
+    def merge[A: Order](lhs: List[Tree[A]], rhs: List[Tree[A]]): List[Tree[A]] =
+      (lhs, rhs) match {
+        case (Nil, ts) => ts
+        case (ts, Nil) => ts
+        case (l1 @ (t1 :: ts1), l2 @ (t2 :: ts2)) =>
+          if (t1.rank < t2.rank) t1 :: merge(ts1, l2)
+          else if (t2.rank < t1.rank) t2 :: merge(l1, ts2)
+          else insert(t1.link(t2), merge(ts1, ts2))
+      }
+
+    //TODO we can make this O(1) by storing a pointer to the smallest root instead
+    def peek[A](trees: List[Tree[A]])(implicit Ord: Order[A]): Option[A] =
+      trees match {
+        case Nil => None
+        case h :: t =>
+          peek(t) match {
+            case None => Some(h.value)
+            case Some(v) => Some(Ord.min(h.value, v))
+          }
+      }
+
+    //TODO we can make this O(1) by storing a pointer to the smallest root instead
+    def take[A](trees: List[Tree[A]])(implicit Ord: Order[A]): (List[Tree[A]], Option[A]) = {
+      //Note this is partial but we don't want to allocate a NonEmptyList
+      def min(trees: List[Tree[A]]): (Tree[A], List[Tree[A]]) =
+        trees match {
+          case t :: Nil => (t, Nil)
+          case t :: ts => {
+            val (t1, ts1) = min(ts)
+            if (Ord.lteqv(t.value, t1.value)) (t, ts) else (t1, t :: ts1)
+          }
+          case _ => throw new AssertionError
+        }
+
+      trees match {
+        case Nil => Nil -> None
+        case l => {
+          val (t, ts) = min(l)
+          merge(t.children.reverse, ts) -> Some(t.value)
+        }
+      }
+
+    }
+
+  }
+
+  private[std] case class Tree[A](rank: Int, value: A, children: List[Tree[A]]) {
+
+    /**
+     * Link two trees of rank R to produce a tree of rank r + 1
+     */
+    def link(other: Tree[A])(implicit Ord: Order[A]): Tree[A] = {
+      assert(rank == other.rank)
+      if (Ord.lteqv(value, other.value))
+        Tree(rank + 1, value, other :: children)
+      else Tree(rank + 1, other.value, this :: other.children)
+    }
+
+  }
+
+}

--- a/std/shared/src/main/scala/cats/effect/std/PQueue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/PQueue.scala
@@ -241,7 +241,10 @@ object PQueue {
 
     def insert(a: A): BinomialHeap[A] = insert(Tree(0, a, Nil))
 
-    def take: (BinomialHeap[A], A) = tryTake.map(_.get)
+    def take: (BinomialHeap[A], A) = {
+      val (ts, head) = BinomialHeap.take(trees)
+      BinomialHeap(ts) -> head.get
+    }
 
     def tryTake: (BinomialHeap[A], Option[A]) = {
       val (ts, head) = BinomialHeap.take(trees)

--- a/std/shared/src/main/scala/cats/effect/std/PQueue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/PQueue.scala
@@ -189,9 +189,9 @@ object PQueue {
             val ((move, release), tail) = offerers.dequeue
             State(rest.insert(move), size, takers, tail) -> release.complete(()).as(a.some)
 
-          case State(queue, size, takers, offerers) if offerers.nonEmpty =>
+          case State(heap, size, takers, offerers) if offerers.nonEmpty =>
             val ((a, release), rest) = offerers.dequeue
-            State(queue, size, takers, rest) -> release.complete(()).as(a.some)
+            State(heap, size, takers, rest) -> release.complete(()).as(a.some)
 
           case s =>
             s -> F.pure(none[A])

--- a/std/shared/src/main/scala/cats/effect/std/internal/BinomialHeap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/internal/BinomialHeap.scala
@@ -45,6 +45,10 @@ private[std] abstract case class BinomialHeap[A](trees: List[BinomialTree[A]]) {
 
   def insert(a: A): BinomialHeap[A] = insert(BinomialTree(0, a, Nil))
 
+  /**
+   * Assumes heap is non-empty. Used in Dequeue where we track
+   * size externally
+   */
   def take: (BinomialHeap[A], A) = {
     val (ts, head) = BinomialHeap.take(trees)
     BinomialHeap(ts) -> head.get

--- a/std/shared/src/main/scala/cats/effect/std/internal/BinomialHeap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/internal/BinomialHeap.scala
@@ -121,7 +121,8 @@ private[std] object BinomialHeap {
 }
 
 /**
- * Children are stored in monotonically decreasing order of rank
+ * Children are stored in strictly monotonically decreasing order of rank
+ * A tree of rank r will have children of ranks r-1, r-2, ..., 1
  */
 private[std] final case class BinomialTree[A](
     rank: Int,

--- a/std/shared/src/main/scala/cats/effect/std/internal/BinomialHeap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/internal/BinomialHeap.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.std.internal
+
+import cats.Order
+
+import scala.annotation.tailrec
+
+/**
+ * A binomial heap is a list of trees maintaining the following invariants:
+ * - The list is strictly monotonically increasing in the rank of the trees
+ *   In fact, a binomial heap built from n elements has is a tree of rank i
+ *   iff there is a 1 in the ith digit of the binary representation of n
+ *   Consequently, the length of the list is <= 1 + log(n)
+ * - Each tree satisfies the heap property (the value at any node is greater
+ *   than that of its parent). This means that the smallest element of the
+ *   heap is found at one of the roots of the trees
+ * - The ranks of the children of a node are strictly monotonically decreasing
+ *   (in fact the rank of the ith child is r - i)
+ */
+private[std] abstract case class BinomialHeap[A](trees: List[Tree[A]]) { self =>
+
+  //Allows us to fix this on construction, ensuring some safety from
+  //different Ord instances for A
+  implicit val Ord: Order[A]
+
+  def nonEmpty: Boolean = trees.nonEmpty
+
+  def insert(tree: Tree[A]): BinomialHeap[A] =
+    BinomialHeap[A](BinomialHeap.insert(tree, trees))
+
+  def insert(a: A): BinomialHeap[A] = insert(Tree(0, a, Nil))
+
+  def take: (BinomialHeap[A], A) = {
+    val (ts, head) = BinomialHeap.take(trees)
+    BinomialHeap(ts) -> head.get
+  }
+
+  def tryTake: (BinomialHeap[A], Option[A]) = {
+    val (ts, head) = BinomialHeap.take(trees)
+    BinomialHeap(ts) -> head
+  }
+}
+
+private[std] object BinomialHeap {
+
+  def empty[A: Order]: BinomialHeap[A] = BinomialHeap(Nil)
+
+  def apply[A](trees: List[Tree[A]])(implicit ord: Order[A]) =
+    new BinomialHeap[A](trees) {
+      implicit val Ord = ord
+    }
+
+  /**
+   * Assumes trees is strictly monotonically increasing in rank
+   */
+  @tailrec
+  def insert[A: Order](tree: Tree[A], trees: List[Tree[A]]): List[Tree[A]] =
+    trees match {
+      case Nil => tree :: Nil
+      case l @ (t :: ts) =>
+        if (tree.rank < t.rank)
+          (tree :: l)
+        else insert(tree.link(t), ts)
+    }
+
+  /**
+   * Assumes each list is strictly monotonically increasing in rank
+   */
+  def merge[A: Order](lhs: List[Tree[A]], rhs: List[Tree[A]]): List[Tree[A]] =
+    (lhs, rhs) match {
+      case (Nil, ts) => ts
+      case (ts, Nil) => ts
+      case (l1 @ (t1 :: ts1), l2 @ (t2 :: ts2)) =>
+        if (t1.rank < t2.rank) t1 :: merge(ts1, l2)
+        else if (t2.rank < t1.rank) t2 :: merge(l1, ts2)
+        else insert(t1.link(t2), merge(ts1, ts2))
+    }
+
+  def take[A](trees: List[Tree[A]])(implicit Ord: Order[A]): (List[Tree[A]], Option[A]) = {
+    //Note this is partial but we don't want to allocate a NonEmptyList
+    def min(trees: List[Tree[A]]): (Tree[A], List[Tree[A]]) =
+      trees match {
+        case t :: Nil => (t, Nil)
+        case t :: ts => {
+          val (t1, ts1) = min(ts)
+          if (Ord.lteqv(t.value, t1.value)) (t, ts) else (t1, t :: ts1)
+        }
+        case _ => throw new AssertionError
+      }
+
+    trees match {
+      case Nil => Nil -> None
+      case l => {
+        val (t, ts) = min(l)
+        merge(t.children.reverse, ts) -> Some(t.value)
+      }
+    }
+
+  }
+
+}
+
+/**
+ * Children are stored in monotonically decreasing order of rank
+ */
+private[std] final case class Tree[A](rank: Int, value: A, children: List[Tree[A]]) {
+
+  /**
+   * Link two trees of rank r to produce a tree of rank r + 1
+   */
+  def link(other: Tree[A])(implicit Ord: Order[A]): Tree[A] = {
+    if (Ord.lteqv(value, other.value))
+      Tree(rank + 1, value, other :: children)
+    else Tree(rank + 1, other.value, this :: other.children)
+  }
+
+}


### PR DESCRIPTION
Priority queue for std, based on Okasaki's binomial heap.

Circular and dropping variants are not supported as the heap condition is not strong enough for us to be able to do this in < O(n).