### PR TITLE
use Dotty-native build of cats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [0.26.0, 0.27.0-RC1, 2.12.12, 2.13.3]
+        scala: [0.27.0-RC1, 2.12.12, 2.13.3]
         java: [adopt@1.8, adopt@11]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ import scala.sys.process._
 ThisBuild / baseVersion := "2.2"
 
 val OldScala = "2.12.12"
-ThisBuild / crossScalaVersions := Seq("0.26.0", "0.27.0-RC1", OldScala, "2.13.3")
+ThisBuild / crossScalaVersions := Seq("0.27.0-RC1", OldScala, "2.13.3")
 ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@11")
 
 ThisBuild / githubWorkflowTargetBranches := Seq("series/2.x")
@@ -52,7 +52,7 @@ ThisBuild / scmInfo := Some(
   ScmInfo(url("https://github.com/typelevel/cats-effect"), "git@github.com:typelevel/cats-effect.git")
 )
 
-val CatsVersion = "2.2.0"
+val CatsVersion = "2.3.0-M1"
 val DisciplineMunitVersion = "0.3.0"
 val SilencerVersion = "1.7.1"
 
@@ -244,7 +244,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       "org.typelevel" %%% "cats-core" % CatsVersion,
       "org.typelevel" %%% "cats-laws" % CatsVersion % Test,
       "org.typelevel" %%% "discipline-munit" % DisciplineMunitVersion % Test
-    ).map(_.withDottyCompat(scalaVersion.value)),
+    ),
     libraryDependencies ++= {
       if (isDotty.value)
         Seq(
@@ -286,7 +286,7 @@ lazy val laws = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-laws" % CatsVersion,
       "org.typelevel" %%% "discipline-munit" % DisciplineMunitVersion % Test
-    ).map(_.withDottyCompat(scalaVersion.value))
+    )
   )
   .jvmSettings(
     mimaPreviousArtifacts := {
@@ -315,7 +315,7 @@ lazy val runtimeTests = project
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-laws" % CatsVersion,
       "org.typelevel" %%% "discipline-munit" % DisciplineMunitVersion % Test
-    ).map(_.withDottyCompat(scalaVersion.value))
+    )
   )
   .configs(FullTracingTest)
   .settings(inConfig(FullTracingTest)(Defaults.testSettings): _*)

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ ThisBuild / scmInfo := Some(
 )
 
 val CatsVersion = "2.3.0-M1"
-val DisciplineMunitVersion = "0.3.0"
+val DisciplineMunitVersion = "1.0.0"
 val SilencerVersion = "1.7.1"
 
 replaceCommandAlias(


### PR DESCRIPTION
This currently doesn't work:

* sjs1 artifacts cannot be resolved for Dotty (:eyes: @djspiewak)
* compile error in core (see below)

```
[info] compiling 78 Scala sources and 1 Java source to /home/lars/proj/typelevel/cats-effect/core/jvm/target/scala-0.27/classes ...
[error] undefined: new simulacrum.noop # 216316: TermRef(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class <root>)),module simulacrum),noop),<init>) at sbt-api
[warn] sbt-api: Unhandled type class dotty.tools.dotc.core.Types$$anon$7 : <error undefined: new simulacrum.noop # 216316: TermRef(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class <root>)),module simulacrum),noop),<init>) at sbt-api>

```