### PR TITLE
Return `Either` rather than `Boolean` from `Deferred#complete`

### DIFF
--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/pure.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/pure.scala
@@ -275,7 +275,12 @@ object pure {
         new Deferred[PureConc[E, *], A] {
           override def get: PureConc[E, A] = mVar.read[PureConc[E, *]]
 
-          override def complete(a: A): PureConc[E, Boolean] = mVar.tryPut[PureConc[E, *]](a)
+          override def complete(
+              a: A): PureConc[E, Either[DeferredSink.AlreadyCompleted, Unit]] =
+            mVar.tryPut[PureConc[E, *]](a).map {
+              case true => Right(())
+              case false => Left(DeferredSink.AlreadyCompleted)
+            }
 
           override def tryGet: PureConc[E, Option[A]] = mVar.tryRead[PureConc[E, *]]
         }

--- a/tests/shared/src/test/scala/cats/effect/kernel/DeferredSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/DeferredSpec.scala
@@ -27,11 +27,11 @@ class DeferredSpec extends BaseSpec { outer =>
   "Deferred" >> {
 
     "complete" in real {
-      val op = Deferred[IO, Int].flatMap { p => p.complete(0) *> p.get }
+      val op = Deferred[IO, Int].flatMap { p => p.complete(0).product(p.get) }
 
       op.flatMap { res =>
         IO {
-          res must beEqualTo(0)
+          res must beEqualTo((Right(()), 0))
         }
       }
     }
@@ -41,7 +41,7 @@ class DeferredSpec extends BaseSpec { outer =>
 
       op.flatMap { res =>
         IO {
-          res must beEqualTo((false, 0))
+          res must beEqualTo((Left(DeferredSink.AlreadyCompleted), 0))
         }
       }
     }


### PR DESCRIPTION
As discussed in #1687. This makes it more obvious that the return value of `Deferred#complete` can represent an error state, and (when `F` has `MonadThrow`) allows just using `.rethrow` to convert a failure value into a failed `F`.