### PR TITLE
Deregister error callback on fiber cancelation

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -697,7 +697,10 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
       Map(),
       oc =>
         oc.fold(
-          canceled,
+          {
+            runtime.fiberErrorCbs.remove(failure)
+            canceled
+          },
           { t =>
             runtime.fiberErrorCbs.remove(failure)
             failure(t)


### PR DESCRIPTION
This fixes a memory leak for canceled fibers which were `unsafeRun`.