### PR TITLE
Add supertypes for concurrent types

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Deferred.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Deferred.scala
@@ -47,30 +47,7 @@ import scala.collection.immutable.LongMap
  * Finally, the blocking mentioned above is semantic only, no actual threads are
  * blocked by the implementation.
  */
-abstract class Deferred[F[_], A] {
-
-  /**
-   * Obtains the value of the `Deferred`, or waits until it has been completed.
-   * The returned value may be canceled.
-   */
-  def get: F[A]
-
-  /**
-   * If this `Deferred` is empty, sets the current value to `a`, and notifies
-   * any and all readers currently blocked on a `get`. Returns true.
-   *
-   * If this `Deferred` has already been completed, returns false.
-   *
-   * Satisfies:
-   *   `Deferred[F, A].flatMap(r => r.complete(a) *> r.get) == a.pure[F]`
-   */
-  def complete(a: A): F[Boolean]
-
-  /**
-   * Obtains the current value of the `Deferred`, or None if it hasn't completed.
-   */
-  def tryGet: F[Option[A]]
-
+abstract class Deferred[F[_], A] extends DeferredSource[F, A] with DeferredSink[F, A] {
   /**
    * Modify the context `F` using transformation `f`.
    */
@@ -235,5 +212,53 @@ object Deferred {
     override def get: G[A] = trans(underlying.get)
     override def tryGet: G[Option[A]] = trans(underlying.tryGet)
     override def complete(a: A): G[Boolean] = trans(underlying.complete(a))
+  }
+}
+
+trait DeferredSource[F[_], A] {
+  /**
+   * Obtains the value of the `Deferred`, or waits until it has been completed.
+   * The returned value may be canceled.
+   */
+  def get: F[A]
+
+  /**
+   * Obtains the current value of the `Deferred`, or None if it hasn't completed.
+   */
+  def tryGet: F[Option[A]]
+}
+
+object DeferredSource {
+  implicit def catsFunctorForDeferredSource[F[_]: Functor]: Functor[DeferredSource[F, *]] = new Functor[DeferredSource[F, *]] {
+    override def map[A, B](fa: DeferredSource[F, A])(f: A => B): DeferredSource[F, B] =
+      new DeferredSource[F, B] {
+        override def get: F[B] =
+          fa.get.map(f)
+        override def tryGet: F[Option[B]] =
+          fa.tryGet.map(_.map(f))
+      }
+  }
+}
+
+trait DeferredSink[F[_], A] {
+  /**
+   * If this `Deferred` is empty, sets the current value to `a`, and notifies
+   * any and all readers currently blocked on a `get`. Returns true.
+   *
+   * If this `Deferred` has already been completed, returns false.
+   *
+   * Satisfies:
+   *   `Deferred[F, A].flatMap(r => r.complete(a) *> r.get) == a.pure[F]`
+   */
+  def complete(a: A): F[Boolean]
+}
+
+object DeferredSink {
+  implicit def catsContravariantForDeferredSink[F[_]: Functor]: Contravariant[DeferredSink[F, *]] = new Contravariant[DeferredSink[F, *]] {
+    override def contramap[A, B](fa: DeferredSink[F, A])(f: B => A): DeferredSink[F, B] =
+      new DeferredSink[F, B] {
+        override def complete(b: B): F[Boolean] =
+          fa.complete(f(b))
+      }
   }
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Deferred.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Deferred.scala
@@ -48,6 +48,7 @@ import scala.collection.immutable.LongMap
  * blocked by the implementation.
  */
 abstract class Deferred[F[_], A] extends DeferredSource[F, A] with DeferredSink[F, A] {
+
   /**
    * Modify the context `F` using transformation `f`.
    */
@@ -193,17 +194,18 @@ object Deferred {
     }
   }
 
-  implicit def catsInvariantForDeferred[F[_]: Functor]: Invariant[Deferred[F, *]] = new Invariant[Deferred[F, *]] {
-    override def imap[A, B](fa: Deferred[F, A])(f: A => B)(g: B => A): Deferred[F, B] =
-      new Deferred[F, B] {
-        override def get: F[B] =
-          fa.get.map(f)
-        override def complete(b: B): F[Boolean] =
-          fa.complete(g(b))
-        override def tryGet: F[Option[B]] =
-          fa.tryGet.map(_.map(f))
-      }
-  }
+  implicit def catsInvariantForDeferred[F[_]: Functor]: Invariant[Deferred[F, *]] =
+    new Invariant[Deferred[F, *]] {
+      override def imap[A, B](fa: Deferred[F, A])(f: A => B)(g: B => A): Deferred[F, B] =
+        new Deferred[F, B] {
+          override def get: F[B] =
+            fa.get.map(f)
+          override def complete(b: B): F[Boolean] =
+            fa.complete(g(b))
+          override def tryGet: F[Option[B]] =
+            fa.tryGet.map(_.map(f))
+        }
+    }
 
   final private[kernel] class TransformedDeferred[F[_], G[_], A](
       underlying: Deferred[F, A],
@@ -216,6 +218,7 @@ object Deferred {
 }
 
 trait DeferredSource[F[_], A] {
+
   /**
    * Obtains the value of the `Deferred`, or waits until it has been completed.
    * The returned value may be canceled.
@@ -229,18 +232,20 @@ trait DeferredSource[F[_], A] {
 }
 
 object DeferredSource {
-  implicit def catsFunctorForDeferredSource[F[_]: Functor]: Functor[DeferredSource[F, *]] = new Functor[DeferredSource[F, *]] {
-    override def map[A, B](fa: DeferredSource[F, A])(f: A => B): DeferredSource[F, B] =
-      new DeferredSource[F, B] {
-        override def get: F[B] =
-          fa.get.map(f)
-        override def tryGet: F[Option[B]] =
-          fa.tryGet.map(_.map(f))
-      }
-  }
+  implicit def catsFunctorForDeferredSource[F[_]: Functor]: Functor[DeferredSource[F, *]] =
+    new Functor[DeferredSource[F, *]] {
+      override def map[A, B](fa: DeferredSource[F, A])(f: A => B): DeferredSource[F, B] =
+        new DeferredSource[F, B] {
+          override def get: F[B] =
+            fa.get.map(f)
+          override def tryGet: F[Option[B]] =
+            fa.tryGet.map(_.map(f))
+        }
+    }
 }
 
 trait DeferredSink[F[_], A] {
+
   /**
    * If this `Deferred` is empty, sets the current value to `a`, and notifies
    * any and all readers currently blocked on a `get`. Returns true.
@@ -254,11 +259,13 @@ trait DeferredSink[F[_], A] {
 }
 
 object DeferredSink {
-  implicit def catsContravariantForDeferredSink[F[_]: Functor]: Contravariant[DeferredSink[F, *]] = new Contravariant[DeferredSink[F, *]] {
-    override def contramap[A, B](fa: DeferredSink[F, A])(f: B => A): DeferredSink[F, B] =
-      new DeferredSink[F, B] {
-        override def complete(b: B): F[Boolean] =
-          fa.complete(f(b))
-      }
-  }
+  implicit def catsContravariantForDeferredSink[F[_]: Functor]
+      : Contravariant[DeferredSink[F, *]] =
+    new Contravariant[DeferredSink[F, *]] {
+      override def contramap[A, B](fa: DeferredSink[F, A])(f: B => A): DeferredSink[F, B] =
+        new DeferredSink[F, B] {
+          override def complete(b: B): F[Boolean] =
+            fa.complete(f(b))
+        }
+    }
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
@@ -466,6 +466,7 @@ object Ref {
 }
 
 trait RefSource[F[_], A] {
+
   /**
    * Obtains the current value.
    *
@@ -476,16 +477,18 @@ trait RefSource[F[_], A] {
 }
 
 object RefSource {
-  implicit def catsFunctorForRefSource[F[_]: Functor]: Functor[RefSource[F, *]] = new Functor[RefSource[F, *]] {
-    override def map[A, B](fa: RefSource[F, A])(f: A => B): RefSource[F, B] =
-      new RefSource[F, B] {
-        override def get: F[B] =
-          fa.get.map(f)
-      }
-  }
+  implicit def catsFunctorForRefSource[F[_]: Functor]: Functor[RefSource[F, *]] =
+    new Functor[RefSource[F, *]] {
+      override def map[A, B](fa: RefSource[F, A])(f: A => B): RefSource[F, B] =
+        new RefSource[F, B] {
+          override def get: F[B] =
+            fa.get.map(f)
+        }
+    }
 }
 
 trait RefSink[F[_], A] {
+
   /**
    * Sets the current value to `a`.
    *
@@ -498,11 +501,12 @@ trait RefSink[F[_], A] {
 }
 
 object RefSink {
-  implicit def catsContravariantForRefSink[F[_]: Functor]: Contravariant[RefSink[F, *]] = new Contravariant[RefSink[F, *]] {
-    override def contramap[A, B](fa: RefSink[F, A])(f: B => A): RefSink[F, B] =
-      new RefSink[F, B] {
-        override def set(b: B): F[Unit] =
-          fa.set(f(b))
-      }
-  }
+  implicit def catsContravariantForRefSink[F[_]: Functor]: Contravariant[RefSink[F, *]] =
+    new Contravariant[RefSink[F, *]] {
+      override def contramap[A, B](fa: RefSink[F, A])(f: B => A): RefSink[F, B] =
+        new RefSink[F, B] {
+          override def set(b: B): F[Unit] =
+            fa.set(f(b))
+        }
+    }
 }

--- a/std/shared/src/main/scala/cats/effect/std/PQueue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/PQueue.scala
@@ -32,50 +32,7 @@ import scala.collection.immutable.{Queue => ScalaQueue}
  * Assumes an `Order` instance is in scope for `A`
  */
 
-abstract class PQueue[F[_], A] { self =>
-
-  /**
-   * Enqueues the given element, possibly semantically
-   * blocking until sufficient capacity becomes available.
-   *
-   * O(log(n))
-   *
-   * @param a the element to be put in the PQueue
-   */
-  def offer(a: A): F[Unit]
-
-  /**
-   * Attempts to enqueue the given element without
-   * semantically blocking.
-   *
-   * O(log(n))
-   *
-   * @param a the element to be put in the PQueue
-   * @return an effect that describes whether the enqueuing of the given
-   *         element succeeded without blocking
-   */
-  def tryOffer(a: A): F[Boolean]
-
-  /**
-   * Dequeues the least element from the PQueue, possibly semantically
-   * blocking until an element becomes available.
-   *
-   * O(log(n))
-   */
-  def take: F[A]
-
-  /**
-   * Attempts to dequeue the least element from the PQueue, if one is
-   * available without semantically blocking.
-   *
-   * O(log(n))
-   *
-   * @return an effect that describes whether the dequeueing of an element from
-   *         the PQueue succeeded without blocking, with `None` denoting that no
-   *         element was available
-   */
-  def tryTake: F[Option[A]]
-
+abstract class PQueue[F[_], A] extends PQueueSource[F, A] with PQueueSink[F, A] { self =>
   /**
    * Modifies the context in which this PQueue is executed using the natural
    * transformation `f`.
@@ -237,3 +194,74 @@ object PQueue {
         s"Bounded queue capacity must be non-negative, was: $capacity")
     else ()
 }
+
+trait PQueueSource[F[_], A] {
+  /**
+   * Dequeues the least element from the PQueue, possibly semantically
+   * blocking until an element becomes available.
+   *
+   * O(log(n))
+   */
+  def take: F[A]
+
+  /**
+   * Attempts to dequeue the least element from the PQueue, if one is
+   * available without semantically blocking.
+   *
+   * O(log(n))
+   *
+   * @return an effect that describes whether the dequeueing of an element from
+   *         the PQueue succeeded without blocking, with `None` denoting that no
+   *         element was available
+   */
+  def tryTake: F[Option[A]]
+}
+
+object PQueueSource {
+  implicit def catsFunctorForPQueueSource[F[_]: Functor]: Functor[PQueueSource[F, *]] = new Functor[PQueueSource[F, *]] {
+    override def map[A, B](fa: PQueueSource[F, A])(f: A => B): PQueueSource[F, B] =
+      new PQueueSource[F, B] {
+        override def take: F[B] =
+          fa.take.map(f)
+        override def tryTake: F[Option[B]] =
+          fa.tryTake.map(_.map(f))
+      }
+  }
+}
+
+trait PQueueSink[F[_], A] {
+  /**
+   * Enqueues the given element, possibly semantically
+   * blocking until sufficient capacity becomes available.
+   *
+   * O(log(n))
+   *
+   * @param a the element to be put in the PQueue
+   */
+  def offer(a: A): F[Unit]
+
+  /**
+   * Attempts to enqueue the given element without
+   * semantically blocking.
+   *
+   * O(log(n))
+   *
+   * @param a the element to be put in the PQueue
+   * @return an effect that describes whether the enqueuing of the given
+   *         element succeeded without blocking
+   */
+  def tryOffer(a: A): F[Boolean]
+}
+
+object PQueueSink {
+  implicit def catsContravariantForPQueueSink[F[_]: Functor]: Contravariant[PQueueSink[F, *]] = new Contravariant[PQueueSink[F, *]] {
+    override def contramap[A, B](fa: PQueueSink[F, A])(f: B => A): PQueueSink[F, B] =
+      new PQueueSink[F, B] {
+        override def offer(b: B): F[Unit] =
+          fa.offer(f(b))
+        override def tryOffer(b: B): F[Boolean] =
+          fa.tryOffer(f(b))
+      }
+  }
+}
+

--- a/std/shared/src/main/scala/cats/effect/std/Queue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Queue.scala
@@ -303,22 +303,24 @@ object Queue {
       State(ScalaQueue.empty, 0, ScalaQueue.empty, ScalaQueue.empty)
   }
 
-  implicit def catsInvariantForQueue[F[_]: Functor]: Invariant[Queue[F, *]] = new Invariant[Queue[F, *]] {
-    override def imap[A, B](fa: Queue[F, A])(f: A => B)(g: B => A): Queue[F, B] = 
-      new Queue[F, B] {
-        override def offer(b: B): F[Unit] =
-          fa.offer(g(b))
-        override def tryOffer(b: B): F[Boolean] =
-          fa.tryOffer(g(b))
-        override def take: F[B] =
-          fa.take.map(f)
-        override def tryTake: F[Option[B]] =
-          fa.tryTake.map(_.map(f))
-      }
-  }
+  implicit def catsInvariantForQueue[F[_]: Functor]: Invariant[Queue[F, *]] =
+    new Invariant[Queue[F, *]] {
+      override def imap[A, B](fa: Queue[F, A])(f: A => B)(g: B => A): Queue[F, B] =
+        new Queue[F, B] {
+          override def offer(b: B): F[Unit] =
+            fa.offer(g(b))
+          override def tryOffer(b: B): F[Boolean] =
+            fa.tryOffer(g(b))
+          override def take: F[B] =
+            fa.take.map(f)
+          override def tryTake: F[Option[B]] =
+            fa.tryTake.map(_.map(f))
+        }
+    }
 }
 
 trait QueueSource[F[_], A] {
+
   /**
    * Dequeues an element from the front of the queue, possibly semantically
    * blocking until an element becomes available.
@@ -337,18 +339,20 @@ trait QueueSource[F[_], A] {
 }
 
 object QueueSource {
-  implicit def catsFunctorForQueueSource[F[_]: Functor]: Functor[QueueSource[F, *]] = new Functor[QueueSource[F, *]] {
-    override def map[A, B](fa: QueueSource[F, A])(f: A => B): QueueSource[F, B] =
-      new QueueSource[F, B] {
-        override def take: F[B] =
-          fa.take.map(f)
-        override def tryTake: F[Option[B]] =
-          fa.tryTake.map(_.map(f))
-      }
-  }
+  implicit def catsFunctorForQueueSource[F[_]: Functor]: Functor[QueueSource[F, *]] =
+    new Functor[QueueSource[F, *]] {
+      override def map[A, B](fa: QueueSource[F, A])(f: A => B): QueueSource[F, B] =
+        new QueueSource[F, B] {
+          override def take: F[B] =
+            fa.take.map(f)
+          override def tryTake: F[Option[B]] =
+            fa.tryTake.map(_.map(f))
+        }
+    }
 }
 
 trait QueueSink[F[_], A] {
+
   /**
    * Enqueues the given element at the back of the queue, possibly semantically
    * blocking until sufficient capacity becomes available.
@@ -369,13 +373,14 @@ trait QueueSink[F[_], A] {
 }
 
 object QueueSink {
-  implicit def catsContravariantForQueueSink[F[_]: Functor]: Contravariant[QueueSink[F, *]] = new Contravariant[QueueSink[F, *]] {
-    override def contramap[A, B](fa: QueueSink[F, A])(f: B => A): QueueSink[F, B] =
-      new QueueSink[F, B] {
-        override def offer(b: B): F[Unit] =
-          fa.offer(f(b))
-        override def tryOffer(b: B): F[Boolean] =
-          fa.tryOffer(f(b))
-      }
-  }
+  implicit def catsContravariantForQueueSink[F[_]: Functor]: Contravariant[QueueSink[F, *]] =
+    new Contravariant[QueueSink[F, *]] {
+      override def contramap[A, B](fa: QueueSink[F, A])(f: B => A): QueueSink[F, B] =
+        new QueueSink[F, B] {
+          override def offer(b: B): F[Unit] =
+            fa.offer(f(b))
+          override def tryOffer(b: B): F[Boolean] =
+            fa.tryOffer(f(b))
+        }
+    }
 }

--- a/std/shared/src/main/scala/cats/effect/std/Queue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Queue.scala
@@ -36,41 +36,7 @@ import scala.collection.immutable.{Queue => ScalaQueue}
  * The [[Queue#tryOffer]] and [[Queue#tryTake]] allow for usecases which want to
  * avoid semantically blocking a fiber.
  */
-abstract class Queue[F[_], A] { self =>
-
-  /**
-   * Enqueues the given element at the back of the queue, possibly semantically
-   * blocking until sufficient capacity becomes available.
-   *
-   * @param a the element to be put at the back of the queue
-   */
-  def offer(a: A): F[Unit]
-
-  /**
-   * Attempts to enqueue the given element at the back of the queue without
-   * semantically blocking.
-   *
-   * @param a the element to be put at the back of the queue
-   * @return an effect that describes whether the enqueuing of the given
-   *         element succeeded without blocking
-   */
-  def tryOffer(a: A): F[Boolean]
-
-  /**
-   * Dequeues an element from the front of the queue, possibly semantically
-   * blocking until an element becomes available.
-   */
-  def take: F[A]
-
-  /**
-   * Attempts to dequeue an element from the front of the queue, if one is
-   * available without semantically blocking.
-   *
-   * @return an effect that describes whether the dequeueing of an element from
-   *         the queue succeeded without blocking, with `None` denoting that no
-   *         element was available
-   */
-  def tryTake: F[Option[A]]
+abstract class Queue[F[_], A] extends QueueSource[F, A] with QueueSink[F, A] { self =>
 
   /**
    * Modifies the context in which this queue is executed using the natural
@@ -348,6 +314,68 @@ object Queue {
           fa.take.map(f)
         override def tryTake: F[Option[B]] =
           fa.tryTake.map(_.map(f))
+      }
+  }
+}
+
+trait QueueSource[F[_], A] {
+  /**
+   * Dequeues an element from the front of the queue, possibly semantically
+   * blocking until an element becomes available.
+   */
+  def take: F[A]
+
+  /**
+   * Attempts to dequeue an element from the front of the queue, if one is
+   * available without semantically blocking.
+   *
+   * @return an effect that describes whether the dequeueing of an element from
+   *         the queue succeeded without blocking, with `None` denoting that no
+   *         element was available
+   */
+  def tryTake: F[Option[A]]
+}
+
+object QueueSource {
+  implicit def catsFunctorForQueueSource[F[_]: Functor]: Functor[QueueSource[F, *]] = new Functor[QueueSource[F, *]] {
+    override def map[A, B](fa: QueueSource[F, A])(f: A => B): QueueSource[F, B] =
+      new QueueSource[F, B] {
+        override def take: F[B] =
+          fa.take.map(f)
+        override def tryTake: F[Option[B]] =
+          fa.tryTake.map(_.map(f))
+      }
+  }
+}
+
+trait QueueSink[F[_], A] {
+  /**
+   * Enqueues the given element at the back of the queue, possibly semantically
+   * blocking until sufficient capacity becomes available.
+   *
+   * @param a the element to be put at the back of the queue
+   */
+  def offer(a: A): F[Unit]
+
+  /**
+   * Attempts to enqueue the given element at the back of the queue without
+   * semantically blocking.
+   *
+   * @param a the element to be put at the back of the queue
+   * @return an effect that describes whether the enqueuing of the given
+   *         element succeeded without blocking
+   */
+  def tryOffer(a: A): F[Boolean]
+}
+
+object QueueSink {
+  implicit def catsContravariantForQueueSink[F[_]: Functor]: Contravariant[QueueSink[F, *]] = new Contravariant[QueueSink[F, *]] {
+    override def contramap[A, B](fa: QueueSink[F, A])(f: B => A): QueueSink[F, B] =
+      new QueueSink[F, B] {
+        override def offer(b: B): F[Unit] =
+          fa.offer(f(b))
+        override def tryOffer(b: B): F[Boolean] =
+          fa.tryOffer(f(b))
       }
   }
 }


### PR DESCRIPTION
Closes #1396 . I took the liberty to go ahead and do this one since http4s will benefit from the `Queue` ones

`Enqueue` and `Dequeue` were the predecessor names for `Queue` in fs2, however, there is already a `Dequeue` (double-ended queue) and also that naming convention doesn't extend well to `Ref`, `Deferred`, and `PQueue`. Not terribly happy with `Sink` and `Source` on everything but lmk if there's something more obvious (maybe `Take` and `Put`)

Also added some `Invariant` instances where it made sense, I think there might be some more opportunities with the parent types