### PR TITLE
Opened uncancelable region to the right

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -615,7 +615,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
   def to[F[_]](implicit F: LiftIO[F]): F[A @uncheckedVariance] =
     F.liftIO(this)
 
-  // override def toString: String = "IO(...)"
+  override def toString: String = "IO(...)"
 
   // unsafe stuff
 

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -246,7 +246,7 @@ private final class IOFiber[A](
       // iteration 0.
       val nextIteration = iteration + 1
 
-      // println(s"<$name> looping on $cur0")
+      // System.out.println(s"looping on $cur0")
       /*
        * The cases have to use continuous constants to generate a `tableswitch`.
        * Do not name or reorder them.
@@ -860,7 +860,7 @@ private final class IOFiber[A](
   }
 
   private[this] def asyncCancel(cb: Either[Throwable, Unit] => Unit): Unit = {
-    // println(s"<$name> running cancelation (finalizers.length = ${finalizers.unsafeIndex()})")
+    // System.out.println(s"running cancelation (finalizers.length = ${finalizers.unsafeIndex()})")
     finalizing = true
 
     if (!finalizers.isEmpty()) {
@@ -1238,24 +1238,14 @@ private final class IOFiber[A](
 
   private[this] def uncancelableSuccessK(result: Any, depth: Int): IO[Any] = {
     masks -= 1
-
-    if (shouldFinalize()) {
-      asyncCancel(null)
-      IOEndFiber
-    } else {
-      succeeded(result, depth + 1)
-    }
+    // System.out.println(s"unmasking after uncancelable (isUnmasked = ${isUnmasked()})")
+    succeeded(result, depth + 1)
   }
 
   private[this] def uncancelableFailureK(t: Throwable, depth: Int): IO[Any] = {
     masks -= 1
-
-    if (shouldFinalize()) {
-      asyncCancel(null)
-      IOEndFiber
-    } else {
-      failed(t, depth + 1)
-    }
+    // System.out.println(s"unmasking after uncancelable (isUnmasked = ${isUnmasked()})")
+    failed(t, depth + 1)
   }
 
   private[this] def unmaskSuccessK(result: Any, depth: Int): IO[Any] = {

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -363,7 +363,7 @@ trait MonadCancel[F[_], E] extends MonadError[F, E] {
         val finalized = onCancel(poll(F.unit >> use(a)), safeRelease(a, Outcome.Canceled()))
         val handled = finalized.onError {
           case e =>
-            safeRelease(a, Outcome.Errored(e)).attempt.void
+            safeRelease(a, Outcome.Errored(e)).handleError(_ => ())
         }
         handled.flatMap { b => safeRelease(a, Outcome.Succeeded(b.pure)).as(b) }
       }

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -28,12 +28,12 @@ trait AsyncLaws[F[_]] extends GenTemporalLaws[F, Throwable] with SyncLaws[F] {
 
   // format: off
   def asyncRightIsUncancelableSequencedPure[A](a: A, fu: F[Unit]) =
-    F.async[A](k => F.delay(k(Right(a))) >> fu.as(None)) <-> (F.uncancelable(_ => fu) >> F.pure(a))
+    (F.async[A](k => F.delay(k(Right(a))) >> fu.as(None)) <* F.unit) <-> (F.uncancelable(_ => fu) >> F.pure(a))
   // format: on
 
   // format: off
   def asyncLeftIsUncancelableSequencedRaiseError[A](e: Throwable, fu: F[Unit]) =
-    F.async[A](k => F.delay(k(Left(e))) >> fu.as(None)) <-> (F.uncancelable(_ => fu) >> F.raiseError(e))
+    (F.async[A](k => F.delay(k(Left(e))) >> fu.as(None)) <* F.unit) <-> (F.uncancelable(_ => fu) >> F.raiseError(e))
   // format: on
 
   def asyncRepeatedCallbackIgnored[A](a: A) =

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
@@ -67,7 +67,6 @@ trait AsyncTests[F[_]] extends GenTemporalTests[F, Throwable] with SyncTests[F] 
       iso: Isomorphisms[F],
       faPP: F[A] => Pretty,
       fuPP: F[Unit] => Pretty,
-      aFUPP: (A => F[Unit]) => Pretty,
       ePP: Throwable => Pretty,
       foaPP: F[Outcome[F, Throwable, A]] => Pretty,
       feauPP: F[Either[A, Unit]] => Pretty,

--- a/laws/shared/src/main/scala/cats/effect/laws/GenSpawnTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenSpawnTests.scala
@@ -57,7 +57,6 @@ trait GenSpawnTests[F[_], E] extends MonadCancelTests[F, E] with UniqueTests[F] 
       iso: Isomorphisms[F],
       faPP: F[A] => Pretty,
       fuPP: F[Unit] => Pretty,
-      aFUPP: (A => F[Unit]) => Pretty,
       ePP: E => Pretty,
       foaPP: F[Outcome[F, E, A]] => Pretty,
       feauPP: F[Either[A, Unit]] => Pretty,

--- a/laws/shared/src/main/scala/cats/effect/laws/GenTemporalTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenTemporalTests.scala
@@ -63,7 +63,6 @@ trait GenTemporalTests[F[_], E] extends GenSpawnTests[F, E] with ClockTests[F] {
       iso: Isomorphisms[F],
       faPP: F[A] => Pretty,
       fuPP: F[Unit] => Pretty,
-      aFUPP: (A => F[Unit]) => Pretty,
       ePP: E => Pretty,
       foaPP: F[Outcome[F, E, A]] => Pretty,
       feauPP: F[Either[A, Unit]] => Pretty,

--- a/laws/shared/src/main/scala/cats/effect/laws/MonadCancelLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/MonadCancelLaws.scala
@@ -76,11 +76,6 @@ trait MonadCancelLaws[F[_], E] extends MonadErrorLaws[F, E] {
     F.onCancel(F.onCancel(F.canceled, fin1), fin2) <->
       F.forceR(F.uncancelable(_ => F.forceR(fin1)(fin2)))(F.canceled)
 
-  // the following set of three laws is formulated in this way to exclude F.never
-  // notably, `F.uncancelable(_ => F.canceled >> fa) >> F.never` results in cancelation
-  // however, `F.uncancelable(_ => fa) >> F.forceR(F.never)(F.canceled)` is nonterminating
-  // these are the semantics we want, but it also means the rewrite rule cannot be generalized
-
   def uncancelableCanceledAssociatesRightOverFlatMapAttempt[A](fa: F[A]) =
     (F.uncancelable(_ => F.canceled >> fa).attempt >> F.unit) <->
       F.forceR(F.uncancelable(_ => fa))(F.canceled)

--- a/laws/shared/src/main/scala/cats/effect/laws/MonadCancelLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/MonadCancelLaws.scala
@@ -41,6 +41,23 @@ trait MonadCancelLaws[F[_], E] extends MonadErrorLaws[F, E] {
   def uncancelableEliminatesOnCancel[A](fa: F[A], fin: F[Unit]) =
     F.uncancelable(_ => F.onCancel(fa, fin)) <-> F.uncancelable(_ => fa)
 
+  /*
+   * NB: This is effectively in violation of the monad laws, since
+   * we consider finalizers to associate over the boundary here, but
+   * we do NOT consider them to right-associate over map or flatMap.
+   * This simply stems from the fact that cancellation is fundamentally
+   * uncomposable, and it's better to pick a semantic for uncancelable
+   * which allows regional composition, since this avoids "gaps" in
+   * otherwise-safe code.
+   *
+   * The argument is that cancellation is a *hint* not a mandate. This
+   * holds for self-cancellation just as much as external-cancellation.
+   * Thus, laws about where the cancellation is visible are always going
+   * to be a bit off.
+   */
+  def onCancelAssociatesOverUncancelableBoundary[A](fa: F[A], fin: F[Unit]) =
+    F.uncancelable(_ => F.onCancel(fa, fin)) <-> F.onCancel(F.uncancelable(_ => fa), fin)
+
   def forceRDiscardsPure[A, B](a: A, fa: F[B]) =
     F.forceR(F.pure(a))(fa) <-> fa
 
@@ -59,9 +76,14 @@ trait MonadCancelLaws[F[_], E] extends MonadErrorLaws[F, E] {
     F.onCancel(F.onCancel(F.canceled, fin1), fin2) <->
       F.forceR(F.uncancelable(_ => F.forceR(fin1)(fin2)))(F.canceled)
 
-  def uncancelableCanceledAssociatesRightOverFlatMap[A](a: A, f: A => F[Unit]) =
-    F.uncancelable(_ => F.canceled.as(a).flatMap(f)) <->
-      F.forceR(F.uncancelable(_ => f(a)))(F.canceled)
+  // the following set of three laws is formulated in this way to exclude F.never
+  // notably, `F.uncancelable(_ => F.canceled >> fa) >> F.never` results in cancelation
+  // however, `F.uncancelable(_ => fa) >> F.forceR(F.never)(F.canceled)` is nonterminating
+  // these are the semantics we want, but it also means the rewrite rule cannot be generalized
+
+  def uncancelableCanceledAssociatesRightOverFlatMapAttempt[A](fa: F[A]) =
+    (F.uncancelable(_ => F.canceled >> fa).attempt >> F.unit) <->
+      F.forceR(F.uncancelable(_ => fa))(F.canceled)
 
   def canceledAssociatesLeftOverFlatMap[A](fa: F[A]) =
     F.canceled >> fa.void <-> F.canceled

--- a/laws/shared/src/main/scala/cats/effect/laws/MonadCancelTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/MonadCancelTests.scala
@@ -53,7 +53,6 @@ trait MonadCancelTests[F[_], E] extends MonadErrorTests[F, E] {
       iso: Isomorphisms[F],
       faPP: F[A] => Pretty,
       fuPP: F[Unit] => Pretty,
-      aFUPP: (A => F[Unit]) => Pretty,
       ePP: E => Pretty): RuleSet = {
 
     new RuleSet {
@@ -70,6 +69,8 @@ trait MonadCancelTests[F[_], E] extends MonadErrorTests[F, E] {
             laws.uncancelablePollInverseNestIsUncancelable[A] _),
           "uncancelable eliminates onCancel" -> forAll(
             laws.uncancelableEliminatesOnCancel[A] _),
+          "onCancel associates over uncancelable boundary" -> forAll(
+            laws.onCancelAssociatesOverUncancelableBoundary[A] _),
           "forceR discards pure" -> forAll(laws.forceRDiscardsPure[A, B] _),
           "forceR discards error" -> forAll(laws.forceRDiscardsError[A] _),
           "forceR canceled short-circuits" -> forAll(laws.forceRCanceledShortCircuits[A] _),
@@ -81,8 +82,8 @@ trait MonadCancelTests[F[_], E] extends MonadErrorTests[F, E] {
             Seq(
               "canceled sequences onCancel in order" -> forAll(
                 laws.canceledSequencesOnCancelInOrder _),
-              "uncancelable canceled associates right over flatMap" -> forAll(
-                laws.uncancelableCanceledAssociatesRightOverFlatMap[A] _),
+              "uncancelable canceled associates right over flatMap attempt" -> forAll(
+                laws.uncancelableCanceledAssociatesRightOverFlatMapAttempt[A] _),
               "canceled associates left over flatMap" -> forAll(
                 laws.canceledAssociatesLeftOverFlatMap[A] _)
             )

--- a/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
@@ -221,8 +221,11 @@ trait TestInstances extends ParallelFGenerators with OutcomeGenerators with Sync
     try {
       var results: Outcome[Option, Throwable, A] = Outcome.Succeeded(None)
 
-      ioa.unsafeRunAsyncOutcome { oc => results = oc.mapK(someK) }(
-        unsafe.IORuntime(ticker.ctx, ticker.ctx, scheduler, () => (), unsafe.IORuntimeConfig()))
+      ioa
+        .flatMap(IO.pure(_))
+        .handleErrorWith(IO.raiseError(_))
+        .unsafeRunAsyncOutcome { oc => results = oc.mapK(someK) }(unsafe
+          .IORuntime(ticker.ctx, ticker.ctx, scheduler, () => (), unsafe.IORuntimeConfig()))
 
       ticker.ctx.tickAll(1.second)
 

--- a/tests/shared/src/test/scala/cats/effect/OptionTIOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/OptionTIOSpec.scala
@@ -23,8 +23,10 @@ import cats.effect.laws.AsyncTests
 import cats.implicits._
 
 import org.scalacheck.Prop
+// import org.scalacheck.rng.Seed
 
 import org.specs2.ScalaCheck
+// import org.specs2.scalacheck.Parameters
 
 import org.typelevel.discipline.specs2.mutable.Discipline
 
@@ -57,7 +59,7 @@ class OptionTIOSpec
     checkAll(
       "OptionT[IO]",
       AsyncTests[OptionT[IO, *]].async[Int, Int, Int](10.millis)
-    ) /*(Parameters(seed = Some(Seed.fromBase64("XidlR_tu11X7_v51XojzZJsm6EaeU99RAEL9vzbkWBD=").get)))*/
+    ) /*(Parameters(seed = Some(Seed.fromBase64("xuJLKQlO7U9WUCzxlh--IB-5ppu1VpQkCFAmUX3tIrM=").get)))*/
   }
 
 }


### PR DESCRIPTION
Fixes #1744 

Requesting expedited reviews from @SystemFw, @wemrysi, @RaasAhsan, and @vasilmkd. Also anyone else who wants to pile on, please do so quickly. I would ideally like to get this merged today so we can release quickly.

This is a major semantic shift in several ways. Bottom line up front: **this change violates the functor laws**. If you're looking for a thing that Cats Effect is choosing to do in the name of "pragmatism over purity", this is it. We didn't take this decision lightly.

Just to provide a bit of context, consider the following construction:

```scala
uncancelable(_(uncancelable(fa) /* think carefully about this spot */))
```

In the encoding which is present in the current HEAD, the commented location in the expression above represents a very small gap in which cancelation may be observed but not suppressed. This in turn means that `poll` and `uncancelable` don't compose *safely*, and this has some quite profound impacts on everything from Fs2 to `Resource`. Ultimately, any function which wraps its contents in `uncancelable` and returns was *actually unsafe* because the caller couldn't close the gap.

This PR changes `uncancelable` to be an *open* region to the right. In other words, we no longer perform a cancelation check upon completion of the region. This is well exemplified by the new law:

```scala
uncancelable(_ => fa.onCancel(fin)) <-> uncancelable(_ => fa).onCancel(fin)
```

Which, transitively, also means the following:

```scala
uncancelable(_ => fa).onCancel(fin) <-> uncancelable(_ => fa)
```

How does this violate the functor laws? Well, imagine an identity `flatMap`:

```scala
uncancelable(_ => fa).flatMap(pure).onCancel(fin)
```

(by the monad laws, this is equivalent to `.map(identity)`, which is why this is about the functor laws specifically)

The above is *not* equivalent: the `onCancel` will sequence the finalizer if `fa` is canceled. If you think about it, this is fundamentally necessary if we want to allow auto-cancelable `flatMap`, but it's also a violation of the functor laws because identity mappings must be identity.

As it turns out, violating the functor laws has… some implications. Nearly all of this PR is just running through and trying to correct all of the problems which arise when you do something like that, though I did also fix a very subtle bug in `Resource#allocated` as well as implemented a more optimized `IO#guarantee`, which should help `Resource` performance a bit.

The hand-wavy justification here is that the violation of functor laws is only observable within confined runtime scopes. Like, for example, what we do in the tests. 😢 The requisite incantation to resurface the old semantics is as follows:

```scala
fa <-> fa.flatMap(pure).handleErrorWith(raiseError)
```

Obviously these two expressions *should* be equivalent, and if we ignore confined runtime scopes such as `unsafeRun`, they *are* indistinguishable. However, the latter expression will guarantee that cancelation is detected if `fa` was indeed canceled, whereas in the former expression, if `fa` is secretly `uncancelable(fa')`, you aren't guaranteed to observe the cancelation.

The one place where this gets *really* strange is `race`, because `race` actually represents a confined evaluation scope similar to `unsafeRun`. However, `race` *already* violates a whole series of laws, which is why we exclude it from the generators, so uh… I guess it's fine?

All in all, this should result in a semantic which is much safer and much more intuitive for users and the ecosystem, with the only serious casualty being our self-respect every time we have to look at what I did in this PR.