### PR TITLE
Remove MonadThrow & ApplicativeThrow

### DIFF
--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -51,18 +51,6 @@ package object effect {
   type Async[F[_]] = cekernel.Async[F]
   val Async = cekernel.Async
 
-  type ApplicativeThrow[F[_]] = cekernel.ApplicativeThrow[F]
-
-  object ApplicativeThrow {
-    def apply[F[_]](implicit F: ApplicativeThrow[F]): F.type = F
-  }
-
-  type MonadThrow[F[_]] = cekernel.MonadThrow[F]
-
-  object MonadThrow {
-    def apply[F[_]](implicit F: MonadThrow[F]): F.type = F
-  }
-
   type MonadCancelThrow[F[_]] = cekernel.MonadCancelThrow[F]
 
   object MonadCancelThrow {

--- a/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
@@ -16,12 +16,8 @@
 
 package cats.effect
 
-import cats.{ApplicativeError, MonadError}
-
 package object kernel {
 
-  type ApplicativeThrow[F[_]] = ApplicativeError[F, Throwable]
-  type MonadThrow[F[_]] = MonadError[F, Throwable]
   type MonadCancelThrow[F[_]] = MonadCancel[F, Throwable]
 
   type Spawn[F[_]] = GenSpawn[F, Throwable]


### PR DESCRIPTION
These aliases are now part of cats, so having them in CE is redundant and a possible source of confusion.