### PR TITLE
Introduce benchmark of scheduling Runnables on WorkStealingThreadPool

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala
@@ -118,6 +118,33 @@ class WorkStealingBenchmark {
     allocBenchmark
   }
 
+  def runnableSchedulingBenchmark(ec: ExecutionContext): Unit = {
+    val theSize = 10000
+    val countDown = new java.util.concurrent.CountDownLatch(theSize)
+
+    def run(j: Int): Unit = {
+      ec.execute { () =>
+        if (j > 1000) {
+          countDown.countDown()
+        } else {
+          run(j + 1)
+        }
+      }
+    }
+
+    (0 to theSize).foreach(_ => run(0))
+
+    countDown.await()
+  }
+
+  /**
+   * Demonstrates performance of WorkStealingThreadPool when executing Runnables (that includes Futures).
+   */
+  @Benchmark
+  def runnableScheduling(): Unit = {
+    runnableSchedulingBenchmark(cats.effect.unsafe.implicits.global.compute)
+  }
+
   lazy val manyThreadsRuntime: IORuntime = {
     val (blocking, blockDown) = {
       val threadCount = new AtomicInteger(0)


### PR DESCRIPTION
Many Scala code bases mix pure cats-effect code, with impure code. Such code bases may want to use `IORuntime#compute` as their `ExecutionContext` for scheduling Futures, or Runnables. I found performance of the `WorkStealingThreadPool` in `cats-effect` 3.1.0 to be sub-optimal in such usecases. Therfore I propose introduction of a micro-benchmark which can drive future improvements in this area.

The new micro-benchmark is called mimics `WorkStealingBenchmark.runnableScheduling` and it mimics the `WorkStealingBenchmark.schedulingBenchmark`, except instead of working with `Fibers` it works with `Runnables`.

### Fibers vs Runnables comparision (CE 3.1.0)

```
[info] Benchmark                          (size)   Mode  Cnt   Score   Error    Units
[info] WorkStealingBenchmark.scheduling  1000000  thrpt   20  34.384 ± 0.400  ops/min
34 * 1e10 = 3.4e11
```

```
[info] Benchmark                                  (size)   Mode  Cnt  Score   Error    Units
[info] WorkStealingBenchmark.runnableScheduling  1000000  thrpt   20  9.402 ± 0.031  ops/min
9.4 * 10e7 = 9.4e7
```

Please keep in mind that `scheduling` does `1e10` scheduling operations per `op` and the `runnableScheduling` does `1e7` scheduling operations per `op`. So in the latest stable release (3.1.0), scheduling Runnables is ~3600 times slower than scheduling Fibers. The difference is at least partially due to exceptionally good performance of Fiber scheduling in `WorkStealingThreadPool`. Nonetheless I think it's worth having a look at possible ways of reducing the gap. In fact @vasilmkd already made a huge leap in that direction with (#1913) improving the score in this benchmark 11.5 times.

### Improvements in series/3.x (#1913)

3.1.0
```
[info] Benchmark                                  (size)   Mode  Cnt  Score   Error    Units
[info] WorkStealingBenchmark.runnableScheduling  1000000  thrpt   20  9.402 ± 0.031  ops/min
9.4e7
```

series/3.x (2c00489aa68bb7c1fd9d83f1e7173125a5b01c6e)
```
[info] Benchmark                                  (size)   Mode  Cnt    Score   Error    Units
[info] WorkStealingBenchmark.runnableScheduling  1000000  thrpt   20  108.812 ± 1.164  ops/min
1.1e9 operations
```
