### PR TITLE
Sketch of takeAll and offerAll

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Queue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Queue.scala
@@ -234,9 +234,9 @@ object Queue {
         .flatten
         .uncancelable
 
-    override val tryTakeAll: F[ScalaQueue[A]] = ???
-
     override val takeAll: F[ScalaQueue[A]] = ???
+    
+    override val tryTakeAll: F[ScalaQueue[A]] = ???
   }
 
   private final class BoundedQueue[F[_], A](capacity: Int, state: Ref[F, State[F, A]])(
@@ -321,10 +321,10 @@ object Queue {
             fa.take.map(f)
           override def tryTake: F[Option[B]] =
             fa.tryTake.map(_.map(f))
-          override def tryTakeAll: F[ScalaQueue[B]] =
-            fa.tryTakeAll.map(_.map(f))
           override def takeAll: F[ScalaQueue[B]] =
             fa.takeAll.map(_.map(f))
+          override def tryTakeAll: F[ScalaQueue[B]] =
+            fa.tryTakeAll.map(_.map(f))
         }
     }
 }
@@ -348,16 +348,16 @@ trait QueueSource[F[_], A] {
   def tryTake: F[Option[A]]
 
   /**
-   * Drains all elements held in the queue. Returns an empty list if there are
-   * no elements available.
-   */
-  def tryTakeAll: F[ScalaQueue[A]]
-
-  /**
    * Drains all elements held in the queue, possibly semantically blocking
    * until an element is available. Returns at least one element.
    */
   def takeAll: F[ScalaQueue[A]]
+
+  /**
+   * Drains all elements held in the queue. Returns an empty list if there are
+   * no elements available.
+   */
+  def tryTakeAll: F[ScalaQueue[A]]
 }
 
 object QueueSource {
@@ -369,10 +369,10 @@ object QueueSource {
             fa.take.map(f)
           override def tryTake: F[Option[B]] =
             fa.tryTake.map(_.map(f))
-          override def tryTakeAll: F[ScalaQueue[B]] =
-            fa.tryTakeAll.map(_.map(f))
           override def takeAll: F[ScalaQueue[B]] =
             fa.takeAll.map(_.map(f))
+          override def tryTakeAll: F[ScalaQueue[B]] =
+            fa.tryTakeAll.map(_.map(f))
         }
     }
 }

--- a/std/shared/src/main/scala/cats/effect/std/Queue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Queue.scala
@@ -195,11 +195,11 @@ object Queue {
     override def tryOfferAll(as: ScalaQueue[A]): F[Boolean] = {
       def go(rest: ScalaQueue[A]): F[Boolean] =
         rest.dequeueOption match {
-          case Some((a, tail)) => 
+          case Some((a, tail)) =>
             tryOffer(a).ifM(go(tail), F.pure(false))
           case None => F.pure(true)
         }
-      
+
       go(as)
     }
 
@@ -250,10 +250,8 @@ object Queue {
         .flatten
         .uncancelable
 
-    override val takeAll: F[ScalaQueue[A]] = 
-      take.flatMap { a =>
-        tryTakeAll.map(_.prepended(a))
-      }
+    override val takeAll: F[ScalaQueue[A]] =
+      take.flatMap { a => tryTakeAll.map(_.prepended(a)) }
 
     override val tryTakeAll: F[ScalaQueue[A]] = {
       def go(acc: ScalaQueue[A]): F[ScalaQueue[A]] =
@@ -344,9 +342,9 @@ object Queue {
             fa.offer(g(b))
           override def tryOffer(b: B): F[Boolean] =
             fa.tryOffer(g(b))
-          override def offerAll(as: ScalaQueue[B]): F[Unit] = 
+          override def offerAll(as: ScalaQueue[B]): F[Unit] =
             fa.offerAll(as.map(g))
-          override def tryOfferAll(as: ScalaQueue[B]): F[Boolean] = 
+          override def tryOfferAll(as: ScalaQueue[B]): F[Boolean] =
             fa.tryOfferAll(as.map(g))
           override def take: F[B] =
             fa.take.map(f)
@@ -452,7 +450,7 @@ object QueueSink {
             fa.tryOffer(f(b))
           override def offerAll(as: ScalaQueue[B]): F[Unit] =
             fa.offerAll(as.map(f))
-          override def tryOfferAll(as: ScalaQueue[B]): F[Boolean] = 
+          override def tryOfferAll(as: ScalaQueue[B]): F[Boolean] =
             fa.tryOfferAll(as.map(f))
         }
     }


### PR DESCRIPTION
This PR (potentially) implements `takeAll`, `tryTakeAll`, `offerAll`, and `tryOfferAll`, as an attempt to squeeze some extra performance out when dealing with batched workloads. In particular, enqueueing and dequeueing multiple elements encounters a memory barrier on every call. The initial implementations are merely placeholders for us to agree on semantics; there are more efficient ones that directly manipulate the internal state. There are a few thorns to get through first though

The biggest obstacle in this PR right now is... the signature for these methods. Here's my first attempt:
```scala
import scala.collection.immutable.{Queue => ScalaQueue}
trait Queue[F[_], A] {
  def takeAll: F[ScalaQueue[A]]
  def tryTakeAll: F[ScalaQueue[A]]
  def offerAll(as: ScalaQueue[A]): F[Unit]
  def tryOfferAll(as: ScalaQueue[A]): F[Boolean]
}
```
The choice of `ScalaQueue` here is completely arbitrary from a user's perspective. My intention is that these operations could just directly manipulate the internal state which is also represented with a `ScalaQueue`. However, this poses a problem: it's really unlikely that a user is going to have their elements residing in a `ScalaQueue`. That means it's really likely that they end up performing a conversion and copy... which might defeat the purpose of doing this anyway because allocations can be as expensive as the memory barriers we want to avoid. I think it's pretty much the same deal no matter what collection type we choose.

Furthermore, the choice of `ScalaQueue` only really makes sense for a subset of our `Queue` implementations. `Dequeue` is another subtype of `Queue` whose internal state is represented by a `List`, so we'd be converting and copying on both batched enqueue and dequeue operations. Not too great. The bottom line is that there's likely to be copying, at the call-site, internally, or even both (imagine we chose `Vector` in the signature but a user has a `List` in their hands). 

The answer to this problem is inching closer and closer towards `fs2.Chunk`. That being said, here are some solutions I've got in mind:
1. Just pick the most common collection type and use that, without any regard to performance. These would really just be convenience methods (`takeAll` in particular is a nice one).
2. Implement `Chunk`. We could either reimplement, implement as a separate library (which is pulled in by `std`), or even pull the fs2 one out, since it's not reliant on `Stream`.
3. Forget doing this in CE and focus efforts on the `fs2.Queue` instead

It's probably worth collecting empirical evidence around what the performance impact of these copying operations and memory barriers are, but I think it's going to largely be sensitive to workload and the specific types involved