### PR TITLE
add three methods to Outcome for easy testing

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
@@ -45,6 +45,24 @@ sealed trait Outcome[F[_], E, A] extends Product with Serializable {
       case Errored(e) => Errored(e)
       case Succeeded(fa) => Succeeded(f(fa))
     }
+
+  def isSuccess: Boolean = this match {
+    case Canceled() => false
+    case Errored(_) => false
+    case Succeeded(_) => true
+  }
+
+  def isError: Boolean = this match {
+    case Canceled() => false
+    case Errored(_) => true
+    case Succeeded(_) => false
+  }
+
+  def isCancelled: Boolean = this match {
+    case Canceled() => true
+    case Errored(_) => false
+    case Succeeded(_) => false
+  }
 }
 
 private[kernel] trait LowPriorityImplicits {

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
@@ -58,7 +58,7 @@ sealed trait Outcome[F[_], E, A] extends Product with Serializable {
     case Succeeded(_) => false
   }
 
-  def isCancelled: Boolean = this match {
+  def isCanceled: Boolean = this match {
     case Canceled() => true
     case Errored(_) => false
     case Succeeded(_) => false


### PR DESCRIPTION
When writing unit-tests on Fibers, I wrote an extension method to allow myself to write:

```
assert(fiber.isCancelled)
```

rather than pattern-matching every time. I thought others might find this useful too!

Let me know if anyone has thoughts on the method names here. I wasn't sure about `isSuccess` vs `wasSuccessful` vs `isSucceeded`, etc, so happy to change this.