### PR TITLE
Make AsyncPlatform a trait

### DIFF
--- a/kernel/js/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
+++ b/kernel/js/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
@@ -18,7 +18,7 @@ package cats.effect.kernel
 
 import scala.scalajs.js.{|, defined, Function1, JavaScriptException, Promise, Thenable}
 
-private[kernel] abstract class AsyncPlatform[F[_]] { this: Async[F] =>
+private[kernel] trait AsyncPlatform[F[_]] { this: Async[F] =>
 
   def fromPromise[A](iop: F[Promise[A]]): F[A] =
     flatMap(iop) { p =>

--- a/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
@@ -18,7 +18,7 @@ package cats.effect.kernel
 
 import java.util.concurrent.CompletableFuture
 
-private[kernel] abstract class AsyncPlatform[F[_]] { this: Async[F] =>
+private[kernel] trait AsyncPlatform[F[_]] { this: Async[F] =>
 
   def fromCompletableFuture[A](fut: F[CompletableFuture[A]]): F[A] =
     flatMap(fut) { cf =>


### PR DESCRIPTION
Otherwise we can't have user code extend another class and `Async`