### PR TITLE
`SyncIO#>>` parameter should be by-name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -279,9 +279,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.FiberErrorHashtable"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.unsafe.IORuntime.fiberErrorCbs"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("cats.effect.unsafe.IORuntime.this"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.unsafe.IORuntime.<init>$default$6"),
-      // introduced by #1947, SyncIO#>> parameter should be by-name
-      ProblemFilters.exclude[IncompatibleMethTypeProblem]("cats.effect.SyncIO.>>")
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.unsafe.IORuntime.<init>$default$6")
     )
   )
   .jvmSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -279,7 +279,9 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.FiberErrorHashtable"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.unsafe.IORuntime.fiberErrorCbs"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("cats.effect.unsafe.IORuntime.this"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.unsafe.IORuntime.<init>$default$6")
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.unsafe.IORuntime.<init>$default$6"),
+      // introduced by #1947, SyncIO#>> parameter should be by-name
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("cats.effect.SyncIO.>>")
     )
   )
   .jvmSettings(

--- a/core/shared/src/main/scala/cats/effect/SyncIO.scala
+++ b/core/shared/src/main/scala/cats/effect/SyncIO.scala
@@ -66,6 +66,10 @@ sealed abstract class SyncIO[+A] private () {
   def >>[B](that: => SyncIO[B]): SyncIO[B] =
     flatMap(_ => that)
 
+  // Necessary overload to preserve binary compatibility #1947
+  private[effect] def >>[B](that: SyncIO[B]): SyncIO[B] =
+    flatMap(_ => that)
+
   /**
    * Alias for `map(_ => b)`.
    *

--- a/core/shared/src/main/scala/cats/effect/SyncIO.scala
+++ b/core/shared/src/main/scala/cats/effect/SyncIO.scala
@@ -63,7 +63,7 @@ sealed abstract class SyncIO[+A] private () {
    *
    * @see [[SyncIO#flatMap]]
    */
-  def >>[B](that: SyncIO[B]): SyncIO[B] =
+  def >>[B](that: => SyncIO[B]): SyncIO[B] =
     flatMap(_ => that)
 
   /**


### PR DESCRIPTION
Unfortunately, this is a binary incompatible change...