### PR TITLE
Replaced memory barrier with something that's actually sound

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -174,7 +174,7 @@ private final class IOFiber[A](
   var cancel: IO[Unit] = IO uncancelable { _ =>
     IO defer {
       canceled = true
-      barrier = true
+      writeBarrier()
 
       // println(s"${name}: attempting cancellation")
 
@@ -881,6 +881,9 @@ private final class IOFiber[A](
          */
       }
     }
+
+  private[this] def writeBarrier(): Unit =
+    barrier = true
 
   private[this] def readBarrier(): Unit = {
     val _ = barrier

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -448,10 +448,10 @@ private final class IOFiber[A](
                 readBarrier()
 
                 if (!shouldFinalize()) {
-                 /*
-                  * If we aren't canceled, loop on `suspended` to wait
-                  * until `get` has released ownership of the runloop.
-                  */
+                  /*
+                   * If we aren't canceled, loop on `suspended` to wait
+                   * until `get` has released ownership of the runloop.
+                   */
                   loop()
                 }
               }


### PR DESCRIPTION
I haven't rewritten the comments yet, this is mostly just to test. I'll rewrite the comments before merge.

Heads up, @RaasAhsan! This is kind of what I was thinking. I thought about your ACK idea but couldn't quite understand what you meant by it, so here's just one proposal. The cost here is actually surprisingly minimal. There's an extra read barrier in `IOCont.Get` and an extra write barrier in `cancel`, but that's it. My understanding is that the JVM can sometimes coalesce barriers so it might not even be that significant of a cost.