### PR TITLE
parallel finalization in Concurrent[Resource]#both

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1119,6 +1119,9 @@ abstract private[effect] class ResourceAsync[F[_]]
   override def never[A]: Resource[F, A] =
     Resource.eval(F.never[A])
 
+  override def both[A, B](fa: Resource[F, A], fb: Resource[F, B]): Resource[F, (A, B)] =
+    Resource.both(fa, fb)
+
   def cont[K, R](body: Cont[Resource[F, *], K, R]): Resource[F, R] =
     Resource applyFull { poll =>
       poll {

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -297,8 +297,8 @@ sealed abstract class Resource[F[_], +A] {
    */
   def race[B](
       that: Resource[F, B]
-  )(implicit F: Async[F]): Resource[F, Either[A, B]] =
-    Async[Resource[F, *]].race(this, that)
+  )(implicit F: Concurrent[F]): Resource[F, Either[A, B]] =
+    Concurrent[Resource[F, *]].race(this, that)
 
   /**
    * Implementation for the `flatMap` operation, as described via the
@@ -675,7 +675,7 @@ object Resource extends ResourceFOInstances0 with ResourceHOInstances0 with Reso
    * Races the evaluation of two resource allocations and returns the result of the winner,
    * except in the case of cancellation.
    */
-  def race[F[_]: Async, A, B](
+  def race[F[_]: Concurrent, A, B](
       rfa: Resource[F, A],
       rfb: Resource[F, B]
   ): Resource[F, Either[A, B]] =
@@ -1073,6 +1073,9 @@ abstract private[effect] class ResourceConcurrent[F[_]]
 
   def ref[A](a: A): Resource[F, Ref[Resource[F, *], A]] =
     Resource.eval(F.ref(a)).map(_.mapK(Resource.liftK[F]))
+
+  override def both[A, B](fa: Resource[F, A], fb: Resource[F, B]): Resource[F, (A, B)] =
+    Resource.both(fa, fb)
 }
 
 private[effect] trait ResourceClock[F[_]] extends Clock[Resource[F, *]] {
@@ -1118,9 +1121,6 @@ abstract private[effect] class ResourceAsync[F[_]]
 
   override def never[A]: Resource[F, A] =
     Resource.eval(F.never[A])
-
-  override def both[A, B](fa: Resource[F, A], fb: Resource[F, B]): Resource[F, (A, B)] =
-    Resource.both(fa, fb)
 
   def cont[K, R](body: Cont[Resource[F, *], K, R]): Resource[F, R] =
     Resource applyFull { poll =>

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -771,50 +771,6 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
       }
     }
 
-    "both" >> {
-      "parallel acquisition and release" in ticked { implicit ticker =>
-        var leftAllocated = false
-        var rightAllocated = false
-        var leftReleasing = false
-        var rightReleasing = false
-        var leftReleased = false
-        var rightReleased = false
-
-        val wait = IO.sleep(1.second)
-        val lhs = Resource.make(wait >> IO { leftAllocated = true }) { _ =>
-          IO { leftReleasing = true } >> wait >> IO { leftReleased = true }
-        }
-        val rhs = Resource.make(wait >> IO { rightAllocated = true }) { _ =>
-          IO { rightReleasing = true } >> wait >> IO { rightReleased = true }
-        }
-
-        Async[Resource[IO, *]].both(lhs, rhs).use(_ => wait).unsafeToFuture()
-
-        // after 1 second:
-        //  both resources have allocated (concurrency, serially it would happen after 2 seconds)
-        //  resources are still open during `use` (correctness)
-        ticker.ctx.tick(1.second)
-        leftAllocated must beTrue
-        rightAllocated must beTrue
-        leftReleasing must beFalse
-        rightReleasing must beFalse
-
-        // after 2 seconds:
-        //  both resources have started cleanup (correctness)
-        ticker.ctx.tick(1.second)
-        leftReleasing must beTrue
-        rightReleasing must beTrue
-        leftReleased must beFalse
-        rightReleased must beFalse
-
-        // after 3 seconds:
-        //  both resources have terminated cleanup (concurrency, serially it would happen after 4 seconds)
-        ticker.ctx.tick(1.second)
-        leftReleased must beTrue
-        rightReleased must beTrue
-      }
-    }
-
     "start" >> {
       "runs fibers in parallel" in ticked { implicit ticker =>
         var completed = false
@@ -889,6 +845,52 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
 
         ticker.ctx.tick(1.second)
         completed must beTrue
+      }
+    }
+  }
+
+  "Concurrent[Resource]" >> {
+    "both" >> {
+      "parallel acquisition and release" in ticked { implicit ticker =>
+        var leftAllocated = false
+        var rightAllocated = false
+        var leftReleasing = false
+        var rightReleasing = false
+        var leftReleased = false
+        var rightReleased = false
+
+        val wait = IO.sleep(1.second)
+        val lhs = Resource.make(wait >> IO { leftAllocated = true }) { _ =>
+          IO { leftReleasing = true } >> wait >> IO { leftReleased = true }
+        }
+        val rhs = Resource.make(wait >> IO { rightAllocated = true }) { _ =>
+          IO { rightReleasing = true } >> wait >> IO { rightReleased = true }
+        }
+
+        Async[Resource[IO, *]].both(lhs, rhs).use(_ => wait).unsafeToFuture()
+
+        // after 1 second:
+        //  both resources have allocated (concurrency, serially it would happen after 2 seconds)
+        //  resources are still open during `use` (correctness)
+        ticker.ctx.tick(1.second)
+        leftAllocated must beTrue
+        rightAllocated must beTrue
+        leftReleasing must beFalse
+        rightReleasing must beFalse
+
+        // after 2 seconds:
+        //  both resources have started cleanup (correctness)
+        ticker.ctx.tick(1.second)
+        leftReleasing must beTrue
+        rightReleasing must beTrue
+        leftReleased must beFalse
+        rightReleased must beFalse
+
+        // after 3 seconds:
+        //  both resources have terminated cleanup (concurrency, serially it would happen after 4 seconds)
+        ticker.ctx.tick(1.second)
+        leftReleased must beTrue
+        rightReleased must beTrue
       }
     }
   }

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -771,6 +771,50 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
       }
     }
 
+    "both" >> {
+      "parallel acquisition and release" in ticked { implicit ticker =>
+        var leftAllocated = false
+        var rightAllocated = false
+        var leftReleasing = false
+        var rightReleasing = false
+        var leftReleased = false
+        var rightReleased = false
+
+        val wait = IO.sleep(1.second)
+        val lhs = Resource.make(wait >> IO { leftAllocated = true }) { _ =>
+          IO { leftReleasing = true } >> wait >> IO { leftReleased = true }
+        }
+        val rhs = Resource.make(wait >> IO { rightAllocated = true }) { _ =>
+          IO { rightReleasing = true } >> wait >> IO { rightReleased = true }
+        }
+
+        Async[Resource[IO, *]].both(lhs, rhs).use(_ => wait).unsafeToFuture()
+
+        // after 1 second:
+        //  both resources have allocated (concurrency, serially it would happen after 2 seconds)
+        //  resources are still open during `use` (correctness)
+        ticker.ctx.tick(1.second)
+        leftAllocated must beTrue
+        rightAllocated must beTrue
+        leftReleasing must beFalse
+        rightReleasing must beFalse
+
+        // after 2 seconds:
+        //  both resources have started cleanup (correctness)
+        ticker.ctx.tick(1.second)
+        leftReleasing must beTrue
+        rightReleasing must beTrue
+        leftReleased must beFalse
+        rightReleased must beFalse
+
+        // after 3 seconds:
+        //  both resources have terminated cleanup (concurrency, serially it would happen after 4 seconds)
+        ticker.ctx.tick(1.second)
+        leftReleased must beTrue
+        rightReleased must beTrue
+      }
+    }
+
     "start" >> {
       "runs fibers in parallel" in ticked { implicit ticker =>
         var completed = false


### PR DESCRIPTION
Fixed the inconsistency between `Resource#both` and `Async[Resource]#both`.
Now both methods run finalizers in parallel. 
Related discussion: https://github.com/typelevel/cats-effect/issues/1576