### PR TITLE
Immediate interpreter for Map, FlatMap and Attempt

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -320,10 +320,53 @@ private final class IOFiber[A](
         case 2 =>
           val cur = cur0.asInstanceOf[FlatMap[Any, Any]]
 
-          objectState.push(cur.f)
-          conts.push(FlatMapK)
+          val ioe = cur.ioe
+          val f = cur.f
 
-          runLoop(cur.ioe, nextIteration)
+          def next(v: Any): IO[Any] =
+            try f(v)
+            catch {
+              case NonFatal(t) => failed(t, 0)
+            }
+
+          (ioe.tag: @switch) match {
+            case 0 =>
+              val pure = ioe.asInstanceOf[Pure[Any]]
+              runLoop(next(pure.value), nextIteration)
+
+            case 3 =>
+              val error = ioe.asInstanceOf[Error]
+              runLoop(failed(error.t, 0), nextIteration)
+
+            case 6 =>
+              val delay = ioe.asInstanceOf[Delay[Any]]
+
+              // this code is inlined in order to avoid two `try` blocks
+              val result =
+                try f(delay.thunk())
+                catch {
+                  case NonFatal(t) => failed(t, 0)
+                }
+
+              runLoop(result, nextIteration)
+
+            case 16 =>
+              val realTime = runtime.scheduler.nowMillis().millis
+              runLoop(next(realTime), nextIteration)
+
+            case 17 =>
+              val monotonic = runtime.scheduler.monotonicNanos().nanos
+              runLoop(next(monotonic), nextIteration)
+
+            case 18 =>
+              val ec = currentCtx
+              runLoop(next(ec), nextIteration)
+
+            case _ =>
+              objectState.push(f)
+              conts.push(FlatMapK)
+              runLoop(ioe, nextIteration)
+          }
 
         case 3 =>
           val cur = cur0.asInstanceOf[Error]


### PR DESCRIPTION
Can the runloop get any faster? I actually didn't think this would make such a difference.

The idea:
When evaluating Map and FlatMap, check if the wrapped IO can be executed immediately (Pure, Error, Delay, Realtime, Monotonic and EC), in that case, execute the IO and immediately continue with the mapping function, without pushing and popping objects and continuation bytes on the fiber stacks. If the wrapped IO cannot be executed immediately, continue normally as was the case before.

| Benchmark | series/3.x | | error | unit | this PR | | error | unit |
| :--- | ---: | :---: | :--- | :--- | ---: | :---: | :--- | :--- |
| AsyncBenchmark.async | 14161.606 | ± | 351.423 | ops/s | 15037.567 | ± | 345.484 | ops/s |
| AsyncBenchmark.bracket | 10762.854 | ± | 119.694 | ops/s | 11148.360 | ± | 124.107 | ops/s |
| AsyncBenchmark.cancelable | 14218.944 | ± | 291.585 | ops/s | 14878.036 | ± | 277.328 | ops/s |
| AsyncBenchmark.race | 19607.572 | ± | 636.625 | ops/s | 18977.227 | ± | 1029.854 | ops/s |
| AsyncBenchmark.racePair | 18517.486 | ± | 1683.380 | ops/s | 18199.912 | ± | 1687.635 | ops/s |
| AsyncBenchmark.start | 5088.309 | ± | 257.448 | ops/s | 5364.297 | ± | 245.464 | ops/s |
| AsyncBenchmark.uncancelable | 22452.885 | ± | 396.834 | ops/s | 23232.545 | ± | 693.276 | ops/s |
| AttemptBenchmark.errorRaised | 937.800 | ± | 31.016 | ops/s | 1115.757 | ± | 75.589 | ops/s |
| AttemptBenchmark.happyPath | 1202.831 | ± | 37.743 | ops/s | 1612.782 | ± | 40.435 | ops/s |
| BothBenchmark.happyPath | 12.276 | ± | 0.875 | ops/s | 13.591 | ± | 1.030 | ops/s |
| DeepBindBenchmark.async | 745.715 | ± | 9.401 | ops/s | 930.214 | ± | 15.624 | ops/s |
| DeepBindBenchmark.delay | 1811.560 | ± | 46.294 | ops/s | 2912.721 | ± | 81.084 | ops/s |
| DeepBindBenchmark.pure | 2210.339 | ± | 115.229 | ops/s | 3391.485 | ± | 67.483 | ops/s |
| HandleErrorBenchmark.errorRaised | 881.112 | ± | 12.825 | ops/s | 1122.994 | ± | 25.544 | ops/s |
| HandleErrorBenchmark.happyPath | 1271.487 | ± | 22.941 | ops/s | 1256.835 | ± | 12.508 | ops/s |
| MapCallsBenchmark.batch120 | 262.836 | ± | 5.792 | ops/s | 265.009 | ± | 6.984 | ops/s |
| MapCallsBenchmark.batch30 | 70.006 | ± | 1.156 | ops/s | 74.866 | ± | 3.273 | ops/s |
| MapCallsBenchmark.one | 2.504 | ± | 0.155 | ops/s | 2.427 | ± | 0.046 | ops/s |
| MapStreamBenchmark.batch120 | 2015.948 | ± | 106.341 | ops/s | 1830.207 | ± | 73.377 | ops/s |
| MapStreamBenchmark.batch30 | 765.682 | ± | 10.155 | ops/s | 678.926 | ± | 11.870 | ops/s |
| MapStreamBenchmark.one | 795.748 | ± | 15.007 | ops/s | 1019.271 | ± | 17.398 | ops/s |
| RaceBenchmark.happyPath | 12.252 | ± | 0.765 | ops/s | 14.810 | ± | 1.372 | ops/s |
| RedeemBenchmark.errorRaised | 671.726 | ± | 6.658 | ops/s | 797.029 | ± | 12.942 | ops/s |
| RedeemBenchmark.happyPath | 750.298 | ± | 9.099 | ops/s | 938.489 | ± | 19.969 | ops/s |
| RedeemWithBenchmark.errorRaised | 850.373 | ± | 10.128 | ops/s | 1091.672 | ± | 68.342 | ops/s |
| RedeemWithBenchmark.happyPath | 1077.482 | ± | 11.676 | ops/s | 1388.954 | ± | 73.799 | ops/s |
| RefBenchmark.getAndUpdate | 1415.336 | ± | 27.671 | ops/s | 2223.957 | ± | 69.161 | ops/s |
| RefBenchmark.modify | 1300.127 | ± | 74.156 | ops/s | 2077.427 | ± | 68.193 | ops/s |
| ShallowBindBenchmark.async | 720.864 | ± | 7.152 | ops/s | 691.183 | ± | 6.237 | ops/s |
| ShallowBindBenchmark.delay | 1778.542 | ± | 39.181 | ops/s | 2969.485 | ± | 186.612 | ops/s |
| ShallowBindBenchmark.pure | 1986.692 | ± | 46.213 | ops/s | 3185.351 | ± | 47.894 | ops/s |
| WorkStealingBenchmark.async | 15.732 | ± | 1.668 | ops/min | 16.158 | ± | 1.472 | ops/min |
| WorkStealingBenchmark.asyncTooManyThreads | 14.472 | ± | 1.227 | ops/min | 15.049 | ± | 1.187 | ops/min |