### PR TITLE
addition of Resource#race

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -270,8 +270,26 @@ sealed abstract class Resource[F[_], +A] {
    */
   def both[B](
       that: Resource[F, B]
-  )(implicit F: Concurrent[F]): Resource[F, (A, B)] =
-    Concurrent[Resource[F, *]].both(this, that)
+  )(implicit F: Concurrent[F]): Resource[F, (A, B)] = {
+    type Update = (F[Unit] => F[Unit]) => F[Unit]
+
+    def allocate[C](r: Resource[F, C], storeFinalizer: Update): F[C] =
+      r.fold(
+        _.pure[F],
+        release => storeFinalizer(MonadCancel[F, Throwable].guarantee(_, release))
+      )
+
+    val bothFinalizers = Ref.of[F, (F[Unit], F[Unit])](().pure[F] -> ().pure[F])
+
+    Resource.make(bothFinalizers)(_.get.flatMap(_.parTupled).void).evalMap { store =>
+      val leftStore: Update = f => store.update(_.leftMap(f))
+      val rightStore: Update =
+        f =>
+          store.update(t => (t._1, f(t._2))) // _.map(f) doesn't work on 0.25.0 for some reason
+
+      (allocate(this, leftStore), allocate(that, rightStore)).parTupled
+    }
+  }
 
   /**
    * Races the evaluation of two resource allocations and returns the result of the winner,

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -270,26 +270,17 @@ sealed abstract class Resource[F[_], +A] {
    */
   def both[B](
       that: Resource[F, B]
-  )(implicit F: Concurrent[F]): Resource[F, (A, B)] = {
-    type Update = (F[Unit] => F[Unit]) => F[Unit]
+  )(implicit F: Concurrent[F]): Resource[F, (A, B)] =
+    Concurrent[Resource[F, *]].both(this, that)
 
-    def allocate[C](r: Resource[F, C], storeFinalizer: Update): F[C] =
-      r.fold(
-        _.pure[F],
-        release => storeFinalizer(MonadCancel[F, Throwable].guarantee(_, release))
-      )
-
-    val bothFinalizers = Ref.of[F, (F[Unit], F[Unit])](().pure[F] -> ().pure[F])
-
-    Resource.make(bothFinalizers)(_.get.flatMap(_.parTupled).void).evalMap { store =>
-      val leftStore: Update = f => store.update(_.leftMap(f))
-      val rightStore: Update =
-        f =>
-          store.update(t => (t._1, f(t._2))) // _.map(f) doesn't work on 0.25.0 for some reason
-
-      (allocate(this, leftStore), allocate(that, rightStore)).parTupled
-    }
-  }
+  /**
+   * Races the evaluation of two resource allocations and returns the result of the winner,
+   * except in the case of cancellation.
+   */
+  def race[B](
+      that: Resource[F, B]
+  )(implicit F: Async[F]): Resource[F, Either[A, B]] =
+    Async[Resource[F, *]].race(this, that)
 
   /**
    * Implementation for the `flatMap` operation, as described via the
@@ -654,10 +645,23 @@ object Resource extends ResourceFOInstances0 with ResourceHOInstances0 with Reso
       def apply[A](fa: F[A]): Resource[F, A] = Resource.eval(fa)
     }
 
+  /**
+   * Allocates two resources concurrently, and combines their results in a tuple.
+   */
   def both[F[_]: Concurrent, A, B](
       rfa: Resource[F, A],
       rfb: Resource[F, B]): Resource[F, (A, B)] =
     rfa.both(rfb)
+
+  /**
+   * Races the evaluation of two resource allocations and returns the result of the winner,
+   * except in the case of cancellation.
+   */
+  def race[F[_]: Async, A, B](
+      rfa: Resource[F, A],
+      rfb: Resource[F, B]
+  ): Resource[F, Either[A, B]] =
+    rfa.race(rfb)
 
   /**
    * Creates a [[Resource]] by wrapping a Java


### PR DESCRIPTION
Related issue: https://github.com/typelevel/cats-effect/issues/1652

Implements `Resource#race` as a delegate to `Async#race` for discoverability reasons.

I have two questions though:

- Tests. I've found that there are tests for `Async[Resource[F, *].race` already. Do I need to duplicate these tests in the Resource spec?
- I've tried to replace manual implementation of `Resource.both` to instead rely on delegation to `Concurrent#both` but tests started to fail. Does this hint that `Concurrent` implementation for Resource is not correct? Or maybe the semantics of the Resouce.both spec are invalid? I will revert this change and then will explore what's up with that.
