### PR TITLE
Deferred with different effects for source and sink

### DIFF
--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/pure.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/pure.scala
@@ -278,6 +278,8 @@ object pure {
           override def complete(a: A): PureConc[E, Boolean] = mVar.tryPut[PureConc[E, *]](a)
 
           override def tryGet: PureConc[E, Option[A]] = mVar.tryRead[PureConc[E, *]]
+
+          override def tryGetG: PureConc[E, Option[A]] = tryGet
         }
 
       def start[A](fa: PureConc[E, A]): PureConc[E, Fiber[PureConc[E, *], E, A]] =

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Deferred.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Deferred.scala
@@ -47,16 +47,28 @@ import scala.collection.immutable.LongMap
  * Finally, the blocking mentioned above is semantic only, no actual threads are
  * blocked by the implementation.
  */
-abstract class Deferred[F[_], A] extends DeferredSource[F, A] with DeferredSink[F, A] {
+trait Deferred2[F[_], G[_], A] extends DeferredSource[F, A] with DeferredSink[G, A] {
 
   /**
-   * Modify the context `F` using transformation `f`.
+   * Modify the contexts `F` and `G` using transformations `f` and `g`.
    */
-  def mapK[G[_]](f: F ~> G): Deferred[G, A] =
-    new TransformedDeferred(this, f)
+  def mapK2[H[_], I[_]](f: F ~> H, g: G ~> I): Deferred2[H, I, A] =
+    new TransformedDeferred[F, G, H, I, A](this, f, g)
+
+  def tryGetG: G[Option[A]]
 }
 
-object Deferred {
+object Deferred2 {
+
+  implicit final class DeferredSyntax[F[_], A](private val self: Deferred[F, A])
+      extends AnyVal {
+
+    /**
+     * Modify the context `F` using transformation `f`.
+     */
+    def mapK[G[_]](f: F ~> G): Deferred[G, A] =
+      self.mapK2(f, f)
+  }
 
   /**
    * Creates an unset Deferred.
@@ -67,6 +79,9 @@ object Deferred {
   def apply[F[_], A](implicit F: GenConcurrent[F, _]): F[Deferred[F, A]] =
     F.deferred[A]
 
+  def apply[F[_], G[_], A](implicit F: Async[F], G: Sync[G]): G[Deferred2[F, G, A]] =
+    in2[G, F, G, A]
+
   /**
    * Like `apply` but returns the newly allocated Deferred directly
    * instead of wrapping it in `F.delay`.  This method is considered
@@ -76,11 +91,25 @@ object Deferred {
    */
   def unsafe[F[_]: Async, A]: Deferred[F, A] = new AsyncDeferred[F, A]
 
+  def unsafe2[F[_]: Async, G[_]: Sync, A]: Deferred2[F, G, A] = {
+    new AsyncDeferred2[F, G, A] {
+      final override def F = Async[F]
+      final override def G = Sync[G]
+    }
+  }
+
   /**
    * Like [[apply]] but initializes state using another effect constructor
    */
   def in[F[_], G[_], A](implicit F: Sync[F], G: Async[G]): F[Deferred[G, A]] =
     F.delay(unsafe[G, A])
+
+  def in2[F[_], G[_], H[_], A](
+      implicit F: Sync[F],
+      G: Async[G],
+      H: Sync[H]): F[Deferred2[G, H, A]] = {
+    F.delay(unsafe2[G, H, A])
+  }
 
   sealed abstract private class State[A]
   private object State {
@@ -91,7 +120,19 @@ object Deferred {
     val dummyId = 0L
   }
 
-  final class AsyncDeferred[F[_], A](implicit F: Async[F]) extends Deferred[F, A] {
+  final class AsyncDeferred[F[_], A](implicit FF: Async[F])
+      extends AsyncDeferred2[F, F, A]
+      with Deferred[F, A] {
+
+    final override def F = FF
+    final override def G = FF
+  }
+
+  trait AsyncDeferred2[F[_], G[_], A] extends Deferred2[F, G, A] {
+
+    implicit protected def F: Async[F]
+    implicit protected def G: Sync[G]
+
     // shared mutable state
     private[this] val ref = new AtomicReference[State[A]](
       State.Unset(LongMap.empty, State.initialId)
@@ -151,69 +192,80 @@ object Deferred {
     }
 
     def tryGet: F[Option[A]] =
-      F.delay {
-        ref.get match {
-          case State.Set(a) => Some(a)
-          case State.Unset(_, _) => None
-        }
-      }
+      F.delay { unsafeTryGet() }
 
-    def complete(a: A): F[Boolean] = {
-      def notifyReaders(readers: LongMap[A => Unit]): F[Unit] = {
+    def tryGetG: G[Option[A]] =
+      G.delay { unsafeTryGet() }
+
+    private def unsafeTryGet(): Option[A] = {
+      ref.get match {
+        case State.Set(a) => Some(a)
+        case State.Unset(_, _) => None
+      }
+    }
+
+    def complete(a: A): G[Boolean] = {
+      def notifyReaders(readers: LongMap[A => Unit]): G[Unit] = {
         // LongMap iterators return values in unsigned key order,
         // which corresponds to the arrival order of readers since
         // insertion is governed by a monotonically increasing id
         val cursor = readers.valuesIterator
-        var acc = F.unit
+        var acc = G.unit
 
         while (cursor.hasNext) {
           val next = cursor.next()
-          val task = F.delay(next(a))
+          val task = G.delay(next(a))
           acc = acc >> task
         }
 
         acc
       }
 
-      // side-effectful (even though it returns F[Unit])
+      // side-effectful (even though it returns G[Boolean])
       @tailrec
-      def loop(): F[Boolean] =
+      def loop(): G[Boolean] =
         ref.get match {
           case State.Set(_) =>
-            F.pure(false)
+            G.pure(false)
           case s @ State.Unset(readers, _) =>
             val updated = State.Set(a)
             if (!ref.compareAndSet(s, updated)) loop()
             else {
-              val notify = if (readers.isEmpty) F.unit else notifyReaders(readers)
+              val notify = if (readers.isEmpty) G.unit else notifyReaders(readers)
               notify.as(true)
             }
         }
 
-      F.defer(loop())
+      G.defer(loop())
     }
   }
 
-  implicit def catsInvariantForDeferred[F[_]: Functor]: Invariant[Deferred[F, *]] =
-    new Invariant[Deferred[F, *]] {
-      override def imap[A, B](fa: Deferred[F, A])(f: A => B)(g: B => A): Deferred[F, B] =
-        new Deferred[F, B] {
+  implicit def catsInvariantForDeferred[F[_]: Functor, G[_]: Functor]
+      : Invariant[Deferred2[F, G, *]] =
+    new Invariant[Deferred2[F, G, *]] {
+      override def imap[A, B](fa: Deferred2[F, G, A])(f: A => B)(
+          g: B => A): Deferred2[F, G, B] =
+        new Deferred2[F, G, B] {
           override def get: F[B] =
             fa.get.map(f)
-          override def complete(b: B): F[Boolean] =
+          override def complete(b: B): G[Boolean] =
             fa.complete(g(b))
           override def tryGet: F[Option[B]] =
             fa.tryGet.map(_.map(f))
+          override def tryGetG: G[Option[B]] =
+            fa.tryGetG.map(_.map(f))
         }
     }
 
-  final private[kernel] class TransformedDeferred[F[_], G[_], A](
-      underlying: Deferred[F, A],
-      trans: F ~> G)
-      extends Deferred[G, A] {
-    override def get: G[A] = trans(underlying.get)
-    override def tryGet: G[Option[A]] = trans(underlying.tryGet)
-    override def complete(a: A): G[Boolean] = trans(underlying.complete(a))
+  final private[kernel] class TransformedDeferred[F[_], G[_], H[_], I[_], A](
+      underlying: Deferred2[F, G, A],
+      trans1: F ~> H,
+      trans2: G ~> I)
+      extends Deferred2[H, I, A] {
+    override def get: H[A] = trans1(underlying.get)
+    override def tryGet: H[Option[A]] = trans1(underlying.tryGet)
+    override def tryGetG: I[Option[A]] = trans2(underlying.tryGetG)
+    override def complete(a: A): I[Boolean] = trans2(underlying.complete(a))
   }
 }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
@@ -33,6 +33,9 @@ package object kernel {
   type Concurrent[F[_]] = GenConcurrent[F, Throwable]
   val Concurrent = GenConcurrent
 
+  type Deferred[F[_], A] = Deferred2[F, F, A]
+  val Deferred = Deferred2
+
   type ParallelF[F[_], A] = Par.ParallelF[F, A]
   val ParallelF = Par.ParallelF
 }


### PR DESCRIPTION
This generalizes `Deferred` to allow different effects for its `DeferredSource` and `DeferredSink` parts. So instead of `Deferred[F, A]` we could have `Deferred2[F, G, A]`, which we can `get` in  `F` and `complete` in `G`.

This is a work in progress. If the general idea is acceptable, I'll work on at least the following:

- The names are terrible (`Deferred2`, `in2`, ...); I'm open to suggestions.
- Scaladoc may need changes.