### PR TITLE
Scalafix migration for the update to 2.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,9 @@ jobs:
 
       - if: matrix.scala == '2.12.13'
         run: sbt ++${{ matrix.scala }} microsite/makeMicrosite
+
+      - name: Scalafix tests
+        if: matrix.scala == '2.13.4'
+        run: |
+          cd scalafix
+          sbt test

--- a/build.sbt
+++ b/build.sbt
@@ -23,10 +23,11 @@ import scala.sys.process._
 ThisBuild / baseVersion := "2.4"
 
 val OldScala = "2.12.13"
+val NewScala = "2.13.4"
 val OldDotty = "3.0.0-M3"
 val NewDotty = "3.0.0-RC1"
 
-ThisBuild / crossScalaVersions := Seq(OldDotty, NewDotty, OldScala, "2.13.4")
+ThisBuild / crossScalaVersions := Seq(OldDotty, NewDotty, OldScala, NewScala)
 ThisBuild / scalaVersion := (ThisBuild / crossScalaVersions).value.last
 
 ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@1.11")
@@ -41,6 +42,13 @@ ThisBuild / githubWorkflowBuildPreamble ++= Seq(
 
 ThisBuild / githubWorkflowBuild +=
   WorkflowStep.Sbt(List("microsite/makeMicrosite"), cond = Some(s"matrix.scala == '$OldScala'"))
+
+ThisBuild / githubWorkflowBuild +=
+  WorkflowStep.Run(
+    List("cd scalafix", "sbt test"),
+    name = Some("Scalafix tests"),
+    cond = Some(s"matrix.scala == '$NewScala'")
+  )
 
 ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"

--- a/scalafix/.scalafmt.conf
+++ b/scalafix/.scalafmt.conf
@@ -1,0 +1,6 @@
+version = 2.7.5
+maxColumn = 100
+spaces.inImportCurlyBraces = true
+project.excludeFilters = [
+   "v2_4_0/output/*"
+]

--- a/scalafix/README.md
+++ b/scalafix/README.md
@@ -1,0 +1,12 @@
+# Scalafix rules for Cats Effect
+
+## How to use
+
+1. [Install the Scalafix sbt plugin](https://scalacenter.github.io/scalafix/docs/users/installation)
+1. Run the rules appropriate to your Cats Effect version (see below)
+
+## Migration to Cats Effect 2.4.0
+
+```sh
+sbt ";scalafixEnable ;scalafixAll github:typelevel/cats-effect/v2_4_0?sha=v2.4.0"
+```

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -1,0 +1,46 @@
+val V = _root_.scalafix.sbt.BuildInfo
+
+inThisBuild(
+  List(
+    scalaVersion := V.scala213,
+    addCompilerPlugin(scalafixSemanticdb)
+  )
+)
+
+lazy val rules = project.settings(
+  libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion
+)
+
+lazy val v2_4_0_input = project
+  .in(file("v2_4_0/input"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "cats-effect" % "2.3.3"
+    )
+  )
+
+lazy val v2_4_0_output = project
+  .in(file("v2_4_0/output"))
+  .settings(
+    libraryDependencies ++= Seq(
+      // Ideally this would be a 2.4.0 release candidate or any other version
+      // newer than 2.3.3.
+      "org.typelevel" %% "cats-effect" % "3.0.0-RC2"
+    )
+  )
+
+lazy val v2_4_0_tests = project
+  .in(file("v2_4_0/tests"))
+  .settings(
+    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafixVersion % Test cross CrossVersion.full,
+    compile.in(Compile) :=
+      compile.in(Compile).dependsOn(compile.in(v2_4_0_input, Compile)).value,
+    scalafixTestkitOutputSourceDirectories :=
+      sourceDirectories.in(v2_4_0_output, Compile).value,
+    scalafixTestkitInputSourceDirectories :=
+      sourceDirectories.in(v2_4_0_input, Compile).value,
+    scalafixTestkitInputClasspath :=
+      fullClasspath.in(v2_4_0_input, Compile).value
+  )
+  .dependsOn(v2_4_0_input, rules)
+  .enablePlugins(ScalafixTestkitPlugin)

--- a/scalafix/project/build.properties
+++ b/scalafix/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.7

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.26")

--- a/scalafix/rules/src/main/scala/fix/v2_4_0.scala
+++ b/scalafix/rules/src/main/scala/fix/v2_4_0.scala
@@ -1,0 +1,11 @@
+package fix
+
+import scalafix.v1._
+
+class v2_4_0 extends SemanticRule("v2_4_0") {
+  override def fix(implicit doc: SemanticDocument): Patch = {
+    Patch.replaceSymbols(
+      "cats/effect/Resource.liftF()." -> "eval"
+    )
+  }
+}

--- a/scalafix/v2_4_0/input/src/main/scala/fix/ResourceRewrites.scala
+++ b/scalafix/v2_4_0/input/src/main/scala/fix/ResourceRewrites.scala
@@ -1,0 +1,12 @@
+/*
+rule = "scala:fix.v2_4_0"
+ */
+package fix
+
+import cats.effect.IO
+import cats.effect.Resource
+
+object ResourceRewrites {
+  Resource.liftF(IO.unit)
+  cats.effect.Resource.liftF(IO.unit)
+}

--- a/scalafix/v2_4_0/output/src/main/scala/fix/ResourceRewrites.scala
+++ b/scalafix/v2_4_0/output/src/main/scala/fix/ResourceRewrites.scala
@@ -1,0 +1,9 @@
+package fix
+
+import cats.effect.IO
+import cats.effect.Resource
+
+object ResourceRewrites {
+  Resource.eval(IO.unit)
+  cats.effect.Resource.eval(IO.unit)
+}

--- a/scalafix/v2_4_0/tests/src/test/scala/fix/CatsEffectTests.scala
+++ b/scalafix/v2_4_0/tests/src/test/scala/fix/CatsEffectTests.scala
@@ -1,0 +1,7 @@
+package fix
+
+import scalafix.testkit._
+
+class CatsEffectTests extends SemanticRuleSuite() {
+  runAllTests()
+}


### PR DESCRIPTION
This adds a Scalafix migration for 2.4.0 (or the next 2.x version) as proposed in https://github.com/typelevel/cats-effect/pull/1732#issuecomment-783429980.