### PR TITLE
Striped and batched overflow queues

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/HelperThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/HelperThread.scala
@@ -56,7 +56,6 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
  * introduces more logic on the hot path.
  */
 private[effect] final class HelperThread(
-    private[this] val threadCount: Int,
     private[this] val threadPrefix: String,
     private[this] val blockingThreadCounter: AtomicInteger,
     private[this] val batched: ScalQueue[Array[IOFiber[_]]],
@@ -176,13 +175,7 @@ private[effect] final class HelperThread(
 
       // Spawn a new `HelperThread`.
       val helper =
-        new HelperThread(
-          threadCount,
-          threadPrefix,
-          blockingThreadCounter,
-          batched,
-          overflow,
-          pool)
+        new HelperThread(threadPrefix, blockingThreadCounter, batched, overflow, pool)
       helper.start()
 
       // With another `HelperThread` started, it is time to execute the blocking

--- a/core/jvm/src/main/scala/cats/effect/unsafe/HelperThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/HelperThread.scala
@@ -138,7 +138,7 @@ private[effect] final class HelperThread(
     while (!isInterrupted() && !signal.get()) {
       val batch = batched.poll(random)
       if (batch ne null) {
-        overflow.offerAllStriped(batch, random)
+        overflow.offerAll(batch, random)
       }
 
       val fiber = overflow.poll(random)

--- a/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
@@ -592,7 +592,7 @@ private final class LocalQueue {
   }
 
   /**
-   * Steals all enqueued fibers and transfers them to the provided list.
+   * Steals all enqueued fibers and transfers them to the provided array.
    *
    * This method is called by the runtime when blocking is detected in order to
    * give a chance to the fibers enqueued behind the `head` of the queue to run
@@ -610,7 +610,9 @@ private final class LocalQueue {
    * main difference being that the `head` of the queue is moved forward to
    * match the `tail` of the queue, thus securing ''all'' remaining fibers.
    *
-   * @param dst the destination list in which all remaining fibers are
+   * @note Can '''only''' be correctly called by the owner [[WorkerThread]].
+   *
+   * @param dst the destination array in which all remaining fibers are
    *            transferred
    */
   def drain(dst: Array[IOFiber[_]]): Unit = {

--- a/core/jvm/src/main/scala/cats/effect/unsafe/ScalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/ScalQueue.scala
@@ -16,7 +16,6 @@
 
 package cats.effect.unsafe
 
-import java.util.ArrayList
 import java.util.concurrent.{ConcurrentLinkedQueue, ThreadLocalRandom}
 
 /**
@@ -60,20 +59,16 @@ private final class ScalQueue[A <: AnyRef](threadCount: Int) {
     ()
   }
 
-  def offerAll(list: ArrayList[A], random: ThreadLocalRandom): Unit = {
-    val idx = random.nextInt(numQueues)
-    queues(idx).addAll(list)
-    ()
-  }
-
-  def offerAllStriped(as: Array[A], random: ThreadLocalRandom): Unit = {
+  def offerAll(as: Array[A], random: ThreadLocalRandom): Unit = {
     val nq = numQueues
     val len = as.length
     var i = 0
     while (i < len) {
       val fiber = as(i)
-      val idx = random.nextInt(nq)
-      queues(idx).offer(fiber)
+      if (fiber ne null) {
+        val idx = random.nextInt(nq)
+        queues(idx).offer(fiber)
+      }
       i += 1
     }
   }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/ScalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/ScalQueue.scala
@@ -86,6 +86,20 @@ private final class ScalQueue[A <: AnyRef](threadCount: Int) {
   /**
    * Enqueues a batch of elements in a striped fashion.
    *
+   * @note By convention, the array of elements cannot contain any null
+   *       references, which are unsupported by the underlying concurrent
+   *       queues.
+   *
+   * @note This method has a somewhat high overhead when enqueueing every single
+   *       element. However, this is acceptable in practice because this method
+   *       is only used on the slowest path when blocking operations are
+   *       anticipated, which is not what the fiber runtime is optimized for.
+   *       This overhead can be substituted for the overhead of allocation of
+   *       array list instances which contain some of the fibers of the batch,
+   *       so that they can be enqueued with a bulk operation on each of the
+   *       concurrent queues. Maybe this can be explored in the future, but
+   *       remains to be seen if it is a worthwhile tradeoff.
+   *
    * @param as the batch of elements to be enqueued
    * @param random an uncontended source of randomness, used for randomly
    *               choosing a destination queue

--- a/core/jvm/src/main/scala/cats/effect/unsafe/ScalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/ScalQueue.scala
@@ -66,6 +66,18 @@ private final class ScalQueue[A <: AnyRef](threadCount: Int) {
     ()
   }
 
+  def offerAllStriped(as: Array[A], random: ThreadLocalRandom): Unit = {
+    val nq = numQueues
+    val len = as.length
+    var i = 0
+    while (i < len) {
+      val fiber = as(i)
+      val idx = random.nextInt(nq)
+      queues(idx).offer(fiber)
+      i += 1
+    }
+  }
+
   def poll(random: ThreadLocalRandom): A = {
     val nq = numQueues
     val from = random.nextInt(nq)

--- a/core/jvm/src/main/scala/cats/effect/unsafe/ScalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/ScalQueue.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.unsafe
+
+import java.util.ArrayList
+import java.util.concurrent.{ConcurrentLinkedQueue, ThreadLocalRandom}
+
+/**
+ * A striped queue implementation inspired by the
+ * [[https://scal.cs.uni-salzburg.at/dq/ Scal]] project. The whole queue
+ * consists of several [[java.util.concurrent.ConcurrentLinkedQueue]] instances
+ * (the number of queues is a power of 2 for optimization purposes) which are
+ * load balanced using random index generation.
+ *
+ * @param threadCount the number of threads to load balance
+ */
+private final class ScalQueue[A <: AnyRef](threadCount: Int) {
+
+  private[this] val mask: Int = {
+    // Bit twiddling hacks.
+    // http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+    var value = threadCount - 1
+    value |= value >> 1
+    value |= value >> 2
+    value |= value >> 4
+    value |= value >> 8
+    value | value >> 16
+  }
+
+  private[this] val numQueues: Int = mask + 1
+
+  private[this] val queues: Array[ConcurrentLinkedQueue[A]] = {
+    val nq = numQueues
+    val queues = new Array[ConcurrentLinkedQueue[A]](nq)
+    var i = 0
+    while (i < nq) {
+      queues(i) = new ConcurrentLinkedQueue()
+      i += 1
+    }
+    queues
+  }
+
+  def offer(a: A, random: ThreadLocalRandom): Unit = {
+    val idx = random.nextInt(numQueues)
+    queues(idx).offer(a)
+    ()
+  }
+
+  def offerAll(list: ArrayList[A], random: ThreadLocalRandom): Unit = {
+    val idx = random.nextInt(numQueues)
+    queues(idx).addAll(list)
+    ()
+  }
+
+  def poll(random: ThreadLocalRandom): A = {
+    val nq = numQueues
+    val from = random.nextInt(nq)
+    var i = 0
+    var a = null.asInstanceOf[A]
+
+    while ((a eq null) && i < nq) {
+      val idx = (from + i) & mask
+      a = queues(idx).poll()
+      i += 1
+    }
+
+    a
+  }
+
+  def isEmpty(): Boolean = {
+    val nq = numQueues
+    var i = 0
+    var empty = true
+
+    while (empty && i < nq) {
+      empty = queues(i).isEmpty()
+      i += 1
+    }
+
+    empty
+  }
+
+  def nonEmpty(): Boolean =
+    !isEmpty()
+
+  def clear(): Unit = {
+    val nq = numQueues
+    var i = 0
+    while (i < nq) {
+      queues(i).clear()
+      i += 1
+    }
+  }
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -75,6 +75,9 @@ private[effect] final class WorkStealingThreadPool(
   private[this] val localQueues: Array[LocalQueue] = new Array(threadCount)
   private[this] val parkedSignals: Array[AtomicBoolean] = new Array(threadCount)
 
+  private[this] val batchedQueue: ScalQueue[Array[IOFiber[_]]] =
+    new ScalQueue(threadCount)
+
   /**
    * The overflow queue on which fibers coming from outside the pool are
    * enqueued, or acts as a place where spillover work from other local queues
@@ -120,6 +123,7 @@ private[effect] final class WorkStealingThreadPool(
           blockingThreadCounter,
           queue,
           parkedSignal,
+          batchedQueue,
           overflowQueue,
           this)
       workerThreads(i) = thread

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -249,7 +249,13 @@ private[effect] final class WorkStealingThreadPool(
     }
 
     // If no work was found in the local queues of the worker threads, look for
-    // work in the external queue.
+    // work in the batched queue.
+    if (batchedQueue.nonEmpty()) {
+      notifyParked(random)
+    }
+
+    // If no work was found in the local queues of the worker threads or in the
+    // batched queue, look for work in the external queue.
     if (overflowQueue.nonEmpty()) {
       notifyParked(random)
     }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -52,7 +52,7 @@ private[effect] final class WorkerThread(
     private[this] val parked: AtomicBoolean,
     // Overflow queue used by the local queue for offloading excess fibers, as well as
     // for drawing fibers when the local queue is exhausted.
-    private[this] val overflow: ConcurrentLinkedQueue[IOFiber[_]],
+    private[this] val overflow: Array[ConcurrentLinkedQueue[IOFiber[_]]],
     // Reference to the `WorkStealingThreadPool` in which this thread operates.
     private[this] val pool: WorkStealingThreadPool)
     extends Thread
@@ -106,7 +106,8 @@ private[effect] final class WorkerThread(
    * @param fiber the fiber to be scheduled on the local queue
    */
   def schedule(fiber: IOFiber[_]): Unit = {
-    queue.enqueue(fiber, overflow)
+    val idx = random.nextInt(threadCount)
+    queue.enqueue(fiber, overflow(idx))
     pool.notifyParked(random.nextInt(threadCount))
   }
 
@@ -225,11 +226,23 @@ private[effect] final class WorkerThread(
       }
     }
 
+    def pollOverflow(): IOFiber[_] = {
+      val from = random.nextInt(threadCount)
+      var i = 0
+      var fiber: IOFiber[_] = null
+      while ((fiber eq null) && i < threadCount) {
+        val idx = (from + i) % threadCount
+        fiber = overflow(idx).poll()
+        i += 1
+      }
+      fiber
+    }
+
     while (!isInterrupted()) {
       ((state & OverflowQueueTicksMask): @switch) match {
         case 0 =>
           // Dequeue a fiber from the overflow queue.
-          val fiber = overflow.poll()
+          val fiber = pollOverflow()
           if (fiber ne null) {
             // Run the fiber.
             fiber.run()
@@ -240,7 +253,7 @@ private[effect] final class WorkerThread(
         case 1 =>
           // Dequeue a fiber from the overflow queue after a failed dequeue
           // from the local queue.
-          val fiber = overflow.poll()
+          val fiber = pollOverflow()
           if (fiber ne null) {
             // Run the fiber.
             fiber.run()
@@ -263,7 +276,9 @@ private[effect] final class WorkerThread(
 
         case 3 =>
           // Try stealing fibers from other worker threads.
-          val fiber = pool.stealFromOtherWorkerThread(index, random.nextInt(threadCount))
+          val workerIdx = random.nextInt(threadCount)
+          val overflowIdx = random.nextInt(threadCount)
+          val fiber = pool.stealFromOtherWorkerThread(index, workerIdx, overflowIdx)
           if (fiber ne null) {
             // Successful steal. Announce that the current thread is no longer
             // looking for work.
@@ -309,7 +324,7 @@ private[effect] final class WorkerThread(
 
         case 6 =>
           // Dequeue a fiber from the overflow queue.
-          val fiber = overflow.poll()
+          val fiber = pollOverflow()
           if (fiber ne null) {
             // Announce that the current thread is no longer looking for work.
             pool.transitionWorkerFromSearching(random.nextInt(threadCount))
@@ -370,7 +385,8 @@ private[effect] final class WorkerThread(
   override def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
     // Drain the local queue to the `overflow` queue.
     queue.drain(drain)
-    overflow.addAll(drain)
+    val idx = random.nextInt(threadCount)
+    overflow(idx).addAll(drain)
     drain.clear()
 
     if (blocking) {
@@ -386,7 +402,8 @@ private[effect] final class WorkerThread(
       blocking = true
 
       // Spawn a new `HelperThread`.
-      val helper = new HelperThread(threadPrefix, blockingThreadCounter, overflow, pool)
+      val helper =
+        new HelperThread(threadCount, threadPrefix, blockingThreadCounter, overflow, pool)
       helper.start()
 
       // With another `HelperThread` started, it is time to execute the blocking

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -248,7 +248,12 @@ private[effect] final class WorkerThread(
             // A batch of fibers has been successfully obtained. Proceed to
             // enqueue all of the fibers on the local queue and execute the
             // first one.
-            val fiber = queue.enqueueBatch(batch)
+            val fiber = batch(0)
+            var i = 1
+            while (i < OverflowBatchSize) {
+              queue.enqueue(batch(i), batched, overflow, random)
+              i += 1
+            }
             // Run the first fiber from the batch.
             fiber.run()
             // Transition to executing fibers from the local queue.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -50,6 +50,7 @@ private[effect] final class WorkerThread(
     private[this] val queue: LocalQueue,
     // The state of the `WorkerThread` (parked/unparked).
     private[this] val parked: AtomicBoolean,
+    private[this] val batched: ScalQueue[Array[IOFiber[_]]],
     // Overflow queue used by the local queue for offloading excess fibers, as well as
     // for drawing fibers when the local queue is exhausted.
     private[this] val overflow: ScalQueue[IOFiber[_]],
@@ -387,7 +388,13 @@ private[effect] final class WorkerThread(
 
       // Spawn a new `HelperThread`.
       val helper =
-        new HelperThread(threadCount, threadPrefix, blockingThreadCounter, overflow, pool)
+        new HelperThread(
+          threadCount,
+          threadPrefix,
+          blockingThreadCounter,
+          batched,
+          overflow,
+          pool)
       helper.start()
 
       // With another `HelperThread` started, it is time to execute the blocking

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -249,6 +249,9 @@ private[effect] final class WorkerThread(
             // enqueue all of the fibers on the local queue and execute the
             // first one.
             val fiber = queue.enqueueBatch(batch)
+            // Many fibers have been enqueued on the local queue. Notify other
+            // worker threads.
+            pool.notifyParked(rnd)
             // Directly run a fiber from the batch.
             fiber.run()
             // Transition to executing fibers from the local queue.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -248,12 +248,7 @@ private[effect] final class WorkerThread(
             // A batch of fibers has been successfully obtained. Proceed to
             // enqueue all of the fibers on the local queue and execute the
             // first one.
-            val fiber = batch(0)
-            var i = 1
-            while (i < OverflowBatchSize) {
-              queue.enqueue(batch(i), batched, overflow, random)
-              i += 1
-            }
+            val fiber = queue.enqueueBatch(batch)
             // Run the first fiber from the batch.
             fiber.run()
             // Transition to executing fibers from the local queue.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -249,7 +249,7 @@ private[effect] final class WorkerThread(
             // enqueue all of the fibers on the local queue and execute the
             // first one.
             val fiber = queue.enqueueBatch(batch)
-            // Run the first fiber from the batch.
+            // Directly run a fiber from the batch.
             fiber.run()
             // Transition to executing fibers from the local queue.
             state = 8


### PR DESCRIPTION
I dedicate this PR to @kubukoz. He challenged me to do better, so here it is.

Benchmark results on a 4 core MacBook Pro with hyperthreading (8 threads)
```
series/3.x
Benchmark (size) Mode Cnt Score Error Units
WorkStealingBenchmark.scheduling  1000000  thrpt   20  13.288 ± 0.368  ops/min
```

```
This PR
Benchmark (size) Mode Cnt Score Error Units
WorkStealingBenchmark.scheduling  1000000  thrpt   20  17.174 ± 0.441  ops/min
```

Benchmark results on a 16 vCPU cloud virtual machine (16 threads)
```
series/3.x
Benchmark                          (size)   Mode  Cnt   Score   Error    Units
WorkStealingBenchmark.scheduling  1000000  thrpt   20     16.775 ±    1.282  ops/min
```

```
This PR
Benchmark                          (size)   Mode  Cnt   Score   Error    Units
WorkStealingBenchmark.scheduling  1000000  thrpt   20  21.146 ± 1.909  ops/min
```

Opening as a draft because I want to work a bit more on the documentation. Some of it has gone stale.