### PR TITLE
Volatile cancelation checks everywhere

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -305,11 +305,11 @@ private final class IOFiber[A](
           (ioe.tag: @switch) match {
             case 0 =>
               val pure = ioe.asInstanceOf[Pure[Any]]
-              runLoop(next(pure.value), nextIteration)
+              runLoop(next(pure.value), nextIteration + 1)
 
             case 1 =>
               val error = ioe.asInstanceOf[Error]
-              runLoop(failed(error.t, 0), nextIteration)
+              runLoop(failed(error.t, 0), nextIteration + 1)
 
             case 2 =>
               val delay = ioe.asInstanceOf[Delay[Any]]
@@ -322,23 +322,20 @@ private final class IOFiber[A](
                   case NonFatal(t) => error = t
                 }
 
-              if (error == null) {
-                runLoop(succeeded(result, 0), nextIteration)
-              } else {
-                runLoop(failed(error, 0), nextIteration)
-              }
+              val nextIO = if (error == null) succeeded(result, 0) else failed(error, 0)
+              runLoop(nextIO, nextIteration + 1)
 
             case 3 =>
               val realTime = runtime.scheduler.nowMillis().millis
-              runLoop(next(realTime), nextIteration)
+              runLoop(next(realTime), nextIteration + 1)
 
             case 4 =>
               val monotonic = runtime.scheduler.monotonicNanos().nanos
-              runLoop(next(monotonic), nextIteration)
+              runLoop(next(monotonic), nextIteration + 1)
 
             case 5 =>
               val ec = currentCtx
-              runLoop(next(ec), nextIteration)
+              runLoop(next(ec), nextIteration + 1)
 
             case _ =>
               objectState.push(f)
@@ -361,11 +358,11 @@ private final class IOFiber[A](
           (ioe.tag: @switch) match {
             case 0 =>
               val pure = ioe.asInstanceOf[Pure[Any]]
-              runLoop(next(pure.value), nextIteration)
+              runLoop(next(pure.value), nextIteration + 1)
 
             case 1 =>
               val error = ioe.asInstanceOf[Error]
-              runLoop(failed(error.t, 0), nextIteration)
+              runLoop(failed(error.t, 0), nextIteration + 1)
 
             case 2 =>
               val delay = ioe.asInstanceOf[Delay[Any]]
@@ -377,19 +374,19 @@ private final class IOFiber[A](
                   case NonFatal(t) => failed(t, 0)
                 }
 
-              runLoop(result, nextIteration)
+              runLoop(result, nextIteration + 1)
 
             case 3 =>
               val realTime = runtime.scheduler.nowMillis().millis
-              runLoop(next(realTime), nextIteration)
+              runLoop(next(realTime), nextIteration + 1)
 
             case 4 =>
               val monotonic = runtime.scheduler.monotonicNanos().nanos
-              runLoop(next(monotonic), nextIteration)
+              runLoop(next(monotonic), nextIteration + 1)
 
             case 5 =>
               val ec = currentCtx
-              runLoop(next(ec), nextIteration)
+              runLoop(next(ec), nextIteration + 1)
 
             case _ =>
               objectState.push(f)
@@ -405,11 +402,11 @@ private final class IOFiber[A](
           (ioa.tag: @switch) match {
             case 0 =>
               val pure = ioa.asInstanceOf[Pure[Any]]
-              runLoop(succeeded(Right(pure.value), 0), nextIteration)
+              runLoop(succeeded(Right(pure.value), 0), nextIteration + 1)
 
             case 1 =>
               val error = ioa.asInstanceOf[Error]
-              runLoop(succeeded(Left(error.t), 0), nextIteration)
+              runLoop(succeeded(Left(error.t), 0), nextIteration + 1)
 
             case 2 =>
               val delay = ioa.asInstanceOf[Delay[Any]]
@@ -424,19 +421,19 @@ private final class IOFiber[A](
 
               val next =
                 if (error == null) succeeded(Right(result), 0) else succeeded(Left(error), 0)
-              runLoop(next, nextIteration)
+              runLoop(next, nextIteration + 1)
 
             case 3 =>
               val realTime = runtime.scheduler.nowMillis().millis
-              runLoop(succeeded(Right(realTime), 0), nextIteration)
+              runLoop(succeeded(Right(realTime), 0), nextIteration + 1)
 
             case 4 =>
               val monotonic = runtime.scheduler.monotonicNanos().nanos
-              runLoop(succeeded(Right(monotonic), 0), nextIteration)
+              runLoop(succeeded(Right(monotonic), 0), nextIteration + 1)
 
             case 5 =>
               val ec = currentCtx
-              runLoop(succeeded(Right(ec), 0), nextIteration)
+              runLoop(succeeded(Right(ec), 0), nextIteration + 1)
 
             case _ =>
               conts.push(AttemptK)

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -91,6 +91,7 @@ private final class IOFiber[A](
   private[this] var currentCtx: ExecutionContext = _
   private[this] var ctxs: ArrayStack[ExecutionContext] = _
 
+  @volatile
   private[this] var canceled: Boolean = false
   private[this] var masks: Int = initMask
   private[this] var finalizing: Boolean = false
@@ -123,7 +124,6 @@ private final class IOFiber[A](
   /* similar prefetch for EndFiber */
   private[this] val IOEndFiber = IO.EndFiber
 
-  private[this] val cancellationCheckThreshold = runtime.config.cancellationCheckThreshold
   private[this] val autoYieldThreshold = runtime.config.autoYieldThreshold
 
   override def run(): Unit = {
@@ -225,11 +225,6 @@ private final class IOFiber[A](
       IO.Error(new NullPointerException())
     } else {
       _cur0
-    }
-
-    if (iteration >= cancellationCheckThreshold) {
-      // Ensure that we see cancellation.
-      readBarrier()
     }
 
     if (shouldFinalize()) {


### PR DESCRIPTION
Will post benchmark results as they come in. The `series/3.x` benchmarks are from yesterday (as of #1742) and they are **probably** slightly higher than the real `series/3.x` (due to the merge of the `BlockContext` PR which might have affected results, but probably not relevant).

This PR's benchmark contain the changes in #1748 which I think are also relevant for this measurement (and the incoming results in this PR are better than the ones in #1748, feel free to compare them).

| Benchmark | series/3.x | | error | unit | this PR | | error | unit |
| :--- | ---: | :---: | :--- | :--- | ---: | :---: | :--- | :--- |
| AsyncBenchmark.async | 15037.567 | ± | 345.484 | ops/s | 15783.607 | ± | 521.709 | ops/s |
| AsyncBenchmark.bracket | 11148.360 | ± | 124.107 | ops/s | 12794.968 | ± | 225.165 | ops/s |
| AsyncBenchmark.cancelable | 14878.036 | ± | 277.328 | ops/s | 15841.530 | ± | 275.670 | ops/s |
| AsyncBenchmark.race | 18977.227 | ± | 1029.854 | ops/s | 20284.993 | ± | 585.982 | ops/s |
| AsyncBenchmark.racePair | 18199.912 | ± | 1687.635 | ops/s | 18112.425 | ± | 1525.525 | ops/s |
| AsyncBenchmark.start | 5364.297 | ± | 245.464 | ops/s | 5965.369 | ± | 61.474 | ops/s |
| AsyncBenchmark.uncancelable | 23232.545 | ± | 693.276 | ops/s | 24295.254 | ± | 960.397 | ops/s |
| AttemptBenchmark.errorRaised | 1115.757 | ± | 75.589 | ops/s | 1347.616 | ± | 55.831 | ops/s |
| AttemptBenchmark.happyPath | 1612.782 | ± | 40.435 | ops/s | 1890.169 | ± | 144.647 | ops/s |
| BothBenchmark.happyPath | 13.591 | ± | 1.030 | ops/s | 15.253 | ± | 1.239 | ops/s |
| DeepBindBenchmark.async | 930.214 | ± | 15.624 | ops/s | 1088.193 | ± | 42.315 | ops/s |
| DeepBindBenchmark.delay | 2912.721 | ± | 81.084 | ops/s | 3180.628 | ± | 37.547 | ops/s |
| DeepBindBenchmark.pure | 3391.485 | ± | 67.483 | ops/s | 4506.327 | ± | 526.730 | ops/s |
| HandleErrorBenchmark.errorRaised | 1122.994 | ± | 25.544 | ops/s | 1440.042 | ± | 34.539 | ops/s |
| HandleErrorBenchmark.happyPath | 1256.835 | ± | 12.508 | ops/s | 1672.656 | ± | 41.480 | ops/s |
| MapCallsBenchmark.batch120 | 265.009 | ± | 6.984 | ops/s | 274.150 | ± | 6.036 | ops/s |
| MapCallsBenchmark.batch30 | 74.866 | ± | 3.273 | ops/s | 72.193 | ± | 2.146 | ops/s |
| MapCallsBenchmark.one | 2.427 | ± | 0.046 | ops/s | 2.443 | ± | 0.042 | ops/s |
| MapStreamBenchmark.batch120 | 1830.207 | ± | 73.377 | ops/s | 2030.622 | ± | 41.075 | ops/s |
| MapStreamBenchmark.batch30 | 678.926 | ± | 11.870 | ops/s | 753.786 | ± | 11.139 | ops/s |
| MapStreamBenchmark.one | 1019.271 | ± | 17.398 | ops/s | 1223.167 | ± | 23.639 | ops/s |
| RaceBenchmark.happyPath | 14.810 | ± | 1.372 | ops/s | 16.342 | ± | 1.486 | ops/s |
| RedeemBenchmark.errorRaised | 797.029 | ± | 12.942 | ops/s | 981.570 | ± | 18.557 | ops/s |
| RedeemBenchmark.happyPath | 938.489 | ± | 19.969 | ops/s | 1165.694 | ± | 27.861 | ops/s |
| RedeemWithBenchmark.errorRaised | 1091.672 | ± | 68.342 | ops/s | 1385.340 | ± | 47.898 | ops/s |
| RedeemWithBenchmark.happyPath | 1388.954 | ± | 73.799 | ops/s | 1728.207 | ± | 80.994 | ops/s |
| RefBenchmark.getAndUpdate | 2223.957 | ± | 69.161 | ops/s | 2194.282 | ± | 55.099 | ops/s |
| RefBenchmark.modify | 2077.427 | ± | 68.193 | ops/s | 2137.972 | ± | 121.298 | ops/s |
| ShallowBindBenchmark.async | 691.183 | ± | 6.237 | ops/s | 854.640 | ± | 19.415 | ops/s |
| ShallowBindBenchmark.delay | 2969.485 | ± | 186.612 | ops/s | 2844.225 | ± | 103.275 | ops/s |
| ShallowBindBenchmark.pure | 3185.351 | ± | 47.894 | ops/s | 3488.717 | ± | 65.429 | ops/s |
| WorkStealingBenchmark.async | 16.158 | ± | 1.472 | ops/min | 17.042 | ± | 1.579 | ops/min |
| WorkStealingBenchmark.asyncTooManyThreads | 15.049 | ± | 1.187 | ops/min | 15.212 | ± | 1.681 | ops/min |