### PR TITLE
AutoCedeR

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -32,7 +32,6 @@ private[effect] object IOFiberConstants {
   val UncancelableK: Byte = 7
   val UnmaskK: Byte = 8
   val AttemptK: Byte = 9
-  val AutoCedeK: Byte = 10
 
   // resume ids
   val ExecR: Byte = 0
@@ -42,7 +41,8 @@ private[effect] object IOFiberConstants {
   val AfterBlockingFailedR: Byte = 4
   val EvalOnR: Byte = 5
   val CedeR: Byte = 6
-  val DoneR: Byte = 7
+  val AutoCedeR: Byte = 7
+  val DoneR: Byte = 8
 
   // ContState tags
   val ContStateInitial: Int = 0

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -32,7 +32,6 @@ final class IOFiberConstants {
   public static final byte UncancelableK = 7;
   public static final byte UnmaskK = 8;
   public static final byte AttemptK = 9;
-  public static final byte AutoCedeK = 10;
 
   // resume ids
   public static final byte ExecR = 0;
@@ -42,7 +41,8 @@ final class IOFiberConstants {
   public static final byte AfterBlockingFailedR = 4;
   public static final byte EvalOnR = 5;
   public static final byte CedeR = 6;
-  public static final byte DoneR = 7;
+  public static final byte AutoCedeR = 7;
+  public static final byte DoneR = 8;
 
   // ContState tags
   public static final int ContStateInitial = 0;


### PR DESCRIPTION
Auto cede is a preparation to relinquish the hold over the run loop, which makes it a _resumption_ mechanism, not a _continutation_. (Also it would have never been visible in `failed`). This occurred to me when I was looking at #1352. Unfortunately I do not see the resemblance between auto cede and a hypothetical `FlattenK`. `FlattenK` is literally a `FlatMap` with an `identity` bind, while `AutoCede` gives up control over the run loop.

I understand that `FlattenK` could be a nice optimization, but it would look closer to what we have already for `Attempt`.

Thoughts?