### PR TITLE
Compute and local queue MBeans

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -363,7 +363,12 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#IOCont.copy"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#IOCont.this"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
-        "cats.effect.unsafe.IORuntimeCompanionPlatform.installGlobal")
+        "cats.effect.unsafe.IORuntimeCompanionPlatform.installGlobal"),
+      // introduced by #1789, MBeans
+      // changes to package private code
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "cats.effect.unsafe.HelperThread.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.unsafe.WorkerThread.this")
     )
   )
   .jvmSettings(

--- a/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -26,6 +26,8 @@ private[effect] sealed abstract class WorkStealingThreadPool private ()
     extends ExecutionContext {
   def execute(runnable: Runnable): Unit
   def reportFailure(cause: Throwable): Unit
+  private[effect] def registerSuspendedFiber(): Unit
+  private[effect] def deregisterSuspendedFiber(): Unit
   private[effect] def executeFiber(fiber: IOFiber[_]): Unit
   private[effect] def rescheduleFiber(fiber: IOFiber[_]): Unit
   private[effect] def scheduleFiber(fiber: IOFiber[_]): Unit

--- a/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -28,6 +28,7 @@ private[effect] sealed abstract class WorkStealingThreadPool private ()
   def reportFailure(cause: Throwable): Unit
   private[effect] def registerSuspendedFiber(): Unit
   private[effect] def deregisterSuspendedFiber(): Unit
+  private[effect] def recordStartedFiber(): Unit
   private[effect] def executeFiber(fiber: IOFiber[_]): Unit
   private[effect] def rescheduleFiber(fiber: IOFiber[_]): Unit
   private[effect] def scheduleFiber(fiber: IOFiber[_]): Unit

--- a/core/jvm/src/main/java/cats/effect/unsafe/MetricsConstants.java
+++ b/core/jvm/src/main/java/cats/effect/unsafe/MetricsConstants.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.unsafe;
+
+import java.util.Optional;
+
+class MetricsConstants {
+
+  public static final boolean metricsEnabled = Optional.ofNullable(System.getProperty("cats.effect.metrics"))
+      .map(Boolean::valueOf).orElse(false);
+}

--- a/core/jvm/src/main/java/cats/effect/unsafe/MetricsConstants.java
+++ b/core/jvm/src/main/java/cats/effect/unsafe/MetricsConstants.java
@@ -21,5 +21,5 @@ import java.util.Optional;
 class MetricsConstants {
 
   public static final boolean metricsEnabled = Optional.ofNullable(System.getProperty("cats.effect.metrics"))
-      .map(Boolean::valueOf).orElse(false);
+      .map(Boolean::valueOf).orElse(true);
 }

--- a/core/jvm/src/main/scala/cats/effect/metrics/ComputePoolSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/ComputePoolSamplerMBean.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package metrics
+
+/**
+ * An MBean interface for monitoring the [[IO]] work stealing compute pool.
+ */
+trait ComputePoolSamplerMBean

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -32,12 +32,23 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
   def createDefaultComputeThreadPool(
       self: => IORuntime,
       threads: Int = Math.max(2, Runtime.getRuntime().availableProcessors()),
-      threadPrefix: String = "io-compute"): (WorkStealingThreadPool, () => Unit) = {
+      threadPrefix: String = "io-compute"): (WorkStealingThreadPool, () => Unit) =
+    createDefaultComputeThreadPoolWithMBeansConfig(
+      self,
+      threads,
+      threadPrefix,
+      MetricsConstants.metricsEnabled)
+
+  private[unsafe] def createDefaultComputeThreadPoolWithMBeansConfig(
+      self: => IORuntime,
+      threads: Int = Math.max(2, Runtime.getRuntime().availableProcessors()),
+      threadPrefix: String = "io-compute",
+      registerMBeans: Boolean): (WorkStealingThreadPool, () => Unit) = {
     val threadPool =
       new WorkStealingThreadPool(threads, threadPrefix, self)
 
     val unregisterMBeans =
-      if (MetricsConstants.metricsEnabled) {
+      if (registerMBeans) {
         val mBeanServer =
           try ManagementFactory.getPlatformMBeanServer()
           catch {

--- a/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
@@ -676,6 +676,20 @@ private final class LocalQueue {
   def nonEmpty(): Boolean = !isEmpty()
 
   /**
+   * Returns the number of currently enqueued fibers in this queue.
+   *
+   * @note This number is an approximation and may not be correct while
+   *       stealing is taking place.
+   *
+   * @return the number of currently enqueued fibers in this queue
+   */
+  def size(): Int = {
+    val hd = head.get()
+    val tl = tailPublisher.get()
+    unsignedShortSubtraction(tl, lsb(hd))
+  }
+
+  /**
    * A ''plain'' load of the `tail` of the queue.
    *
    * Serves mostly as a forwarder method such that `tail` can remain

--- a/core/jvm/src/main/scala/cats/effect/unsafe/ScalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/ScalQueue.scala
@@ -173,6 +173,24 @@ private final class ScalQueue[A <: AnyRef](threadCount: Int) {
     !isEmpty()
 
   /**
+   * Returns the number of elements enqueued on this Scal queue.
+   *
+   * @return the number of elements enqueued on this Scal queue
+   */
+  def size(): Int = {
+    val nq = numQueues
+    var i = 0
+    var result = 0
+
+    while (i < nq) {
+      result += queues(i).size()
+      i += 1
+    }
+
+    result
+  }
+
+  /**
    * Clears all concurrent queues that make up this Scal queue.
    */
   def clear(): Unit = {

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -115,7 +115,7 @@ private[effect] final class WorkStealingThreadPool(
    * whose asynchronous callback has not been executed yet). Does not include
    * fibers which have not started execution at all.
    */
-  private[this] val suspendedFiberCounter: LongAdder = new LongAdder()
+  private[this] val suspendedFiberGauge: LongAdder = new LongAdder()
 
   /**
    * The shutdown latch of the work stealing thread pool.
@@ -360,7 +360,7 @@ private[effect] final class WorkStealingThreadPool(
    */
   private[effect] def registerSuspendedFiber(): Unit = {
     if (MetricsConstants.metricsEnabled) {
-      suspendedFiberCounter.increment()
+      suspendedFiberGauge.increment()
     }
   }
 
@@ -370,7 +370,7 @@ private[effect] final class WorkStealingThreadPool(
    */
   private[effect] def deregisterSuspendedFiber(): Unit = {
     if (MetricsConstants.metricsEnabled) {
-      suspendedFiberCounter.decrement()
+      suspendedFiberGauge.decrement()
     }
   }
 
@@ -639,7 +639,7 @@ private[effect] final class WorkStealingThreadPool(
    * @return the number of suspended fibers
    */
   private[unsafe] def getSuspendedFiberCount: Int =
-    suspendedFiberCounter.intValue()
+    suspendedFiberGauge.intValue()
 
   /**
    * Returns the number of fibers currently assigned to the monitored compute

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -578,4 +578,26 @@ private[effect] final class WorkStealingThreadPool(
    */
   def getBatchedQueueFiberCount: Int =
     batchedQueue.size() * OverflowBatchSize
+
+  /**
+   * Returns the number of fibers enqueued in the local queues of the worker
+   * threads. This is an aggregate number consisting of metrics from all
+   * worker threads.
+   *
+   * @note This method is a part of the
+   *       [[cats.effect.unsafe.metrics.ComputePoolSamplerMBean]] interface.
+   *
+   * @return the number of fibers enqueued in the local queues
+   */
+  def getLocalQueueFiberCount: Int = {
+    var i = 0
+    var count = 0
+
+    while (i < threadCount) {
+      count += localQueues(i).size()
+      i += 1
+    }
+
+    count
+  }
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -545,6 +545,13 @@ private[effect] final class WorkStealingThreadPool(
   }
 
   /**
+   * A forwarder method to `localQueues`.
+   *
+   * @return a reference to the global array of local queues
+   */
+  private[unsafe] def getLocalQueues: Array[LocalQueue] = localQueues
+
+  /**
    * Returns the number of worker threads in this thread pool.
    *
    * @note This method is a part of the

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -552,4 +552,16 @@ private[effect] final class WorkStealingThreadPool(
    */
   private[unsafe] def getActiveHelperThreadCount: Int =
     activeHelperThreadGauge.get()
+
+  /**
+   * Returns the number of fibers enqueued on the overflow queue. This queue
+   * also accepts fibers scheduled for execution by external threads.
+   *
+   * @note This method is a part of the
+   *       [[cats.effect.unsafe.metrics.ComputePoolSamplerMBean]] interface.
+   *
+   * @return the number of fibers enqueued on the overflow queue
+   */
+  private[unsafe] def getOverflowQueueFiberCount: Int =
+    overflowQueue.size()
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -59,6 +59,7 @@ private[effect] final class WorkStealingThreadPool(
     self0: => IORuntime
 ) extends ExecutionContext {
 
+  import LocalQueueConstants.OverflowBatchSize
   import WorkStealingThreadPoolConstants._
 
   /**
@@ -564,4 +565,17 @@ private[effect] final class WorkStealingThreadPool(
    */
   private[unsafe] def getOverflowQueueFiberCount: Int =
     overflowQueue.size()
+
+  /**
+   * Returns the number of fibers enqueued on the batched queue. This queue
+   * holds batches of fibers for more efficient transfer between worker threads.
+   * Each batch contains `129` fibers.
+   *
+   * @note This method is a part of the
+   *       [[cats.effect.unsafe.metrics.ComputePoolSamplerMBean]] interface.
+   *
+   * @return the number of fibers enqueued on the batched queue
+   */
+  def getBatchedQueueFiberCount: Int =
+    batchedQueue.size() * OverflowBatchSize
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -496,4 +496,14 @@ private[effect] final class WorkStealingThreadPool(
       Thread.currentThread().interrupt()
     }
   }
+
+  /**
+   * Returns the number of worker threads in this thread pool.
+   *
+   * @note This method is a part of the
+   *       [[cats.effect.unsafe.metrics.ComputePoolSamplerMBean]] interface.
+   *
+   * @return the number of worker threads in this thread pool
+   */
+  private[unsafe] def getWorkerThreadCount: Int = threadCount
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -506,4 +506,17 @@ private[effect] final class WorkStealingThreadPool(
    * @return the number of worker threads in this thread pool
    */
   private[unsafe] def getWorkerThreadCount: Int = threadCount
+
+  /**
+   * Returns the number of active worker threads currently executing fibers.
+   *
+   * @note This method is a part of the
+   *       [[cats.effect.unsafe.metrics.ComputePoolSamplerMBean]] interface.
+   *
+   * @return the number of currently active worker threads
+   */
+  private[unsafe] def getActiveThreadCount: Int = {
+    val st = state.get()
+    (st & UnparkMask) >>> UnparkShift
+  }
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -519,4 +519,18 @@ private[effect] final class WorkStealingThreadPool(
     val st = state.get()
     (st & UnparkMask) >>> UnparkShift
   }
+
+  /**
+   * Returns the number of worker threads searching for work to steal from other
+   * worker threads.
+   *
+   * @note This method is a part of the
+   *       [[cats.effect.unsafe.metrics.ComputePoolSamplerMBean]] interface.
+   *
+   * @return the number of worker threads searching for work
+   */
+  private[unsafe] def getSearchingThreadCount: Int = {
+    val st = state.get()
+    st & SearchMask
+  }
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -640,4 +640,22 @@ private[effect] final class WorkStealingThreadPool(
    */
   private[unsafe] def getSuspendedFiberCount: Int =
     suspendedFiberCounter.intValue()
+
+  /**
+   * Returns the number of fibers currently assigned to the monitored compute
+   * pool. This includes fibers enqueued on the local queues, the batched queue,
+   * the overflow queue and suspended fibers.
+   *
+   * @note This method is a part of the
+   *       [[cats.effect.unsafe.metrics.ComputePoolSamplerMBean]] interface.
+   *
+   * @return the number of fibers currently assigned to the compute pool
+   */
+  private[unsafe] def getActiveFiberCount: Int = {
+    val r1 = getLocalQueueFiberCount
+    val r2 = getBatchedQueueFiberCount
+    val r3 = getOverflowQueueFiberCount
+    val r4 = getSuspendedFiberCount
+    r1 + r2 + r3 + r4
+  }
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -43,6 +43,8 @@ private final class WorkerThread(
     private[this] val threadPrefix: String,
     // Instance to a global counter used when naming new instances of `HelperThread`.
     private[this] val blockingThreadCounter: AtomicInteger,
+    // Instance to a global gauge used for tracking the number of active `HelperThread`s.
+    private[this] val activeHelperThreadGauge: AtomicInteger,
     // Local queue instance with exclusive write access.
     private[this] val queue: LocalQueue,
     // The state of the `WorkerThread` (parked/unparked).
@@ -453,7 +455,13 @@ private final class WorkerThread(
 
         // Spawn a new `HelperThread`.
         val helper =
-          new HelperThread(threadPrefix, blockingThreadCounter, batched, overflow, pool)
+          new HelperThread(
+            threadPrefix,
+            blockingThreadCounter,
+            activeHelperThreadGauge,
+            batched,
+            overflow,
+            pool)
         helper.start()
 
         // With another `HelperThread` started, it is time to execute the blocking

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
@@ -32,4 +32,5 @@ final class ComputePoolSampler(pool: WorkStealingThreadPool) extends ComputePool
   def getBatchedQueueFiberCount: Int = pool.getBatchedQueueFiberCount
   def getLocalQueueFiberCount: Int = pool.getLocalQueueFiberCount
   def getSuspendedFiberCount: Int = pool.getSuspendedFiberCount
+  def getActiveFiberCount: Int = pool.getActiveFiberCount
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
@@ -25,4 +25,5 @@ package metrics
  */
 final class ComputePoolSampler(pool: WorkStealingThreadPool) extends ComputePoolSamplerMBean {
   def getWorkerThreadCount: Int = pool.getWorkerThreadCount
+  def getActiveThreadCount: Int = pool.getActiveThreadCount
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
@@ -29,4 +29,5 @@ final class ComputePoolSampler(pool: WorkStealingThreadPool) extends ComputePool
   def getSearchingThreadCount: Int = pool.getSearchingThreadCount
   def getActiveHelperThreadCount: Int = pool.getActiveHelperThreadCount
   def getOverflowQueueFiberCount: Int = pool.getOverflowQueueFiberCount
+  def getBatchedQueueFiberCount: Int = pool.getBatchedQueueFiberCount
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
@@ -30,4 +30,5 @@ final class ComputePoolSampler(pool: WorkStealingThreadPool) extends ComputePool
   def getActiveHelperThreadCount: Int = pool.getActiveHelperThreadCount
   def getOverflowQueueFiberCount: Int = pool.getOverflowQueueFiberCount
   def getBatchedQueueFiberCount: Int = pool.getBatchedQueueFiberCount
+  def getLocalQueueFiberCount: Int = pool.getLocalQueueFiberCount
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
@@ -27,4 +27,5 @@ final class ComputePoolSampler(pool: WorkStealingThreadPool) extends ComputePool
   def getWorkerThreadCount: Int = pool.getWorkerThreadCount
   def getActiveThreadCount: Int = pool.getActiveThreadCount
   def getSearchingThreadCount: Int = pool.getSearchingThreadCount
+  def getActiveHelperThreadCount: Int = pool.getActiveHelperThreadCount
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
@@ -33,4 +33,5 @@ final class ComputePoolSampler(pool: WorkStealingThreadPool) extends ComputePool
   def getLocalQueueFiberCount: Int = pool.getLocalQueueFiberCount
   def getSuspendedFiberCount: Int = pool.getSuspendedFiberCount
   def getActiveFiberCount: Int = pool.getActiveFiberCount
+  def getLifetimeFiberCount: Long = pool.getLifetimeFiberCount
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
@@ -17,12 +17,11 @@
 package cats.effect.unsafe
 package metrics
 
-import cats.effect.metrics.ComputePoolSamplerMBean
-
 /**
- * An implementation of the [[cats.effect.metrics.ComputePoolSamplerMBean]] for
- * monitoring the default [[cats.effect.unsafe.IORuntime]] compute pool backed
- * by [[cats.effect.unsafe.WorkStealingThreadPool]].
+ * An implementation of the
+ * [[cats.effect.unsafe.metrics.ComputePoolSamplerMBean]] for monitoring the
+ * default [[cats.effect.unsafe.IORuntime]] compute pool backed by a
+ * `cats.effect.unsafe.WorkStealingThreadPool`.
  */
 final class ComputePoolSampler(pool: WorkStealingThreadPool) extends ComputePoolSamplerMBean {
   locally {

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
@@ -28,4 +28,5 @@ final class ComputePoolSampler(pool: WorkStealingThreadPool) extends ComputePool
   def getActiveThreadCount: Int = pool.getActiveThreadCount
   def getSearchingThreadCount: Int = pool.getSearchingThreadCount
   def getActiveHelperThreadCount: Int = pool.getActiveHelperThreadCount
+  def getOverflowQueueFiberCount: Int = pool.getOverflowQueueFiberCount
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
@@ -24,7 +24,5 @@ package metrics
  * `cats.effect.unsafe.WorkStealingThreadPool`.
  */
 final class ComputePoolSampler(pool: WorkStealingThreadPool) extends ComputePoolSamplerMBean {
-  locally {
-    val _ = pool
-  }
+  def getWorkerThreadCount: Int = pool.getWorkerThreadCount
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
@@ -26,4 +26,5 @@ package metrics
 final class ComputePoolSampler(pool: WorkStealingThreadPool) extends ComputePoolSamplerMBean {
   def getWorkerThreadCount: Int = pool.getWorkerThreadCount
   def getActiveThreadCount: Int = pool.getActiveThreadCount
+  def getSearchingThreadCount: Int = pool.getSearchingThreadCount
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
@@ -23,7 +23,8 @@ package metrics
  * default [[cats.effect.unsafe.IORuntime]] compute pool backed by a
  * `cats.effect.unsafe.WorkStealingThreadPool`.
  */
-final class ComputePoolSampler(pool: WorkStealingThreadPool) extends ComputePoolSamplerMBean {
+private[unsafe] final class ComputePoolSampler(pool: WorkStealingThreadPool)
+    extends ComputePoolSamplerMBean {
   def getWorkerThreadCount: Int = pool.getWorkerThreadCount
   def getActiveThreadCount: Int = pool.getActiveThreadCount
   def getSearchingThreadCount: Int = pool.getSearchingThreadCount

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.unsafe
+package metrics
+
+import cats.effect.metrics.ComputePoolSamplerMBean
+
+/**
+ * An implementation of the [[cats.effect.metrics.ComputePoolSamplerMBean]] for
+ * monitoring the default [[cats.effect.unsafe.IORuntime]] compute pool backed
+ * by [[cats.effect.unsafe.WorkStealingThreadPool]].
+ */
+final class ComputePoolSampler(pool: WorkStealingThreadPool) extends ComputePoolSamplerMBean {
+  locally {
+    val _ = pool
+  }
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
@@ -31,4 +31,5 @@ final class ComputePoolSampler(pool: WorkStealingThreadPool) extends ComputePool
   def getOverflowQueueFiberCount: Int = pool.getOverflowQueueFiberCount
   def getBatchedQueueFiberCount: Int = pool.getBatchedQueueFiberCount
   def getLocalQueueFiberCount: Int = pool.getLocalQueueFiberCount
+  def getSuspendedFiberCount: Int = pool.getSuspendedFiberCount
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
@@ -86,4 +86,13 @@ trait ComputePoolSamplerMBean {
    * @return the number of suspended fibers
    */
   def getSuspendedFiberCount: Int
+
+  /**
+   * Returns the number of fibers currently assigned to the monitored compute
+   * pool. This includes fibers enqueued on the local queues, the batched queue,
+   * the overflow queue and suspended fibers.
+   *
+   * @return the number of fibers currently assigned to the compute pool
+   */
+  def getActiveFiberCount: Int
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
@@ -20,4 +20,12 @@ package metrics
 /**
  * An MBean interface for monitoring the [[IO]] work stealing compute pool.
  */
-trait ComputePoolSamplerMBean
+trait ComputePoolSamplerMBean {
+
+  /**
+   * Returns the number of worker threads in the compute pool.
+   *
+   * @return the number of worker threads in the compute pool
+   */
+  def getWorkerThreadCount: Int
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
@@ -43,4 +43,12 @@ trait ComputePoolSamplerMBean {
    * @return the number of worker threads searching for work
    */
   def getSearchingThreadCount: Int
+
+  /**
+   * Returns the number of currently active helper threads substituting for
+   * worker threads currently executing blocking actions.
+   *
+   * @return the number of currently active helper threads
+   */
+  def getActiveHelperThreadCount: Int
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package cats.effect
+package cats.effect.unsafe
 package metrics
 
 /**

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
@@ -28,4 +28,11 @@ trait ComputePoolSamplerMBean {
    * @return the number of worker threads in the compute pool
    */
   def getWorkerThreadCount: Int
+
+  /**
+   * Returns the number of active worker threads currently executing fibers.
+   *
+   * @return the number of currently active worker threads
+   */
+  def getActiveThreadCount: Int
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
@@ -77,4 +77,13 @@ trait ComputePoolSamplerMBean {
    * @return the number of fibers enqueued in the local queues
    */
   def getLocalQueueFiberCount: Int
+
+  /**
+   * Returns the number of suspended fibers (fibers whose asynchronous callback
+   * has not been executed yet. Includes fibers executing `IO.async` or
+   * `IO#sleep` calls.
+   *
+   * @return the number of suspended fibers
+   */
+  def getSuspendedFiberCount: Int
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
@@ -68,4 +68,13 @@ trait ComputePoolSamplerMBean {
    * @return the number of fibers enqueued on the batched queue
    */
   def getBatchedQueueFiberCount: Int
+
+  /**
+   * Returns the number of fibers enqueued in the local queues of the worker
+   * threads. This is an aggregate number consisting of metrics from all
+   * worker threads.
+   *
+   * @return the number of fibers enqueued in the local queues
+   */
+  def getLocalQueueFiberCount: Int
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
@@ -51,4 +51,12 @@ trait ComputePoolSamplerMBean {
    * @return the number of currently active helper threads
    */
   def getActiveHelperThreadCount: Int
+
+  /**
+   * Returns the number of fibers enqueued on the overflow queue. This queue
+   * also accepts fibers scheduled for execution by external threads.
+   *
+   * @return the number of fibers enqueued on the overflow queue
+   */
+  def getOverflowQueueFiberCount: Int
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
@@ -35,4 +35,12 @@ trait ComputePoolSamplerMBean {
    * @return the number of currently active worker threads
    */
   def getActiveThreadCount: Int
+
+  /**
+   * Returns the number of worker threads searching for fibers to steal from
+   * other worker threads.
+   *
+   * @return the number of worker threads searching for work
+   */
+  def getSearchingThreadCount: Int
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
@@ -95,4 +95,12 @@ trait ComputePoolSamplerMBean {
    * @return the number of fibers currently assigned to the compute pool
    */
   def getActiveFiberCount: Int
+
+  /**
+   * Returns the total number of fibers started on the compute pool during its
+   * whole lifetime.
+   *
+   * @return the total number of fibers started on the compute pool
+   */
+  def getLifetimeFiberCount: Long
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
@@ -20,7 +20,7 @@ package metrics
 /**
  * An MBean interface for monitoring the [[IO]] work stealing compute pool.
  */
-trait ComputePoolSamplerMBean {
+private[unsafe] trait ComputePoolSamplerMBean {
 
   /**
    * Returns the number of worker threads in the compute pool.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
@@ -59,4 +59,13 @@ trait ComputePoolSamplerMBean {
    * @return the number of fibers enqueued on the overflow queue
    */
   def getOverflowQueueFiberCount: Int
+
+  /**
+   * Returns the number of fibers enqueued on the batched queue. This queue
+   * holds batches of fibers for more efficient transfer between worker threads.
+   * Each batch contains `129` fibers.
+   *
+   * @return the number of fibers enqueued on the batched queue
+   */
+  def getBatchedQueueFiberCount: Int
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/LocalQueueSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/LocalQueueSampler.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.unsafe
+package metrics
+
+final class LocalQueueSampler(queue: LocalQueue) extends LocalQueueSamplerMBean {
+  locally {
+    val _ = queue
+  }
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/LocalQueueSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/LocalQueueSampler.scala
@@ -17,7 +17,8 @@
 package cats.effect.unsafe
 package metrics
 
-final class LocalQueueSampler(queue: LocalQueue) extends LocalQueueSamplerMBean {
+private[unsafe] final class LocalQueueSampler(queue: LocalQueue)
+    extends LocalQueueSamplerMBean {
   locally {
     val _ = queue
   }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/LocalQueueSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/LocalQueueSamplerMBean.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.unsafe.metrics
+
+/**
+ * An MBean interface for monitoring a single worker thread local queue.
+ */
+trait LocalQueueSamplerMBean

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/LocalQueueSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/LocalQueueSamplerMBean.scala
@@ -19,4 +19,4 @@ package cats.effect.unsafe.metrics
 /**
  * An MBean interface for monitoring a single worker thread local queue.
  */
-trait LocalQueueSamplerMBean
+private[unsafe] trait LocalQueueSamplerMBean

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1151,7 +1151,10 @@ private final class IOFiber[A](
   private[this] def execR(): Unit = {
     // println(s"$name: starting at ${Thread.currentThread().getName} + ${suspended.get()}")
 
-    resumeTag = DoneR
+    if (currentCtx.isInstanceOf[WorkStealingThreadPool]) {
+      currentCtx.asInstanceOf[WorkStealingThreadPool].recordStartedFiber()
+    }
+
     if (canceled) {
       done(IOFiber.OutcomeCanceled.asInstanceOf[OutcomeIO[A]])
     } else {

--- a/tests/jvm/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
@@ -35,9 +35,10 @@ class StripedHashtableSpec extends BaseSpec with Runners {
       val (scheduler, schedDown) =
         IORuntime.createDefaultScheduler(threadPrefix = s"io-scheduler-${getClass.getName}")
       val (compute, compDown) =
-        IORuntime.createDefaultComputeThreadPool(
+        IORuntime.createDefaultComputeThreadPoolWithMBeansConfig(
           rt,
-          threadPrefix = s"io-compute-${getClass.getName}")
+          threadPrefix = s"io-compute-${getClass.getName}",
+          registerMBeans = false)
 
       new IORuntime(
         compute,


### PR DESCRIPTION
A stab at #1568.

The MBean registration and deregistration logic is a bit of a mess. It was actually crashing the tests because of duplicate MBeans. I think I managed to find a somewhat nice solution.

@Daenyth Let me know what you think. This is my first ever exposure to MBeans, so any feedback is greatly appreciated.