### PR TITLE
Calculate child mask on demand

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -21,6 +21,13 @@ private[effect] object IOFiberConstants {
 
   val MaxStackDepth: Int = 512
 
+  /*
+   * allow for 255 masks before conflicting; 255 chosen because it is a familiar bound,
+   * and because it's evenly divides UnsignedInt.MaxValue.
+   * This scheme gives us 16,843,009 (~2^24) potential derived fibers before masks can conflict
+   */
+  val ChildMaskOffset: Int = 255
+
   // continuation ids (should all be inlined)
   val MapK: Byte = 0
   val FlatMapK: Byte = 1

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -21,6 +21,14 @@ final class IOFiberConstants {
 
   public static final int MaxStackDepth = 512;
 
+  /*
+   * allow for 255 masks before conflicting; 255 chosen because it is a familiar
+   * bound, and because it's evenly divides UnsignedInt.MaxValue. This scheme
+   * gives us 16,843,009 (~2^24) potential derived fibers before masks can
+   * conflict
+   */
+  public static final int ChildMaskOffset = 255;
+
   // continuation ids (should all be inlined)
   public static final byte MapK = 0;
   public static final byte FlatMapK = 1;

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -65,12 +65,12 @@ import java.util.concurrent.atomic.AtomicBoolean
  * merely a fast-path and are not necessary for correctness.
  */
 private final class IOFiber[A](
-    initMask: Int,
+    private[this] val initMask: Int,
     initLocalState: IOLocalState,
     cb: OutcomeIO[A] => Unit,
     startIO: IO[A],
     startEC: ExecutionContext,
-    runtime: IORuntime
+    private[this] val runtime: IORuntime
 ) extends IOFiberPlatform[A]
     with FiberIO[A]
     with Runnable {

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -95,13 +95,6 @@ private final class IOFiber[A](
   private[this] var masks: Int = initMask
   private[this] var finalizing: Boolean = false
 
-  /*
-   * allow for 255 masks before conflicting; 255 chosen because it is a familiar bound,
-   * and because it's evenly divides UnsignedInt.MaxValue.
-   * This scheme gives us 16,843,009 (~2^24) potential derived fibers before masks can conflict
-   */
-  private[this] val childMask: Int = initMask + 255
-
   private[this] val finalizers = new ArrayStack[IO[Unit]](16)
 
   private[this] val callbacks = new CallbackStack[A](cb)
@@ -765,10 +758,10 @@ private final class IOFiber[A](
         case 17 =>
           val cur = cur0.asInstanceOf[Start[Any]]
 
-          val initMask2 = childMask
+          val childMask = initMask + ChildMaskOffset
           val ec = currentCtx
           val fiber = new IOFiber[Any](
-            initMask2,
+            childMask,
             localState,
             null,
             cur.ioa,


### PR DESCRIPTION
Right now `childMask` is a field, and it's probably not used as often. It's also very simple to derive, so there's no need for it to take 4 bytes in the object.