### PR TITLE
More accurate runloop filter

### DIFF
--- a/core/shared/src/main/scala/cats/effect/internals/IORunLoop.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/IORunLoop.scala
@@ -403,7 +403,7 @@ private[effect] object IORunLoop {
 
   private[this] val runLoopFilter = List(
     "cats.effect.",
-    "scala."
+    "scala.runtime."
   )
 
   /**


### PR DESCRIPTION
Fixes #1447 . I wouldn't be surprised if we find other edge cases down the line, but we'll just have to take these on a case-by-case basis.

Exception stack trace looks like this now:
```
java.lang.IllegalArgumentException: requirement failed: hello world!
	at scala.Predef$.require(Predef.scala:338)
	at example.TestApp$.$anonfun$program$1(TestApp.scala:23)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at map @ example.TestApp$.run(TestApp.scala:27)
	at main$ @ example.TestApp$.main(TestApp.scala:21)
```

cc @Avasil as Monix should probably make a similar change until we adopt the shared library :D 