### PR TITLE
IO#to, IO#option, IO.none, IO.some, Async.evalOnK

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -194,6 +194,9 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
   def void: IO[Unit] =
     map(_ => ())
 
+  def to[F[_]](implicit F: LiftIO[F]): F[A @uncheckedVariance] =
+    F.liftIO(this)
+
   override def toString: String = "IO(...)"
 
   // unsafe stuff

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -65,6 +65,9 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
   def attempt: IO[Either[Throwable, A]] =
     IO.Attempt(this)
 
+  def option: IO[Option[A]] =
+    redeem(_ => None, Some(_))
+
   def bothOutcome[B](that: IO[B]): IO[(OutcomeIO[A @uncheckedVariance], OutcomeIO[B])] =
     IO.uncancelable { poll =>
       racePair(that).flatMap {
@@ -329,6 +332,10 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
   def monotonic: IO[FiniteDuration] = Monotonic
 
   def never[A]: IO[A] = _never
+
+  def none[A]: IO[Option[A]] = pure(None)
+
+  def some[A](a: A): IO[Option[A]] = pure(Some(a))
 
   /**
    * Like `Parallel.parTraverse`, but limits the degree of parallelism.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -50,6 +50,11 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
   // evalOn(executionContext, ec) <-> pure(ec)
   def evalOn[A](fa: F[A], ec: ExecutionContext): F[A]
 
+  def evalOnK(ec: ExecutionContext): F ~> F =
+    new (F ~> F) {
+      def apply[A](fa: F[A]): F[A] = evalOn(fa, ec)
+    }
+
   def startOn[A](fa: F[A], ec: ExecutionContext): F[Fiber[F, Throwable, A]] =
     evalOn(start(fa), ec)
 


### PR DESCRIPTION
Bunch of small utility methods ported from CE2 + Async.evalOnK

https://github.com/typelevel/cats-effect/issues/1722
https://github.com/typelevel/cats-effect/issues/1723
https://github.com/typelevel/cats-effect/issues/1724
https://github.com/typelevel/cats-effect/issues/1728