### PR TITLE
Non-volatile sleeping flag

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -58,7 +58,7 @@ private final class WorkerThread(
 
   // Flag that indicates that this worker thread is currently sleeping, in order to
   // guard against spurious wakeups.
-  @volatile private[unsafe] var sleeping: Boolean = false
+  private[unsafe] var sleeping: Boolean = false
 
   /**
    * Enqueues a fiber to the local work stealing queue. This method always


### PR DESCRIPTION
The flag need not be volatile because it will be published by the `LockSupport.park` and `LockSupport.unpark` operations, which form a full memory fence.

Also verified on ARM, thanks to @djspiewak.