### PR TITLE
Move `FiberLocal.apply` to `IO.fiberLocal`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/FiberLocal.scala
+++ b/core/shared/src/main/scala/cats/effect/FiberLocal.scala
@@ -33,37 +33,3 @@ trait FiberLocal[F[_], A] {
   def getAndClear: F[A]
 
 }
-
-object FiberLocal {
-
-  def apply[A](default: A): IO[FiberLocal[IO, A]] =
-    IO {
-      new FiberLocal[IO, A] { self =>
-        override def get: IO[A] =
-          IO.Local(state => (state, state.get(self).map(_.asInstanceOf[A]).getOrElse(default)))
-
-        override def set(value: A): IO[Unit] =
-          IO.Local(state => (state + (self -> value), ()))
-
-        override def clear: IO[Unit] =
-          IO.Local(state => (state - self, ()))
-
-        override def update(f: A => A): IO[Unit] =
-          get.flatMap(a => set(f(a)))
-
-        override def modify[B](f: A => (A, B)): IO[B] =
-          get.flatMap { a =>
-            val (a2, b) = f(a)
-            set(a2).as(b)
-          }
-
-        override def getAndSet(value: A): IO[A] =
-          get <* set(value)
-
-        override def getAndClear: IO[A] =
-          get <* clear
-
-      }
-    }
-
-}

--- a/tests/shared/src/test/scala/cats/effect/FiberLocalSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/FiberLocalSpec.scala
@@ -19,16 +19,16 @@ package effect
 
 class FiberLocalSpec extends BaseSpec {
 
-  "Local" should {
+  "FiberLocal" should {
     "return a default value" in ticked { implicit ticker =>
-      val io = FiberLocal(0).flatMap(_.get)
+      val io = IO.fiberLocal(0).flatMap(_.get)
 
       io must completeAs(0)
     }
 
     "set and get a value" in ticked { implicit ticker =>
       val io = for {
-        local <- FiberLocal(0)
+        local <- IO.fiberLocal(0)
         _ <- local.set(10)
         value <- local.get
       } yield value
@@ -38,7 +38,7 @@ class FiberLocalSpec extends BaseSpec {
 
     "preserve locals across async boundaries" in ticked { implicit ticker =>
       val io = for {
-        local <- FiberLocal(0)
+        local <- IO.fiberLocal(0)
         _ <- local.set(10)
         _ <- IO.cede
         value <- local.get
@@ -49,7 +49,7 @@ class FiberLocalSpec extends BaseSpec {
 
     "copy locals to children fibers" in ticked { implicit ticker =>
       val io = for {
-        local <- FiberLocal(0)
+        local <- IO.fiberLocal(0)
         _ <- local.set(10)
         f <- local.get.start
         value <- f.joinWithNever
@@ -60,7 +60,7 @@ class FiberLocalSpec extends BaseSpec {
 
     "child local manipulation is invisible to parents" in ticked { implicit ticker =>
       val io = for {
-        local <- FiberLocal(10)
+        local <- IO.fiberLocal(10)
         f <- local.set(20).start
         _ <- f.join
         value <- local.get
@@ -71,7 +71,7 @@ class FiberLocalSpec extends BaseSpec {
 
     "parent local manipulation is invisible to children" in ticked { implicit ticker =>
       val io = for {
-        local <- FiberLocal(0)
+        local <- IO.fiberLocal(0)
         d1 <- Deferred[IO, Unit]
         f <- (d1.get *> local.get).start
         _ <- local.set(10)


### PR DESCRIPTION
This opens the door of possibly moving `FiberLocal` to std/kernel in the future without breaking binary compatibility. I also think it helps discoverability for IO useres.

I think this is orthogonal to #1821 and #1822.