### PR TITLE
Remove a branch and expensive modulo operation in the runloop

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -305,11 +305,11 @@ private final class IOFiber[A](
           (ioe.tag: @switch) match {
             case 0 =>
               val pure = ioe.asInstanceOf[Pure[Any]]
-              runLoop(next(pure.value), nextIteration)
+              runLoop(next(pure.value), nextIteration + 1)
 
             case 1 =>
               val error = ioe.asInstanceOf[Error]
-              runLoop(failed(error.t, 0), nextIteration)
+              runLoop(failed(error.t, 0), nextIteration + 1)
 
             case 2 =>
               val delay = ioe.asInstanceOf[Delay[Any]]
@@ -322,23 +322,20 @@ private final class IOFiber[A](
                   case NonFatal(t) => error = t
                 }
 
-              if (error == null) {
-                runLoop(succeeded(result, 0), nextIteration)
-              } else {
-                runLoop(failed(error, 0), nextIteration)
-              }
+              val nextIO = if (error == null) succeeded(result, 0) else failed(error, 0)
+              runLoop(nextIO, nextIteration + 1)
 
             case 3 =>
               val realTime = runtime.scheduler.nowMillis().millis
-              runLoop(next(realTime), nextIteration)
+              runLoop(next(realTime), nextIteration + 1)
 
             case 4 =>
               val monotonic = runtime.scheduler.monotonicNanos().nanos
-              runLoop(next(monotonic), nextIteration)
+              runLoop(next(monotonic), nextIteration + 1)
 
             case 5 =>
               val ec = currentCtx
-              runLoop(next(ec), nextIteration)
+              runLoop(next(ec), nextIteration + 1)
 
             case _ =>
               objectState.push(f)
@@ -361,11 +358,11 @@ private final class IOFiber[A](
           (ioe.tag: @switch) match {
             case 0 =>
               val pure = ioe.asInstanceOf[Pure[Any]]
-              runLoop(next(pure.value), nextIteration)
+              runLoop(next(pure.value), nextIteration + 1)
 
             case 1 =>
               val error = ioe.asInstanceOf[Error]
-              runLoop(failed(error.t, 0), nextIteration)
+              runLoop(failed(error.t, 0), nextIteration + 1)
 
             case 2 =>
               val delay = ioe.asInstanceOf[Delay[Any]]
@@ -377,19 +374,19 @@ private final class IOFiber[A](
                   case NonFatal(t) => failed(t, 0)
                 }
 
-              runLoop(result, nextIteration)
+              runLoop(result, nextIteration + 1)
 
             case 3 =>
               val realTime = runtime.scheduler.nowMillis().millis
-              runLoop(next(realTime), nextIteration)
+              runLoop(next(realTime), nextIteration + 1)
 
             case 4 =>
               val monotonic = runtime.scheduler.monotonicNanos().nanos
-              runLoop(next(monotonic), nextIteration)
+              runLoop(next(monotonic), nextIteration + 1)
 
             case 5 =>
               val ec = currentCtx
-              runLoop(next(ec), nextIteration)
+              runLoop(next(ec), nextIteration + 1)
 
             case _ =>
               objectState.push(f)
@@ -405,11 +402,11 @@ private final class IOFiber[A](
           (ioa.tag: @switch) match {
             case 0 =>
               val pure = ioa.asInstanceOf[Pure[Any]]
-              runLoop(succeeded(Right(pure.value), 0), nextIteration)
+              runLoop(succeeded(Right(pure.value), 0), nextIteration + 1)
 
             case 1 =>
               val error = ioa.asInstanceOf[Error]
-              runLoop(succeeded(Left(error.t), 0), nextIteration)
+              runLoop(succeeded(Left(error.t), 0), nextIteration + 1)
 
             case 2 =>
               val delay = ioa.asInstanceOf[Delay[Any]]
@@ -424,19 +421,19 @@ private final class IOFiber[A](
 
               val next =
                 if (error == null) succeeded(Right(result), 0) else succeeded(Left(error), 0)
-              runLoop(next, nextIteration)
+              runLoop(next, nextIteration + 1)
 
             case 3 =>
               val realTime = runtime.scheduler.nowMillis().millis
-              runLoop(succeeded(Right(realTime), 0), nextIteration)
+              runLoop(succeeded(Right(realTime), 0), nextIteration + 1)
 
             case 4 =>
               val monotonic = runtime.scheduler.monotonicNanos().nanos
-              runLoop(succeeded(Right(monotonic), 0), nextIteration)
+              runLoop(succeeded(Right(monotonic), 0), nextIteration + 1)
 
             case 5 =>
               val ec = currentCtx
-              runLoop(succeeded(Right(ec), 0), nextIteration)
+              runLoop(succeeded(Right(ec), 0), nextIteration + 1)
 
             case _ =>
               conts.push(AttemptK)


### PR DESCRIPTION
Benchmark results:
| Benchmark | series/3.x | | error | unit | this PR | | error | unit |
| :--- | ---: | :---: | :--- | :--- | ---: | :---: | :--- | :--- |
| AsyncBenchmark.async | 14736.270 | ± | 308.178 | ops/s | 15877.845 | ± | 261.945 | ops/s |
| AsyncBenchmark.bracket | 11310.638 | ± | 87.655 | ops/s | 12399.818 | ± | 183.229 | ops/s |
| AsyncBenchmark.cancelable | 14998.181 | ± | 217.001 | ops/s | 16154.551 | ± | 230.503 | ops/s |
| AsyncBenchmark.race | 19786.617 | ± | 674.921 | ops/s | 20154.692 | ± | 935.900 | ops/s |
| AsyncBenchmark.racePair | 19376.490 | ± | 1156.979 | ops/s | 19760.217 | ± | 1265.284 | ops/s |
| AsyncBenchmark.start | 5578.943 | ± | 126.214 | ops/s | 5848.368 | ± | 63.555 | ops/s |
| AsyncBenchmark.uncancelable | 23514.142 | ± | 777.421 | ops/s | 24143.991 | ± | 506.112 | ops/s |
| AttemptBenchmark.errorRaised | 1044.409 | ± | 30.807 | ops/s | 1296.478 | ± | 26.720 | ops/s |
| AttemptBenchmark.happyPath | 1642.381 | ± | 39.014 | ops/s | 1748.002 | ± | 43.235 | ops/s |
| BothBenchmark.happyPath | 13.394 | ± | 0.930 | ops/s | 15.310 | ± | 1.057 | ops/s |
| DeepBindBenchmark.async | 910.943 | ± | 24.892 | ops/s | 1144.150 | ± | 31.322 | ops/s |
| DeepBindBenchmark.delay | 2987.775 | ± | 168.490 | ops/s | 3149.757 | ± | 67.515 | ops/s |
| DeepBindBenchmark.pure | 3365.297 | ± | 68.632 | ops/s | 3902.027 | ± | 136.851 | ops/s |
| HandleErrorBenchmark.errorRaised | 1134.609 | ± | 32.456 | ops/s | 1375.955 | ± | 31.961 | ops/s |
| HandleErrorBenchmark.happyPath | 1226.965 | ± | 36.201 | ops/s | 1611.970 | ± | 47.262 | ops/s |
| MapCallsBenchmark.batch120 | 257.869 | ± | 9.501 | ops/s | 257.988 | ± | 11.430 | ops/s |
| MapCallsBenchmark.batch30 | 72.235 | ± | 2.236 | ops/s | 73.328 | ± | 3.577 | ops/s |
| MapCallsBenchmark.one | 2.531 | ± | 0.087 | ops/s | 2.493 | ± | 0.082 | ops/s |
| MapStreamBenchmark.batch120 | 1810.159 | ± | 100.919 | ops/s | 2017.140 | ± | 59.214 | ops/s |
| MapStreamBenchmark.batch30 | 671.752 | ± | 19.855 | ops/s | 725.826 | ± | 14.841 | ops/s |
| MapStreamBenchmark.one | 1050.759 | ± | 36.302 | ops/s | 1200.927 | ± | 25.573 | ops/s |
| RaceBenchmark.happyPath | 13.868 | ± | 1.181 | ops/s | 14.608 | ± | 0.903 | ops/s |
| RedeemBenchmark.errorRaised | 801.674 | ± | 16.978 | ops/s | 963.899 | ± | 19.427 | ops/s |
| RedeemBenchmark.happyPath | 936.797 | ± | 20.809 | ops/s | 1142.584 | ± | 41.320 | ops/s |
| RedeemWithBenchmark.errorRaised | 1113.020 | ± | 72.522 | ops/s | 1421.290 | ± | 69.553 | ops/s |
| RedeemWithBenchmark.happyPath | 1482.720 | ± | 26.246 | ops/s | 1749.011 | ± | 41.499 | ops/s |
| RefBenchmark.getAndUpdate | 2153.913 | ± | 123.160 | ops/s | 2219.788 | ± | 27.186 | ops/s |
| RefBenchmark.modify | 2013.005 | ± | 97.462 | ops/s | 2200.220 | ± | 89.091 | ops/s |
| ShallowBindBenchmark.async | 676.137 | ± | 7.354 | ops/s | 836.106 | ± | 16.662 | ops/s |
| ShallowBindBenchmark.delay | 2902.835 | ± | 73.292 | ops/s | 3056.358 | ± | 63.412 | ops/s |
| ShallowBindBenchmark.pure | 3145.676 | ± | 92.770 | ops/s | 3236.344 | ± | 253.777 | ops/s |
| WorkStealingBenchmark.async | 15.672 | ± | 1.296 | ops/min | 16.807 | ± | 1.579 | ops/min |
| WorkStealingBenchmark.asyncTooManyThreads | 15.494 | ± | 1.135 | ops/min | 15.950 | ± | 1.291 | ops/min |