### PR TITLE
Fix last checked value for index in hash table

### DIFF
--- a/core/shared/src/main/scala/cats/effect/unsafe/FiberErrorHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/FiberErrorHashtable.scala
@@ -61,7 +61,7 @@ private[effect] final class FiberErrorHashtable(initialSize: Int) {
         } else {
           idx += 1
           idx &= mask
-          if (idx == init - 1) {
+          if (idx == init) {
             cont = false
           }
         }


### PR DESCRIPTION
The index was incremented before the check, so the comparison with the index before the starting one was wrong. Discovered in #1868.