### PR TITLE
Unsafe and cache distancing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -204,7 +204,9 @@ lazy val core = crossProject(JSPlatform, JVMPlatform).in(file("core"))
       "org.typelevel" %%% "cats-kernel-laws"  % CatsVersion       % Test))
   .jvmSettings(
     Test / fork := true,
-    Test / javaOptions += s"-Dsbt.classpath=${(Test / fullClasspath).value.map(_.data.getAbsolutePath).mkString(File.pathSeparator)}")
+    Test / javaOptions += s"-Dsbt.classpath=${(Test / fullClasspath).value.map(_.data.getAbsolutePath).mkString(File.pathSeparator)}",
+    javacOptions := javacOptions.value.filterNot(_ == "-Werror")
+  )
 
 /**
  * Implementations lof standard functionality (e.g. Semaphore, Console, Queue)

--- a/core/jvm/src/main/java/cats/effect/Unsafe.java
+++ b/core/jvm/src/main/java/cats/effect/Unsafe.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.unsafe;
+
+import java.lang.reflect.Field;
+
+final class Unsafe {
+  private static final sun.misc.Unsafe UNSAFE;
+
+  static {
+    UNSAFE = findUnsafe();
+  }
+
+  static void acquireFence() {
+    UNSAFE.loadFence();
+  }
+
+  static void releaseFence() {
+    UNSAFE.storeFence();
+  }
+
+  static boolean compareAndSwapInt(Object object, long offset, int expected, int value) {
+    return UNSAFE.compareAndSwapInt(object, offset, expected, value);
+  }
+
+  static int getAndAddInt(Object object, long offset, int delta) {
+    return UNSAFE.getAndAddInt(object, offset, delta);
+  }
+
+  static int getInt(Object object, long offset) {
+    return UNSAFE.getInt(object, offset);
+  }
+
+  static void putInt(Object object, long offset, int value) {
+    UNSAFE.putInt(object, offset, value);
+  }
+
+  static long objectFieldOffset(Field field) {
+    return UNSAFE.objectFieldOffset(field);
+  }
+
+  private static sun.misc.Unsafe findUnsafe() {
+    sun.misc.Unsafe found = null;
+    try {
+      Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+      for (Field field : unsafeClass.getDeclaredFields()) {
+        if (field.getType() == unsafeClass) {
+          field.setAccessible(true);
+          found = (sun.misc.Unsafe) field.get(null);
+          break;
+        }
+      }
+    } catch (ClassNotFoundException | IllegalAccessException e) {
+      found = null;
+    }
+    return found;
+  }
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/ConcurrentCircularBuffer.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/ConcurrentCircularBuffer.scala
@@ -16,12 +16,28 @@
 
 package cats.effect.unsafe
 
-import java.util.concurrent.atomic.AtomicInteger
+private final class ConcurrentCircularBuffer(initialCapacity: Int)
+    extends ConcurrentCircularBuffer.TailPadding {
 
-private final class ConcurrentCircularBuffer(initialCapacity: Int) {
-  private[this] val head: AtomicInteger = new AtomicInteger(0)
+  private[this] val headOffset: Long = {
+    try {
+      val field = classOf[ConcurrentCircularBuffer.Head].getDeclaredField("head")
+      Unsafe.objectFieldOffset(field)
+    } catch {
+      case t: Throwable =>
+        throw new ExceptionInInitializerError(t)
+    }
+  }
 
-  private[this] val tail: AtomicInteger = new AtomicInteger(0)
+  private[this] val tailOffset: Long = {
+    try {
+      val field = classOf[ConcurrentCircularBuffer.Tail].getDeclaredField("tail")
+      Unsafe.objectFieldOffset(field)
+    } catch {
+      case t: Throwable =>
+        throw new ExceptionInInitializerError(t)
+    }
+  }
 
   private[this] val mask: Int = {
     // Bit twiddling hacks.
@@ -40,7 +56,7 @@ private final class ConcurrentCircularBuffer(initialCapacity: Int) {
     src & mask
 
   def enqueue(wt: WorkerThread): Unit = {
-    val tl = tail.getAndIncrement()
+    val tl = Unsafe.getAndAddInt(this, tailOffset, 1)
     val idx = index(tl)
     buffer(idx) = wt
   }
@@ -49,21 +65,90 @@ private final class ConcurrentCircularBuffer(initialCapacity: Int) {
     var idx = 0
     var hd = 0
     var tl = 0
+    var nx = 0
 
     while ({
-      hd = head.get()
-      tl = tail.get()
+      hd = Unsafe.getInt(this, headOffset)
+      tl = Unsafe.getInt(this, tailOffset)
 
       if (hd == tl)
         return null
 
       idx = hd
-      !head.compareAndSet(hd, hd + 1)
+      nx = hd + 1
+      !Unsafe.compareAndSwapInt(this, headOffset, hd, nx)
     }) ()
 
     idx = index(idx)
     val t = buffer(idx)
     buffer(idx) = null
     t
+  }
+}
+
+private object ConcurrentCircularBuffer {
+  abstract class InitPadding {
+    protected var pinit00: Long = _
+    protected var pinit01: Long = _
+    protected var pinit02: Long = _
+    protected var pinit03: Long = _
+    protected var pinit04: Long = _
+    protected var pinit05: Long = _
+    protected var pinit06: Long = _
+    protected var pinit07: Long = _
+    protected var pinit08: Long = _
+    protected var pinit09: Long = _
+    protected var pinit10: Long = _
+    protected var pinit11: Long = _
+    protected var pinit12: Long = _
+    protected var pinit13: Long = _
+    protected var pinit14: Long = _
+    protected var pinit15: Long = _
+  }
+
+  abstract class Head extends InitPadding {
+    @volatile protected var head: Int = 0
+  }
+
+  abstract class HeadPadding extends Head {
+    protected var phead00: Long = _
+    protected var phead01: Long = _
+    protected var phead02: Long = _
+    protected var phead03: Long = _
+    protected var phead04: Long = _
+    protected var phead05: Long = _
+    protected var phead06: Long = _
+    protected var phead07: Long = _
+    protected var phead08: Long = _
+    protected var phead09: Long = _
+    protected var phead10: Long = _
+    protected var phead11: Long = _
+    protected var phead12: Long = _
+    protected var phead13: Long = _
+    protected var phead14: Long = _
+    protected var phead15: Long = _
+  }
+
+  abstract class Tail extends HeadPadding {
+    @volatile protected var tail: Int = 0
+  }
+
+  abstract class TailPadding extends Tail {
+    protected var ptail00: Long = _
+    protected var ptail01: Long = _
+    protected var ptail02: Long = _
+    protected var ptail03: Long = _
+    protected var ptail04: Long = _
+    protected var ptail05: Long = _
+    protected var ptail06: Long = _
+    protected var ptail07: Long = _
+    protected var ptail08: Long = _
+    protected var ptail09: Long = _
+    protected var ptail10: Long = _
+    protected var ptail11: Long = _
+    protected var ptail12: Long = _
+    protected var ptail13: Long = _
+    protected var ptail14: Long = _
+    protected var ptail15: Long = _
   }
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -40,7 +40,7 @@ import java.util.concurrent.locks.LockSupport
 private final class WorkerThread(
     private[this] val index: Int, // index assigned by the thread pool in which this thread operates
     private[this] val pool: WorkStealingThreadPool // reference to the thread pool in which this thread operates
-) extends Thread {
+) extends WorkerThread.SleepingPadding {
 
   import WorkStealingThreadPoolConstants._
 
@@ -56,10 +56,6 @@ private final class WorkerThread(
 
   // Source of randomness.
   private[this] val random: Random = new Random()
-
-  // Flag that indicates that this worker thread is currently sleeping, in order to
-  // guard against spurious wakeups.
-  @volatile private[unsafe] var sleeping: Boolean = false
 
   /**
    * Enqueues a fiber to the local work stealing queue. This method always
@@ -298,5 +294,51 @@ private final class WorkerThread(
         fiber = null
       }
     }
+  }
+}
+
+private object WorkerThread {
+  abstract class InitPadding extends Thread {
+    protected var pinit00: Long = _
+    protected var pinit01: Long = _
+    protected var pinit02: Long = _
+    protected var pinit03: Long = _
+    protected var pinit04: Long = _
+    protected var pinit05: Long = _
+    protected var pinit06: Long = _
+    protected var pinit07: Long = _
+    protected var pinit08: Long = _
+    protected var pinit09: Long = _
+    protected var pinit10: Long = _
+    protected var pinit11: Long = _
+    protected var pinit12: Long = _
+    protected var pinit13: Long = _
+    protected var pinit14: Long = _
+    protected var pinit15: Long = _
+  }
+
+  abstract class Sleeping extends InitPadding {
+    // Flag that indicates that this worker thread is currently sleeping, in order to
+    // guard against spurious wakeups.
+    @volatile private[unsafe] var sleeping: Boolean = false
+  }
+
+  abstract class SleepingPadding extends Sleeping {
+    protected var pslp00: Long = _
+    protected var pslp01: Long = _
+    protected var pslp02: Long = _
+    protected var pslp03: Long = _
+    protected var pslp04: Long = _
+    protected var pslp05: Long = _
+    protected var pslp06: Long = _
+    protected var pslp07: Long = _
+    protected var pslp08: Long = _
+    protected var pslp09: Long = _
+    protected var pslp10: Long = _
+    protected var pslp11: Long = _
+    protected var pslp12: Long = _
+    protected var pslp13: Long = _
+    protected var pslp14: Long = _
+    protected var pslp15: Long = _
   }
 }


### PR DESCRIPTION
Before (on `series/3.x`):
```
WorkStealingBenchmark.async  1000000  thrpt   20  10.795 ± 0.406  ops/min
```
After (this PR):
```
WorkStealingBenchmark.async  1000000  thrpt   20  11.752 ± 0.150  ops/min
```