### PR TITLE
Use platform-dependent implementation of Clock.realTime

### DIFF
--- a/core/js/src/main/scala/cats/effect/internals/DefaultClock.scala
+++ b/core/js/src/main/scala/cats/effect/internals/DefaultClock.scala
@@ -16,23 +16,11 @@
 
 package cats.effect.internals
 
-import java.time.Instant
+import cats.effect.{Clock, Sync}
 
-import cats.Functor
-import cats.effect.Clock
+import scala.concurrent.duration.{MILLISECONDS, TimeUnit}
 
-import scala.concurrent.duration.NANOSECONDS
-
-private[effect] trait ClockPlatform {
-  implicit class JvmClockOps[F[_]](val self: Clock[F]) {
-
-    /**
-     * Creates a `java.time.Instant` derived from the clock's `realTime` in milliseconds
-     * for any `F` that has `Functor` defined.
-     */
-    def instantNow(implicit F: Functor[F]): F[Instant] =
-      F.map(self.realTime(NANOSECONDS)) { ns =>
-        Instant.EPOCH.plusNanos(ns)
-      }
-  }
+abstract private[effect] class DefaultClock[F[_]](implicit F: Sync[F]) extends Clock[F] {
+  def realTime(unit: TimeUnit): F[Long] =
+    F.delay(unit.convert(System.currentTimeMillis(), MILLISECONDS))
 }

--- a/core/shared/src/main/scala/cats/effect/Clock.scala
+++ b/core/shared/src/main/scala/cats/effect/Clock.scala
@@ -17,12 +17,12 @@
 package cats.effect
 
 import cats.effect.internals.ClockPlatform
-
+import cats.effect.internals.DefaultClock
 import cats.{~>, Applicative, Functor, Monoid}
 import cats.data._
 
 import scala.annotation.implicitNotFound
-import scala.concurrent.duration.{MILLISECONDS, NANOSECONDS, TimeUnit}
+import scala.concurrent.duration.{NANOSECONDS, TimeUnit}
 
 /**
  * Clock provides the current time, as a pure alternative to:
@@ -132,14 +132,10 @@ object Clock extends LowPriorityImplicits with ClockPlatform {
   /**
    * Provides Clock instance for any `F` that has `Sync` defined
    */
-  def create[F[_]](implicit F: Sync[F]): Clock[F] =
-    new Clock[F] {
-      override def realTime(unit: TimeUnit): F[Long] =
-        F.delay(unit.convert(System.currentTimeMillis(), MILLISECONDS))
-
-      override def monotonic(unit: TimeUnit): F[Long] =
-        F.delay(unit.convert(System.nanoTime(), NANOSECONDS))
-    }
+  def create[F[_]](implicit F: Sync[F]): Clock[F] = new DefaultClock[F] {
+    def monotonic(unit: TimeUnit): F[Long] =
+      F.delay(unit.convert(System.nanoTime(), NANOSECONDS))
+  }
 
   implicit class ClockOps[F[_]](val self: Clock[F]) extends AnyVal {
 


### PR DESCRIPTION
As discussed in #1460 