### PR TITLE
Reduce contention in the work stealing pool for single fiber workloads

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -27,4 +27,5 @@ private[effect] sealed abstract class WorkStealingThreadPool private ()
   def reportFailure(cause: Throwable): Unit = ()
   private[effect] def executeFiber(fiber: IOFiber[_]): Unit = { val _ = fiber }
   private[effect] def rescheduleFiber(fiber: IOFiber[_]): Unit = { val _ = fiber }
+  private[effect] def rescheduleFiberAndNotify(fiber: IOFiber[_]): Unit = { val _ = fiber }
 }

--- a/core/shared/src/test/scala/cats/effect/Runners.scala
+++ b/core/shared/src/test/scala/cats/effect/Runners.scala
@@ -287,8 +287,6 @@ trait Runners extends SpecificationLike with RunnersPlatform { outer =>
     def mustEqual(a: A) = fa.flatMap { res => IO(res must beEqualTo(a)) }
   }
 
-
-
   def unsafeRun[A](ioa: IO[A])(implicit ticker: Ticker): Outcome[Option, Throwable, A] =
     try {
       var results: Outcome[Option, Throwable, A] = Outcome.Succeeded(None)


### PR DESCRIPTION
Before:
```
Benchmark                                   (size)   Mode  Cnt      Score     Error    Units
AsyncBenchmark.async                           100  thrpt   20  13667.317 ± 348.631    ops/s
AsyncBenchmark.bracket                         100  thrpt   20  22014.508 ± 127.456    ops/s
AsyncBenchmark.cancelable                      100  thrpt   20  13961.902 ±  70.182    ops/s
AsyncBenchmark.race                            100  thrpt   20   6185.285 ± 121.977    ops/s
AsyncBenchmark.racePair                        100  thrpt   20   6694.116 ±  17.849    ops/s
AsyncBenchmark.start                           100  thrpt   20   5947.459 ± 107.673    ops/s
AsyncBenchmark.uncancelable                    100  thrpt   20  43282.296 ± 199.842    ops/s
AttemptBenchmark.errorRaised                 10000  thrpt   20   1063.594 ±   6.589    ops/s
AttemptBenchmark.happyPath                   10000  thrpt   20   1441.435 ±   9.481    ops/s
BothBenchmark.happyPath                      10000  thrpt   20     16.865 ±   0.096    ops/s
DeepBindBenchmark.async                      10000  thrpt   20    350.478 ±  12.766    ops/s
DeepBindBenchmark.delay                      10000  thrpt   20   1961.104 ±   8.073    ops/s
DeepBindBenchmark.pure                       10000  thrpt   20   2282.658 ±  16.618    ops/s
HandleErrorBenchmark.errorRaised             10000  thrpt   20   1189.041 ±   8.580    ops/s
HandleErrorBenchmark.happyPath               10000  thrpt   20   1349.987 ±   6.605    ops/s
MapCallsBenchmark.batch120                     N/A  thrpt   20    521.934 ±   4.615    ops/s
MapCallsBenchmark.batch30                      N/A  thrpt   20    143.441 ±   1.336    ops/s
MapCallsBenchmark.one                          N/A  thrpt   20      4.907 ±   0.059    ops/s
MapStreamBenchmark.batch120                    N/A  thrpt   20   2195.644 ±   7.286    ops/s
MapStreamBenchmark.batch30                     N/A  thrpt   20    910.502 ±  26.783    ops/s
MapStreamBenchmark.one                         N/A  thrpt   20   1030.835 ±   3.434    ops/s
RaceBenchmark.happyPath                      10000  thrpt   20     15.170 ±   0.173    ops/s
RedeemBenchmark.errorRaised                  10000  thrpt   20    845.651 ±  22.259    ops/s
RedeemBenchmark.happyPath                    10000  thrpt   20    994.516 ±  10.649    ops/s
RedeemWithBenchmark.errorRaised              10000  thrpt   20   1018.239 ±   7.005    ops/s
RedeemWithBenchmark.happyPath                10000  thrpt   20   1354.019 ±  28.942    ops/s
RefBenchmark.getAndUpdate                      N/A  thrpt   20   1740.730 ±  10.334    ops/s
RefBenchmark.modify                            N/A  thrpt   20   1710.516 ±   7.529    ops/s
ShallowBindBenchmark.async                   10000  thrpt   20    350.767 ±  10.072    ops/s
ShallowBindBenchmark.delay                   10000  thrpt   20   2255.537 ±  10.828    ops/s
ShallowBindBenchmark.pure                    10000  thrpt   20   2207.037 ±  32.914    ops/s
WorkStealingBenchmark.async                1000000  thrpt   20      5.491 ±   0.335  ops/min
WorkStealingBenchmark.asyncTooManyThreads  1000000  thrpt   20      6.463 ±   0.478  ops/min
```

After:
```
Benchmark                                   (size)   Mode  Cnt      Score     Error    Units
AsyncBenchmark.async                           100  thrpt   20  13619.061 ±  70.505    ops/s
AsyncBenchmark.bracket                         100  thrpt   20  24427.880 ±  81.277    ops/s
AsyncBenchmark.cancelable                      100  thrpt   20  13984.036 ± 168.993    ops/s
AsyncBenchmark.race                            100  thrpt   20   6237.630 ± 101.186    ops/s
AsyncBenchmark.racePair                        100  thrpt   20   6240.244 ±  20.452    ops/s
AsyncBenchmark.start                           100  thrpt   20   6309.757 ± 135.034    ops/s
AsyncBenchmark.uncancelable                    100  thrpt   20  43199.947 ± 249.499    ops/s
AttemptBenchmark.errorRaised                 10000  thrpt   20   1299.874 ±   1.146    ops/s
AttemptBenchmark.happyPath                   10000  thrpt   20   1804.523 ±   0.636    ops/s
BothBenchmark.happyPath                      10000  thrpt   20     15.821 ±   0.945    ops/s
DeepBindBenchmark.async                      10000  thrpt   20   1101.472 ±  48.721    ops/s
DeepBindBenchmark.delay                      10000  thrpt   20   2414.858 ±   4.997    ops/s
DeepBindBenchmark.pure                       10000  thrpt   20   2712.536 ±   2.313    ops/s
HandleErrorBenchmark.errorRaised             10000  thrpt   20   1563.104 ±  16.091    ops/s
HandleErrorBenchmark.happyPath               10000  thrpt   20   1658.463 ±   0.449    ops/s
MapCallsBenchmark.batch120                     N/A  thrpt   20    524.269 ±   4.537    ops/s
MapCallsBenchmark.batch30                      N/A  thrpt   20    139.856 ±   1.367    ops/s
MapCallsBenchmark.one                          N/A  thrpt   20      4.967 ±   0.048    ops/s
MapStreamBenchmark.batch120                    N/A  thrpt   20   2475.578 ±  67.613    ops/s
MapStreamBenchmark.batch30                     N/A  thrpt   20   1007.556 ±   7.326    ops/s
MapStreamBenchmark.one                         N/A  thrpt   20   1213.595 ±   3.109    ops/s
RaceBenchmark.happyPath                      10000  thrpt   20     17.027 ±   0.398    ops/s
RedeemBenchmark.errorRaised                  10000  thrpt   20   1024.799 ±   1.156    ops/s
RedeemBenchmark.happyPath                    10000  thrpt   20   1195.834 ±   1.516    ops/s
RedeemWithBenchmark.errorRaised              10000  thrpt   20   1304.302 ±   1.780    ops/s
RedeemWithBenchmark.happyPath                10000  thrpt   20   1633.559 ±  20.349    ops/s
RefBenchmark.getAndUpdate                      N/A  thrpt   20   2214.352 ±  67.742    ops/s
RefBenchmark.modify                            N/A  thrpt   20   2005.837 ±   5.864    ops/s
ShallowBindBenchmark.async                   10000  thrpt   20   1073.247 ±  24.908    ops/s
ShallowBindBenchmark.delay                   10000  thrpt   20   2743.170 ±   2.191    ops/s
ShallowBindBenchmark.pure                    10000  thrpt   20   2853.326 ±  78.354    ops/s
WorkStealingBenchmark.async                1000000  thrpt   20      5.766 ±   0.238  ops/min
WorkStealingBenchmark.asyncTooManyThreads  1000000  thrpt   20      6.770 ±   0.447  ops/min
```