### PR TITLE
Tracing on CE3

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -23,16 +23,16 @@ import scala.scalajs.js.Promise
 private[effect] abstract class IOCompanionPlatform { this: IO.type =>
 
   def blocking[A](thunk: => A): IO[A] =
-    apply(thunk)
+    apply(thunk, null)
 
   def interruptible[A](many: Boolean)(thunk: => A): IO[A] = {
     val _ = many
-    apply(thunk)
+    apply(thunk, null)
   }
 
   def suspend[A](hint: Sync.Type)(thunk: => A): IO[A] = {
     val _ = hint
-    apply(thunk)
+    apply(thunk, null)
   }
 
   def fromPromise[A](iop: IO[Promise[A]]): IO[A] =

--- a/core/js/src/main/scala/cats/effect/TracingConstants.scala
+++ b/core/js/src/main/scala/cats/effect/TracingConstants.scala
@@ -1,0 +1,13 @@
+package cats.effect
+
+object TracingConstants {
+  final val isCachedStackTracing: Boolean = false
+
+  final val isFullStackTracing: Boolean = false
+
+  final val isStackTracing: Boolean = isFullStackTracing || isCachedStackTracing
+
+  final val traceBufferLogSize: Int = 4
+
+  final val enhancedExceptions: Boolean = false
+}

--- a/core/jvm/src/main/java/cats/effect/TracingConstants.java
+++ b/core/jvm/src/main/java/cats/effect/TracingConstants.java
@@ -1,0 +1,46 @@
+package cats.effect;
+
+final class TracingConstants {
+
+    /**
+     * Sets stack tracing mode for a JVM process, which controls
+     * how much stack trace information is captured.
+     * Acceptable values are: NONE, CACHED, FULL.
+     */
+    private static final String stackTracingMode = Optional.ofNullable(System.getProperty("cats.effect.stackTracingMode"))
+            .filter(x -> !x.isEmpty())
+            .orElse("cached");
+
+    public static final boolean isCachedStackTracing = stackTracingMode.equalsIgnoreCase("cached");
+
+    public static final boolean isFullStackTracing = stackTracingMode.equalsIgnoreCase("full");
+
+    public static final boolean isStackTracing = isFullStackTracing || isCachedStackTracing;
+
+    /**
+     * The number of trace lines to retain during tracing. If more trace
+     * lines are produced, then the oldest trace lines will be discarded.
+     * Automatically rounded up to the nearest power of 2.
+     */
+    public static final int traceBufferLogSize = Optional.ofNullable(System.getProperty("cats.effect.traceBufferLogSize"))
+        .filter(x -> !x.isEmpty())
+        .flatMap(x -> {
+            try {
+                return Optional.of(Integer.valueOf(x));
+            } catch (Exception e) {
+                return Optional.empty();
+            }
+        })
+        .orElse(4);
+
+    /**
+     * Sets the enhanced exceptions flag, which controls whether or not the
+     * stack traces of IO exceptions are augmented to include async stack trace information.
+     * Stack tracing must be enabled in order to use this feature.
+     * This flag is enabled by default.
+     */
+    public static final boolean enhancedExceptions = Optional.ofNullable(System.getProperty("cats.effect.enhancedExceptions"))
+            .map(x -> Boolean.valueOf(x))
+            .orElse(true);
+
+}

--- a/core/jvm/src/main/java/cats/effect/TracingConstants.java
+++ b/core/jvm/src/main/java/cats/effect/TracingConstants.java
@@ -1,4 +1,22 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cats.effect;
+
+import java.util.Optional;
 
 final class TracingConstants {
 

--- a/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -27,16 +27,19 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
   private[this] val TypeInterruptibleMany = Sync.Type.InterruptibleMany
 
   def blocking[A](thunk: => A): IO[A] =
-    Blocking(TypeBlocking, () => thunk)
+    Blocking(TypeBlocking, () => thunk, IOTracing.calculateStackTraceEvent(thunk.getClass))
 
   def interruptible[A](many: Boolean)(thunk: => A): IO[A] =
-    Blocking(if (many) TypeInterruptibleMany else TypeInterruptibleOnce, () => thunk)
+    Blocking(
+      if (many) TypeInterruptibleMany else TypeInterruptibleOnce,
+      () => thunk,
+      IOTracing.calculateStackTraceEvent(thunk.getClass))
 
   def suspend[A](hint: Sync.Type)(thunk: => A): IO[A] =
     if (hint eq TypeDelay)
       apply(thunk)
     else
-      Blocking(hint, () => thunk)
+      Blocking(hint, () => thunk, IOTracing.calculateStackTraceEvent(thunk.getClass))
 
   def fromCompletableFuture[A](fut: IO[CompletableFuture[A]]): IO[A] =
     asyncForIO.fromCompletableFuture(fut)

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1324,7 +1324,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def tag = 1
   }
 
-  private[effect] final case class Delay[+A](thunk: () => A) extends IO[A] {
+  private[effect] final case class Delay[+A](thunk: () => A, event: IOEvent) extends IO[A] {
     def tag = 2
   }
 
@@ -1340,11 +1340,11 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def tag = 5
   }
 
-  private[effect] final case class Map[E, +A](ioe: IO[E], f: E => A) extends IO[A] {
+  private[effect] final case class Map[E, +A](ioe: IO[E], f: E => A, event: IOEvent) extends IO[A] {
     def tag = 6
   }
 
-  private[effect] final case class FlatMap[E, +A](ioe: IO[E], f: E => IO[A]) extends IO[A] {
+  private[effect] final case class FlatMap[E, +A](ioe: IO[E], f: E => IO[A], event: IOEvent) extends IO[A] {
     def tag = 7
   }
 
@@ -1352,7 +1352,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def tag = 8
   }
 
-  private[effect] final case class HandleErrorWith[+A](ioa: IO[A], f: Throwable => IO[A])
+  private[effect] final case class HandleErrorWith[+A](ioa: IO[A], f: Throwable => IO[A], event: IOEvent)
       extends IO[A] {
     def tag = 9
   }
@@ -1365,7 +1365,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def tag = 11
   }
 
-  private[effect] final case class Uncancelable[+A](body: Poll[IO] => IO[A]) extends IO[A] {
+  private[effect] final case class Uncancelable[+A](body: Poll[IO] => IO[A], event: IOEvent) extends IO[A] {
     def tag = 12
   }
   private[effect] object Uncancelable {
@@ -1402,7 +1402,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def tag = 19
   }
 
-  private[effect] final case class Blocking[+A](hint: Sync.Type, thunk: () => A) extends IO[A] {
+  private[effect] final case class Blocking[+A](hint: Sync.Type, thunk: () => A, event: IOEvent) extends IO[A] {
     def tag = 20
   }
 

--- a/core/shared/src/main/scala/cats/effect/IOEvent.scala
+++ b/core/shared/src/main/scala/cats/effect/IOEvent.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+private[effect] sealed abstract class IOEvent
+
+private[effect] object IOEvent {
+
+  final case class StackTrace(stackTrace: List[StackTraceElement]) extends IOEvent
+
+}

--- a/core/shared/src/main/scala/cats/effect/IOTracing.scala
+++ b/core/shared/src/main/scala/cats/effect/IOTracing.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import java.util.concurrent.ConcurrentHashMap
+
+private[effect] object IOTracing {
+  
+  
+  /**
+   * Global cache for trace frames. Keys are references to lambda classes.
+   * Should converge to the working set of traces very quickly for hot code paths.
+   */
+  private[this] val frameCache: ConcurrentHashMap[Class[_], IOEvent] = new ConcurrentHashMap()
+
+}

--- a/core/shared/src/main/scala/cats/effect/RingBuffer.scala
+++ b/core/shared/src/main/scala/cats/effect/RingBuffer.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+private[effect] final class RingBuffer[A <: AnyRef](logSize: Int) {
+
+  // These two probably don't need to be allocated every single time, maybe in Java?
+  private[this] val length = 1 << logSize
+  private[this] val mask = length - 1
+
+  private[this] val array: Array[AnyRef] = new Array(length)
+  private[this] var index: Int = 0
+
+  def push(a: A): A = {
+    val wi = index & mask
+    val old = array(wi).asInstanceOf[A]
+    array(wi) = a
+    index += 1
+    old
+  }
+
+  def isEmpty: Boolean =
+    index == 0
+
+  def capacity: Int =
+    length
+
+  // returns a list in reverse order of insertion
+  def toList: List[A] = {
+    val start = index - 1
+    val end = Math.max(index - length, 0)
+    (start to end by -1).toList.map(i => array(i & mask).asInstanceOf[A])
+  }
+
+}


### PR DESCRIPTION
apologies for this taking so long, but I think this is a decent start. Instead of copying over the various performance tricks we snuck in on CE2, I elected to write things out "nicely" so that we can benchmark and optimize later.

TODO:
- [ ] I don't think anyone made use of the `IO.traced` combinator in CE2 (enhanced exceptions are way better), so I'm going to avoid porting it for now. We can add it in later
- [ ] Figure out if/where we need to improve performance
- [ ] Add in the `Trace()` op for non-cached constructors
- [ ] Port tests