### PR TITLE
One-line fix for memory barrier issues!

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -756,7 +756,7 @@ private final class IOFiber[A](
     masks == initMask
 
   private[this] def resume(): Boolean =
-    suspended.compareAndSet(true, false)
+    suspended.getAndSet(false)
 
   private[this] def suspend(): Unit =
     suspended.set(true)

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -755,6 +755,16 @@ private final class IOFiber[A](
   private[this] def isUnmasked(): Boolean =
     masks == initMask
 
+  /*
+   * You should probably just read this as `suspended.compareAndSet(true, false)`.
+   * This implementation has the same semantics as the above, except that it guarantees
+   * a write memory barrier in all cases, even when resumption fails. This in turn
+   * makes it suitable as a publication mechanism (as we're using it).
+   *
+   * On x86, this should have almost exactly the same performance as a CAS even taking
+   * into account the extra barrier (which x86 doesn't need anyway). On ARM without LSE
+   * it should actually be *faster* because CAS isn't primitive but get-and-set is.
+   */
   private[this] def resume(): Boolean =
     suspended.getAndSet(false)
 


### PR DESCRIPTION
Fix for #1363 suggested by @viktorklang. I seriously had to write down a truth table to convince myself that it works, but it does! The nice thing about `getAndSet` is it's exactly as fast as `compareAndSet` on x86 (and *faster* on ARM), but also deterministically forms a write barrier.