### PR TITLE
Port IOApp.Simple to CE2

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOApp.scala
+++ b/core/shared/src/main/scala/cats/effect/IOApp.scala
@@ -62,7 +62,7 @@ trait IOApp {
   def run(args: List[String]): IO[ExitCode]
 
   /**
-   * The main method that runs the `IO` returned by [[run]] and exits
+   * The main method that runs the `IO` returned by run and exits
    * the app with the resulting code on completion.
    */
   def main(args: Array[String]): Unit =
@@ -121,4 +121,11 @@ trait IOApp {
     IOAppPlatform.defaultExecutionContext
 }
 
-object IOApp extends IOAppCompanionPlatform
+object IOApp extends IOAppCompanionPlatform {
+
+  trait Simple extends IOApp {
+    def run: IO[Unit]
+    final def run(args: List[String]): IO[ExitCode] = run.as(ExitCode.Success)
+  }
+
+}

--- a/site/src/main/mdoc/datatypes/ioapp.md
+++ b/site/src/main/mdoc/datatypes/ioapp.md
@@ -76,7 +76,17 @@ In terms of the behavior, the contract is currently this:
   with that as an error code (via `sys.exit`)
 - if the `IO` terminates in error, it is printed to standard error and
   `sys.exit` is called
-  
+
+Or if you don't need to use arguments and return exit codes:
+
+```scala mdoc:reset:silent
+import cats.effect._
+
+object Main extends IOApp.Simple {
+  val run = IO(println("Hello, World!"))
+}
+```
+
 ### Cancelation and Safe Resource Release
 
 The `cats.effect.IO` implementation is cancelable and so is `IOApp`.


### PR DESCRIPTION
This PR  fixes #1721 by porting the `Simple` trait  from CE3 to CE2
