### PR TITLE
Remove race and both specialization

### DIFF
--- a/core/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/core/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -103,7 +103,7 @@ abstract class IOPlatformSpecification extends Specification with ScalaCheck wit
           }
         }
 
-        task.replicateA(100000).as(ok)
+        task.replicateA(1000).as(ok)
       }
 
       "round trip through j.u.c.CompletableFuture" in ticked { implicit ticker =>

--- a/core/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/core/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -103,7 +103,7 @@ abstract class IOPlatformSpecification extends Specification with ScalaCheck wit
           }
         }
 
-        task.replicateA(1000).as(ok)
+        task.replicateA(100).as(ok)
       }
 
       "round trip through j.u.c.CompletableFuture" in ticked { implicit ticker =>

--- a/core/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/core/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -103,7 +103,7 @@ abstract class IOPlatformSpecification extends Specification with ScalaCheck wit
           }
         }
 
-        task.as(ok)
+        task.replicateA(100000).as(ok)
       }
 
       "round trip through j.u.c.CompletableFuture" in ticked { implicit ticker =>

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -441,6 +441,7 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
               IO.both(IO.never.onCancel(l.set(true)), IO.never.onCancel(r.set(true))).start
             _ <- IO(ticker.ctx.tickAll())
             _ <- fiber.cancel
+            _ <- IO(ticker.ctx.tickAll())
             l2 <- l.get
             r2 <- r.get
           } yield (l2 -> r2)) must completeAs(true -> true)
@@ -516,6 +517,7 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
               IO.race(IO.never.onCancel(l.set(true)), IO.never.onCancel(r.set(true))).start
             _ <- IO(ticker.ctx.tickAll())
             _ <- fiber.cancel
+            _ <- IO(ticker.ctx.tickAll())
             l2 <- l.get
             r2 <- r.get
           } yield (l2 -> r2)) must completeAs(true -> true)

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -80,6 +80,46 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
     }
   }
 
+  override def racePair[A, B](fa: F[A], fb: F[B]): F[Either[(Outcome[F, E, A], Fiber[F, E, B]), (Fiber[F, E, A], Outcome[F, E, B])]] = {
+    implicit val F: GenConcurrent[F, E] = this
+
+    uncancelable { poll =>
+      for {
+        fibADef <- deferred[Fiber[F, E, A]]
+        fibBDef <- deferred[Fiber[F, E, B]]
+
+        result <- deferred[Either[(Outcome[F, E, A], Fiber[F, E, B]), (Fiber[F, E, A], Outcome[F, E, B])]]
+
+        fibA <- start {
+          guaranteeCase(fa) { oc =>
+            fibBDef.get flatMap { fibB =>
+              result.complete(Left((oc, fibB))).void
+            }
+          }
+        }
+
+        fibB <- start {
+          guaranteeCase(fb) { oc =>
+            fibADef.get flatMap { fibA =>
+              result.complete(Right((fibA, oc))).void
+            }
+          }
+        }
+
+        _ <- fibADef.complete(fibA)
+        _ <- fibBDef.complete(fibB)
+
+        back <- onCancel(poll(result.get), {
+          for {
+            done <- deferred[Unit]
+            _ <- start(guarantee(fibA.cancel, done.complete(()).void))
+            _ <- start(guarantee(fibB.cancel, done.complete(()).void))
+            _ <- done.get
+          } yield ()
+        })
+      } yield back
+    }
+  }
 }
 
 object GenConcurrent {
@@ -143,6 +183,9 @@ object GenConcurrent {
 
     override def deferred[A]: OptionT[F, Deferred[OptionT[F, *], A]] =
       OptionT.liftF(F.map(F.deferred[A])(_.mapK(OptionT.liftK)))
+
+    override def racePair[A, B](fa: OptionT[F, A], fb: OptionT[F, B]): OptionT[F, Either[(Outcome[OptionT[F, *], E, A], Fiber[OptionT[F, *], E, B]), (Fiber[OptionT[F, *], E, A], Outcome[OptionT[F, *], E, B])]] =
+      super.racePair(fa, fb)
   }
 
   private[kernel] trait EitherTGenConcurrent[F[_], E0, E]
@@ -155,6 +198,9 @@ object GenConcurrent {
 
     override def deferred[A]: EitherT[F, E0, Deferred[EitherT[F, E0, *], A]] =
       EitherT.liftF(F.map(F.deferred[A])(_.mapK(EitherT.liftK)))
+
+    override def racePair[A, B](fa: EitherT[F, E0, A], fb: EitherT[F, E0, B]): EitherT[F, E0, Either[(Outcome[EitherT[F, E0, *], E, A], Fiber[EitherT[F, E0, *], E, B]), (Fiber[EitherT[F, E0, *], E, A], Outcome[EitherT[F, E0, *], E, B])]] =
+      super.racePair(fa, fb)
   }
 
   private[kernel] trait KleisliGenConcurrent[F[_], R, E]
@@ -167,6 +213,9 @@ object GenConcurrent {
 
     override def deferred[A]: Kleisli[F, R, Deferred[Kleisli[F, R, *], A]] =
       Kleisli.liftF(F.map(F.deferred[A])(_.mapK(Kleisli.liftK)))
+
+    override def racePair[A, B](fa: Kleisli[F, R, A], fb: Kleisli[F, R, B]): Kleisli[F, R, Either[(Outcome[Kleisli[F, R, *], E, A], Fiber[Kleisli[F, R, *], E, B]), (Fiber[Kleisli[F, R, *], E, A], Outcome[Kleisli[F, R, *], E, B])]] =
+      super.racePair(fa, fb)
   }
 
   private[kernel] trait IorTGenConcurrent[F[_], L, E]
@@ -181,6 +230,9 @@ object GenConcurrent {
 
     override def deferred[A]: IorT[F, L, Deferred[IorT[F, L, *], A]] =
       IorT.liftF(F.map(F.deferred[A])(_.mapK(IorT.liftK)))
+
+    override def racePair[A, B](fa: IorT[F, L, A], fb: IorT[F, L, B]): IorT[F, L, Either[(Outcome[IorT[F, L, *], E, A], Fiber[IorT[F, L, *], E, B]), (Fiber[IorT[F, L, *], E, A], Outcome[IorT[F, L, *], E, B])]] =
+      super.racePair(fa, fb)
   }
 
   private[kernel] trait WriterTGenConcurrent[F[_], L, E]
@@ -196,6 +248,9 @@ object GenConcurrent {
 
     override def deferred[A]: WriterT[F, L, Deferred[WriterT[F, L, *], A]] =
       WriterT.liftF(F.map(F.deferred[A])(_.mapK(WriterT.liftK)))
+
+    override def racePair[A, B](fa: WriterT[F, L, A], fb: WriterT[F, L, B]): WriterT[F, L, Either[(Outcome[WriterT[F, L, *], E, A], Fiber[WriterT[F, L, *], E, B]), (Fiber[WriterT[F, L, *], E, A], Outcome[WriterT[F, L, *], E, B])]] =
+      super.racePair(fa, fb)
   }
 
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -332,7 +332,7 @@ trait GenSpawn[F[_], E] extends MonadCancel[F, E] {
    */
   def race[A, B](fa: F[A], fb: F[B]): F[Either[A, B]] =
     uncancelable { poll =>
-      racePair(fa, fb).flatMap {
+      poll(racePair(fa, fb)).flatMap {
         case Left((oc, f)) =>
           oc match {
             case Outcome.Succeeded(fa) => f.cancel *> fa.map(Left(_))
@@ -405,7 +405,7 @@ trait GenSpawn[F[_], E] extends MonadCancel[F, E] {
    */
   def both[A, B](fa: F[A], fb: F[B]): F[(A, B)] =
     uncancelable { poll =>
-      racePair(fa, fb).flatMap {
+      poll(racePair(fa, fb)).flatMap {
         case Left((oc, f)) =>
           oc match {
             case Outcome.Succeeded(fa) =>

--- a/testkit/shared/src/main/scala/cats/effect/testkit/TimeT.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/TimeT.scala
@@ -115,7 +115,7 @@ object TimeT {
     def never[A]: TimeT[F, A] =
       TimeT.liftF(F.never[A])
 
-    def racePair[A, B](fa: TimeT[F, A], fb: TimeT[F, B]): TimeT[
+    override def racePair[A, B](fa: TimeT[F, A], fb: TimeT[F, B]): TimeT[
       F,
       Either[
         (Outcome[TimeT[F, *], E, A], Fiber[TimeT[F, *], E, B]),


### PR DESCRIPTION
Opening to raise awareness of the problem with `racePair` and other race combinators.

Here I just removed the specialization of `both` and `race`, and that leads to failed tests and timeouts, related to cancelation.

Will eventually resolve #1380.