### PR TITLE
More ParTraverseN 

### DIFF
--- a/core/shared/src/test/scala/cats/effect/IOPropSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOPropSpec.scala
@@ -30,7 +30,6 @@ import org.scalacheck.Gen
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
 
-
 //We allow these tests to have a longer timeout than IOSpec as they run lots of iterations
 class IOPropSpec extends IOPlatformSpecification with Discipline with ScalaCheck with BaseSpec {
   outer =>
@@ -45,9 +44,7 @@ class IOPropSpec extends IOPlatformSpecification with Discipline with ScalaCheck
         case (n, l) =>
           val f: Int => IO[Int] = n => IO.pure(n + 1)
 
-          l.parTraverse(f).flatMap { expected =>
-            l.parTraverseN(n)(f).mustEqual(expected)
-          }
+          l.parTraverse(f).flatMap { expected => l.parTraverseN(n)(f).mustEqual(expected) }
       }
 
       "never exceed the maximum bound of concurrent tasks" in realProp {
@@ -55,21 +52,23 @@ class IOPropSpec extends IOPlatformSpecification with Discipline with ScalaCheck
           length <- Gen.chooseNum(0, 50)
           limit <- Gen.chooseNum(1, 15, 2, 5)
         } yield length -> limit
-      } { case (length, limit) =>
-        Queue.unbounded[IO, Int].flatMap { q =>
-          val task = q.offer(1) >> IO.sleep(7.millis) >> q.offer(-1)
-          val testRun = List.fill(length)(task).parSequenceN(limit)
-          def check(acc: Int = 0): IO[Unit] = q.tryTake.flatMap {
-            case None => IO.unit
-            case Some(n) =>
-              val newAcc = acc + n
-              if (newAcc > limit)
-                IO.raiseError(new Exception(s"Limit of $limit exceeded, was $newAcc"))
-              else check(newAcc)
-          }
+      } {
+        case (length, limit) =>
+          Queue.unbounded[IO, Int].flatMap { q =>
+            val task = q.offer(1) >> IO.sleep(7.millis) >> q.offer(-1)
+            val testRun = List.fill(length)(task).parSequenceN(limit)
+            def check(acc: Int = 0): IO[Unit] =
+              q.tryTake.flatMap {
+                case None => IO.unit
+                case Some(n) =>
+                  val newAcc = acc + n
+                  if (newAcc > limit)
+                    IO.raiseError(new Exception(s"Limit of $limit exceeded, was $newAcc"))
+                  else check(newAcc)
+              }
 
-          testRun >> check().mustEqual(())
-        }
+            testRun >> check().mustEqual(())
+          }
       }
     }
 

--- a/core/shared/src/test/scala/cats/effect/IOPropSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOPropSpec.scala
@@ -38,30 +38,24 @@ class IOPropSpec extends IOPlatformSpecification with Discipline with ScalaCheck
   "io monad" should {
 
     "parTraverseN" should {
-
-      "should give the same result as parTraverse" in realProp(
+      "give the same result as parTraverse" in realProp(
         Gen.posNum[Int].flatMap(n => arbitrary[List[Int]].map(n -> _))) {
         case (n, l) =>
           val f: Int => IO[Int] = n => IO.pure(n + 1)
-          for {
-            actual <- IO.parTraverseN(n)(l)(f)
-            expected <- l.parTraverse(f)
-            res <- IO(actual mustEqual expected)
-          } yield res
-      }
 
+          l.parTraverse(f).flatMap { expected =>
+            l.parTraverseN(n)(f).mustEqual(expected)
+          }
+      }
     }
 
     "parSequenceN" should {
-
-      "should give the same result as parSequence" in realProp(
+      "give the same result as parSequence" in realProp(
         Gen.posNum[Int].flatMap(n => arbitrary[List[Int]].map(n -> _))) {
         case (n, l) =>
-          for {
-            actual <- IO.parSequenceN(n)(l.map(IO.pure(_)))
-            expected <- l.map(IO.pure(_)).parSequence
-            res <- IO(actual mustEqual expected)
-          } yield res
+          l.map(IO.pure(_)).parSequence.flatMap { expected =>
+            l.map(IO.pure(_)).parSequenceN(n).mustEqual(expected)
+          }
       }
 
     }

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -960,14 +960,14 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
         }.mustFailWith[IllegalArgumentException]
       }
 
-      "should propagate errors" in real {
+      "propagate errors" in real {
         List(1, 2, 3)
           .parTraverseN(2) { (n: Int) =>
             if (n == 2) IO.raiseError(new RuntimeException) else n.pure[IO]
           }.mustFailWith[RuntimeException]
       }
 
-      "should be cancelable" in ticked { implicit ticker =>
+      "be cancelable" in ticked { implicit ticker =>
         val p = for {
           f <- List(1, 2, 3).parTraverseN(2)(_ => IO.never).start
           _ <- IO.sleep(100.millis)

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -964,7 +964,8 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
         List(1, 2, 3)
           .parTraverseN(2) { (n: Int) =>
             if (n == 2) IO.raiseError(new RuntimeException) else n.pure[IO]
-          }.mustFailWith[RuntimeException]
+          }
+          .mustFailWith[RuntimeException]
       }
 
       "be cancelable" in ticked { implicit ticker =>

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -954,8 +954,8 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
 
     "parTraverseN" should {
 
-      "should raise error when n < 1" in real {
-        List.empty[Int].parTraverseN(0)((n: Int) => IO.pure(n + 1)).attempt.flatMap { res =>
+      "throw when n < 1" in real {
+        IO.defer(List.empty[Int].parTraverseN(0)((n: Int) => IO.pure(n + 1))).attempt.flatMap { res =>
           IO(res must beLike {
             case Left(e) => e must haveClass[IllegalArgumentException]
           })

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -967,21 +967,6 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
           }.mustFailWith[RuntimeException]
       }
 
-      "should cleanup on error" in real {
-        for {
-          c <- IO.ref(0)
-          f <- List(1, 2, 3)
-            .parTraverseN(1) { (n: Int) =>
-              IO.sleep(1.second) >> (if (n == 2) IO.raiseError(new RuntimeException)
-              else IO.pure(n)) >> c.update(_ + 1)
-            }
-            .start
-          _ <- f.join
-          r <- c.get
-          res <- IO(r must beLessThanOrEqualTo(2))
-        } yield res
-      }
-
       "should be cancelable" in real {
         for {
           c <- IO.ref(0)

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -967,15 +967,14 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
           }.mustFailWith[RuntimeException]
       }
 
-      "should be cancelable" in real {
-        for {
-          c <- IO.ref(0)
-          f <- List(1, 2, 3).parTraverseN(1)(_ => IO.sleep(1.second) >> c.update(_ + 1)).start
-          _ <- IO.sleep(10.millis)
+      "should be cancelable" in ticked { implicit ticker =>
+        val p = for {
+          f <- List(1, 2, 3).parTraverseN(2)(_ => IO.never).start
+          _ <- IO.sleep(100.millis)
           _ <- f.cancel
-          _ <- IO.sleep(1.second)
-          r <- c.get.mustEqual(0)
-         } yield r
+        } yield true
+
+        p must completeAs(true)
       }
 
     }

--- a/core/shared/src/test/scala/cats/effect/kernel/MiniSemaphoreSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/kernel/MiniSemaphoreSpec.scala
@@ -19,79 +19,76 @@ package effect
 package kernel
 
 import scala.concurrent.duration._
-import java.util.concurrent.TimeoutException
 
 class MiniSemaphoreSpec extends BaseSpec { outer =>
 
   "mini semaphore" should {
-
     "throw on negative n" in real {
-      IO.defer(MiniSemaphore[IO](-1)).attempt.flatMap { res =>
-        IO {
-          res must beLike {
-            case Left(e) => e must haveClass[IllegalArgumentException]
-          }
-        }
+      IO.defer(MiniSemaphore[IO](-1)).mustFailWith[IllegalArgumentException]
+    }
 
+    "block if no permits available" in ticked { implicit ticker =>
+      MiniSemaphore[IO](0).flatMap { sem =>
+        sem.withPermit(IO.unit)
+      } must nonTerminate
+    }
+
+    "execute action if permit is available for it" in real {
+      MiniSemaphore[IO](1).flatMap { sem =>
+        sem.withPermit(IO.unit).mustEqual(())
       }
     }
 
-    "block if no permits available" in real {
-      for {
-        sem <- MiniSemaphore[IO](0)
-        r <- sem.acquire.timeout(10.millis).attempt
-        res <- IO {
-          r must beLike {
-            case Left(e) => e must haveClass[TimeoutException]
-          }
-        }
-      } yield res
-    }
+    "unblock when permit is released" in ticked { implicit ticker =>
+      val p =
+        for {
+          sem <- MiniSemaphore[IO](1)
+          ref <- IO.ref(0)
+          _ <- sem.withPermit { IO.sleep(1.second) >> ref.set(1) }.start
+          _ <- IO.sleep(500.millis)
+          _ <- sem.withPermit(IO.unit)
+          v <- ref.get
+        } yield v
 
-    "acquire if permit is available" in real {
-      for {
-        sem <- MiniSemaphore[IO](1)
-        r <- sem.acquire.timeout(10.millis).attempt
-        res <- IO { r must beEqualTo(Right(())) }
-      } yield res
-
-    }
-
-    "unblock when permit is released" in real {
-      for {
-        sem <- MiniSemaphore[IO](1)
-        _ <- sem.acquire
-        f <- sem.acquire.start
-        _ <- IO.sleep(100.millis)
-        _ <- sem.release
-        r <- f.joinAndEmbedNever
-        res <- IO { r must beEqualTo(()) }
-      } yield res
+      p must completeAs(1)
     }
 
     "release permit if withPermit errors" in real {
       for {
         sem <- MiniSemaphore[IO](1)
-        _ <- sem.withPermit(IO.raiseError(new RuntimeException("BOOM"))).attempt
-        //withPermit should have released the permit again
-        r <- sem.acquire.timeout(10.millis).attempt
-        res <- IO { r must beEqualTo(Right(())) }
+        _ <- sem.withPermit(IO.raiseError(new Exception)).attempt
+        res <- sem.withPermit(IO.unit).mustEqual(())
       } yield res
     }
 
-    "acquire is cancelable" in real {
-      for {
-        sem <- MiniSemaphore[IO](1)
-        _ <- sem.acquire
-        f <- sem.acquire.start
-        _ <- IO.sleep(100.millis)
-        _ <- f.cancel
-        _ <- sem.release
-        //The fiber that was cancelled should not have acquired the permit
-        r <- sem.acquire.timeout(10.millis).attempt
-        res <- IO { r must beEqualTo(Right(())) }
-      } yield res
-    }
+    // // TODO falsify this test
+    // "release permit if action gets canceled" in ticked { implicit ticker =>
+    //   val p =
+    //     for {
+    //       sem <- MiniSemaphore[IO](1)
+    //       fiber <- sem.withPermit(IO.never).start
+    //       _ <- IO.sleep(1.second)
+    //       _ <- fiber.cancel
+    //       _ <- sem.withPermit(IO.unit)
+    //     } yield ()
+
+    //   p must completeAs(())
+    // }
+
+    // "allow cancelation if blocked waiting for permit" in ticked { implicit ticker =>
+    //   for {
+    //     sem <- MiniSemaphore[IO](1)
+    //     _ <- sem.acquire
+    //     f <- sem.acquire.start
+    //     _ <- IO.sleep(100.millis)
+    //     _ <- f.cancel
+    //     _ <- sem.release
+    //     //The fiber that was cancelled should not have acquired the permit
+    //     r <- sem.acquire.timeout(10.millis).attempt
+    //     res <- IO { r must beEqualTo(Right(())) }
+    //   } yield res
+
+   // }
   }
 
 }

--- a/core/shared/src/test/scala/cats/effect/kernel/MiniSemaphoreSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/kernel/MiniSemaphoreSpec.scala
@@ -29,15 +29,11 @@ class MiniSemaphoreSpec extends BaseSpec { outer =>
     }
 
     "block if no permits available" in ticked { implicit ticker =>
-      MiniSemaphore[IO](0).flatMap { sem =>
-        sem.withPermit(IO.unit)
-      } must nonTerminate
+      MiniSemaphore[IO](0).flatMap { sem => sem.withPermit(IO.unit) } must nonTerminate
     }
 
     "execute action if permit is available for it" in real {
-      MiniSemaphore[IO](1).flatMap { sem =>
-        sem.withPermit(IO.unit).mustEqual(())
-      }
+      MiniSemaphore[IO](1).flatMap { sem => sem.withPermit(IO.unit).mustEqual(()) }
     }
 
     "unblock when permit is released" in ticked { implicit ticker =>

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -85,8 +85,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
   /**
    * Like `Parallel.parSequence`, but limits the degree of parallelism.
    */
-  def parSequenceN[T[_]: Traverse, A](n: Int)(
-      tma: T[F[A]]): F[T[A]] =
+  def parSequenceN[T[_]: Traverse, A](n: Int)(tma: T[F[A]]): F[T[A]] =
     parTraverseN(n)(tma)(identity)
 
   /**
@@ -95,17 +94,12 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
    * fairness: when a spot to execute becomes available, every task
    * has a chance to claim it, and not only the next `n` tasks in `ta`
    */
-  def parTraverseN[T[_]: Traverse, A, B](n: Int)(ta: T[A])(
-    f: A => F[B]): F[T[B]] = {
+  def parTraverseN[T[_]: Traverse, A, B](n: Int)(ta: T[A])(f: A => F[B]): F[T[B]] = {
     require(n >= 1, s"Concurrency limit should be at least 1, was: $n")
 
     implicit val F: GenConcurrent[F, E] = this
 
-    MiniSemaphore[F](n).flatMap { sem =>
-      ta.parTraverse { a =>
-        sem.withPermit(f(a))
-      }
-    }
+    MiniSemaphore[F](n).flatMap { sem => ta.parTraverse { a => sem.withPermit(f(a)) } }
   }
 
   override def racePair[A, B](fa: F[A], fb: F[B])

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -16,9 +16,11 @@
 
 package cats.effect.kernel
 
-import cats.{Monoid, Parallel, Semigroup, Traverse}
+import cats.{Monoid, Semigroup, Traverse}
 import cats.syntax.all._
 import cats.effect.kernel.syntax.all._
+import  cats.effect.kernel.instances.spawn._
+
 import cats.data.{EitherT, IorT, Kleisli, OptionT, WriterT}
 
 trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
@@ -84,14 +86,14 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
    * Like `Parallel.parSequence`, but limits the degree of parallelism.
    */
   def parSequenceN[T[_]: Traverse, A](n: Int)(
-      tma: T[F[A]])(implicit P: Parallel[F], ev: E <:< Throwable): F[T[A]] =
+      tma: T[F[A]])(implicit ev: E <:< Throwable): F[T[A]] =
     parTraverseN(n)(tma)(identity)
 
   /**
    * Like `Parallel.parTraverse`, but limits the degree of parallelism.
    */
   def parTraverseN[T[_]: Traverse, A, B](n: Int)(ta: T[A])(
-      f: A => F[B])(implicit P: Parallel[F], ev: E <:< Throwable): F[T[B]] = {
+      f: A => F[B])(implicit ev: E <:< Throwable): F[T[B]] = {
 
     implicit val F: GenConcurrent[F, Throwable] = this.asInstanceOf[GenConcurrent[F, Throwable]]
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MiniSemaphore.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MiniSemaphore.scala
@@ -19,7 +19,7 @@ package effect
 package kernel
 
 import cats.syntax.all._
-
+import cats.effect.kernel.syntax.all._
 import scala.collection.immutable.{Queue => ScalaQueue}
 
 /**
@@ -46,6 +46,59 @@ private[kernel] abstract class MiniSemaphore[F[_]] {
 }
 
 private[kernel] object MiniSemaphore {
+
+  def mini[F[_]](n: Int)(implicit F: GenConcurrent[F, _]): F[MiniSemaphore[F]] = {
+
+    // this representation appears more intuitive at first, but it's
+    // actually weird, since a semaphore at zero permits is Right(0)
+    // in `acquire`, but Left(empty) in `release`
+    type State = Either[ScalaQueue[Deferred[F, Unit]], Int]
+
+    F.ref[State](Right(n)).map { state =>
+      new MiniSemaphore[F] {
+        def acquire: F[Unit] =
+          F.uncancelable { poll =>
+            F.deferred[Unit].flatMap { wait =>
+              val cleanup = state.update {
+                case Left(waiting) => Left(waiting.filterNot(_ eq wait))
+                case Right(m) => Right(m)
+              }
+
+              state.modify {
+                case Right(permits) =>
+                  if (permits == 0)
+                    Left(ScalaQueue(wait)) -> poll(wait.get).onCancel(cleanup)
+                  else
+                    Right(permits - 1) -> ().pure[F]
+
+                case Left(waiting) =>
+                  Left(waiting :+ wait) -> poll(wait.get).onCancel(cleanup)
+              }.flatten
+            }
+          }
+
+        def release: F[Unit] =
+          state.modify { st =>
+            st match {
+              case Left(waiting) =>
+                if (waiting.isEmpty)
+                  Right(1) -> ().pure[F]
+                else
+                  Left(waiting.tail) -> waiting.head.complete(()).void
+              case Right(m) =>
+                Right(m + 1) -> ().pure[F]
+            }
+          }.flatten
+            .uncancelable
+
+        def withPermit[A](fa: F[A]): F[A] =
+          F.uncancelable { poll =>
+            poll(acquire) >> poll(fa).guarantee(release)
+          }
+      }
+    }
+  }
+
 
   /**
    * Creates a new `Semaphore`, initialized with `n` available permits.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MiniSemaphore.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MiniSemaphore.scala
@@ -31,7 +31,6 @@ private[kernel] abstract class MiniSemaphore[F[_]] {
    * Sequence an action while holding a permit
    */
   def withPermit[A](fa: F[A]): F[A]
-
 }
 
 private[kernel] object MiniSemaphore {

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenConcurrentSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenConcurrentSyntax.scala
@@ -41,8 +41,7 @@ final class GenConcurrentOps[F[_], E, A] private[syntax] (private[syntax] val wr
 final class ConcurrentParTraverseNOps[F[_], T[_], A, B] private[syntax] (
     private[syntax] val wrapped: T[A])
     extends AnyVal {
-  def parTraverseN(n: Int)(
-      f: A => F[B])(implicit F: Concurrent[F], T: Traverse[T]): F[T[B]] =
+  def parTraverseN(n: Int)(f: A => F[B])(implicit F: Concurrent[F], T: Traverse[T]): F[T[B]] =
     F.parTraverseN(n)(wrapped)(f)
 }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenConcurrentSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenConcurrentSyntax.scala
@@ -17,7 +17,7 @@
 package cats.effect.kernel.syntax
 
 import cats.effect.kernel.{Concurrent, GenConcurrent}
-import cats.{Parallel, Traverse}
+import cats.Traverse
 
 trait GenConcurrentSyntax {
   implicit def genConcurrentOps[F[_], E, A](wrapped: F[A]): GenConcurrentOps[F, E, A] =
@@ -42,13 +42,13 @@ final class ConcurrentParTraverseNOps[F[_], T[_], A, B] private[syntax] (
     private[syntax] val wrapped: T[A])
     extends AnyVal {
   def parTraverseN(n: Int)(
-      f: A => F[B])(implicit F: Concurrent[F], P: Parallel[F], T: Traverse[T]): F[T[B]] =
+      f: A => F[B])(implicit F: Concurrent[F], T: Traverse[T]): F[T[B]] =
     F.parTraverseN(n)(wrapped)(f)
 }
 
 final class ConcurrentParSequenceNOps[F[_], T[_], A] private[syntax] (
     private[syntax] val wrapped: T[F[A]])
     extends AnyVal {
-  def parSequenceN(n: Int)(implicit F: Concurrent[F], P: Parallel[F], T: Traverse[T]): F[T[A]] =
+  def parSequenceN(n: Int)(implicit F: Concurrent[F], T: Traverse[T]): F[T[A]] =
     F.parSequenceN(n)(wrapped)
 }

--- a/kernel/shared/src/test/scala/cats/effect/kernel/SyntaxSpec.scala
+++ b/kernel/shared/src/test/scala/cats/effect/kernel/SyntaxSpec.scala
@@ -44,7 +44,6 @@ class SyntaxSpec extends Specification {
 
   def concurrentSyntax[F[_], A](target: F[A])(implicit F: Concurrent[F]) = {
     import syntax.concurrent._
-    import instances.all._
 
     Concurrent[F]: F.type
 


### PR DESCRIPTION
Several changes to parTraverseN

- Fixes a bug in MiniSemaphore, which prevented interruption during acquire
- Reverted to simplest implementation of parTraverseN
- Changed encoding of MiniSemaphore to take advantage of `uncancelable/poll`
- Strengthened tests