### PR TITLE
Replace interruptible with blocking in Console.readLine

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Console.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Console.scala
@@ -239,7 +239,7 @@ object Console {
 
   private final class SyncConsole[F[_]](implicit F: Sync[F]) extends Console[F] {
     def readLineWithCharset(charset: Charset): F[String] =
-      F.interruptible(false) {
+      F.blocking {
         val in = System.in
         val decoder = charset
           .newDecoder()


### PR DESCRIPTION
Fixes #1793 