### PR TITLE
Reclaim unused fiber stack memory

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -48,4 +48,10 @@ private[effect] object IOFiberConstants {
   val ContStateInitial: Int = 0
   val ContStateWaiting: Int = 1
   val ContStateResult: Int = 2
+
+  // Initial sizes of fiber stacks
+  val ContsStackInitSize: Int = 16
+  val ObjectStateStackInitSize: Int = 16
+  val FinalizersStackInitSize: Int = 16
+  val ECStackInitSize: Int = 2
 }

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -48,4 +48,10 @@ final class IOFiberConstants {
   public static final int ContStateInitial = 0;
   public static final int ContStateWaiting = 1;
   public static final int ContStateResult = 2;
+
+  // Initial sizes of fiber stacks
+  public static final int ContsStackInitSize = 16;
+  public static final int ObjectStateStackInitSize = 16;
+  public static final int FinalizersStackInitSize = 16;
+  public static final int ECStackInitSize = 2;
 }

--- a/core/shared/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/shared/src/main/scala/cats/effect/ArrayStack.scala
@@ -80,10 +80,14 @@ private[effect] final class ArrayStack[A <: AnyRef](
       buffer = buffer2
     }
 
-  def reclaim(): Unit = {
+  /**
+   * The lower bound is passed as an argument to avoid
+   * storing an extra integer in each stack instance.
+   */
+  def reclaim(bound: Int): Unit = {
     val len = buffer.length
     val quarter = len / 4
-    if (index < quarter) {
+    if (len > bound && index < quarter) {
       val half = len / 2
       val buffer2 = new Array[AnyRef](half)
       System.arraycopy(buffer, 0, buffer2, 0, index)

--- a/core/shared/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/shared/src/main/scala/cats/effect/ArrayStack.scala
@@ -79,4 +79,15 @@ private[effect] final class ArrayStack[A <: AnyRef](
       System.arraycopy(buffer, 0, buffer2, 0, len)
       buffer = buffer2
     }
+
+  def reclaim(): Unit = {
+    val len = buffer.length
+    val quarter = len / 4
+    if (index < quarter) {
+      val half = len / 2
+      val buffer2 = new Array[AnyRef](half)
+      System.arraycopy(buffer, 0, buffer2, 0, index)
+      buffer = buffer2
+    }
+  }
 }

--- a/core/shared/src/main/scala/cats/effect/ByteStack.scala
+++ b/core/shared/src/main/scala/cats/effect/ByteStack.scala
@@ -71,10 +71,14 @@ private[effect] final class ByteStack(
       buffer = buffer2
     }
 
-  def reclaim(): Unit = {
+  /**
+   * The lower bound is passed as an argument to avoid
+   * storing an extra integer in each stack instance.
+   */
+  def reclaim(bound: Int): Unit = {
     val len = buffer.length
     val quarter = len / 4
-    if (index < quarter) {
+    if (len > bound && index < quarter) {
       val half = len / 2
       val buffer2 = new Array[Byte](half)
       System.arraycopy(buffer, 0, buffer2, 0, index)

--- a/core/shared/src/main/scala/cats/effect/ByteStack.scala
+++ b/core/shared/src/main/scala/cats/effect/ByteStack.scala
@@ -70,4 +70,15 @@ private[effect] final class ByteStack(
       System.arraycopy(buffer, 0, buffer2, 0, len)
       buffer = buffer2
     }
+
+  def reclaim(): Unit = {
+    val len = buffer.length
+    val quarter = len / 4
+    if (index < quarter) {
+      val half = len / 2
+      val buffer2 = new Array[Byte](half)
+      System.arraycopy(buffer, 0, buffer2, 0, index)
+      buffer = buffer2
+    }
+  }
 }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -867,7 +867,11 @@ private final class IOFiber[A](
     }
   }
 
-  private[this] def execute(ec: ExecutionContext)(fiber: IOFiber[_]): Unit =
+  private[this] def execute(ec: ExecutionContext)(fiber: IOFiber[_]): Unit = {
+    conts.reclaim()
+    objectState.reclaim()
+    ctxs.reclaim()
+    finalizers.reclaim()
     if (ec.isInstanceOf[WorkStealingThreadPool]) {
       ec.asInstanceOf[WorkStealingThreadPool].executeFiber(fiber)
     } else {
@@ -881,18 +885,29 @@ private final class IOFiber[A](
          */
       }
     }
+  }
 
-  private[this] def reschedule(ec: ExecutionContext)(fiber: IOFiber[_]): Unit =
+  private[this] def reschedule(ec: ExecutionContext)(fiber: IOFiber[_]): Unit = {
+    conts.reclaim()
+    objectState.reclaim()
+    ctxs.reclaim()
+    finalizers.reclaim()
     if (ec.isInstanceOf[WorkStealingThreadPool])
       ec.asInstanceOf[WorkStealingThreadPool].rescheduleFiber(fiber)
     else
       scheduleOnForeignEC(ec)(fiber)
+  }
 
-  private[this] def rescheduleAndNotify(ec: ExecutionContext)(fiber: IOFiber[_]): Unit =
+  private[this] def rescheduleAndNotify(ec: ExecutionContext)(fiber: IOFiber[_]): Unit = {
+    conts.reclaim()
+    objectState.reclaim()
+    ctxs.reclaim()
+    finalizers.reclaim()
     if (ec.isInstanceOf[WorkStealingThreadPool])
       ec.asInstanceOf[WorkStealingThreadPool].rescheduleFiberAndNotify(fiber)
     else
       scheduleOnForeignEC(ec)(fiber)
+  }
 
   private[this] def scheduleOnForeignEC(ec: ExecutionContext)(fiber: IOFiber[_]): Unit =
     try {


### PR DESCRIPTION
In case the stacks grow too much, it would be good to keep them in line from time to time.

If a stack uses less than a quarter of the array capacity, the capacity is halved. This should avoid unnecessary allocations back and forth (thrashing) when operating close to the capacity.

The checks happen at async boundaries, which is often enough since we have auto yielding and should not be noticeable at all when it comes to performance.