### PR TITLE
[Alternative to #1784] Exactly emulate the old cont state mechanism

### DIFF
--- a/core/shared/src/main/scala/cats/effect/ContState.scala
+++ b/core/shared/src/main/scala/cats/effect/ContState.scala
@@ -16,11 +16,17 @@
 
 package cats.effect
 
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 // TODO rename
 // `result` is published by a volatile store on the atomic integer extended
 // by this class.
-private class ContState(var wasFinalizing: Boolean) extends AtomicInteger(0) {
-  var result: Either[Throwable, Any] = _
+private final class ContState(var wasFinalizing: Boolean)
+    extends AtomicReference[ContState.Phase](ContState.Initial)
+
+object ContState {
+  sealed abstract class Phase
+  case object Initial extends Phase
+  case object Waiting extends Phase
+  final case class Result(result: Either[Throwable, Any]) extends Phase
 }


### PR DESCRIPTION
Same problem to solve as in #1784.

Less awkward implementation without busy waiting. This is probably better than #1784. But it will impact performance. Benchmarking now.

```
series/3.x
Benchmark                    (size)   Mode  Cnt      Score      Error  Units
AsyncBenchmark.async            100  thrpt   20  16725.740 ±  217.911  ops/s
AsyncBenchmark.bracket          100  thrpt   20  12660.225 ±  143.069  ops/s
AsyncBenchmark.cancelable       100  thrpt   20  16825.642 ±  309.211  ops/s
AsyncBenchmark.race             100  thrpt   20  20926.912 ±  808.158  ops/s
AsyncBenchmark.racePair         100  thrpt   20  19911.614 ± 1019.030  ops/s
AsyncBenchmark.start            100  thrpt   20   5865.932 ±  367.434  ops/s
AsyncBenchmark.uncancelable     100  thrpt   20  26447.650 ±  352.700  ops/s
```

```
With this change
Benchmark                    (size)   Mode  Cnt      Score      Error  Units
AsyncBenchmark.async            100  thrpt   20  15929.750 ±  411.636  ops/s
AsyncBenchmark.bracket          100  thrpt   20  12602.900 ±  222.989  ops/s
AsyncBenchmark.cancelable       100  thrpt   20  16294.542 ±  152.693  ops/s
AsyncBenchmark.race             100  thrpt   20  18560.839 ± 1375.054  ops/s
AsyncBenchmark.racePair         100  thrpt   20  18890.427 ± 1182.748  ops/s
AsyncBenchmark.start            100  thrpt   20   5148.700 ±  422.635  ops/s
AsyncBenchmark.uncancelable     100  thrpt   20  26360.871 ±  288.238  ops/s
```