### PR TITLE
Implemented an artificial write barrier

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -19,6 +19,8 @@ package cats.effect
 // defined in Java for the JVM, Scala for ScalaJS (where object field access is faster)
 private[effect] object IOFiberConstants {
 
+  val AggressiveCasSemantics = true
+
   val MaxStackDepth: Int = 512
 
   // continuation ids (should all be inlined)

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -19,6 +19,9 @@ package cats.effect;
 // defined in Java since Scala doesn't let us define static fields
 final class IOFiberConstants {
 
+  // TODO there will likely be more in here, such as ARM ≥8.1
+  public static final boolean AggressiveCasSemantics = System.getProperty("os.arch").startsWith("x86");
+
   public static final int MaxStackDepth = 512;
 
   // continuation ids (should all be inlined)


### PR DESCRIPTION
This is only required on architectures where CAS can under some circumstances be a read barrier and *not* a write barrier. For example, on ARM64 without LSE, CAS is non-primitive and, when it fails, will not publish the `canceled` write. This PR adds a check for architecture (at class-load time) and, when we don't *know* that it's safe to rely on CAS for publication, we explicitly add an extra publication. This isn't quite sufficient though because, in some circumstances, both the added publication and the `resume()` might fail, which would still result in a situation where `canceled` is unpublished. This is resolved by looping until we successfully publish.

Notably, this does not affect the efficiency of the *read* side, only the efficiency of the *write* side, and also only on troublesome architectures.

This is an alternative to #1411 