### PR TITLE
Change to rename IOApp#config to runtimeConfig

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOApp.scala
+++ b/core/js/src/main/scala/cats/effect/IOApp.scala
@@ -25,7 +25,7 @@ trait IOApp {
   private[this] var _runtime: unsafe.IORuntime = null
 
   protected def runtime: unsafe.IORuntime = _runtime
-  protected def config: unsafe.IORuntimeConfig = unsafe.IORuntimeConfig()
+  protected def runtimeConfig: unsafe.IORuntimeConfig = unsafe.IORuntimeConfig()
 
   def run(args: List[String]): IO[ExitCode]
 
@@ -39,7 +39,7 @@ trait IOApp {
           IORuntime.defaultComputeExecutionContext,
           IORuntime.defaultScheduler,
           () => (),
-          config)
+          runtimeConfig)
       }
 
       _runtime = IORuntime.global

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -25,7 +25,7 @@ trait IOApp {
   private[this] var _runtime: unsafe.IORuntime = null
   protected def runtime: unsafe.IORuntime = _runtime
 
-  protected def config: unsafe.IORuntimeConfig = unsafe.IORuntimeConfig()
+  protected def runtimeConfig: unsafe.IORuntimeConfig = unsafe.IORuntimeConfig()
 
   protected def computeWorkerThreadCount: Int =
     Math.max(2, Runtime.getRuntime().availableProcessors())
@@ -57,7 +57,7 @@ trait IOApp {
             blockDown()
             schedDown()
           },
-          config)
+          runtimeConfig)
       }
 
       _runtime = IORuntime.global


### PR DESCRIPTION
This change is because `config` is a fairly common name used in `IOApp`, since it's the point where you normally load and construct 'the world'. We've already seen a conflict in the following pull request: https://github.com/vlovgr/ciris/pull/439. There is also a Gitter discussion about it here: https://gitter.im/typelevel/cats-effect-dev?at=6058ebcc8478e061b9528068.