### PR TITLE
Restore ECBenchmark behavior

### DIFF
--- a/benchmarks/shared/src/main/scala/cats/effect/benchmarks/ECBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/cats/effect/benchmarks/ECBenchmark.scala
@@ -44,11 +44,11 @@ class ECBenchmark {
 
   @Benchmark
   def app(): Unit = {
-    val _ = ioApp.run
+    val _ = ioApp.main(Array.empty)
   }
 
   @Benchmark
   def appWithCtx(): Unit = {
-    val _ = ioAppCtx.run
+    val _ = ioAppCtx.main(Array.empty)
   }
 }


### PR DESCRIPTION
This was changed in #1759 and I think we should still be using `main`.