### PR TITLE
Raise exception when IOApp main fiber is canceled

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOApp.scala
+++ b/core/js/src/main/scala/cats/effect/IOApp.scala
@@ -42,7 +42,8 @@ trait IOApp {
       else
         args.toList
 
-    Spawn[IO].raceOutcome[ExitCode, Nothing](run(argList), keepAlive)
+    Spawn[IO]
+      .raceOutcome[ExitCode, Nothing](run(argList), keepAlive)
       .flatMap {
         case Left(Outcome.Canceled()) =>
           IO.raiseError(new RuntimeException("IOApp main fiber canceled"))

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -34,15 +34,21 @@ trait IOApp {
 
     val ioa = run(args.toList)
 
-    val fiber = ioa.unsafeRunFiber(
-      { t =>
-        error = t
-        latch.countDown()
-      },
-      { a =>
-        result = a
-        latch.countDown()
-      })(runtime)
+    val fiber =
+      ioa.onCancel(
+        IO {
+          error = new RuntimeException("IOApp main fiber canceled")
+          latch.countDown()
+        })
+      .unsafeRunFiber(
+        { t =>
+          error = t
+          latch.countDown()
+        },
+        { a =>
+          result = a
+          latch.countDown()
+        })(runtime)
 
     def handleShutdown(): Unit = {
       if (latch.getCount() > 0) {

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -35,20 +35,20 @@ trait IOApp {
     val ioa = run(args.toList)
 
     val fiber =
-      ioa.onCancel(
-        IO {
+      ioa
+        .onCancel(IO {
           error = new RuntimeException("IOApp main fiber canceled")
           latch.countDown()
         })
-      .unsafeRunFiber(
-        { t =>
-          error = t
-          latch.countDown()
-        },
-        { a =>
-          result = a
-          latch.countDown()
-        })(runtime)
+        .unsafeRunFiber(
+          { t =>
+            error = t
+            latch.countDown()
+          },
+          { a =>
+            result = a
+            latch.countDown()
+          })(runtime)
 
     def handleShutdown(): Unit = {
       if (latch.getCount() > 0) {

--- a/core/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/core/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -108,6 +108,12 @@ class IOAppSpec extends Specification {
         h.awaitStatus() mustEqual 1
         h.stderr() must contain("Boom!")
       }
+
+      "exit on canceled" in {
+        val h = java(Canceled, List.empty)
+        h.awaitStatus() mustEqual 1
+        h.stderr() must contain("canceled")
+      }
     }
   }
 
@@ -178,5 +184,10 @@ package examples {
         _ <- IO.blocking(IO(throw new OutOfMemoryError("Boom!")).start.unsafeRunSync())
         _ <- IO.never[Unit]
       } yield ExitCode.Success
+  }
+
+  object Canceled extends IOApp {
+    def run(args: List[String]): IO[ExitCode] =
+      IO.canceled.as(ExitCode.Success)
   }
 }


### PR DESCRIPTION
Ensures `IOApp` terminates with an exception if the main fiber is canceled.

Closes #1451 