### PR TITLE
Use latest JDKs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,14 @@ jobs:
         java:
           - adopt@1.8
           - adopt@1.11
-          - adopt@1.15
+          - adopt@1.16
           - graalvm-ce-java8@21.0
         ci: [ciJVM, ciJS, ciFirefox]
         exclude:
           - ci: ciJS
             java: adopt@1.11
           - ci: ciJS
-            java: adopt@1.15
+            java: adopt@1.16
           - ci: ciJS
             java: graalvm-ce-java8@21.0
           - os: windows-latest
@@ -47,7 +47,7 @@ jobs:
           - ci: ciFirefox
             java: adopt@1.11
           - ci: ciFirefox
-            java: adopt@1.15
+            java: adopt@1.16
           - ci: ciFirefox
             java: graalvm-ce-java8@21.0
           - os: windows-latest
@@ -58,7 +58,7 @@ jobs:
             scala: 2.12.13
           - os: windows-latest
             ci: ciFirefox
-          - java: adopt@1.15
+          - java: adopt@1.16
             os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ ThisBuild / crossScalaVersions := Seq("3.0.0-RC2", "3.0.0-RC3", "2.12.13", Scala
 ThisBuild / githubWorkflowTargetBranches := Seq("series/3.x")
 
 val LTSJava = "adopt@1.11"
-val LatestJava = "adopt@1.15"
+val LatestJava = "adopt@1.16"
 val GraalVM8 = "graalvm-ce-java8@21.0"
 
 ThisBuild / githubWorkflowJavaVersions := Seq(ScalaJSJava, LTSJava, LatestJava, GraalVM8)


### PR DESCRIPTION
Jabba, the JDK downloader that we depend on through our Github Actions configuration has not been updated in quite some time, and hacks like this need to be done to get a hold of the latests JDK releases in any of the major versions (8, 11, 16, Graal).