### PR TITLE
Correct logic in `Sync.interruptible`

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
@@ -92,7 +92,7 @@ trait Sync[F[_]] extends MonadCancel[F, Throwable] with Clock[F] with Unique[F] 
    * and evaluated on a blocking execution context
    */
   def interruptible[A](many: Boolean)(thunk: => A): F[A] =
-    suspend(if (many) InterruptibleOnce else InterruptibleMany)(thunk)
+    suspend(if (many) InterruptibleMany else InterruptibleOnce)(thunk)
 
   def suspend[A](hint: Sync.Type)(thunk: => A): F[A]
 }


### PR DESCRIPTION
Fix for #1883