### PR TITLE
Revise finalizer error semantics

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -79,20 +79,18 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
   def bracket[B](use: A => IO[B])(release: A => IO[Unit]): IO[B] =
     bracketCase(use)((a, _) => release(a))
 
-  def bracketCase[B](use: A => IO[B])(release: (A, OutcomeIO[B]) => IO[Unit]): IO[B] = {
-    def doRelease(a: A, outcome: OutcomeIO[B]): IO[Unit] =
-      release(a, outcome).handleErrorWith { t =>
-        IO.executionContext.flatMap(ec => IO(ec.reportFailure(t)))
-      }
-
-    IO uncancelable { poll =>
+  def bracketCase[B](use: A => IO[B])(release: (A, OutcomeIO[B]) => IO[Unit]): IO[B] =
+    IO.uncancelable { poll =>
       flatMap { a =>
         val finalized = poll(use(a)).onCancel(release(a, Outcome.Canceled()))
-        val handled = finalized.onError(e => doRelease(a, Outcome.Errored(e)))
-        handled.flatMap(b => doRelease(a, Outcome.Succeeded(IO.pure(b))).as(b))
+        val handled = finalized.onError { e => 
+          release(a, Outcome.Errored(e)).handleErrorWith { t =>
+            IO.executionContext.flatMap(ec => IO(ec.reportFailure(t)))
+          }
+        }
+        handled.flatMap(b => release(a, Outcome.Succeeded(IO.pure(b))).as(b))
       }
     }
-  }
 
   def evalOn(ec: ExecutionContext): IO[A] = IO.EvalOn(this, ec)
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -83,7 +83,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
     IO.uncancelable { poll =>
       flatMap { a =>
         val finalized = poll(use(a)).onCancel(release(a, Outcome.Canceled()))
-        val handled = finalized.onError { e => 
+        val handled = finalized.onError { e =>
           release(a, Outcome.Errored(e)).handleErrorWith { t =>
             IO.executionContext.flatMap(ec => IO(ec.reportFailure(t)))
           }

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -188,6 +188,15 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
           .handleErrorWith(_ => (throw TestException): IO[Unit])
           .attempt must completeAs(Left(TestException))
       }
+
+      "raise first bracket release exception if use effect succeeded" in ticked { implicit ticker =>
+        case object TestException extends RuntimeException
+        case object WrongException extends RuntimeException
+        val io = IO.unit.bracket { _ =>
+          IO.unit.bracket(_ => IO.unit)(_ => IO.raiseError(TestException))
+        }(_ => IO.raiseError(WrongException))
+        io.attempt must completeAs(Left(TestException))
+      }
     }
 
     "suspension of side effects" should {

--- a/core/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -189,13 +189,16 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
           .attempt must completeAs(Left(TestException))
       }
 
-      "raise first bracket release exception if use effect succeeded" in ticked { implicit ticker =>
-        case object TestException extends RuntimeException
-        case object WrongException extends RuntimeException
-        val io = IO.unit.bracket { _ =>
-          IO.unit.bracket(_ => IO.unit)(_ => IO.raiseError(TestException))
-        }(_ => IO.raiseError(WrongException))
-        io.attempt must completeAs(Left(TestException))
+      "raise first bracket release exception if use effect succeeded" in ticked {
+        implicit ticker =>
+          case object TestException extends RuntimeException
+          case object WrongException extends RuntimeException
+          val io =
+            IO.unit
+              .bracket { _ =>
+                IO.unit.bracket(_ => IO.unit)(_ => IO.raiseError(TestException))
+              }(_ => IO.raiseError(WrongException))
+          io.attempt must completeAs(Left(TestException))
       }
     }
 

--- a/core/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -308,7 +308,11 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
 
     "allocated produces the same value as the resource" in ticked { implicit ticker =>
       forAll { (resource: Resource[IO, Int]) =>
-        val a0 = IO.uncancelable(p => p(resource.allocated).flatTap(_._2.attempt)).map(_._1)
+        val a0 = IO.uncancelable { p => 
+          p(resource.allocated).flatMap { 
+            case (b, fin) => fin.as(b)
+          }
+        }
         val a1 = resource.use(IO.pure)
 
         a0 eqv a1

--- a/core/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/core/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -308,8 +308,8 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
 
     "allocated produces the same value as the resource" in ticked { implicit ticker =>
       forAll { (resource: Resource[IO, Int]) =>
-        val a0 = IO.uncancelable { p => 
-          p(resource.allocated).flatMap { 
+        val a0 = IO.uncancelable { p =>
+          p(resource.allocated).flatMap {
             case (b, fin) => fin.as(b)
           }
         }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -353,9 +353,11 @@ trait MonadCancel[F[_], E] extends MonadError[F, E] {
         // runtime, otherwise we'll throw here and the error handler will never be registered
         val finalized = onCancel(poll(F.unit >> use(a)), safeRelease(a, Outcome.Canceled()))
         val handled = finalized.onError {
-          case e => void(attempt(safeRelease(a, Outcome.Errored(e))))
+          case e => safeRelease(a, Outcome.Errored(e)).attempt.void
         }
-        handled.flatTap { b => safeRelease(a, Outcome.Succeeded(b.pure)).attempt }
+        handled.flatMap { b => 
+          safeRelease(a, Outcome.Succeeded(b.pure)).as(b)
+        }
       }
     }
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -355,9 +355,7 @@ trait MonadCancel[F[_], E] extends MonadError[F, E] {
         val handled = finalized.onError {
           case e => safeRelease(a, Outcome.Errored(e)).attempt.void
         }
-        handled.flatMap { b => 
-          safeRelease(a, Outcome.Succeeded(b.pure)).as(b)
-        }
+        handled.flatMap { b => safeRelease(a, Outcome.Succeeded(b.pure)).as(b) }
       }
     }
 }


### PR DESCRIPTION
Fixes #1494 . The change is pretty simple: in the happy path, if we encounter an error when running the finalizer, just return that. If we're running the failing finalizer in the error path, we'll return the original error, like before.