### PR TITLE
Remove final fields startIO and startEC

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -35,14 +35,15 @@ private[effect] object IOFiberConstants {
 
   // resume ids
   val ExecR: Byte = 0
-  val AsyncContinueR: Byte = 1
-  val BlockingR: Byte = 2
-  val AfterBlockingSuccessfulR: Byte = 3
-  val AfterBlockingFailedR: Byte = 4
-  val EvalOnR: Byte = 5
-  val CedeR: Byte = 6
-  val AutoCedeR: Byte = 7
-  val DoneR: Byte = 8
+  val AsyncContinueSuccessfulR: Byte = 1
+  val AsyncContinueFailedR: Byte = 2
+  val BlockingR: Byte = 3
+  val AfterBlockingSuccessfulR: Byte = 4
+  val AfterBlockingFailedR: Byte = 5
+  val EvalOnR: Byte = 6
+  val CedeR: Byte = 7
+  val AutoCedeR: Byte = 8
+  val DoneR: Byte = 9
 
   // ContState tags
   val ContStateInitial: Int = 0

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -35,14 +35,15 @@ final class IOFiberConstants {
 
   // resume ids
   public static final byte ExecR = 0;
-  public static final byte AsyncContinueR = 1;
-  public static final byte BlockingR = 2;
-  public static final byte AfterBlockingSuccessfulR = 3;
-  public static final byte AfterBlockingFailedR = 4;
-  public static final byte EvalOnR = 5;
-  public static final byte CedeR = 6;
-  public static final byte AutoCedeR = 7;
-  public static final byte DoneR = 8;
+  public static final byte AsyncContinueSuccessfulR = 1;
+  public static final byte AsyncContinueFailedR = 2;
+  public static final byte BlockingR = 3;
+  public static final byte AfterBlockingSuccessfulR = 4;
+  public static final byte AfterBlockingFailedR = 5;
+  public static final byte EvalOnR = 6;
+  public static final byte CedeR = 7;
+  public static final byte AutoCedeR = 8;
+  public static final byte DoneR = 9;
 
   // ContState tags
   public static final int ContStateInitial = 0;

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -792,7 +792,7 @@ private final class IOFiber[A](
 
           if (cur.hint eq TypeBlocking) {
             resumeTag = BlockingR
-            objectState.push(cur)
+            resumeIO = cur
             runtime.blocking.execute(this)
           } else {
             runLoop(interruptibleImpl(cur, runtime.blocking), nextIteration)
@@ -1079,7 +1079,8 @@ private final class IOFiber[A](
 
   private[this] def blockingR(): Unit = {
     var error: Throwable = null
-    val cur = objectState.pop().asInstanceOf[Blocking[Any]]
+    val cur = resumeIO.asInstanceOf[Blocking[Any]]
+    resumeIO = null
     val r =
       try cur.thunk()
       catch {

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -782,7 +782,7 @@ private final class IOFiber[A](
             conts.push(EvalOnK)
 
             resumeTag = EvalOnR
-            objectState.push(cur.ioa)
+            resumeIO = cur.ioa
             execute(ec)(this)
           }
 
@@ -1108,7 +1108,8 @@ private final class IOFiber[A](
   }
 
   private[this] def evalOnR(): Unit = {
-    val ioa = objectState.pop().asInstanceOf[IO[Any]]
+    val ioa = resumeIO
+    resumeIO = null
     runLoop(ioa, 0)
   }
 

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -827,6 +827,7 @@ private final class IOFiber[A](
     masks = initMask
 
     resumeTag = DoneR
+    resumeIO = null
     /*
      * Write barrier to publish masks. The thread which owns the runloop is
      * effectively a single writer, so lazy set can be utilized for relaxed

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -963,7 +963,7 @@ private final class IOFiber[A](
     var k: Byte = -1
 
     /*
-     * short circuit on error by dropping map, flatMap, and auto-cede continuations
+     * short circuit on error by dropping map and flatMap continuations
      * until we hit a continuation that needs to deal with errors.
      */
     while (i >= 0 && k < 0) {

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -737,7 +737,8 @@ private final class IOFiber[A](
 
         /* Cede */
         case 16 =>
-          cede()
+          resumeTag = CedeR
+          rescheduleFiber(currentCtx)(this)
 
         case 17 =>
           val cur = cur0.asInstanceOf[Start[Any]]
@@ -870,11 +871,6 @@ private final class IOFiber[A](
 
       done(OutcomeCanceled)
     }
-  }
-
-  private[this] def cede(): Unit = {
-    resumeTag = CedeR
-    rescheduleFiber(currentCtx)(this)
   }
 
   /*

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -572,7 +572,7 @@ private final class IOFiber[A](
                         objectState.push(t)
                       case Right(a) =>
                         resumeTag = AsyncContinueSuccessfulR
-                        objectState.push(a.asInstanceOf[Object])
+                        objectState.push(a.asInstanceOf[AnyRef])
                     }
                     execute(ec)(this)
                   } else {
@@ -1089,7 +1089,7 @@ private final class IOFiber[A](
 
     if (error == null) {
       resumeTag = AfterBlockingSuccessfulR
-      objectState.push(r.asInstanceOf[Object])
+      objectState.push(r.asInstanceOf[AnyRef])
     } else {
       resumeTag = AfterBlockingFailedR
       objectState.push(error)
@@ -1194,7 +1194,7 @@ private final class IOFiber[A](
 
     if (!shouldFinalize()) {
       resumeTag = AfterBlockingSuccessfulR
-      objectState.push(result.asInstanceOf[Object])
+      objectState.push(result.asInstanceOf[AnyRef])
       execute(ec)(this)
     } else {
       asyncCancel(null)


### PR DESCRIPTION
Because we used `startIO` and `startEC` as part of `execR`, this escaped the constructor of `IOFiber` and the constructor arguments became (final) fields after compilation, resulting in unnecessary bloat to each fiber. On top of that, we were unnecessarily holding onto the root `IO` object, for the whole lifetime of the fiber.

Before:
```
Compiled from "IOFiber.scala"
public final class cats.effect.IOFiber<A> extends cats.effect.IOFiberPlatform<A> implements cats.effect.kernel.Fiber<cats.effect.IO, java.lang.Throwable, A>, java.lang.Runnable {
  private final int initMask;

  private final cats.effect.IO<A> startIO;

  private final scala.concurrent.ExecutionContext startEC;

  private final cats.effect.unsafe.IORuntime runtime;

  private cats.effect.ByteStack conts;

  private final cats.effect.ArrayStack<java.lang.Object> objectState;

  private scala.concurrent.ExecutionContext currentCtx;

  private cats.effect.ArrayStack<scala.concurrent.ExecutionContext> ctxs;

  private boolean canceled;

  private int masks;

  private boolean finalizing;

  private final int childMask;

...
```

After:
```
Compiled from "IOFiber.scala"
public final class cats.effect.IOFiber<A> extends cats.effect.IOFiberPlatform<A> implements cats.effect.kernel.Fiber<cats.effect.IO, java.lang.Throwable, A>, java.lang.Runnable {
  private final int initMask;

  private final cats.effect.unsafe.IORuntime runtime;

  private cats.effect.ByteStack conts;

  private final cats.effect.ArrayStack<java.lang.Object> objectState;

  private scala.concurrent.ExecutionContext currentCtx;

  private cats.effect.ArrayStack<scala.concurrent.ExecutionContext> ctxs;

  private boolean canceled;

  private int masks;

  private boolean finalizing;

  private final int childMask;

...
```

Then I figured, why not use it for `autoCede` as well. Here are the results.

Benchmark results (very marginal improvements, but this is to be expected):
| Benchmark | series/3.x | | error | unit | this PR | | error | unit |
| :--- | ---: | :---: | :--- | :--- | ---: | :---: | :--- | :--- |
| AsyncBenchmark.async | 16944.240 | ± | 260.687 | ops/s | 17251.533 | ± | 232.521 | ops/s |
| AsyncBenchmark.race | 21521.173 | ± | 410.881 | ops/s | 21687.002 | ± | 306.729 | ops/s |
| AsyncBenchmark.racePair | 20644.814 | ± | 1180.355 | ops/s | 21109.900 | ± | 1268.308 | ops/s |
| AsyncBenchmark.start | 5888.046 | ± | 356.687 | ops/s | 5943.158 | ± | 74.453 | ops/s |
| DeepBindBenchmark.async | 1313.741 | ± | 76.735 | ops/s | 1389.603 | ± | 33.490 | ops/s |
| DeepBindBenchmark.delay | 3128.832 | ± | 112.297 | ops/s | 3175.600 | ± | 131.373 | ops/s |
| DeepBindBenchmark.pure | 4164.669 | ± | 116.216 | ops/s | 4184.599 | ± | 112.218 | ops/s |
| ShallowBindBenchmark.async | 976.105 | ± | 6.784 | ops/s | 979.814 | ± | 16.856 | ops/s |
| ShallowBindBenchmark.delay | 2792.907 | ± | 78.072 | ops/s | 2911.944 | ± | 287.622 | ops/s |
| ShallowBindBenchmark.pure | 3115.989 | ± | 30.956 | ops/s | 3528.893 | ± | 102.307 | ops/s |