### PR TITLE
Fix java version strings to please jabba

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,23 +25,23 @@ jobs:
         scala: [0.27.0-RC1, 2.12.12, 2.13.3]
         java:
           - adopt@1.8
-          - adopt@11
-          - adopt@14
-          - graalvm8@20.1.0
+          - adopt@1.11
+          - adopt@1.15
+          - graalvm-ce-java8@20.2.0
         ci: [ciJVM, ciJS, ciFirefox]
         exclude:
           - ci: ciJS
-            java: adopt@11
+            java: adopt@1.11
           - ci: ciJS
-            java: adopt@14
+            java: adopt@1.15
           - ci: ciJS
-            java: graalvm8@20.1.0
+            java: graalvm-ce-java8@20.2.0
           - ci: ciFirefox
-            java: adopt@11
+            java: adopt@1.11
           - ci: ciFirefox
-            java: adopt@14
+            java: adopt@1.15
           - ci: ciFirefox
-            java: graalvm8@20.1.0
+            java: graalvm-ce-java8@20.2.0
           - ci: ciJS
             os: windows-latest
           - ci: ciFirefox

--- a/build.sbt
+++ b/build.sbt
@@ -46,9 +46,9 @@ ThisBuild / crossScalaVersions := Seq("0.27.0-RC1", "2.12.12", Scala213)
 
 ThisBuild / githubWorkflowTargetBranches := Seq("series/3.x")
 
-val LTSJava = "adopt@11"
-val LatestJava = "adopt@14"
-val GraalVM8 = "graalvm8@20.1.0"
+val LTSJava = "adopt@1.11"
+val LatestJava = "adopt@1.15"
+val GraalVM8 = "graalvm-ce-java8@20.2.0"
 
 ThisBuild / githubWorkflowJavaVersions := Seq(ScalaJSJava, LTSJava, LatestJava, GraalVM8)
 ThisBuild / githubWorkflowOSes := Seq(PrimaryOS, Windows)


### PR DESCRIPTION
It seems that jabba changed the version strings for java from underneath, so every build variant defaulted to AdoptOpenJDK 8. That is now fixed.

Furthermore, I have updated to the latest Java version and to the latest GraalVM CE version.