### PR TITLE
Docs

### DIFF
--- a/docs/datatypes/deferred.md
+++ b/docs/datatypes/deferred.md
@@ -3,9 +3,6 @@ id: deferred
 title: deferred
 ---
 
-{:.responsive-pic}
-![concurrency deferred](../img/concurrency-deferred.png)
-
 A purely functional synchronization primitive which represents a single value which may not yet be available.
 
 When created, a `Deferred` is empty. It can then be completed exactly once, and never be made empty again.
@@ -21,15 +18,14 @@ Expected behavior of `get`
 
 - `get` on an empty `Deferred` will block until the `Deferred` is completed
 - `get` on a completed `Deferred` will always immediately return its content
-- `get` is cancelable if `F[_]` implements `Concurrent` and if the `Deferred`
-  value was built via the normal `apply` (and not via `uncancelable`); and on
-  cancellation it will unsubscribe the registered listener, an operation that's
-  possible for as long as the `Deferred` value isn't complete
+- `get` is cancelable and on cancellation it will unsubscribe the registered
+  listener, an operation that's possible for as long as the `Deferred` value
+  isn't complete
 
 Expected behavior of `complete`
 
-- `complete(a)` on an empty `Deferred` will set it to `a`, and notify any and all readers currently blocked on a call to `get`.
-- `complete(a)` on a `Deferred` that has already been completed will not modify its content, and result in a failed `F`.
+- `complete(a)` on an empty `Deferred` will set it to `a`, notify any and all readers currently blocked on a call to `get` and return `true`
+- `complete(a)` on a `Deferred` that has already been completed will not modify its content, and will result `false`
 
 Albeit simple, `Deferred` can be used in conjunction with `Ref` to build complex concurrent behaviour and data structures like queues and semaphores.
 
@@ -42,13 +38,8 @@ Whenever you are in a scenario when many processes can modify the same value but
 Two processes will try to complete at the same time but only one will succeed, completing the deferred primitive exactly once. The loser one will raise an error when trying to complete a deferred already completed and automatically be canceled by the `IO.race` mechanism, that’s why we call attempt on the evaluation.
 
 ```scala mdoc:reset:silent
-import cats.effect.IO
-import cats.effect.concurrent.Deferred
+import cats.effect.{IO, Deferred}
 import cats.syntax.all._
-import scala.concurrent.ExecutionContext
-
-// Needed for `start` or `Concurrent[IO]` and therefore `parSequence`
-implicit val cs = IO.contextShift(ExecutionContext.global)
 
 def start(d: Deferred[IO, Int]): IO[Unit] = {
   val attemptCompletion: Int => IO[Unit] = n => d.complete(n).attempt.void
@@ -65,20 +56,3 @@ val program: IO[Unit] =
     _ <- start(d)
   } yield ()
 ```
-
-## Cancellation
-
-`Deferred` is a cancelable data type, if the underlying `F[_]` is
-capable of it. This means that cancelling a `get` will unsubscribe the 
-registered listener and can thus avoid memory leaks.
-
-However `Deferred` can also work with `Async` data types, or
-in situations where the cancelable behavior isn't desirable.
-To do so you can use the `uncancelable` builder:
-
-```scala mdoc:silent
-Deferred.uncancelable[IO, Int]
-```
-
-The restriction on the `uncancelable` builder is just `Async`,
-whereas the restriction on the normal `apply` builder is `Concurrent`.

--- a/docs/datatypes/deferred.md
+++ b/docs/datatypes/deferred.md
@@ -1,0 +1,84 @@
+---
+id: deferred
+title: deferred
+---
+
+{:.responsive-pic}
+![concurrency deferred](../img/concurrency-deferred.png)
+
+A purely functional synchronization primitive which represents a single value which may not yet be available.
+
+When created, a `Deferred` is empty. It can then be completed exactly once, and never be made empty again.
+
+```scala mdoc:silent
+abstract class Deferred[F[_], A] {
+  def get: F[A]
+  def complete(a: A): F[Unit]
+}
+```
+
+Expected behavior of `get`
+
+- `get` on an empty `Deferred` will block until the `Deferred` is completed
+- `get` on a completed `Deferred` will always immediately return its content
+- `get` is cancelable if `F[_]` implements `Concurrent` and if the `Deferred`
+  value was built via the normal `apply` (and not via `uncancelable`); and on
+  cancellation it will unsubscribe the registered listener, an operation that's
+  possible for as long as the `Deferred` value isn't complete
+
+Expected behavior of `complete`
+
+- `complete(a)` on an empty `Deferred` will set it to `a`, and notify any and all readers currently blocked on a call to `get`.
+- `complete(a)` on a `Deferred` that has already been completed will not modify its content, and result in a failed `F`.
+
+Albeit simple, `Deferred` can be used in conjunction with `Ref` to build complex concurrent behaviour and data structures like queues and semaphores.
+
+Finally, the blocking mentioned above is semantic only, no actual threads are blocked by the implementation.
+
+### Only Once
+
+Whenever you are in a scenario when many processes can modify the same value but you only care about the first one in doing so and stop processing, then this is a great use case of `Deferred[F, A]`.
+
+Two processes will try to complete at the same time but only one will succeed, completing the deferred primitive exactly once. The loser one will raise an error when trying to complete a deferred already completed and automatically be canceled by the `IO.race` mechanism, that’s why we call attempt on the evaluation.
+
+```scala mdoc:reset:silent
+import cats.effect.IO
+import cats.effect.concurrent.Deferred
+import cats.syntax.all._
+import scala.concurrent.ExecutionContext
+
+// Needed for `start` or `Concurrent[IO]` and therefore `parSequence`
+implicit val cs = IO.contextShift(ExecutionContext.global)
+
+def start(d: Deferred[IO, Int]): IO[Unit] = {
+  val attemptCompletion: Int => IO[Unit] = n => d.complete(n).attempt.void
+
+  List(
+    IO.race(attemptCompletion(1), attemptCompletion(2)),
+    d.get.flatMap { n => IO(println(show"Result: $n")) }
+  ).parSequence.void
+}
+
+val program: IO[Unit] =
+  for {
+    d <- Deferred[IO, Int]
+    _ <- start(d)
+  } yield ()
+```
+
+## Cancellation
+
+`Deferred` is a cancelable data type, if the underlying `F[_]` is
+capable of it. This means that cancelling a `get` will unsubscribe the 
+registered listener and can thus avoid memory leaks.
+
+However `Deferred` can also work with `Async` data types, or
+in situations where the cancelable behavior isn't desirable.
+To do so you can use the `uncancelable` builder:
+
+```scala mdoc:silent
+Deferred.uncancelable[IO, Int]
+```
+
+The restriction on the `uncancelable` builder is just `Async`,
+whereas the restriction on the normal `apply` builder is `Concurrent`.

--- a/docs/datatypes/ref.md
+++ b/docs/datatypes/ref.md
@@ -3,9 +3,6 @@ id: ref
 title: ref
 ---
 
-{:.responsive-pic}
-![concurrency ref](../img/concurrency-ref.png)
-
 An asynchronous, concurrent mutable reference.
 
 ```scala mdoc:silent
@@ -17,7 +14,7 @@ abstract class Ref[F[_], A] {
 }
 ```
 
-Provides safe concurrent access and modification of its content, but no functionality for synchronisation, which is instead handled by `Deferred`.
+Provides safe concurrent access and modification of its content, but no functionality for synchronisation, which is instead handled by [Deferred](./deferred.md).
 
 For this reason, a `Ref` is always initialised to a value.
 
@@ -39,13 +36,8 @@ The workers will concurrently run and modify the value of the Ref so this is one
 ```
 
 ```scala mdoc:reset:silent
-import cats.effect.{IO, Sync}
-import cats.effect.concurrent.Ref
+import cats.effect.{IO, Sync, Ref}
 import cats.syntax.all._
-import scala.concurrent.ExecutionContext
-
-// Needed for triggering evaluation in parallel
-implicit val ctx = IO.contextShift(ExecutionContext.global)
 
 class Worker[F[_]](number: Int, ref: Ref[F, Int])(implicit F: Sync[F]) {
 
@@ -63,7 +55,7 @@ class Worker[F[_]](number: Int, ref: Ref[F, Int])(implicit F: Sync[F]) {
 
 val program: IO[Unit] =
   for {
-    ref <- Ref.of[IO, Int](0)
+    ref <- Ref[F].of(0)
     w1  = new Worker[IO](1, ref)
     w2  = new Worker[IO](2, ref)
     w3  = new Worker[IO](3, ref)

--- a/docs/datatypes/ref.md
+++ b/docs/datatypes/ref.md
@@ -1,0 +1,77 @@
+---
+id: ref
+title: ref
+---
+
+{:.responsive-pic}
+![concurrency ref](../img/concurrency-ref.png)
+
+An asynchronous, concurrent mutable reference.
+
+```scala mdoc:silent
+abstract class Ref[F[_], A] {
+  def get: F[A]
+  def set(a: A): F[Unit]
+  def modify[B](f: A => (A, B)): F[B]
+  // ... and more
+}
+```
+
+Provides safe concurrent access and modification of its content, but no functionality for synchronisation, which is instead handled by `Deferred`.
+
+For this reason, a `Ref` is always initialised to a value.
+
+The default implementation is nonblocking and lightweight, consisting essentially of a purely functional wrapper over an `AtomicReference`.
+
+### Concurrent Counter
+
+This is probably one of the most common uses of this concurrency primitive.
+
+The workers will concurrently run and modify the value of the Ref so this is one possible outcome showing “#worker » currentCount”:
+
+```
+#2 >> 0
+#1 >> 0
+#3 >> 0
+#1 >> 0
+#3 >> 2
+#2 >> 1
+```
+
+```scala mdoc:reset:silent
+import cats.effect.{IO, Sync}
+import cats.effect.concurrent.Ref
+import cats.syntax.all._
+import scala.concurrent.ExecutionContext
+
+// Needed for triggering evaluation in parallel
+implicit val ctx = IO.contextShift(ExecutionContext.global)
+
+class Worker[F[_]](number: Int, ref: Ref[F, Int])(implicit F: Sync[F]) {
+
+  private def putStrLn(value: String): F[Unit] = F.delay(println(value))
+
+  def start: F[Unit] =
+    for {
+      c1 <- ref.get
+      _  <- putStrLn(show"#$number >> $c1")
+      c2 <- ref.modify(x => (x + 1, x))
+      _  <- putStrLn(show"#$number >> $c2")
+    } yield ()
+
+}
+
+val program: IO[Unit] =
+  for {
+    ref <- Ref.of[IO, Int](0)
+    w1  = new Worker[IO](1, ref)
+    w2  = new Worker[IO](2, ref)
+    w3  = new Worker[IO](3, ref)
+    _   <- List(
+             w1.start,
+             w2.start,
+             w3.start
+           ).parSequence.void
+  } yield ()
+```
+

--- a/docs/datatypes/ref.md
+++ b/docs/datatypes/ref.md
@@ -55,7 +55,7 @@ class Worker[F[_]](number: Int, ref: Ref[F, Int])(implicit F: Sync[F]) {
 
 val program: IO[Unit] =
   for {
-    ref <- Ref[F].of(0)
+    ref <- Ref[IO].of(0)
     w1  = new Worker[IO](1, ref)
     w2  = new Worker[IO](2, ref)
     w3  = new Worker[IO](3, ref)

--- a/docs/typeclasses.md
+++ b/docs/typeclasses.md
@@ -465,9 +465,23 @@ There has been plenty of excellent material written on this subject. See [here](
 ## `Temporal`
 
 `Temporal` extends `Concurrent` with the ability to suspend a fiber by sleeping for
-a specified duration. This enables us to define powerful time-dependent
+a specified duration.
+
+```scala
+firstThing >> IO.sleep(5.seconds) >> secondThing
+```
+
+Note that this should *always* be used instead of `IO(Thread.sleep(duration))`. TODO
+link to appropriate section on `Sync`, blocking operations and underlying threads
+
+This enables us to define powerful time-dependent
 derived combinators like `timeoutTo`
 
 ```scala
 val data = fetchFromRemoteService.timeoutTo(2.seconds, cachedValue)
 ```
+
+## `Sync`
+
+This typeclass encodes the ability to suspend synchronous side effects in a referentially
+transparent manner.

--- a/docs/typeclasses.md
+++ b/docs/typeclasses.md
@@ -169,9 +169,10 @@ The primary differences between self-cancellation and `raiseError` are two-fold.
 ```scala
 for {
   fib <- (IO.uncancelable(_ =>
-      IO.canceled >> IO.println("This will print")
+      IO.canceled >> IO.println("This will print as cancelation is suppressed")
     ) >> IO.println(
-    "This will never be called as we are canceled as soon as the uncancelable block finishes")).start res <- fib.join
+    "This will never be called as we are canceled as soon as the uncancelable block finishes")).start
+  res <- fib.join
 } yield res //Canceled()
 ```
 There is no analogue for this kind of functionality with errors. Second, if you sequence an error with `raiseError`, it's always possible to use `attempt` or `handleError` to *handle* the error and resume normal execution. No such functionality is available for cancellation. 

--- a/docs/typeclasses.md
+++ b/docs/typeclasses.md
@@ -397,11 +397,11 @@ concurrent state, including `memoize` and `parTraverseN`.
 
 ### `Ref`
 
-TODO copy doc from CE2?
+TODO copy doc from CE2? Or link to separate docs?
 
 ### `Deferred`
 
-TODO  copy doc from CE2?
+TODO  copy doc from CE2? Or link to separate docs?
 
 ### Memoization
 


### PR DESCRIPTION
Docs on `Concurrent` and `Temporal`. Also port docs for `Ref` and `Deferred` from CE2 with the minimal set of changes to make them not wrong