### PR TITLE
Try waking up a WorkerThread before spawning a HelperThread

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -279,7 +279,10 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.FiberErrorHashtable"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.unsafe.IORuntime.fiberErrorCbs"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("cats.effect.unsafe.IORuntime.this"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.unsafe.IORuntime.<init>$default$6")
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.unsafe.IORuntime.<init>$default$6"),
+      // introduced by #1928, wake up a worker thread before spawning a helper thread when blocking
+      // changes to `cats.effect.unsafe` package private code
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.unsafe.WorkStealingThreadPool.notifyParked")
     )
   )
   .jvmSettings(

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -101,6 +101,7 @@ private final class WorkerThread(
     val rnd = random
     queue.enqueue(fiber, batched, overflow, rnd)
     pool.notifyParked(rnd)
+    ()
   }
 
   /**
@@ -409,58 +410,83 @@ private final class WorkerThread(
    * monomorphic callsites in the `IOFiber` runloop.
    */
   override def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
-    // Drain the local queue to the `overflow` queue.
-    val drain = new Array[IOFiber[_]](LocalQueueCapacity)
-    queue.drain(drain)
-    overflow.offerAll(drain, random)
+    // Try waking up a `WorkerThread` to steal fibers from the `LocalQueue` of
+    // this thread.
+    val rnd = random
+    if (pool.notifyParked(rnd)) {
+      // Successfully woke up another `WorkerThread` to help out with the
+      // anticipated blocking. Even if this thread ends up being blocked for
+      // some time, the other worker would be able to steal its fibers.
 
-    if (blocking) {
-      // This `WorkerThread` is already inside an enclosing blocking region.
-      // There is no need to spawn another `HelperThread`. Instead, directly
-      // execute the blocking action.
-      thunk
-    } else {
-      // Spawn a new `HelperThread` to take the place of this thread, as the
-      // current thread prepares to execute a blocking action.
+      if (blocking) {
+        // This `WorkerThread` is already inside an enclosing blocking region.
+        thunk
+      } else {
+        // Logically enter the blocking region.
+        blocking = true
 
-      // Logically enter the blocking region.
-      blocking = true
+        val result = thunk
 
-      // Spawn a new `HelperThread`.
-      val helper =
-        new HelperThread(threadPrefix, blockingThreadCounter, batched, overflow, pool)
-      helper.start()
+        // Logically exit the blocking region.
+        blocking = false
 
-      // With another `HelperThread` started, it is time to execute the blocking
-      // action.
-      val result = thunk
-
-      // Blocking is finished. Time to signal the spawned helper thread.
-      helper.setSignal()
-
-      // Do not proceed until the helper thread has fully died. This is terrible
-      // for performance, but it is justified in this case as the stability of
-      // the `WorkStealingThreadPool` is of utmost importance in the face of
-      // blocking, which in itself is **not** what the pool is optimized for.
-      // In practice however, unless looking at a completely pathological case
-      // of propagating blocking actions on every spawned helper thread, this is
-      // not an issue, as the `HelperThread`s are all executing `IOFiber[_]`
-      // instances, which mostly consist of non-blocking code.
-      try helper.join()
-      catch {
-        case _: InterruptedException =>
-          // Propagate interruption to the helper thread.
-          Thread.interrupted()
-          helper.interrupt()
-          helper.join()
-          this.interrupt()
+        // Return the computed result from the blocking operation.
+        result
       }
+    } else {
+      // Drain the local queue to the `overflow` queue.
+      val drain = new Array[IOFiber[_]](LocalQueueCapacity)
+      queue.drain(drain)
+      overflow.offerAll(drain, random)
 
-      // Logically exit the blocking region.
-      blocking = false
+      if (blocking) {
+        // This `WorkerThread` is already inside an enclosing blocking region.
+        // There is no need to spawn another `HelperThread`. Instead, directly
+        // execute the blocking action.
+        thunk
+      } else {
+        // Spawn a new `HelperThread` to take the place of this thread, as the
+        // current thread prepares to execute a blocking action.
 
-      // Return the computed result from the blocking operation
-      result
+        // Logically enter the blocking region.
+        blocking = true
+
+        // Spawn a new `HelperThread`.
+        val helper =
+          new HelperThread(threadPrefix, blockingThreadCounter, batched, overflow, pool)
+        helper.start()
+
+        // With another `HelperThread` started, it is time to execute the blocking
+        // action.
+        val result = thunk
+
+        // Blocking is finished. Time to signal the spawned helper thread.
+        helper.setSignal()
+
+        // Do not proceed until the helper thread has fully died. This is terrible
+        // for performance, but it is justified in this case as the stability of
+        // the `WorkStealingThreadPool` is of utmost importance in the face of
+        // blocking, which in itself is **not** what the pool is optimized for.
+        // In practice however, unless looking at a completely pathological case
+        // of propagating blocking actions on every spawned helper thread, this is
+        // not an issue, as the `HelperThread`s are all executing `IOFiber[_]`
+        // instances, which mostly consist of non-blocking code.
+        try helper.join()
+        catch {
+          case _: InterruptedException =>
+            // Propagate interruption to the helper thread.
+            Thread.interrupted()
+            helper.interrupt()
+            helper.join()
+            this.interrupt()
+        }
+
+        // Logically exit the blocking region.
+        blocking = false
+
+        // Return the computed result from the blocking operation
+        result
+      }
     }
   }
 }


### PR DESCRIPTION
At the moment, any `scala.concurrent.blocking` operation is handled too paranoiacally, with a `HelperThread` being spawned almost every time and the local queue of the blocked worker thread completely drained. This is not ideal for the situations where there are blocking operations which occur infrequently. In those situations, it is better to try to wake up another worker thread which would be able to steal the fibers of the blocked thread. That way, no new thread needs to be spawned, which is much faster and safer. If the blocking does propagate to other worker threads, or if a worker thread could not be woken up due to any reason, this degrades to the old implementation where a `HelperThread` is spawned in anticipation.