### PR TITLE
Finalize, if necessary, when exiting an uncancelable region

### DIFF
--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -316,7 +316,7 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
           .flatMap(_ => IO.raiseError(TestException)))
           .void must failAs(TestException)
       }
-    // format: on
+      // format: on
 
       "repeated async callback" in ticked { implicit ticker =>
         case object TestException extends RuntimeException
@@ -913,6 +913,36 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
         test must completeAs(())
         success must beTrue
       }
+
+      // format: off
+      "finalize after uncancelable with suppressed cancellation (succeeded)" in ticked { implicit ticker =>
+        var finalized = false
+
+        val test =
+          IO.uncancelable(_ => IO.canceled >> IO.pure(42))
+            .onCancel(IO { finalized = true })
+            .void
+
+        test must selfCancel
+        finalized must beTrue
+      }
+      // format: on
+
+      // format: off
+      "finalize after uncancelable with suppressed cancellation (errored)" in ticked { implicit ticker =>
+        case object TestException extends RuntimeException
+
+        var finalized = false
+
+        val test =
+          IO.uncancelable(_ => IO.canceled >> IO.raiseError(TestException))
+            .onCancel(IO { finalized = true })
+            .void
+
+        test must selfCancel
+        finalized must beTrue
+      }
+      // format: on
 
     }
 

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
@@ -55,8 +55,8 @@ trait AsyncTests[F[_]] extends GenTemporalTests[F, Throwable] with SyncTests[F] 
       EqFAB: Eq[F[Either[A, B]]],
       EqFEitherEU: Eq[F[Either[Throwable, Unit]]],
       EqFEitherEA: Eq[F[Either[Throwable, A]]],
-//    EqFEitherUA: Eq[F[Either[Unit, A]]],
-//    EqFEitherAU: Eq[F[Either[A, Unit]]],
+      EqFEitherUA: Eq[F[Either[Unit, A]]],
+      EqFEitherAU: Eq[F[Either[A, Unit]]],
       EqFOutcomeEA: Eq[F[Outcome[F, Throwable, A]]],
       EqFOutcomeEU: Eq[F[Outcome[F, Throwable, Unit]]],
       EqFABC: Eq[F[(A, B, C)]],
@@ -70,8 +70,8 @@ trait AsyncTests[F[_]] extends GenTemporalTests[F, Throwable] with SyncTests[F] 
       aFUPP: (A => F[Unit]) => Pretty,
       ePP: Throwable => Pretty,
       foaPP: F[Outcome[F, Throwable, A]] => Pretty,
-//    feauPP: F[Either[A, Unit]] => Pretty,
-//    feuaPP: F[Either[Unit, A]] => Pretty,
+      feauPP: F[Either[A, Unit]] => Pretty,
+      feuaPP: F[Either[Unit, A]] => Pretty,
       fouPP: F[Outcome[F, Throwable, Unit]] => Pretty): RuleSet = {
 
     new RuleSet {

--- a/laws/shared/src/main/scala/cats/effect/laws/GenSpawnLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenSpawnLaws.scala
@@ -96,6 +96,12 @@ trait GenSpawnLaws[F[_], E] extends MonadCancelLaws[F, E] with DeferLaws[F] {
   def raceCanceledIdentityRight[A](fa: F[A]) =
     F.race(fa, F.canceled) <-> fa.map(_.asLeft[Unit])
 
+  def raceNeverIdentityLeft[A](fa: F[A]) =
+    F.race(F.never[Unit], fa) <-> fa.map(_.asRight[Unit])
+
+  def raceNeverIdentityRight[A](fa: F[A]) =
+    F.race(fa, F.never[Unit]) <-> fa.map(_.asLeft[Unit])
+
   // I really like these laws, since they relate cede to timing, but they're definitely nondeterministic
   /*def raceLeftCedeYields[A](a: A) =
     F.race(F.cede, F.pure(a)) <-> F.pure(Right(a))*/

--- a/laws/shared/src/main/scala/cats/effect/laws/GenSpawnLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenSpawnLaws.scala
@@ -88,19 +88,17 @@ trait GenSpawnLaws[F[_], E] extends MonadCancelLaws[F, E] with DeferLaws[F] {
     F.race(F.never[A], fb) <-> results
   }
 
-  // FIXME fails when fa is IO.Uncancelable(...)
   def raceCanceledIdentityLeft[A](fa: F[A]) =
     F.race(F.canceled, fa) <-> fa.map(_.asRight[Unit])
 
-  // FIXME fails when fa is IO.Uncancelable(...)
   def raceCanceledIdentityRight[A](fa: F[A]) =
     F.race(fa, F.canceled) <-> fa.map(_.asLeft[Unit])
 
-  def raceNeverIdentityLeft[A](fa: F[A]) =
-    F.race(F.never[Unit], fa) <-> fa.map(_.asRight[Unit])
+  def raceNeverNoncanceledIdentityLeft[A](fa: F[A]) =
+    F.race(F.never[Unit], fa) <-> F.onCancel(fa.map(_.asRight[Unit]), F.never)
 
-  def raceNeverIdentityRight[A](fa: F[A]) =
-    F.race(fa, F.never[Unit]) <-> fa.map(_.asLeft[Unit])
+  def raceNeverNoncanceledIdentityRight[A](fa: F[A]) =
+    F.race(fa, F.never[Unit]) <-> F.onCancel(fa.map(_.asLeft[Unit]), F.never)
 
   // I really like these laws, since they relate cede to timing, but they're definitely nondeterministic
   /*def raceLeftCedeYields[A](a: A) =

--- a/laws/shared/src/main/scala/cats/effect/laws/GenSpawnTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenSpawnTests.scala
@@ -49,8 +49,8 @@ trait GenSpawnTests[F[_], E] extends MonadCancelTests[F, E] with DeferTests[F] {
       EqFAB: Eq[F[Either[A, B]]],
       EqFEitherEU: Eq[F[Either[E, Unit]]],
       EqFEitherEA: Eq[F[Either[E, A]]],
-//    EqFEitherUA: Eq[F[Either[Unit, A]]],
-//    EqFEitherAU: Eq[F[Either[A, Unit]]],
+      EqFEitherUA: Eq[F[Either[Unit, A]]],
+      EqFEitherAU: Eq[F[Either[A, Unit]]],
       EqFOutcomeEA: Eq[F[Outcome[F, E, A]]],
       EqFOutcomeEU: Eq[F[Outcome[F, E, Unit]]],
       EqFABC: Eq[F[(A, B, C)]],
@@ -61,8 +61,8 @@ trait GenSpawnTests[F[_], E] extends MonadCancelTests[F, E] with DeferTests[F] {
       aFUPP: (A => F[Unit]) => Pretty,
       ePP: E => Pretty,
       foaPP: F[Outcome[F, E, A]] => Pretty,
-//    feauPP: F[Either[A, Unit]] => Pretty,
-//    feuaPP: F[Either[Unit, A]] => Pretty,
+      feauPP: F[Either[A, Unit]] => Pretty,
+      feuaPP: F[Either[Unit, A]] => Pretty,
       fouPP: F[Outcome[F, E, Unit]] => Pretty): RuleSet = {
 
     new RuleSet {
@@ -78,6 +78,8 @@ trait GenSpawnTests[F[_], E] extends MonadCancelTests[F, E] with DeferTests[F] {
         "race canceled identity (left)" -> forAll(laws.raceCanceledIdentityLeft[A] _),
         "race canceled identity (right)" -> forAll(laws.raceCanceledIdentityRight[A] _),
          */
+        "race never identity attempt (left)" -> forAll(laws.raceNeverIdentityLeft[A] _),
+        "race never identity attempt (right)" -> forAll(laws.raceNeverIdentityRight[A] _),
         // "race left cede yields" -> forAll(laws.raceLeftCedeYields[A] _),
         // "race right cede yields" -> forAll(laws.raceRightCedeYields[A] _),
         "fiber pure is completed pure" -> forAll(laws.fiberPureIsOutcomeCompletedPure[A] _),

--- a/laws/shared/src/main/scala/cats/effect/laws/GenSpawnTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenSpawnTests.scala
@@ -74,12 +74,12 @@ trait GenSpawnTests[F[_], E] extends MonadCancelTests[F, E] with DeferTests[F] {
         "race derives from racePair (left)" -> forAll(laws.raceDerivesFromRacePairLeft[A, B] _),
         "race derives from racePair (right)" -> forAll(
           laws.raceDerivesFromRacePairRight[A, B] _),
-        /* FIXME falsified when fa == IO.Uncancelable(...)
         "race canceled identity (left)" -> forAll(laws.raceCanceledIdentityLeft[A] _),
         "race canceled identity (right)" -> forAll(laws.raceCanceledIdentityRight[A] _),
-         */
-        "race never identity attempt (left)" -> forAll(laws.raceNeverIdentityLeft[A] _),
-        "race never identity attempt (right)" -> forAll(laws.raceNeverIdentityRight[A] _),
+        "race never non-canceled identity (left)" -> forAll(
+          laws.raceNeverNoncanceledIdentityLeft[A] _),
+        "race never non-canceled identity (right)" -> forAll(
+          laws.raceNeverNoncanceledIdentityRight[A] _),
         // "race left cede yields" -> forAll(laws.raceLeftCedeYields[A] _),
         // "race right cede yields" -> forAll(laws.raceRightCedeYields[A] _),
         "fiber pure is completed pure" -> forAll(laws.fiberPureIsOutcomeCompletedPure[A] _),

--- a/laws/shared/src/main/scala/cats/effect/laws/GenTemporalTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenTemporalTests.scala
@@ -51,8 +51,8 @@ trait GenTemporalTests[F[_], E] extends GenSpawnTests[F, E] with ClockTests[F] {
       EqFAB: Eq[F[Either[A, B]]],
       EqFEitherEU: Eq[F[Either[E, Unit]]],
       EqFEitherEA: Eq[F[Either[E, A]]],
-//    EqFEitherUA: Eq[F[Either[Unit, A]]],
-//    EqFEitherAU: Eq[F[Either[A, Unit]]],
+      EqFEitherUA: Eq[F[Either[Unit, A]]],
+      EqFEitherAU: Eq[F[Either[A, Unit]]],
       EqFOutcomeEA: Eq[F[Outcome[F, E, A]]],
       EqFOutcomeEU: Eq[F[Outcome[F, E, Unit]]],
       EqFABC: Eq[F[(A, B, C)]],
@@ -66,8 +66,8 @@ trait GenTemporalTests[F[_], E] extends GenSpawnTests[F, E] with ClockTests[F] {
       aFUPP: (A => F[Unit]) => Pretty,
       ePP: E => Pretty,
       foaPP: F[Outcome[F, E, A]] => Pretty,
-//    feauPP: F[Either[A, Unit]] => Pretty,
-//    feuaPP: F[Either[Unit, A]] => Pretty,
+      feauPP: F[Either[A, Unit]] => Pretty,
+      feuaPP: F[Either[Unit, A]] => Pretty,
       fouPP: F[Outcome[F, E, Unit]] => Pretty): RuleSet = {
 
     import laws.F


### PR DESCRIPTION
In `IOFiber#runLoop` we need to check if finalization is necessary after exiting an uncancelable region to ensure finalizers are run in the case where the rest of the call stack never requires reentering `runLoop`.

Consider, `F.onCancel(F.uncancelable(_ => F.canceled >> fa), cleanup)`. `cleanup` is not currently invoked as there is no node (`FlatMap`, `HandleErrorWith`, etc) between `onCancel` and `uncancelable` that would send us back into `runLoop`, the rest of the expression is evaluated completely within `IOFiber#succeeded` or `IOFiber#failed` (depending on `fa`).

This fixes four of the failing laws observed in #1484.

Closes #1525 