### PR TITLE
IOFiber extends AtomicBoolean

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -18,7 +18,10 @@ package cats.effect
 
 import scala.concurrent.ExecutionContext
 
-private[effect] abstract class IOFiberPlatform[A] { this: IOFiber[A] =>
+import java.util.concurrent.atomic.AtomicBoolean
+
+private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(true) {
+  this: IOFiber[A] =>
 
   // in theory this code should never be hit due to the override in IOCompanionPlatform
   def interruptibleImpl(cur: IO.Blocking[Any], blockingEc: ExecutionContext): IO[Any] = {

--- a/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -22,7 +22,8 @@ import scala.util.control.NonFatal
 import java.util.{concurrent => juc}
 import juc.atomic.{AtomicBoolean, AtomicReference}
 
-private[effect] abstract class IOFiberPlatform[A] { this: IOFiber[A] =>
+private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(true) {
+  this: IOFiber[A] =>
 
   private[this] val TypeInterruptibleMany = Sync.Type.InterruptibleMany
 


### PR DESCRIPTION
It has been said that operations in the run loop, apart from allocating new `IO` objects, are instantaneous. This should help out with both allocations and speed.

Benchmarks:
```
series/3.x:
Benchmark             (size)   Mode  Cnt      Score     Error  Units
AsyncBenchmark.async     100  thrpt   10  19675.613 ± 379.777  ops/s
```

```
this PR:
Benchmark             (size)   Mode  Cnt      Score     Error  Units
AsyncBenchmark.async     100  thrpt   10  20235.886 ± 252.208  ops/s
```