### PR TITLE
Consolidated IORuntime configuration and enabled access in IOApp itself

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala
@@ -103,26 +103,16 @@ class WorkStealingBenchmark {
 
       val compute = new WorkStealingThreadPool(256, "io-compute", runtime)
 
-      val cancellationCheckThreshold =
-        System.getProperty("cats.effect.cancellation.check.threshold", "512").toInt
-
       new IORuntime(
         compute,
         blocking,
         scheduler,
-        () => (),
-        IORuntimeConfig(
-          cancellationCheckThreshold,
-          System
-            .getProperty("cats.effect.auto.yield.threshold.multiplier", "2")
-            .toInt * cancellationCheckThreshold
-        ),
-        internalShutdown = () => {
+        { () =>
           compute.shutdown()
           blockDown()
           schedDown()
-        }
-      )
+        },
+        IORuntimeConfig())
     }
 
     benchmark

--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -38,10 +38,25 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
       def monotonicNanos() = System.nanoTime()
     }
 
-  lazy val global: IORuntime =
-    IORuntime(
-      defaultComputeExecutionContext,
-      defaultComputeExecutionContext,
-      defaultScheduler,
-      () => ())
+  private[this] var _global: IORuntime = null
+
+  private[effect] def installGlobal(global: IORuntime): Unit = {
+    require(_global == null)
+    _global = global
+  }
+
+  lazy val global: IORuntime = {
+    if (_global == null) {
+      installGlobal {
+        IORuntime(
+          defaultComputeExecutionContext,
+          defaultComputeExecutionContext,
+          defaultScheduler,
+          () => (),
+          IORuntimeConfig())
+      }
+    }
+
+    _global
+  }
 }

--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package unsafe
+
+abstract class IORuntimeConfigCompanionPlatform { this: IORuntimeConfig.type =>
+  def apply(): IORuntimeConfig =
+    apply(512, 1024)
+}

--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
@@ -18,6 +18,6 @@ package cats.effect
 package unsafe
 
 abstract class IORuntimeConfigCompanionPlatform { this: IORuntimeConfig.type =>
-  def apply(): IORuntimeConfig =
+  protected final val Default: IORuntimeConfig =
     apply(512, 1024)
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package unsafe
+
+abstract class IORuntimeConfigCompanionPlatform { this: IORuntimeConfig.type =>
+  def apply(): IORuntimeConfig = {
+    val cancellationCheckThreshold =
+      System.getProperty("cats.effect.cancellation.check.threshold", "512").toInt
+
+    apply(
+      cancellationCheckThreshold,
+      System
+        .getProperty("cats.effect.auto.yield.threshold.multiplier", "2")
+        .toInt * cancellationCheckThreshold)
+  }
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
@@ -18,7 +18,8 @@ package cats.effect
 package unsafe
 
 abstract class IORuntimeConfigCompanionPlatform { this: IORuntimeConfig.type =>
-  def apply(): IORuntimeConfig = {
+
+  protected final val Default: IORuntimeConfig = {
     val cancellationCheckThreshold =
       System.getProperty("cats.effect.cancellation.check.threshold", "512").toInt
 

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -144,7 +144,6 @@ private final class IOFiber[A](
       }
     } catch {
       case t: Throwable =>
-        runtime.internalShutdown()
         runtime.shutdown()
         Thread.interrupted()
         currentCtx.reportFailure(t)

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -39,36 +39,12 @@ final class IORuntime private[effect] (
     val scheduler: Scheduler,
     val shutdown: () => Unit,
     val config: IORuntimeConfig,
-    private[effect] val fiberErrorCbs: FiberErrorHashtable = new FiberErrorHashtable(16),
-    private[effect] val internalShutdown: () => Unit = () => ()
+    private[effect] val fiberErrorCbs: FiberErrorHashtable = new FiberErrorHashtable(16)
 ) {
   override def toString: String = s"IORuntime($compute, $scheduler, $config)"
 }
 
-final case class IORuntimeConfig private (
-    val cancellationCheckThreshold: Int,
-    val autoYieldThreshold: Int)
-
-object IORuntimeConfig {
-  def apply(): IORuntimeConfig = new IORuntimeConfig(512, 1024)
-
-  def apply(cancellationCheckThreshold: Int, autoYieldThreshold: Int): IORuntimeConfig = {
-    if (autoYieldThreshold % cancellationCheckThreshold == 0)
-      new IORuntimeConfig(cancellationCheckThreshold, autoYieldThreshold)
-    else
-      throw new AssertionError(
-        s"Auto yield threshold $autoYieldThreshold must be a multiple of cancellation check threshold $cancellationCheckThreshold")
-  }
-}
-
 object IORuntime extends IORuntimeCompanionPlatform {
-  def apply(
-      compute: ExecutionContext,
-      blocking: ExecutionContext,
-      scheduler: Scheduler,
-      shutdown: () => Unit): IORuntime =
-    new IORuntime(compute, blocking, scheduler, shutdown, IORuntimeConfig())
-
   def apply(
       compute: ExecutionContext,
       blocking: ExecutionContext,

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package unsafe
+
+final case class IORuntimeConfig private (
+    val cancellationCheckThreshold: Int,
+    val autoYieldThreshold: Int)
+
+object IORuntimeConfig extends IORuntimeConfigCompanionPlatform {
+
+  def apply(cancellationCheckThreshold: Int, autoYieldThreshold: Int): IORuntimeConfig = {
+    if (autoYieldThreshold % cancellationCheckThreshold == 0)
+      new IORuntimeConfig(cancellationCheckThreshold, autoYieldThreshold)
+    else
+      throw new AssertionError(
+        s"Auto yield threshold $autoYieldThreshold must be a multiple of cancellation check threshold $cancellationCheckThreshold")
+  }
+}

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
@@ -23,6 +23,8 @@ final case class IORuntimeConfig private (
 
 object IORuntimeConfig extends IORuntimeConfigCompanionPlatform {
 
+  def apply(): IORuntimeConfig = Default
+
   def apply(cancellationCheckThreshold: Int, autoYieldThreshold: Int): IORuntimeConfig = {
     if (autoYieldThreshold % cancellationCheckThreshold == 0)
       new IORuntimeConfig(cancellationCheckThreshold, autoYieldThreshold)

--- a/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
@@ -222,7 +222,7 @@ trait TestInstances extends ParallelFGenerators with OutcomeGenerators with Sync
       var results: Outcome[Option, Throwable, A] = Outcome.Succeeded(None)
 
       ioa.unsafeRunAsyncOutcome { oc => results = oc.mapK(someK) }(
-        unsafe.IORuntime(ticker.ctx, ticker.ctx, scheduler, () => ()))
+        unsafe.IORuntime(ticker.ctx, ticker.ctx, scheduler, () => (), unsafe.IORuntimeConfig()))
 
       ticker.ctx.tickAll(1.second)
 
@@ -255,7 +255,7 @@ trait TestInstances extends ParallelFGenerators with OutcomeGenerators with Sync
   }
 
   implicit def materializeRuntime(implicit ticker: Ticker): unsafe.IORuntime =
-    unsafe.IORuntime(ticker.ctx, ticker.ctx, scheduler, () => ())
+    unsafe.IORuntime(ticker.ctx, ticker.ctx, scheduler, () => (), unsafe.IORuntimeConfig())
 
   def scheduler(implicit ticker: Ticker): unsafe.Scheduler =
     new unsafe.Scheduler {

--- a/tests/jvm/src/test/scala/cats/effect/RunnersPlatform.scala
+++ b/tests/jvm/src/test/scala/cats/effect/RunnersPlatform.scala
@@ -27,32 +27,26 @@ trait RunnersPlatform extends BeforeAfterAll {
   protected def runtime(): IORuntime = runtime0
 
   def beforeAll(): Unit = {
-    val cancellationCheckThreshold =
-      System.getProperty("cats.effect.cancellation.check.threshold", "512").toInt
-
     val (blocking, blockDown) =
-      IORuntime.createDefaultBlockingExecutionContext(s"io-blocking-${getClass.getName}")
+      IORuntime.createDefaultBlockingExecutionContext(threadPrefix =
+        s"io-blocking-${getClass.getName}")
     val (scheduler, schedDown) =
-      IORuntime.createDefaultScheduler(s"io-scheduler-${getClass.getName}")
+      IORuntime.createDefaultScheduler(threadPrefix = s"io-scheduler-${getClass.getName}")
     val (compute, compDown) =
-      IORuntime.createDefaultComputeThreadPool(runtime0, s"io-compute-${getClass.getName}")
+      IORuntime.createDefaultComputeThreadPool(
+        runtime0,
+        threadPrefix = s"io-compute-${getClass.getName}")
 
     runtime0 = new IORuntime(
       compute,
       blocking,
       scheduler,
-      () => (),
-      IORuntimeConfig(
-        cancellationCheckThreshold,
-        System
-          .getProperty("cats.effect.auto.yield.threshold.multiplier", "2")
-          .toInt * cancellationCheckThreshold
-      ),
-      internalShutdown = () => {
+      { () =>
         compDown()
         blockDown()
         schedDown()
-      }
+      },
+      IORuntimeConfig()
     )
   }
 

--- a/tests/jvm/src/test/scala/cats/effect/std/DeferredJVMSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/std/DeferredJVMSpec.scala
@@ -231,7 +231,12 @@ abstract class BaseDeferredJVMTests(parallelism: Int)
 
     try {
       ioa.unsafeRunTimed(10.seconds)(
-        unsafe.IORuntime(ctx, ctx, unsafe.Scheduler.fromScheduledExecutor(scheduler), () => ()))
+        unsafe.IORuntime(
+          ctx,
+          ctx,
+          unsafe.Scheduler.fromScheduledExecutor(scheduler),
+          () => (),
+          unsafe.IORuntimeConfig()))
     } finally {
       executor.shutdown()
       scheduler.shutdown()


### PR DESCRIPTION
Fixes #1238

I also removed `internalShutdown` and a few other nice bits of cleanup. Note that this doesn't move pool configuration into `IORuntimeConfig` since pools are configured adjacent to the `IORuntimeConfig` options.