### PR TITLE
CE2: add Resource.eval, deprecate liftF

### DIFF
--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/ECBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/ECBenchmark.scala
@@ -40,7 +40,7 @@ class ECBenchmark {
   private val ioApp = new IOApp with Run
   private val ioAppCtx = new IOApp.WithContext with Run {
     protected def executionContextResource: Resource[SyncIO, ExecutionContext] =
-      Resource.liftF(SyncIO.pure(ExecutionContext.Implicits.global))
+      Resource.eval(SyncIO.pure(ExecutionContext.Implicits.global))
   }
 
   @Benchmark

--- a/core/jvm/src/main/scala/cats/effect/internals/IOAppCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/IOAppCompanionPlatform.scala
@@ -131,7 +131,7 @@ private[effect] trait IOAppCompanionPlatform {
   }
 
   private[this] val defaultScheduler: Resource[SyncIO, ScheduledExecutorService] =
-    Resource.liftF(SyncIO(IOTimer.scheduler))
+    Resource.eval(SyncIO(IOTimer.scheduler))
 
   final private class Context(val executionContext: ExecutionContext, val scheduler: ScheduledExecutorService) {
     val timer: Timer[IO] = IO.timer(executionContext, scheduler)

--- a/core/shared/src/main/scala/cats/effect/Clock.scala
+++ b/core/shared/src/main/scala/cats/effect/Clock.scala
@@ -238,10 +238,10 @@ protected[effect] trait LowPriorityImplicits extends LowerPriorityImplicits {
   implicit def deriveResource[F[_]](implicit F: Applicative[F], clock: Clock[F]): Clock[Resource[F, *]] =
     new Clock[Resource[F, *]] {
       def realTime(unit: TimeUnit): Resource[F, Long] =
-        Resource.liftF(clock.realTime(unit))
+        Resource.eval(clock.realTime(unit))
 
       def monotonic(unit: TimeUnit): Resource[F, Long] =
-        Resource.liftF(clock.monotonic(unit))
+        Resource.eval(clock.monotonic(unit))
     }
 }
 

--- a/core/shared/src/main/scala/cats/effect/Timer.scala
+++ b/core/shared/src/main/scala/cats/effect/Timer.scala
@@ -164,7 +164,7 @@ object Timer {
       val clock: Clock[Resource[F, *]] = Clock.deriveResource
 
       def sleep(duration: FiniteDuration): Resource[F, Unit] =
-        Resource.liftF(timer.sleep(duration))
+        Resource.eval(timer.sleep(duration))
     }
 
   implicit class TimerOps[F[_]](val self: Timer[F]) extends AnyVal {

--- a/core/shared/src/test/scala/cats/effect/ResourceSyntax.scala
+++ b/core/shared/src/test/scala/cats/effect/ResourceSyntax.scala
@@ -34,14 +34,14 @@ object Test {
     // Dotty does not have +* kind projector syntax
     type PartiallyApplied[+A] = F[Throwable, A]
     Resource
-      .liftF[PartiallyApplied, Either[Base, Nothing]](f[PartiallyApplied])
+      .eval[PartiallyApplied, Either[Base, Nothing]](f[PartiallyApplied])
       .map(x => x)
   }
 
   // this one fails, but not the above
   def g[F[+_]](implicit F: Sync[F]): Resource[F, Either[Base, Nothing]] =
     Resource
-      .liftF[F, Either[Base, Nothing]](f[F])
+      .eval[F, Either[Base, Nothing]](f[F])
       .map(x => x)
       .flatMap(x => Resource.pure[F, Either[Base, Nothing]](x))
 


### PR DESCRIPTION
Backporting this change to CE2 should help smoothen the transition, especially when maintaining multiple branches based on different CE versions.