### PR TITLE
surround and surroundK added to Resource

### DIFF
--- a/core/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -470,6 +470,25 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
     //   }
     // }
 
+    "surround - should wrap an effect in a usage and ignore the value produced by resource" in ticked {
+      implicit ticker =>
+        val r = Resource.liftF(IO.pure(0))
+        val surroundee = IO(1)
+        val surrounded = r.surround(surroundee)
+
+        surrounded eqv surroundee
+    }
+
+    "surroundK - should wrap an effect in a usage, ignore the value produced by resource and return FunctionK" in ticked {
+      implicit ticker =>
+        val r = Resource.liftF(IO.pure(0))
+        val surroundee = IO(1)
+        val surround = r.surroundK
+        val surrounded = surround(surroundee)
+
+        surrounded eqv surroundee
+    }
+
   }
 
   {

--- a/core/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -473,7 +473,7 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
     "surround - should wrap an effect in a usage and ignore the value produced by resource" in ticked {
       implicit ticker =>
         val r = Resource.liftF(IO.pure(0))
-        val surroundee = IO(1)
+        val surroundee = IO("hello")
         val surrounded = r.surround(surroundee)
 
         surrounded eqv surroundee
@@ -482,7 +482,7 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
     "surroundK - should wrap an effect in a usage, ignore the value produced by resource and return FunctionK" in ticked {
       implicit ticker =>
         val r = Resource.liftF(IO.pure(0))
-        val surroundee = IO(1)
+        val surroundee = IO("hello")
         val surround = r.surroundK
         val surrounded = surround(surroundee)
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -419,13 +419,13 @@ sealed abstract class Resource[+F[_], +A] {
   private[effect] def invariant: Resource.InvariantResource[F0, A]
 
   /**
-   * Wraps an effect in a usage and ignores the value produced by resource.
+   * Acquires the resource, runs `gb` and closes the resource once `gb` terminates, fails or gets interrupted
    */
   def surround[G[x] >: F[x]: Resource.Bracket, B](gb: G[B]): G[B] =
     use(_ => gb)
 
   /**
-   * Creates a FunctionK that wraps an effect in a usage when applied. Value produced by the resource is ignored.
+   * Creates a FunctionK that can run `gb` within a resource, which is then closed once `gb` terminates, fails or gets interrupted
    */
   def surroundK[G[x] >: F[x]: Resource.Bracket]: G ~> G =
     new (G ~> G) {

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -421,7 +421,7 @@ sealed abstract class Resource[+F[_], +A] {
   /**
    * Wraps an effect in a usage and ignores the value produced by resource.
    */
-  def surround[G[x] >: F[x]: Resource.Bracket, B >: A](gb: G[B]): G[B] =
+  def surround[G[x] >: F[x]: Resource.Bracket, B](gb: G[B]): G[B] =
     use(_ => gb)
 
   /**
@@ -429,7 +429,7 @@ sealed abstract class Resource[+F[_], +A] {
    */
   def surroundK[G[x] >: F[x]: Resource.Bracket]: G ~> G =
     new (G ~> G) {
-      override def apply[B](gb: G[B]): G[B] = use(_ => gb)
+      override def apply[B](gb: G[B]): G[B] = surround(gb)
     }
 }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -417,6 +417,20 @@ sealed abstract class Resource[+F[_], +A] {
    */
 
   private[effect] def invariant: Resource.InvariantResource[F0, A]
+
+  /**
+   * Wraps an effect in a usage and ignores the value produced by resource.
+   */
+  def surround[G[x] >: F[x]: Resource.Bracket, B >: A](gb: G[B]): G[B] =
+    use(_ => gb)
+
+  /**
+   * Creates a FunctionK that wraps an effect in a usage when applied. Value produced by the resource is ignored.
+   */
+  def surroundK[G[x] >: F[x]: Resource.Bracket]: G ~> G =
+    new (G ~> G) {
+      override def apply[B](gb: G[B]): G[B] = use(_ => gb)
+    }
 }
 
 object Resource extends ResourceInstances with ResourcePlatform {


### PR DESCRIPTION
As requested in https://github.com/typelevel/cats-effect/issues/1338 - added `surround` and `surroundK` methods on `Resource`