### PR TITLE
Exactly emulate the old cont state mechanism

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -48,5 +48,6 @@ private[effect] object IOFiberConstants {
   // ContState tags
   val ContStateInitial: Int = 0
   val ContStateWaiting: Int = 1
-  val ContStateResult: Int = 2
+  val ContStateWinner: Int = 2
+  val ContStateResult: Int = 3
 }

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -48,5 +48,6 @@ final class IOFiberConstants {
   // ContState tags
   public static final int ContStateInitial = 0;
   public static final int ContStateWaiting = 1;
-  public static final int ContStateResult = 2;
+  public static final int ContStateWinner = 2;
+  public static final int ContStateResult = 3;
 }

--- a/core/shared/src/main/scala/cats/effect/ContState.scala
+++ b/core/shared/src/main/scala/cats/effect/ContState.scala
@@ -21,6 +21,6 @@ import java.util.concurrent.atomic.AtomicInteger
 // TODO rename
 // `result` is published by a volatile store on the atomic integer extended
 // by this class.
-private class ContState(var wasFinalizing: Boolean) extends AtomicInteger(0) {
+private final class ContState(var wasFinalizing: Boolean) extends AtomicInteger(0) {
   var result: Either[Throwable, Any] = _
 }


### PR DESCRIPTION
With #1634, I introduced a bug, by always blindly setting the `result` in the async callback. The reason we don't ever see it occur is because we make sure to not sequence the `Cont` `get` twice in our `async` implementation. But I believe this would be a visible issue when executing the async callback more than once and sequencing `get` more than once.

The solution is just another small step in the `ContState` mechanism which adds another value used exclusively for making the `result` value visible to other threads. As soon as a thread "wins" the privilege to set the result, it does and immediately publishes the result by changing the `ContState` again. This does not influence the `Get` mechanism, except in the short section where the intermediate value of `ContState` is visible. After the value has been changed again by the winner thread, the `result` is safe to read and will never be changed again.

There is no negative impact on performance. Proof:
```
series/3.x
[info] Benchmark                    (size)   Mode  Cnt      Score      Error  Units
[info] AsyncBenchmark.async            100  thrpt   20  16725.740 ±  217.911  ops/s
[info] AsyncBenchmark.bracket          100  thrpt   20  12660.225 ±  143.069  ops/s
[info] AsyncBenchmark.cancelable       100  thrpt   20  16825.642 ±  309.211  ops/s
[info] AsyncBenchmark.race             100  thrpt   20  20926.912 ±  808.158  ops/s
[info] AsyncBenchmark.racePair         100  thrpt   20  19911.614 ± 1019.030  ops/s
[info] AsyncBenchmark.start            100  thrpt   20   5865.932 ±  367.434  ops/s
[info] AsyncBenchmark.uncancelable     100  thrpt   20  26447.650 ±  352.700  ops/s
```

```
With this change
[info] Benchmark                    (size)   Mode  Cnt      Score      Error  Units
[info] AsyncBenchmark.async            100  thrpt   20  16690.321 ±  199.680  ops/s
[info] AsyncBenchmark.bracket          100  thrpt   20  13067.828 ±  168.756  ops/s
[info] AsyncBenchmark.cancelable       100  thrpt   20  16902.434 ±  327.712  ops/s
[info] AsyncBenchmark.race             100  thrpt   20  21376.103 ±  781.904  ops/s
[info] AsyncBenchmark.racePair         100  thrpt   20  20945.363 ± 1516.602  ops/s
[info] AsyncBenchmark.start            100  thrpt   20   6030.291 ±  121.567  ops/s
[info] AsyncBenchmark.uncancelable     100  thrpt   20  27149.332 ±  299.306  ops/s
```

All within the margins of error.