### PR TITLE
Fix incorrect scheduling of fibers on the work stealing runtime in presence of parasitic execution contexts

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -30,16 +30,3 @@ private[effect] sealed abstract class WorkStealingThreadPool private ()
   private[effect] def rescheduleFiber(fiber: IOFiber[_]): Unit
   private[effect] def scheduleFiber(fiber: IOFiber[_]): Unit
 }
-
-// Unfortunately, due to the explicit branching for optimization purposes, this
-// type leaks into the shared source code of IOFiber.scala.
-private[effect] sealed abstract class WorkerThread private () extends Thread {
-  def reschedule(fiber: IOFiber[_]): Unit
-  def schedule(fiber: IOFiber[_]): Unit
-}
-
-// Unfortunately, due to the explicit branching for optimization purposes, this
-// type leaks into the shared source code of IOFiber.scala.
-private[effect] sealed abstract class HelperThread private () extends Thread {
-  def schedule(fiber: IOFiber[_]): Unit
-}

--- a/core/js/src/main/scala/cats/effect/unsafe/workstealing.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/workstealing.scala
@@ -27,6 +27,8 @@ private[effect] sealed abstract class WorkStealingThreadPool private ()
   def execute(runnable: Runnable): Unit
   def reportFailure(cause: Throwable): Unit
   private[effect] def executeFiber(fiber: IOFiber[_]): Unit
+  private[effect] def rescheduleFiber(fiber: IOFiber[_]): Unit
+  private[effect] def scheduleFiber(fiber: IOFiber[_]): Unit
 }
 
 // Unfortunately, due to the explicit branching for optimization purposes, this

--- a/core/jvm/src/main/scala/cats/effect/unsafe/HelperThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/HelperThread.scala
@@ -55,7 +55,7 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
  * [[WorkerThread]]s, and having a dynamic number of [[WorkerThread]] instances
  * introduces more logic on the hot path.
  */
-private[effect] final class HelperThread(
+private final class HelperThread(
     private[this] val threadPrefix: String,
     private[this] val blockingThreadCounter: AtomicInteger,
     private[this] val batched: ScalQueue[Array[IOFiber[_]]],

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -36,7 +36,7 @@ import java.util.concurrent.locks.LockSupport
  * highly parallel system when compared to a fixed size thread pool whose worker
  * threads all draw tasks from a single global work queue.
  */
-private[effect] final class WorkerThread(
+private final class WorkerThread(
     // Index assigned by the `WorkStealingThreadPool` for identification purposes.
     private[unsafe] val index: Int,
     // Thread prefix string used for naming new instances of `WorkerThread` and `HelperThread`.

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1062,22 +1062,16 @@ private final class IOFiber[A](
   }
 
   private[this] def rescheduleFiber(ec: ExecutionContext)(fiber: IOFiber[_]): Unit = {
-    val thread = Thread.currentThread()
-    if (thread.isInstanceOf[WorkerThread]) {
-      thread.asInstanceOf[WorkerThread].reschedule(fiber)
-    } else if (thread.isInstanceOf[HelperThread]) {
-      thread.asInstanceOf[HelperThread].schedule(fiber)
+    if (ec.isInstanceOf[WorkStealingThreadPool]) {
+      ec.asInstanceOf[WorkStealingThreadPool].rescheduleFiber(fiber)
     } else {
       scheduleOnForeignEC(ec)(fiber)
     }
   }
 
   private[this] def scheduleFiber(ec: ExecutionContext)(fiber: IOFiber[_]): Unit = {
-    val thread = Thread.currentThread()
-    if (thread.isInstanceOf[WorkerThread]) {
-      thread.asInstanceOf[WorkerThread].schedule(fiber)
-    } else if (thread.isInstanceOf[HelperThread]) {
-      thread.asInstanceOf[HelperThread].schedule(fiber)
+    if (ec.isInstanceOf[WorkStealingThreadPool]) {
+      ec.asInstanceOf[WorkStealingThreadPool].scheduleFiber(fiber)
     } else {
       scheduleOnForeignEC(ec)(fiber)
     }

--- a/tests/jvm/src/test/scala/cats/effect/ParasiticECSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/ParasiticECSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.effect.testkit.TestInstances
+import cats.syntax.all._
+import org.scalacheck.Arbitrary
+
+import scala.concurrent.duration._
+
+class ParasiticECSpec extends BaseSpec with TestInstances {
+
+  override def executionTimeout: FiniteDuration = 60.seconds
+
+  "IO monad" should {
+    "evaluate fibers correctly in presence of a parasitic execution context" in real {
+      implicit val ticker = Ticker()
+
+      val test = IO(implicitly[Arbitrary[IO[Int]]].arbitrary.sample.get).flatMap { io =>
+        IO.delay(io.eqv(io))
+      }
+
+      val iterations = 15000
+
+      List.fill(iterations)(test).sequence.map(_.count(identity)).flatMap { c =>
+        IO {
+          c mustEqual iterations
+        }
+      }
+    }
+  }
+}

--- a/tests/shared/src/test/scala/cats/effect/IOPropSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOPropSpec.scala
@@ -87,7 +87,7 @@ class IOPropSpec extends IOPlatformSpecification with Discipline with ScalaCheck
       implicit val ticker = Ticker()
 
       val test = IO(implicitly[Arbitrary[IO[Int]]].arbitrary.sample.get).flatMap { io =>
-        IO.delay(io === io)
+        IO.delay(io.eqv(io))
       }
 
       val iterations = 15000

--- a/tests/shared/src/test/scala/cats/effect/IOPropSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOPropSpec.scala
@@ -20,7 +20,7 @@ import cats.syntax.all._
 import cats.effect.implicits._
 import cats.effect.std.Queue
 
-import org.scalacheck.Arbitrary, Arbitrary.arbitrary
+import org.scalacheck.Arbitrary.arbitrary
 
 import org.specs2.ScalaCheck
 
@@ -79,23 +79,6 @@ class IOPropSpec extends IOPlatformSpecification with Discipline with ScalaCheck
           l.map(IO.pure(_)).parSequence.flatMap { expected =>
             l.map(IO.pure(_)).parSequenceN(n).mustEqual(expected)
           }
-      }
-
-    }
-
-    "evaluate fibers correctly in presence of a parasitic execution context" in real {
-      implicit val ticker = Ticker()
-
-      val test = IO(implicitly[Arbitrary[IO[Int]]].arbitrary.sample.get).flatMap { io =>
-        IO.delay(io.eqv(io))
-      }
-
-      val iterations = 5000
-
-      List.fill(iterations)(test).sequence.map(_.count(identity)).flatMap { c =>
-        IO {
-          c mustEqual iterations
-        }
       }
     }
   }

--- a/tests/shared/src/test/scala/cats/effect/IOPropSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOPropSpec.scala
@@ -90,7 +90,7 @@ class IOPropSpec extends IOPlatformSpecification with Discipline with ScalaCheck
         IO.delay(io.eqv(io))
       }
 
-      val iterations = 15000
+      val iterations = 5000
 
       List.fill(iterations)(test).sequence.map(_.count(identity)).flatMap { c =>
         IO {

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -25,7 +25,7 @@ import cats.effect.laws.AsyncTests
 import cats.effect.testkit.TestContext
 import cats.syntax.all._
 
-import org.scalacheck.{Arbitrary, Prop}, Prop.forAll
+import org.scalacheck.Prop, Prop.forAll
 // import org.scalacheck.rng.Seed
 
 import org.specs2.ScalaCheck
@@ -1147,22 +1147,6 @@ class IOSpec extends IOPlatformSpecification with Discipline with ScalaCheck wit
         }
 
         test.flatMap(_ => IO(canceled)) must completeAs(true)
-      }
-
-      "evaluate blocking actions without losing fibers" in real {
-        implicit val ticker = Ticker()
-
-        val test = IO(implicitly[Arbitrary[IO[Int]]].arbitrary.sample.get).flatMap { io =>
-          IO.delay(io === io)
-        }
-
-        val iterations = 1000
-
-        List.fill(iterations)(test).sequence.map(_.count(identity)).flatMap { c =>
-          IO {
-            c mustEqual iterations
-          }
-        }
       }
     }
 


### PR DESCRIPTION
Thank you @Baccata for the minimized reproduction and thank you @oleg-py for discovering the issue.

Gitter discussion that goes into more detail is available [here](https://gitter.im/typelevel/cats-effect-dev?at=60708532a2ac0d38e7a6e57d).