### PR TITLE
New ContState

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -43,4 +43,9 @@ private[effect] object IOFiberConstants {
   val EvalOnR: Byte = 5
   val CedeR: Byte = 6
   val DoneR: Byte = 7
+
+  // ContState tags
+  val ContStateInitial: Int = 0
+  val ContStateWaiting: Int = 1
+  val ContStateResult: Int = 2
 }

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -43,4 +43,9 @@ final class IOFiberConstants {
   public static final byte EvalOnR = 5;
   public static final byte CedeR = 6;
   public static final byte DoneR = 7;
+
+  // ContState tags
+  public static final int ContStateInitial = 0;
+  public static final int ContStateWaiting = 1;
+  public static final int ContStateResult = 2;
 }

--- a/core/shared/src/main/scala/cats/effect/ContState.scala
+++ b/core/shared/src/main/scala/cats/effect/ContState.scala
@@ -16,23 +16,11 @@
 
 package cats.effect
 
+import java.util.concurrent.atomic.AtomicInteger
+
 // TODO rename
-sealed abstract private[effect] class ContState extends Product with Serializable {
-  def result: Either[Throwable, Any] = sys.error("impossible")
-  def tag: Byte
-}
-
-private[effect] object ContState {
-  // no one completed
-  case object Initial extends ContState {
-    def tag = 0
-  }
-
-  case object Waiting extends ContState {
-    def tag = 1
-  }
-
-  final case class Result(override val result: Either[Throwable, Any]) extends ContState {
-    def tag = 2
-  }
+// `result` is published by a volatile store on the atomic integer extended
+// by this class.
+private class ContState(var wasFinalizing: Boolean) extends AtomicInteger(0) {
+  var result: Either[Throwable, Any] = _
 }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -44,8 +44,6 @@ import scala.concurrent.{
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
-
 sealed abstract class IO[+A] private () extends IOPlatform[A] {
 
   private[effect] def tag: Byte
@@ -664,8 +662,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
   }
   private[effect] object IOCont {
     // INTERNAL, it's only created by the runloop itself during the execution of `IOCont`
-    final case class Get[A](state: AtomicReference[ContState], wasFinalizing: AtomicBoolean)
-        extends IO[A] {
+    final case class Get[A](state: ContState) extends IO[A] {
       def tag = 12
     }
   }


### PR DESCRIPTION
```
x86_64 before
AsyncBenchmark.async 100 thrpt 20 18689.050 ± 318.821 ops/s
```

```
x86_64 after
AsyncBenchmark.async 100 thrpt 20 20999.016 ± 210.829 ops/s
```

```
arm64 before
AsyncBenchmark.async 100 thrpt 20 4224.226 ± 59.762 ops/s
```

```
arm64 after
AsyncBenchmark.async 100 thrpt 20 4404.651 ± 14.764 ops/s
```
