### PR TITLE
Null out reference to last stolen fiber

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingQueue.scala
@@ -305,6 +305,7 @@ private final class WorkStealingQueue {
     // fiber has already been written by `internalStealInto` but the
     // tail has still not been published.
     val ret = dst.buffer(retIdx)
+    dst.buffer(retIdx) = null
 
     if (n == 0) {
       // No need for arithmetic and volatile updates. We are immediately


### PR DESCRIPTION
Not a bug, just a nice, consistent cleanup.

I observed this when stress testing `fs2-netty`.

When fibers are stolen, the last fiber in the chain of stolen fibers is directly executed. Here, I forgot to null out the reference to this fiber in the local queue which does the stealing. While this exact fiber is executed, a concurrent worker thread might come and steal all other fibers from this same queue. At this point, if there is no more work, all threads will go to sleep but this reference will remain set in the queue.

This is not a bug, safety is still guaranteed because this reference is technically "out" of the circular buffer. It's just that the memory for the already executed fiber will not be reclaimed until new work arrives in the pool, which might take a long time. During this time, that fiber is still strongly referenced in memory and the GC cannot reclaim it.