### PR TITLE
CE2: deprecate Sync#suspend

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Async.scala
+++ b/core/shared/src/main/scala/cats/effect/Async.scala
@@ -307,7 +307,7 @@ object Async {
       case RaiseError(e) => F.raiseError(e)
       case Delay(thunk)  => F.delay(thunk())
       case _ =>
-        F.suspend {
+        F.defer {
           IORunLoop.step(io) match {
             case Pure(a)       => F.pure(a)
             case RaiseError(e) => F.raiseError(e)

--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -405,7 +405,7 @@ object Concurrent {
       case RaiseError(e) => F.raiseError(e)
       case Delay(thunk)  => F.delay(thunk())
       case _ =>
-        F.suspend {
+        F.defer {
           IORunLoop.step(ioa) match {
             case Pure(a)       => F.pure(a)
             case RaiseError(e) => F.raiseError(e)
@@ -512,7 +512,7 @@ object Concurrent {
    *        the source completing, a `TimeoutException` is raised
    */
   def timeout[F[_], A](fa: F[A], duration: FiniteDuration)(implicit F: Concurrent[F], timer: Timer[F]): F[A] = {
-    val timeoutException = F.suspend(F.raiseError[A](new TimeoutException(duration.toString)))
+    val timeoutException = F.defer(F.raiseError[A](new TimeoutException(duration.toString)))
     timeoutTo(fa, duration, timeoutException)
   }
 

--- a/core/shared/src/main/scala/cats/effect/concurrent/Deferred.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/Deferred.scala
@@ -164,7 +164,7 @@ object Deferred {
   final private class ConcurrentDeferred[F[_], A](ref: AtomicReference[State[A]])(implicit F: Concurrent[F])
       extends TryableDeferred[F, A] {
     def get: F[A] =
-      F.suspend {
+      F.defer {
         ref.get match {
           case State.Set(a) =>
             F.pure(a)
@@ -214,7 +214,7 @@ object Deferred {
     }
 
     def complete(a: A): F[Unit] =
-      F.suspend(unsafeComplete(a))
+      F.defer(unsafeComplete(a))
 
     @tailrec
     private def unsafeComplete(a: A): F[Unit] =

--- a/core/shared/src/main/scala/cats/effect/internals/MVarAsync.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/MVarAsync.scala
@@ -43,10 +43,10 @@ final private[effect] class MVarAsync[F[_], A] private (initial: MVarAsync.State
     }
 
   def tryPut(a: A): F[Boolean] =
-    F.suspend(unsafeTryPut(a))
+    F.defer(unsafeTryPut(a))
 
   val tryTake: F[Option[A]] =
-    F.suspend(unsafeTryTake())
+    F.defer(unsafeTryTake())
 
   val take: F[A] =
     F.flatMap(tryTake) {

--- a/core/shared/src/main/scala/cats/effect/internals/MVarConcurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/internals/MVarConcurrent.scala
@@ -45,10 +45,10 @@ final private[effect] class MVarConcurrent[F[_], A] private (initial: MVarConcur
     }
 
   def tryPut(a: A): F[Boolean] =
-    F.suspend(unsafeTryPut(a))
+    F.defer(unsafeTryPut(a))
 
   val tryTake: F[Option[A]] =
-    F.suspend(unsafeTryTake())
+    F.defer(unsafeTryTake())
 
   val take: F[A] =
     F.flatMap(tryTake) {

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -35,7 +35,7 @@ trait AsyncLaws[F[_]] extends SyncLaws[F] {
     F.async[A](_(Left(e))) <-> F.raiseError(e)
 
   def repeatedAsyncEvaluationNotMemoized[A](a: A, f: A => A) =
-    F.suspend {
+    F.defer {
       var cur = a
 
       val change: F[Unit] = F.async { cb =>
@@ -49,7 +49,7 @@ trait AsyncLaws[F[_]] extends SyncLaws[F] {
     } <-> F.pure(f(f(a)))
 
   def repeatedAsyncFEvaluationNotMemoized[A](a: A, f: A => A) =
-    F.suspend {
+    F.defer {
       var cur = a
 
       val change: F[Unit] = F.asyncF { cb =>
@@ -63,7 +63,7 @@ trait AsyncLaws[F[_]] extends SyncLaws[F] {
     } <-> F.pure(f(f(a)))
 
   def repeatedCallbackIgnored[A](a: A, f: A => A) =
-    F.suspend {
+    F.defer {
       var cur = a
       val change = F.delay { cur = f(cur) }
       val readResult = F.delay(cur)

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
@@ -28,16 +28,16 @@ trait SyncLaws[F[_]] extends BracketLaws[F, Throwable] with DeferLaws[F] {
     F.delay(a) <-> F.pure(a)
 
   def suspendConstantIsPureJoin[A](fa: F[A]) =
-    F.suspend(fa) <-> F.flatten(F.pure(fa))
+    F.defer(fa) <-> F.flatten(F.pure(fa))
 
   def delayThrowIsRaiseError[A](e: Throwable) =
     F.delay[A](throw e) <-> F.raiseError(e)
 
   def suspendThrowIsRaiseError[A](e: Throwable) =
-    F.suspend[A](throw e) <-> F.raiseError(e)
+    F.defer[A](throw e) <-> F.raiseError(e)
 
   def unsequencedDelayIsNoop[A](a: A, f: A => A) =
-    F.suspend {
+    F.defer {
       var cur = a
       val change = F.delay { cur = f(cur) }
       val _ = change
@@ -46,7 +46,7 @@ trait SyncLaws[F[_]] extends BracketLaws[F, Throwable] with DeferLaws[F] {
     } <-> F.pure(a)
 
   def repeatedSyncEvaluationNotMemoized[A](a: A, f: A => A) =
-    F.suspend {
+    F.defer {
       var cur = a
       val change = F.delay { cur = f(cur) }
       val read = F.delay(cur)
@@ -61,7 +61,7 @@ trait SyncLaws[F[_]] extends BracketLaws[F, Throwable] with DeferLaws[F] {
   }
 
   def bindSuspendsEvaluation[A](fa: F[A], a1: A, f: (A, A) => A) =
-    F.suspend {
+    F.defer {
       var state = a1
       val evolve = F.flatMap(fa) { a2 =>
         state = f(a1, a2)
@@ -72,7 +72,7 @@ trait SyncLaws[F[_]] extends BracketLaws[F, Throwable] with DeferLaws[F] {
     } <-> F.map(fa)(a2 => f(a1, f(a1, a2)))
 
   def mapSuspendsEvaluation[A](fa: F[A], a1: A, f: (A, A) => A) =
-    F.suspend {
+    F.defer {
       var state = a1
       val evolve = F.map(fa) { a2 =>
         state = f(a1, a2)

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -1251,7 +1251,7 @@ object IOTests {
     def runAsync[A](fa: IO[A])(cb: (Either[Throwable, A]) => IO[Unit]): SyncIO[Unit] =
       ref.runAsync(fa)(cb)
     def suspend[A](thunk: => IO[A]): IO[A] =
-      ref.suspend(thunk)
+      ref.defer(thunk)
     def bracketCase[A, B](acquire: IO[A])(use: A => IO[B])(release: (A, ExitCase[Throwable]) => IO[Unit]): IO[B] =
       ref.bracketCase(acquire)(use)(release)
   }


### PR DESCRIPTION
In a similar vein to #1732 - the change from `suspend` to `defer` is a particular gotcha since CE3 has `suspend` with a different signature.

This is a bit of a weird one since it still requires implementers of `Sync` to implement the deprecated `suspend` method, but I don't think that should cause any actual problems.

I'll try to add the scalafix migration if people think this is a good idea.