### PR TITLE
Implement UUIDGen capability trait.

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
+++ b/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
@@ -1,16 +1,46 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cats.effect.std
 
 import cats.effect.kernel.Sync
 
 import java.util.UUID
 
+/**
+ * A purely functional UUID Generator
+ */
 trait UUIDGen[F[_]] {
+
+  /**
+   * Generates a UUID in a pseudorandom manner.
+   * @return randomly generated UUID
+   */
   def randomUUID: F[UUID]
-  def fromString(uuidString: String)
+
+  /**
+   * Creates a UUID from standard String representation.
+   * @param uuidString a standard String UUID representation
+   * @return A UUID with specified value
+   */
+  def fromString(uuidString: String): F[UUID]
 }
 
 object UUIDGen {
   def randomUUID[F[_]: Sync]: F[UUID] = Sync[F].delay(UUID.randomUUID())
-  def fromString[F[_]: Sync](uuidString: String): F[UUID] = Sync[F].delay(UUID.fromString(uuidString))
+  def fromString[F[_]: Sync](uuidString: String): F[UUID] =
+    Sync[F].delay(UUID.fromString(uuidString))
 }
-

--- a/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
+++ b/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
@@ -1,0 +1,16 @@
+package cats.effect.std
+
+import cats.effect.kernel.Sync
+
+import java.util.UUID
+
+trait UUIDGen[F[_]] {
+  def randomUUID: F[UUID]
+  def fromString(uuidString: String)
+}
+
+object UUIDGen {
+  def randomUUID[F[_]: Sync]: F[UUID] = Sync[F].delay(UUID.randomUUID())
+  def fromString[F[_]: Sync](uuidString: String): F[UUID] = Sync[F].delay(UUID.fromString(uuidString))
+}
+

--- a/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
+++ b/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
@@ -16,8 +16,10 @@
 
 package cats.effect.std
 
+import cats.Functor
 import cats.effect.kernel.Sync
 import cats.implicits._
+
 import java.util.UUID
 
 /**
@@ -30,20 +32,14 @@ trait UUIDGen[F[_]] {
    * @return randomly generated UUID
    */
   def randomUUID: F[UUID]
-
-  /**
-   * Generates a UUID in a pseudorandom manner and returns String representation of this UUID.
-   * @return randomly generated UUID string
-   */
-  def randomString: F[String]
 }
 
 object UUIDGen {
   def apply[F[_]](implicit ev: UUIDGen[F]): UUIDGen[F] = ev
 
   implicit def fromSync[F[_]: Sync]: UUIDGen[F] = new UUIDGen[F] {
-
     override def randomUUID: F[UUID] = Sync[F].delay(UUID.randomUUID())
-    override def randomString: F[String] = randomUUID.map(_.toString)
   }
+  def randomUUID[F[_]: UUIDGen]: F[UUID] = UUIDGen[F].randomUUID
+  def randomString[F[_]: UUIDGen: Functor]: F[String] = randomUUID.map(_.toString)
 }

--- a/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
+++ b/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
@@ -17,7 +17,7 @@
 package cats.effect.std
 
 import cats.effect.kernel.Sync
-
+import cats.implicits._
 import java.util.UUID
 
 /**
@@ -32,15 +32,18 @@ trait UUIDGen[F[_]] {
   def randomUUID: F[UUID]
 
   /**
-   * Creates a UUID from standard String representation.
-   * @param uuidString a standard String UUID representation
-   * @return A UUID with specified value
+   * Generates a UUID in a pseudorandom manner and returns String representation of this UUID.
+   * @return randomly generated UUID string
    */
-  def fromString(uuidString: String): F[UUID]
+  def randomString: F[String]
 }
 
 object UUIDGen {
-  def randomUUID[F[_]: Sync]: F[UUID] = Sync[F].delay(UUID.randomUUID())
-  def fromString[F[_]: Sync](uuidString: String): F[UUID] =
-    Sync[F].delay(UUID.fromString(uuidString))
+  def apply[F[_]](implicit ev: UUIDGen[F]): UUIDGen[F] = ev
+
+  implicit def fromSync[F[_]: Sync]: UUIDGen[F] = new UUIDGen[F] {
+
+    override def randomUUID: F[UUID] = Sync[F].delay(UUID.randomUUID())
+    override def randomString: F[String] = randomUUID.map(_.toString)
+  }
 }


### PR DESCRIPTION
This PR implements UUIDGen capability trait as discussed in https://github.com/typelevel/cats-effect/issues/1741. 

The implementation is as simple as possible, not sure if we need any tests for that, but if so I will be happy to add that.
The issue mentions introducing potential literal macro, IMHO it's not a very commonly used feature, so I've just decided to skip it but If we want to have it anyway, again happy to add.