### PR TITLE
implicits don't need to be package objects

### DIFF
--- a/core/shared/src/main/scala/cats/effect/implicits/package.scala
+++ b/core/shared/src/main/scala/cats/effect/implicits/package.scala
@@ -16,4 +16,4 @@
 
 package cats.effect
 
-package object implicits extends syntax.AllSyntax with instances.AllInstances
+object implicits extends syntax.AllSyntax with instances.AllInstances

--- a/kernel/shared/src/main/scala/cats/effect/kernel/implicits/package.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/implicits/package.scala
@@ -16,4 +16,4 @@
 
 package cats.effect.kernel
 
-package object implicits extends syntax.AllSyntax with instances.AllInstances
+object implicits extends syntax.AllSyntax with instances.AllInstances


### PR DESCRIPTION
Package object inheritance was deprecated for a while, came back, slated for deprecation in 2.14, and will be swept out with package objects themselves in Dotty.  I'm also observing weirdness summoning implicits with default arguments from package objects in 3.0.0-M3.

With package objects are falling out of fashion, let's not use them where they're not needed.  