### PR TITLE
Shutdown the runtime after notifying all listeners

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -145,7 +145,6 @@ private final class IOFiber[A](
       }
     } catch {
       case t: Throwable =>
-        runtime.shutdown()
         Thread.interrupted()
         currentCtx.reportFailure(t)
         runtime.fiberErrorCbs.synchronized {
@@ -159,6 +158,7 @@ private final class IOFiber[A](
             idx += 1
           }
         }
+        runtime.shutdown()
         Thread.currentThread().interrupt()
     }
   }

--- a/tests/shared/src/test/scala/cats/effect/std/DequeueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DequeueSpec.scala
@@ -189,8 +189,7 @@ class UnboundedDequeueSpec extends BaseSpec with QueueTests[Dequeue] {
       tryOffer: (Dequeue[IO, Int], Int) => IO[Boolean],
       take: Dequeue[IO, Int] => IO[Int],
       tryTake: Dequeue[IO, Int] => IO[Option[Int]],
-      size: Dequeue[IO, Int] => IO[Int],
-  ): Fragments = {
+      size: Dequeue[IO, Int] => IO[Int]): Fragments = {
     tryOfferOnFullTests(name, _ => constructor, offer, tryOffer, true)
     tryOfferTryTakeTests(name, _ => constructor, tryOffer, tryTake)
     commonTests(name, _ => constructor, offer, tryOffer, take, tryTake, size)


### PR DESCRIPTION
A fix for the issue first encountered in #1795.

I have decided that nulling out the internal implementation objects of the `WorkStealingThreadPool` is too strict, as the shutdown of the pool can be concurrent to other fibers being rescheduled back on the pool (such as in the case of a fiber blocking on the `blocking` EC, trying to continue on the compute pool). The scheduling of the fiber can take place, but there are no worker threads anymore to execute that fiber. The worker threads are still being interrupted and finalized properly (including `join`ing them), as part of the shutdown of the pool. As a bonus, we can always allow a fiber to be scheduled on the pool, without checking the status of the pool, and thus saving a volatile read when rescheduling a fiber from an external thread.