### PR TITLE
Avoid integer overflow in TestInstances#unsafeRun

### DIFF
--- a/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
@@ -231,7 +231,7 @@ trait TestInstances extends ParallelFGenerators with OutcomeGenerators with Sync
       ioa.unsafeRunAsyncOutcome { oc => results = oc.mapK(someK) }(
         unsafe.IORuntime(ticker.ctx, ticker.ctx, scheduler, () => ()))
 
-      ticker.ctx.tickAll(1.days)
+      ticker.ctx.tickAll(1.second)
 
       /*println("====================================")
       println(s"completed ioa with $results")


### PR DESCRIPTION
Before this PR, FS2 tests would sometimes fail with:

```scala
java.lang.IllegalArgumentException: integer overflow
	at scala.concurrent.duration.FiniteDuration.safeAdd(Duration.scala:616)
	at scala.concurrent.duration.FiniteDuration.add(Duration.scala:621)
	at scala.concurrent.duration.FiniteDuration.$plus(Duration.scala:654)
	at cats.effect.kernel.testkit.TestContext.tick(TestContext.scala:229)
	at cats.effect.kernel.testkit.TestContext.tickAll(TestContext.scala:253)
	at cats.effect.testkit.TestInstances.unsafeRun(TestInstances.scala:234)
	at cats.effect.testkit.TestInstances.unsafeRun$(TestInstances.scala:227)
```

With this change, those tests pass as well as all the CE3 tests. `tickAll` makes the assumption that if there are remaining tasks, then we need to advance the clock. When advancing by a day at a time, we only get `(Long.MaxValue / NanosPerDay) = 106751` ticks before overflow.