### PR TITLE
Runnable scheduling improvements

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala
@@ -118,6 +118,33 @@ class WorkStealingBenchmark {
     allocBenchmark
   }
 
+  def runnableSchedulingBenchmark(ec: ExecutionContext): Unit = {
+    val theSize = 10000
+    val countDown = new java.util.concurrent.CountDownLatch(theSize)
+
+    def run(j: Int): Unit = {
+      ec.execute { () =>
+        if (j > 1000) {
+          countDown.countDown()
+        } else {
+          run(j + 1)
+        }
+      }
+    }
+
+    (0 to theSize).foreach(_ => run(0))
+
+    countDown.await()
+  }
+
+  /**
+   * Demonstrates performance of WorkStealingThreadPool when executing Runnables (that includes Futures).
+   */
+  @Benchmark
+  def runnableScheduling(): Unit = {
+    runnableSchedulingBenchmark(cats.effect.unsafe.implicits.global.compute)
+  }
+
   lazy val manyThreadsRuntime: IORuntime = {
     val (blocking, blockDown) = {
       val threadCount = new AtomicInteger(0)

--- a/core/shared/src/main/scala/cats/effect/unsafe/StripedHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/StripedHashtable.scala
@@ -25,7 +25,7 @@ package cats.effect.unsafe
 private[effect] final class StripedHashtable {
 
   // we expect to have at least this many tables (it will be rounded up to a power of two by the log2NumTables computation)
-  private[this] def minNumTables: Int = Runtime.getRuntime().availableProcessors()
+  private[this] def minNumTables: Int = Runtime.getRuntime().availableProcessors() * 4
 
   private[this] val log2NumTables = {
     var result = 0

--- a/core/shared/src/main/scala/cats/effect/unsafe/StripedHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/StripedHashtable.scala
@@ -23,22 +23,25 @@ package cats.effect.unsafe
  * hash table.
  */
 private[effect] final class StripedHashtable {
-  val numTables: Int = {
-    val cpus = Runtime.getRuntime().availableProcessors()
-    // Bit twiddling hacks.
-    // http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
-    var value = cpus - 1
-    value |= value >> 1
-    value |= value >> 2
-    value |= value >> 4
-    value |= value >> 8
-    value |= value >> 16
-    value + 1
+
+  // we expect to have at least this many tables (it will be rounded up to a power of two by the log2NumTables computation)
+  private[this] def minNumTables: Int = Runtime.getRuntime().availableProcessors()
+
+  private[this] val log2NumTables = {
+    var result = 0
+    var x = minNumTables
+    while (x != 0) {
+      result += 1
+      x >>= 1
+    }
+    result
   }
+
+  def numTables: Int = 1 << log2NumTables
 
   private[this] val mask: Int = numTables - 1
 
-  private[this] val initialCapacity: Int = 8
+  private[this] def initialCapacity: Int = 8
 
   val tables: Array[ThreadSafeHashtable] = {
     val array = new Array[ThreadSafeHashtable](numTables)
@@ -53,12 +56,12 @@ private[effect] final class StripedHashtable {
   def put(cb: Throwable => Unit): Unit = {
     val hash = System.identityHashCode(cb)
     val idx = hash & mask
-    tables(idx).put(cb, hash)
+    tables(idx).put(cb, hash >> log2NumTables)
   }
 
   def remove(cb: Throwable => Unit): Unit = {
     val hash = System.identityHashCode(cb)
     val idx = hash & mask
-    tables(idx).remove(cb, hash)
+    tables(idx).remove(cb, hash >> log2NumTables)
   }
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -38,7 +38,7 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
 
   def put(cb: Throwable => Unit, hash: Int): Unit = this.synchronized {
     val cap = capacity
-    if (size == cap) {
+    if (size << 1 >= cap) { // the << 1 ensures that the load factor will remain between 0.25 and 0.5
       val newCap = cap * 2
       val newHashtable = new Array[Throwable => Unit](newCap)
       System.arraycopy(hashtable, 0, newHashtable, 0, cap)


### PR DESCRIPTION
This branch is based on the #1935 as it relies on the `runnableScheduling` benchmark introduced there. You may want to review / merge #1935 first.

In this PR I'm aiming to improving performance of scheduling Runnables / Futures on `WorkStealingThreadPool` by improving performance of the `StripedHashtable`/`ThreadSafeHashtable`, without any major redesign of the process of scheduling or the hashtable itself.

### Measurments

Baseline (#1935):
```
[info] Benchmark                                  (size)   Mode  Cnt    Score   Error    Units
[info] WorkStealingBenchmark.runnableScheduling  1000000  thrpt   20  116.584 ± 0.705  ops/min
```

This PR:
```
[info] Benchmark                                  (size)   Mode  Cnt    Score   Error    Units
[info] WorkStealingBenchmark.runnableScheduling  1000000  thrpt   20  143.404 ± 3.828  ops/min
```

It seems there is some kind of "lottery" wher some forks of the benchmark get a bit better score and some get a bit worse score. That is the reason for the increased error (uncertainity).


This PR is focused just on a part of the benchmarked operation, that means there is an upper limit to the improvement that can be achieved. That upper limit is the score that we would get in this benchmark if the `StripedHashtable` was infinity fast. We can easily measure that limit by replacing the `put` and `remove` operations in `StripedHashtable` with a `()`. I find measuring it useful for building some sort of intuition about the performance.

The Limit:
```
[info] Benchmark                                  (size)   Mode  Cnt    Score   Error    Units
[info] WorkStealingBenchmark.runnableScheduling  1000000  thrpt   20  169.251 ± 0.301  ops/min
```

### Reasoning behind the changes

I've instrumented the `ThreadSafeHashtable.put` with counters measuring how many interations of the while loop are executed per inserted element. The baseline result was `4.29` iterations per `put` operation. It could be higher if we picked less favorable configuration of the benchmark (one that would make it more likely for the hashtables to stay at high load-factors). For example if we choose `theSize = 14*1024` then we hit `6.84` iterations per `put` operation. This PR reduces this average number of operations to `1.27` (in the default configuration of the benchmark).

#### 2b5c857 
The `StripedHashtable` distributes values between `numTables` `ThreadSafeHashtable`. This distribution is based on `log2NumTables` lowest bits of the `hashCode` of the values. The problem is that the  `ThreadSafeHashtable` also uses the lowest bits of hash code to address it's hash table. That means that for each of the `ThreadSafeHashtable` value of `log2NumTables` lowest bits in the hashcode is fixed and only one i every `numTables` cells in the hash table is actually ever directly address, which leads to lot's of collisions. 

#### 427db12
The current implementation of  `ThreadSafeHashtable` only resizes itself when it reaches load-factor == 1 (`size` / `capacity` == 1). This can lead to lots of expensive collisions. As the load-factor approaches 1, the probability of collision approaches 1, and the cost of a collision (measured in number of iterations of the while loop in `ThreadSafeHashtable.put`) approaches `capacity / 2`. To avoid this popular hashtable implementations attempt to keep load-factor below some reasonable value (typically in the vicinity of `0.7`). To keep the thing trivial I solve the problem here with a `<< 1` which will result in keeping the load-factor below `0.5`

#### 566e20b 
I like the idea of scaling the number of `tables` in `StripedHashtable` along with the number of processors. It means machines capable of lots of parallel operations will get lots of independent locks. But there's nothing stopping us from going from `availableProcessors` to `2 * availableProcessors` or `4 * availableProcessors` etc. Increasing the number of tables further reduces lock contention, while more smaller tables uses just a bit more memory than less bigger tables. I picked `4 * availableProcessors`, because `8 *`, and `16 *` didn't give any noticeable improvements. 
