### PR TITLE
Remove `Resource.liftF`

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -637,10 +637,6 @@ object Resource extends ResourceFOInstances0 with ResourceHOInstances0 with Reso
    *
    * @param fa the value to lift into a resource
    */
-  @deprecated("please use `eval` instead.", since = "3.0")
-  def liftF[F[_], A](fa: F[A]): Resource[F, A] =
-    Resource.Eval(fa)
-
   def eval[F[_], A](fa: F[A]): Resource[F, A] =
     Resource.Eval(fa)
 


### PR DESCRIPTION
It was deprecated in 2.4.0 and there's a working migration for users moving to it - I think it can be removed at this point.