### PR TITLE
Add `backgroundOn` and `startOn` combinators.

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -84,10 +84,10 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
 
   def evalOn(ec: ExecutionContext): IO[A] = IO.EvalOn(this, ec)
 
-  def startOn(ec: ExecutionContext): IO[FiberIO[A @uncheckedVariance]] = evalOn(ec).start
+  def startOn(ec: ExecutionContext): IO[FiberIO[A @uncheckedVariance]] = start.evalOn(ec)
 
   def backgroundOn(ec: ExecutionContext): ResourceIO[IO[OutcomeIO[A @uncheckedVariance]]] =
-    evalOn(ec).background
+    background.map(f => f.evalOn(ec))
 
   def flatMap[B](f: A => IO[B]): IO[B] = IO.FlatMap(this, f)
 
@@ -536,14 +536,6 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
     def evalOn[A](fa: IO[A], ec: ExecutionContext): IO[A] =
       fa.evalOn(ec)
-
-    def startOn[A](fa: IO[A], ec: ExecutionContext): IO[FiberIO[A]] =
-      fa.startOn(ec)
-
-    override def backgroundOn[A](
-        fa: IO[A],
-        ec: ExecutionContext): Resource[IO, IO[Outcome[IO, Throwable, A]]] =
-      fa.backgroundOn(ec)
 
     val executionContext: IO[ExecutionContext] =
       IO.executionContext

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -87,7 +87,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
   def startOn(ec: ExecutionContext): IO[FiberIO[A @uncheckedVariance]] = start.evalOn(ec)
 
   def backgroundOn(ec: ExecutionContext): ResourceIO[IO[OutcomeIO[A @uncheckedVariance]]] =
-    background.map(f => f.evalOn(ec))
+    Resource.make(startOn(ec))(_.cancel).map(_.join)
 
   def flatMap[B](f: A => IO[B]): IO[B] = IO.FlatMap(this, f)
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -84,6 +84,8 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
 
   def evalOn(ec: ExecutionContext): IO[A] = IO.EvalOn(this, ec)
 
+  def startOn(ec: ExecutionContext): IO[FiberIO[A @uncheckedVariance]] = evalOn(ec).start
+
   def flatMap[B](f: A => IO[B]): IO[B] = IO.FlatMap(this, f)
 
   def flatten[B](implicit ev: A <:< IO[B]): IO[B] = flatMap(ev)
@@ -531,6 +533,9 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
     def evalOn[A](fa: IO[A], ec: ExecutionContext): IO[A] =
       fa.evalOn(ec)
+
+    def startOn[A](fa: IO[A], ec: ExecutionContext): IO[FiberIO[A]] =
+      fa.startOn(ec)
 
     val executionContext: IO[ExecutionContext] =
       IO.executionContext

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -56,7 +56,7 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
   def backgroundOn[A](
       fa: F[A],
       ec: ExecutionContext): Resource[F, F[Outcome[F, Throwable, A]]] =
-    background(fa).map(f => evalOn(f, ec))
+    Resource.make(startOn(fa, ec))(_.cancel)(this).map(_.join)
 
   def executionContext: F[ExecutionContext]
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -52,6 +52,8 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
 
   def startOn[A](fa: F[A], ec: ExecutionContext): F[Fiber[F, Throwable, A]]
 
+  def backgroundOn[A](fa: F[A], ec: ExecutionContext): Resource[F, F[Outcome[F, Throwable, A]]]
+
   def executionContext: F[ExecutionContext]
 
   def fromFuture[A](fut: F[Future[A]]): F[A] =
@@ -205,9 +207,14 @@ object Async {
     def evalOn[A](fa: OptionT[F, A], ec: ExecutionContext): OptionT[F, A] =
       OptionT(F.evalOn(fa.value, ec))
 
-    override def startOn[A](fa: OptionT[F, A], ec: ExecutionContext): OptionT[F, Fiber[OptionT[F, *], Throwable, A]] =
+    override def startOn[A](
+        fa: OptionT[F, A],
+        ec: ExecutionContext): OptionT[F, Fiber[OptionT[F, *], Throwable, A]] =
       start(evalOn(fa, ec))
 
+    override def backgroundOn[A](fa: OptionT[F, A], ec: ExecutionContext)
+        : Resource[OptionT[F, *], OptionT[F, Outcome[OptionT[F, *], Throwable, A]]] =
+      background(evalOn(fa, ec))
 
     def executionContext: OptionT[F, ExecutionContext] = OptionT.liftF(F.executionContext)
 
@@ -269,8 +276,14 @@ object Async {
     def evalOn[A](fa: EitherT[F, E, A], ec: ExecutionContext): EitherT[F, E, A] =
       EitherT(F.evalOn(fa.value, ec))
 
-    override def startOn[A](fa: EitherT[F, E, A], ec: ExecutionContext): EitherT[F, E, Fiber[EitherT[F, E, *], Throwable, A]] =
+    override def startOn[A](
+        fa: EitherT[F, E, A],
+        ec: ExecutionContext): EitherT[F, E, Fiber[EitherT[F, E, *], Throwable, A]] =
       start(evalOn(fa, ec))
+
+    override def backgroundOn[A](fa: EitherT[F, E, A], ec: ExecutionContext)
+        : Resource[EitherT[F, E, *], EitherT[F, E, Outcome[EitherT[F, E, *], Throwable, A]]] =
+      background(evalOn(fa, ec))
 
     def executionContext: EitherT[F, E, ExecutionContext] = EitherT.liftF(F.executionContext)
 
@@ -333,6 +346,15 @@ object Async {
     def evalOn[A](fa: IorT[F, L, A], ec: ExecutionContext): IorT[F, L, A] =
       IorT(F.evalOn(fa.value, ec))
 
+    override def startOn[A](
+        fa: IorT[F, L, A],
+        ec: ExecutionContext): IorT[F, L, Fiber[IorT[F, L, *], Throwable, A]] =
+      start(evalOn(fa, ec))
+
+    override def backgroundOn[A](fa: IorT[F, L, A], ec: ExecutionContext)
+        : Resource[IorT[F, L, *], IorT[F, L, Outcome[IorT[F, L, *], Throwable, A]]] =
+      background(evalOn(fa, ec))
+
     def executionContext: IorT[F, L, ExecutionContext] = IorT.liftF(F.executionContext)
 
     override def never[A]: IorT[F, L, A] = IorT.liftF(F.never)
@@ -393,8 +415,14 @@ object Async {
     def evalOn[A](fa: WriterT[F, L, A], ec: ExecutionContext): WriterT[F, L, A] =
       WriterT(F.evalOn(fa.run, ec))
 
-    override def startOn[A](fa: WriterT[F, L, A], ec: ExecutionContext): WriterT[F, L, Fiber[WriterT[F, L, *], Throwable, A]] =
+    override def startOn[A](
+        fa: WriterT[F, L, A],
+        ec: ExecutionContext): WriterT[F, L, Fiber[WriterT[F, L, *], Throwable, A]] =
       start(evalOn(fa, ec))
+
+    override def backgroundOn[A](fa: WriterT[F, L, A], ec: ExecutionContext)
+        : Resource[WriterT[F, L, *], WriterT[F, L, Outcome[WriterT[F, L, *], Throwable, A]]] =
+      background(evalOn(fa, ec))
 
     def executionContext: WriterT[F, L, ExecutionContext] = WriterT.liftF(F.executionContext)
 
@@ -456,9 +484,14 @@ object Async {
     def evalOn[A](fa: Kleisli[F, R, A], ec: ExecutionContext): Kleisli[F, R, A] =
       Kleisli(r => F.evalOn(fa.run(r), ec))
 
-
-    override def startOn[A](fa: Kleisli[F, R, A], ec: ExecutionContext): Kleisli[F, R, Fiber[Kleisli[F, R, *], Throwable, A]] =
+    override def startOn[A](
+        fa: Kleisli[F, R, A],
+        ec: ExecutionContext): Kleisli[F, R, Fiber[Kleisli[F, R, *], Throwable, A]] =
       start(evalOn(fa, ec))
+
+    override def backgroundOn[A](fa: Kleisli[F, R, A], ec: ExecutionContext)
+        : Resource[Kleisli[F, R, *], Kleisli[F, R, Outcome[Kleisli[F, R, *], Throwable, A]]] =
+      background(evalOn(fa, ec))
 
     def executionContext: Kleisli[F, R, ExecutionContext] = Kleisli.liftF(F.executionContext)
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -53,7 +53,9 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
   def startOn[A](fa: F[A], ec: ExecutionContext): F[Fiber[F, Throwable, A]] =
     evalOn(start(fa), ec)
 
-  def backgroundOn[A](fa: F[A], ec: ExecutionContext): Resource[F, F[Outcome[F, Throwable, A]]] =
+  def backgroundOn[A](
+      fa: F[A],
+      ec: ExecutionContext): Resource[F, F[Outcome[F, Throwable, A]]] =
     background(fa).map(f => evalOn(f, ec))
 
   def executionContext: F[ExecutionContext]

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1121,8 +1121,14 @@ abstract private[effect] class ResourceAsync[F[_]]
       }
     }
 
-  override def startOn[A](fa: Resource[F, A], ec: ExecutionContext): Resource[F, Fiber[Resource[F, *], Throwable, A]] =
+  override def startOn[A](
+      fa: Resource[F, A],
+      ec: ExecutionContext): Resource[F, Fiber[Resource[F, *], Throwable, A]] =
     start(evalOn(fa, ec))
+
+  override def backgroundOn[A](fa: Resource[F, A], ec: ExecutionContext)
+      : Resource[Resource[F, *], Resource[F, Outcome[Resource[F, *], Throwable, A]]] =
+    background(evalOn(fa, ec))
 
   def executionContext: Resource[F, ExecutionContext] =
     Resource.eval(F.executionContext)

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1121,15 +1121,6 @@ abstract private[effect] class ResourceAsync[F[_]]
       }
     }
 
-  override def startOn[A](
-      fa: Resource[F, A],
-      ec: ExecutionContext): Resource[F, Fiber[Resource[F, *], Throwable, A]] =
-    start(evalOn(fa, ec))
-
-  override def backgroundOn[A](fa: Resource[F, A], ec: ExecutionContext)
-      : Resource[Resource[F, *], Resource[F, Outcome[Resource[F, *], Throwable, A]]] =
-    background(evalOn(fa, ec))
-
   def executionContext: Resource[F, ExecutionContext] =
     Resource.eval(F.executionContext)
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1121,6 +1121,9 @@ abstract private[effect] class ResourceAsync[F[_]]
       }
     }
 
+  override def startOn[A](fa: Resource[F, A], ec: ExecutionContext): Resource[F, Fiber[Resource[F, *], Throwable, A]] =
+    start(evalOn(fa, ec))
+
   def executionContext: Resource[F, ExecutionContext] =
     Resource.eval(F.executionContext)
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AsyncSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AsyncSyntax.scala
@@ -30,8 +30,7 @@ final class AsyncOps[F[_], A] private[syntax] (private[syntax] val wrapped: F[A]
   def evalOn(ec: ExecutionContext)(implicit F: Async[F]): F[A] =
     Async[F].evalOn(wrapped, ec)
 
-  def startOn(ec: ExecutionContext)(
-      implicit F: Async[F]): F[Fiber[F, Throwable, A]] =
+  def startOn(ec: ExecutionContext)(implicit F: Async[F]): F[Fiber[F, Throwable, A]] =
     Async[F].startOn(wrapped, ec)
 
   def backgroundOn(ec: ExecutionContext)(

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AsyncSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AsyncSyntax.scala
@@ -30,11 +30,11 @@ final class AsyncOps[F[_], A] private[syntax] (private[syntax] val wrapped: F[A]
   def evalOn(ec: ExecutionContext)(implicit F: Async[F]): F[A] =
     Async[F].evalOn(wrapped, ec)
 
-  def startOn[A](fa: F[A], ec: ExecutionContext)(
+  def startOn(ec: ExecutionContext)(
       implicit F: Async[F]): F[Fiber[F, Throwable, A]] =
-    Async[F].startOn(fa, ec)
+    Async[F].startOn(wrapped, ec)
 
-  def backgroundOn[A](fa: F[A], ec: ExecutionContext)(
+  def backgroundOn(ec: ExecutionContext)(
       implicit F: Async[F]): Resource[F, F[Outcome[F, Throwable, A]]] =
-    Async[F].backgroundOn(fa, ec)
+    Async[F].backgroundOn(wrapped, ec)
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AsyncSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AsyncSyntax.scala
@@ -16,7 +16,7 @@
 
 package cats.effect.kernel.syntax
 
-import cats.effect.kernel.Async
+import cats.effect.kernel.{Async, Fiber, Outcome, Resource}
 
 import scala.concurrent.ExecutionContext
 
@@ -29,4 +29,12 @@ final class AsyncOps[F[_], A] private[syntax] (private[syntax] val wrapped: F[A]
     extends AnyVal {
   def evalOn(ec: ExecutionContext)(implicit F: Async[F]): F[A] =
     Async[F].evalOn(wrapped, ec)
+
+  def startOn[A](fa: F[A], ec: ExecutionContext)(
+      implicit F: Async[F]): F[Fiber[F, Throwable, A]] =
+    Async[F].startOn(fa, ec)
+
+  def backgroundOn[A](fa: F[A], ec: ExecutionContext)(
+      implicit F: Async[F]): Resource[F, F[Outcome[F, Throwable, A]]] =
+    Async[F].backgroundOn(fa, ec)
 }


### PR DESCRIPTION
This PR introduces new combinators `backgroundOn` and `startOn` as described in https://github.com/typelevel/cats-effect/issues/1613.

Not sure if we need any additional tests, if so I will be happy to add them.