### PR TITLE
Cyclic Barrier follow up

### DIFF
--- a/core/shared/src/test/scala/cats/effect/std/CyclicBarrierSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/CyclicBarrierSpec.scala
@@ -70,6 +70,13 @@ class CyclicBarrierSpec extends BaseSpec {
       }
     }
 
+    s"$name - await is cancelable" in ticked { implicit ticker =>
+      newBarrier(2)
+        .flatMap(_.await)
+        .timeoutTo(1.second, IO.unit) must completeAs(())
+    }
+
+
     s"$name - remaining when constructed" in real {
       newBarrier(5).flatMap { barrier =>
         barrier.awaiting.mustEqual(0) >>
@@ -79,17 +86,6 @@ class CyclicBarrierSpec extends BaseSpec {
 
 
 
-    // TODO ticker here
-    s"$name - await is cancelable" in real {
-      for {
-        barrier <- newBarrier(2)
-        f <- barrier.await.start
-        _ <- IO.sleep(100.millis)
-        _ <- f.cancel
-        res <- f.join.mustEqual(Outcome.Canceled())
-        _ <- barrier.awaiting.mustEqual(0)
-      } yield res
-    }
 
     s"$name - reset once full" in real {
       for {

--- a/core/shared/src/test/scala/cats/effect/std/CyclicBarrierSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/CyclicBarrierSpec.scala
@@ -121,12 +121,5 @@ class CyclicBarrierSpec extends BaseSpec {
 
       List.fill(iterations)(run).reduce(_ >> _)
     }
-
-    s"$name - remaining when constructed" in real {
-      newBarrier(5).flatMap { barrier =>
-        barrier.awaiting.mustEqual(0) >>
-        barrier.remaining.mustEqual(5)
-      }
-    }
   }
 }

--- a/core/shared/src/test/scala/cats/effect/std/CyclicBarrierSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/CyclicBarrierSpec.scala
@@ -64,6 +64,12 @@ class CyclicBarrierSpec extends BaseSpec {
       newBarrier(2).flatMap(_.await) must nonTerminate
     }
 
+    s"$name - await releases all fibers" in real {
+      newBarrier(2).flatMap { barrier =>
+        (barrier.await, barrier.await).parTupled.void.mustEqual(())
+      }
+    }
+
     s"$name - remaining when constructed" in real {
       newBarrier(5).flatMap { barrier =>
         barrier.awaiting.mustEqual(0) >>
@@ -71,16 +77,6 @@ class CyclicBarrierSpec extends BaseSpec {
       }
     }
 
-    s"$name - await releases all fibers" in real {
-      for {
-        barrier <- newBarrier(2)
-        f1 <- barrier.await.start
-        f2 <- barrier.await.start
-        r  = (f1.joinAndEmbedNever, f2.joinAndEmbedNever).tupled
-        res <- r.mustEqual(((), ()))
-        _ <- barrier.awaiting.mustEqual(0)
-      } yield res
-    }
 
 
     // TODO ticker here

--- a/core/shared/src/test/scala/cats/effect/std/CyclicBarrierSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/CyclicBarrierSpec.scala
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * These tests have been inspired by and adapted from `monix-catnap`'s `ConcurrentQueueSuite`, available at
- * https://github.com/monix/monix/blob/series/3.x/monix-catnap/shared/src/test/scala/monix/catnap/ConcurrentQueueSuite.scala.
- */
-
 package cats.effect
 package std
 

--- a/core/shared/src/test/scala/cats/effect/std/CyclicBarrierSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/CyclicBarrierSpec.scala
@@ -60,6 +60,10 @@ class CyclicBarrierSpec extends BaseSpec {
       IO.defer(newBarrier(0)).mustFailWith[IllegalArgumentException]
     }
 
+    s"$name - await is blocking" in ticked { implicit ticker =>
+      newBarrier(2).flatMap(_.await) must nonTerminate
+    }
+
     s"$name - remaining when constructed" in real {
       newBarrier(5).flatMap { barrier =>
         barrier.awaiting.mustEqual(0) >>
@@ -78,12 +82,6 @@ class CyclicBarrierSpec extends BaseSpec {
       } yield res
     }
 
-    // TODO ticker here
-    s"$name - await is blocking" in real {
-      newBarrier(2).flatMap {
-        _.await.timeout(100.millis).mustFailWith[TimeoutException]
-      }
-    }
 
     // TODO ticker here
     s"$name - await is cancelable" in real {

--- a/core/shared/src/test/scala/cats/effect/std/CyclicBarrierSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/CyclicBarrierSpec.scala
@@ -22,7 +22,6 @@ import cats.arrow.FunctionK
 import scala.concurrent.duration._
 
 import org.specs2.specification.core.Fragments
-import java.util.concurrent.TimeoutException
 import scala.reflect.ClassTag
 
 class CyclicBarrierSpec extends BaseSpec {

--- a/core/shared/src/test/scala/cats/effect/std/CyclicBarrierSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/CyclicBarrierSpec.scala
@@ -22,7 +22,6 @@ import cats.arrow.FunctionK
 import scala.concurrent.duration._
 
 import org.specs2.specification.core.Fragments
-import scala.reflect.ClassTag
 
 class CyclicBarrierSpec extends BaseSpec {
 
@@ -31,19 +30,6 @@ class CyclicBarrierSpec extends BaseSpec {
     cyclicBarrierTests(
       "Cyclic barrier mapK",
       CyclicBarrier.apply[IO](_).map(_.mapK(FunctionK.id)))
-  }
-
-  implicit class Assertions[A](fa: IO[A]) {
-    def mustFailWith[E <: Throwable: ClassTag] =
-      fa.attempt.flatMap { res =>
-        IO {
-          res must beLike {
-            case Left(e) => e must haveClass[E]
-          }
-        }
-      }
-
-    def mustEqual(a: A) = fa.flatMap { res => IO(res must beEqualTo(a)) }
   }
 
   private def cyclicBarrierTests(

--- a/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
+++ b/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
@@ -77,10 +77,10 @@ object CyclicBarrier {
                       State(capacity, epoch + 1, gate) -> unblock.complete(()).void
                     else {
                       val newState = State(awaitingNow, epoch, unblock)
+                      // reincrement count if this await gets canceled,
+                      // but only if the barrier hasn't reset in the meantime
                       val cleanup = state.update { s =>
-                        // if the barrier has reset, do not modify the count
-                        if (s.epoch == epoch)
-                          s.copy(awaiting = s.awaiting + 1)
+                        if (s.epoch == epoch) s.copy(awaiting = s.awaiting + 1)
                         else s
                       }
 

--- a/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
+++ b/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
@@ -74,7 +74,7 @@ object CyclicBarrier {
     case class State[F[_]](awaiting: Int, epoch: Long, unblock: Deferred[F, Unit])
 
     F.deferred[Unit]
-      .map(gate => State(awaiting = capacity, epoch = 0, unblock = gate))
+      .map(gate => State(capacity,0, gate))
       .flatMap(F.ref)
       .map { state =>
         new CyclicBarrier[F] {

--- a/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
+++ b/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
@@ -90,6 +90,7 @@ object CyclicBarrier {
                     else {
                       val newState = State(awaitingNow, epoch, unblock)
                       val cleanup = state.update { s =>
+                        // if the barrier has reset, do not modify the count
                         if (s.epoch == epoch)
                           s.copy(awaiting = s.awaiting + 1)
                         else s

--- a/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
+++ b/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
@@ -39,16 +39,6 @@ abstract class CyclicBarrier[F[_]] { self =>
    */
   def await: F[Unit]
 
-  /*
-   * The number of fibers required to trip the barrier
-   */
-  def remaining: F[Int]
-
-  /*
-   * The number of fibers currently awaiting
-   */
-  def awaiting: F[Int]
-
   /**
    * Modifies the context in which this cyclic barrier is executed using the natural
    * transformation `f`.
@@ -59,8 +49,6 @@ abstract class CyclicBarrier[F[_]] { self =>
   def mapK[G[_]](f: F ~> G): CyclicBarrier[G] =
     new CyclicBarrier[G] {
       def await: G[Unit] = f(self.await)
-      def remaining: G[Int] = f(self.remaining)
-      def awaiting: G[Int] = f(self.awaiting)
     }
 
 }
@@ -102,9 +90,6 @@ object CyclicBarrier {
                 }.flatten
               }
             }
-
-          val remaining: F[Int] = state.get.map(_.awaiting)
-          val awaiting: F[Int] = state.get.map(s => capacity - s.awaiting)
         }
       }
   }

--- a/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
+++ b/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
@@ -59,7 +59,7 @@ object CyclicBarrier {
       throw new IllegalArgumentException(
         s"Cyclic barrier constructed with capacity $capacity. Must be > 0")
 
-    case class State[F[_]](awaiting: Int, epoch: Long, unblock: Deferred[F, Unit])
+    case class State(awaiting: Int, epoch: Long, unblock: Deferred[F, Unit])
 
     F.deferred[Unit].map(State(capacity, 0, _)).flatMap(F.ref).map { state =>
       new CyclicBarrier[F] {

--- a/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
+++ b/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
@@ -17,7 +17,7 @@
 package cats.effect.std
 
 import cats.~>
-import cats.effect.kernel.{Deferred, GenConcurrent, Ref}
+import cats.effect.kernel.{Deferred, GenConcurrent}
 import cats.effect.kernel.syntax.all._
 import cats.syntax.all._
 

--- a/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
+++ b/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
@@ -66,50 +66,45 @@ abstract class CyclicBarrier[F[_]] { self =>
 }
 
 object CyclicBarrier {
-  def apply[F[_]](n: Int)(implicit F: GenConcurrent[F, _]): F[CyclicBarrier[F]] =
-    if (n < 1)
+  def apply[F[_]](capacity: Int)(implicit F: GenConcurrent[F, _]): F[CyclicBarrier[F]] = {
+    if (capacity < 1)
       throw new IllegalArgumentException(
-        s"Cyclic barrier constructed with capacity $n. Must be > 0")
-    else
-      for {
-        state <- State.initial[F]
-        ref <- F.ref(state)
-      } yield new ConcurrentCyclicBarrier(n, ref)
+        s"Cyclic barrier constructed with capacity $capacity. Must be > 0")
 
-  private[std] class ConcurrentCyclicBarrier[F[_]](capacity: Int, state: Ref[F, State[F]])(
-      implicit F: GenConcurrent[F, _])
-      extends CyclicBarrier[F] {
+    case class State[F[_]](awaiting: Int, epoch: Long, unblock: Deferred[F, Unit])
 
-    val await: F[Unit] =
-      F.deferred[Unit].flatMap { newSignal =>
-        F.uncancelable { poll =>
-          state.modify {
-            case State(awaiting, epoch, signal) =>
-              if (awaiting < capacity - 1) {
-                val cleanup = state.update { s =>
-                  if (epoch == s.epoch)
-                    //The cyclic barrier hasn't been reset since the cancelled fiber start to await
-                    s.copy(awaiting = s.awaiting - 1)
-                  else s
-                }
+    F.deferred[Unit]
+      .map(gate => State(awaiting = capacity, epoch = 0, unblock = gate))
+      .flatMap(F.ref)
+      .map { state =>
+        new CyclicBarrier[F] {
+          val await: F[Unit] =
+            F.deferred[Unit].flatMap { gate =>
+              F.uncancelable { poll =>
+                state.modify {
+                  case State(awaiting, epoch, unblock) =>
+                    val awaitingNow = awaiting - 1
 
-                val nextState = State(awaiting + 1, epoch, signal)
-                (nextState, poll(signal.get).onCancel(cleanup))
-              } else (State(0, epoch + 1, newSignal), signal.complete(()).void)
-          }.flatten
+                    if (awaitingNow == 0)
+                      State(capacity, epoch + 1, gate) -> unblock.complete(()).void
+                    else {
+                      val newState = State(awaitingNow, epoch, unblock)
+                      val cleanup = state.update { s =>
+                        if (s.epoch == epoch)
+                          s.copy(awaiting = s.awaiting + 1)
+                        else s
+                      }
+
+                      newState -> poll(unblock.get).onCancel(cleanup)
+                    }
+
+                }.flatten
+              }
+            }
+
+          val remaining: F[Int] = state.get.map(_.awaiting)
+          val awaiting: F[Int] = state.get.map(s => capacity - s.awaiting)
         }
       }
-
-    val remaining: F[Int] = state.get.map(s => capacity - s.awaiting)
-
-    val awaiting: F[Int] = state.get.map(_.awaiting)
-
-  }
-
-  private[std] case class State[F[_]](awaiting: Int, epoch: Long, signal: Deferred[F, Unit])
-
-  private[std] object State {
-    def initial[F[_]](implicit F: GenConcurrent[F, _]): F[State[F]] =
-      F.deferred[Unit].map { signal => State(0, 0, signal) }
   }
 }


### PR DESCRIPTION
Few changes:
- Changed the state machine to align with Countdown latch, I think it makes for slightly easier logic, see `awaitingNow == 0` vs `awaiting < capacity - 1`
- Changed the tests to never rely on inspecting the internal state of the barrier
- Removed awaiting and remaining