### PR TITLE
fromCompletableFuture: unwrap CompletionExceptions

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -38,20 +38,8 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
     else
       Blocking(hint, () => thunk)
 
-  // TODO deduplicate with AsyncPlatform#fromCompletableFuture (requires Dotty 0.26 or higher)
   def fromCompletableFuture[A](fut: IO[CompletableFuture[A]]): IO[A] =
-    fut flatMap { cf =>
-      async[A] { cb =>
-        IO {
-          val stage = cf.handle[Unit] {
-            case (a, null) => cb(Right(a))
-            case (_, t) => cb(Left(t))
-          }
-
-          Some(IO(stage.cancel(false)).void)
-        }
-      }
-    }
+    asyncForIO.fromCompletableFuture(fut)
 
   def realTimeInstant: IO[Instant] = asyncForIO.realTimeInstant
 }

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -125,7 +125,7 @@ abstract class IOPlatformSpecification extends Specification with ScalaCheck wit
       "errors in j.u.c.CompletableFuture are not wrapped" in ticked { implicit ticker =>
         val e = new RuntimeException("stuff happened")
         val test = IO
-          .fromCompletableFuture(IO {
+          .fromCompletableFuture[Int](IO {
             val root = new CompletableFuture[Int]
             root.completeExceptionally(e)
             root.thenApply(_ + 1)


### PR DESCRIPTION
`CompletionException`s often occur when a downstream CompletableFuture is `compleExceptionally`-ed.