### PR TITLE
Add dual-effect Queue constructors, expose methods to change effect type of `SyncRef` and `AsyncDeferred` without `mapK`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -222,13 +222,12 @@ lazy val kernel = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies += "org.specs2" %%% "specs2-core" % Specs2Version % Test)
   .settings(dottyLibrarySettings)
   .settings(libraryDependencies += "org.typelevel" %%% "cats-core" % CatsVersion)
-  .jsSettings(
-    Compile / doc / sources := {
-      if (scalaVersion.value == "3.0.0-RC2")
-        Seq()
-      else
-        (Compile / doc / sources).value
-    })
+  .jsSettings(Compile / doc / sources := {
+    if (scalaVersion.value == "3.0.0-RC2")
+      Seq()
+    else
+      (Compile / doc / sources).value
+  })
 
 /**
  * Reference implementations (including a pure ConcurrentBracket), generic ScalaCheck
@@ -274,7 +273,12 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     mimaBinaryIssueFilters ++= Seq(
       // introduced by #1837, removal of package private class
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.AsyncPropagateCancelation"),
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.AsyncPropagateCancelation$")
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.AsyncPropagateCancelation$"),
+      // introduced by #1889, removal of private classes
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$AbstractQueue"),
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$BoundedQueue"),
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$DroppingQueue"),
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$CircularBufferQueue")
     )
   )
   .jvmSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -273,12 +273,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     mimaBinaryIssueFilters ++= Seq(
       // introduced by #1837, removal of package private class
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.AsyncPropagateCancelation"),
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.AsyncPropagateCancelation$"),
-      // introduced by #1889, removal of private classes
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$AbstractQueue"),
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$BoundedQueue"),
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$DroppingQueue"),
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$CircularBufferQueue")
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.AsyncPropagateCancelation$")
     )
   )
   .jvmSettings(
@@ -333,7 +328,14 @@ lazy val std = crossProject(JSPlatform, JVMPlatform)
       else
         "org.specs2" %%% "specs2-scalacheck" % Specs2Version % Test
     },
-    libraryDependencies += "org.scalacheck" %%% "scalacheck" % ScalaCheckVersion % Test
+    libraryDependencies += "org.scalacheck" %%% "scalacheck" % ScalaCheckVersion % Test,
+    mimaBinaryIssueFilters ++= Seq(
+      // introduced by #1889, removal of private classes
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$AbstractQueue"),
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$BoundedQueue"),
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$DroppingQueue"),
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$CircularBufferQueue")
+    )
   )
 
 /**

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Deferred.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Deferred.scala
@@ -98,7 +98,9 @@ object Deferred {
     val dummyId = 0L
   }
 
-  private[kernel] sealed trait AsyncDeferredSource[F[_], A] extends DeferredSource[F, A] {
+  private[kernel] sealed trait AsyncDeferredSource[F[_], A]
+      extends DeferredSource[F, A]
+      with AsyncDeferredLike[A] {
     protected implicit def F: Async[F]
     private[Deferred] val ref: AtomicReference[State[A]]
 
@@ -216,6 +218,10 @@ object Deferred {
         override protected val F: Sync[G] = G
         override private[Deferred] val ref: AtomicReference[State[A]] = self.ref
       }
+  }
+
+  sealed trait AsyncDeferredLike[A] {
+    def transformAsync[G[_]](implicit G: Async[G]): AsyncDeferred[G, A]
   }
 
   sealed class AsyncDeferred[F[_], A](implicit protected val F: Async[F])

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Deferred.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Deferred.scala
@@ -206,7 +206,7 @@ object Deferred {
 
     /*
      * Returns a new view of this `SyncDeferredSink` instance that shares
-     * the same state but which suspends operations in `F` rather than `G`.
+     * the same state but which suspends operations in `G` rather than `F`.
      *
      * Similar to `mapK`, but requires a [[Sync]] instance instead of a natural
      * transformation.


### PR DESCRIPTION
The motivation for this is to be able to allocate resources in the form `Resource[F, Thing[G]]` where the same state needs to be accessed in `G` by the `Thing` but in F for the `Resource`.

I'll add tests and typeclass instances if this is approved in principle, and do something similar for Ref.