### PR TITLE
Tailor made `async_` Cont implementation

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1235,6 +1235,16 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
   private[this] val _asyncForIO: kernel.Async[IO] = new kernel.Async[IO]
     with StackSafeMonad[IO] {
 
+    override def async_[A](k: (Either[Throwable, A] => Unit) => Unit): IO[A] = {
+      val body = new Cont[IO, A, A] {
+        def apply[G[_]](implicit G: MonadCancel[G, Throwable]) = { (resume, get, lift) =>
+          G.uncancelable { poll => lift(IO.delay(k(resume))).flatMap(_ => poll(get)) }
+        }
+      }
+
+      cont(body)
+    }
+
     override def as[A, B](ioa: IO[A], b: B): IO[B] =
       ioa.as(b)
 


### PR DESCRIPTION
Here are the benchmark results:
```
series/3.x
Benchmark             (size)   Mode  Cnt      Score     Error  Units
AsyncBenchmark.async     100  thrpt   20  16727.395 ± 261.562  ops/s
```

```
This PR
Benchmark             (size)   Mode  Cnt      Score     Error  Units
AsyncBenchmark.async     100  thrpt   20  18505.947 ± 258.256  ops/s
```