### PR TITLE
fix inference for default show args

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -415,7 +415,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
    *
    * @param a value to be printed to the standard output
    */
-  def print[A](a: A)(implicit S: Show[A] = Show.fromToString): IO[Unit] =
+  def print[A](a: A)(implicit S: Show[A] = Show.fromToString[A]): IO[Unit] =
     Console[IO].print(a)
 
   /**
@@ -427,7 +427,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
    *
    * @param a value to be printed to the standard output
    */
-  def println[A](a: A)(implicit S: Show[A] = Show.fromToString): IO[Unit] =
+  def println[A](a: A)(implicit S: Show[A] = Show.fromToString[A]): IO[Unit] =
     Console[IO].println(a)
 
   def eval[A](fa: Eval[A]): IO[A] =

--- a/core/shared/src/test/scala/cats/effect/std/ConsoleSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/std/ConsoleSpec.scala
@@ -72,6 +72,15 @@ class ConsoleSpec extends BaseSpec {
   }
 
   "Console" should {
+
+    case class Foo(n: Int, b: Boolean)
+
+    "select default Show.fromToString (IO)" in {
+      IO.print(Foo(1, true))   // compilation test
+      IO.println(Foo(1, true)) // compilation test
+      true
+    }
+
     "print to the standard output" in real {
       val message = "Message"
       standardOutTest(IO.print(message)).flatMap { msg =>
@@ -88,6 +97,14 @@ class ConsoleSpec extends BaseSpec {
           msg must beEqualTo(s"$message${System.lineSeparator()}")
         }
       }
+    }
+
+    "select default Show.fromToString (Console[IO])" in {
+      Console[IO].print(Foo(1, true))   // compilation test
+      Console[IO].println(Foo(1, true)) // compilation test
+      Console[IO].error(Foo(1, true))   // compilation test
+      Console[IO].errorln(Foo(1, true)) // compilation test
+      true
     }
 
     "print to the standard error" in real {
@@ -107,5 +124,6 @@ class ConsoleSpec extends BaseSpec {
         }
       }
     }
+
   }
 }

--- a/std/shared/src/main/scala/cats/effect/std/Console.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Console.scala
@@ -95,7 +95,7 @@ trait Console[F[_]] { self =>
    * @param a value to be printed to the standard output
    * @param S implicit `cats.Show[A]` instance, defaults to `cats.Show.fromToString`
    */
-  def print[A](a: A)(implicit S: Show[A] = Show.fromToString): F[Unit]
+  def print[A](a: A)(implicit S: Show[A] = Show.fromToString[A]): F[Unit]
 
   /**
    * Prints a value to the standard output followed by a new line using the
@@ -104,7 +104,7 @@ trait Console[F[_]] { self =>
    * @param a value to be printed to the standard output
    * @param S implicit `cats.Show[A]` instance, defaults to `cats.Show.fromToString`
    */
-  def println[A](a: A)(implicit S: Show[A] = Show.fromToString): F[Unit]
+  def println[A](a: A)(implicit S: Show[A] = Show.fromToString[A]): F[Unit]
 
   /**
    * Prints a value to the standard error output using the implicit `cats.Show`
@@ -113,7 +113,7 @@ trait Console[F[_]] { self =>
    * @param a value to be printed to the standard error output
    * @param S implicit `cats.Show[A]` instance, defaults to `cats.Show.fromToString`
    */
-  def error[A](a: A)(implicit S: Show[A] = Show.fromToString): F[Unit]
+  def error[A](a: A)(implicit S: Show[A] = Show.fromToString[A]): F[Unit]
 
   /**
    * Prints a value to the standard error output followed by a new line using
@@ -122,7 +122,7 @@ trait Console[F[_]] { self =>
    * @param a value to be printed to the standard error output
    * @param S implicit `cats.Show[A]` instance, defaults to `cats.Show.fromToString`
    */
-  def errorln[A](a: A)(implicit S: Show[A] = Show.fromToString): F[Unit]
+  def errorln[A](a: A)(implicit S: Show[A] = Show.fromToString[A]): F[Unit]
 
   /**
    * Modifies the context in which this console operates using the natural
@@ -301,22 +301,22 @@ object Console {
         loop()
       }
 
-    def print[A](a: A)(implicit S: Show[A] = Show.fromToString): F[Unit] = {
+    def print[A](a: A)(implicit S: Show[A] = Show.fromToString[A]): F[Unit] = {
       val text = a.show
       F.blocking(System.out.print(text))
     }
 
-    def println[A](a: A)(implicit S: Show[A] = Show.fromToString): F[Unit] = {
+    def println[A](a: A)(implicit S: Show[A] = Show.fromToString[A]): F[Unit] = {
       val text = a.show
       F.blocking(System.out.println(text))
     }
 
-    def error[A](a: A)(implicit S: Show[A] = Show.fromToString): F[Unit] = {
+    def error[A](a: A)(implicit S: Show[A] = Show.fromToString[A]): F[Unit] = {
       val text = a.show
       F.blocking(System.err.print(text))
     }
 
-    def errorln[A](a: A)(implicit S: Show[A] = Show.fromToString): F[Unit] = {
+    def errorln[A](a: A)(implicit S: Show[A] = Show.fromToString[A]): F[Unit] = {
       val text = a.show
       F.blocking(System.err.println(text))
     }


### PR DESCRIPTION
Inference flows backwards with default args, so `implicit S: Show[A] = Show.fromString`, rather than inferring `showString[A]` it infers `A =:= Nothing` so you can't actually use the default arg. In any case providing a type arg fixes it.