### PR TITLE
Reimplement how `Runnable` instances are executed on the `WorkStealingThreadPool`

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -424,7 +424,10 @@ private[effect] final class WorkStealingThreadPool(
    * Preallocated fiber callback function for transforming
    * [[java.lang.Runnable]] values into [[cats.effect.IOFiber]] instances.
    */
-  private[this] val outcomeToUnit: OutcomeIO[Unit] => Unit = _ => ()
+  private[this] val outcomeToUnit: OutcomeIO[Unit] => Unit = {
+    case Outcome.Errored(t) => reportFailure(t)
+    case _ => ()
+  }
 
   /**
    * Reports unhandled exceptions and errors by printing them to the error

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -415,10 +415,16 @@ private[effect] final class WorkStealingThreadPool(
       // Executing a general purpose computation on the thread pool.
       // Wrap the runnable in an `IO` and execute it as a fiber.
       val io = IO.delay(runnable.run())
-      val fiber = new IOFiber[Unit](0, Map.empty, _ => (), io, this, self)
+      val fiber = new IOFiber[Unit](0, Map.empty, outcomeToUnit, io, this, self)
       executeFiber(fiber)
     }
   }
+
+  /**
+   * Preallocated fiber callback function for transforming
+   * [[java.lang.Runnable]] values into [[cats.effect.IOFiber]] instances.
+   */
+  private[this] val outcomeToUnit: OutcomeIO[Unit] => Unit = _ => ()
 
   /**
    * Reports unhandled exceptions and errors by printing them to the error

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -414,8 +414,9 @@ private[effect] final class WorkStealingThreadPool(
     } else {
       // Executing a general purpose computation on the thread pool.
       // Wrap the runnable in an `IO` and execute it as a fiber.
-      IO(runnable.run()).unsafeRunFiber((), reportFailure, _ => ())(self)
-      ()
+      val io = IO.delay(runnable.run())
+      val fiber = new IOFiber[Unit](0, Map.empty, _ => (), io, this, self)
+      executeFiber(fiber)
     }
   }
 


### PR DESCRIPTION
Tangentially related to #1898.

@RafalSumislawski if you could run the Runnables scheduling on this branch, it would be great. Thank you in advance. In any case, curious to hear what you think.