### PR TITLE
Merge the EndFiber branch with the tags

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1464,7 +1464,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
   // INTERNAL, only created by the runloop itself as the terminal state of several operations
   private[effect] case object EndFiber extends IO[Nothing] {
-    def tag = -1
+    def tag = 23
   }
 
 }


### PR DESCRIPTION
This is an experimental branch but I think the shenanigans I pulled here might point to a couple of bugs. I will comment on the relevant code segments.

The main idea behind this experiment is to get rid of the branching at the top of `runLoop`, particularly the one which checks if the current `IO` is `IOFiberEnd` and whether the runloop should be dropped. I used the tag of `IOFiberEnd` to fuse this branch with the tableswitch. However, this uncovered some potential issues with calling `asyncCancel` multiple times from the runloop itself.

@djspiewak @RaasAhsan please take a look at the comments and the questions I raised. Thank you in advance.

Slight warning, this branch does contain some code from #1869 because I was benchmarking all changes together. I hope this is not too confusing. Only the second commit is relevant for the discussion.