### PR TITLE
Add discord badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cats Effect
 
-[![Gitter](https://img.shields.io/gitter/room/typelevel/cats-effect.svg)](https://gitter.im/typelevel/cats-effect) [![Latest version](https://index.scala-lang.org/typelevel/cats-effect/cats-effect/latest.svg?color=orange)](https://index.scala-lang.org/typelevel/cats-effect/cats-effect)
+[![Latest version](https://index.scala-lang.org/typelevel/cats-effect/cats-effect/latest.svg?color=orange)](https://index.scala-lang.org/typelevel/cats-effect/cats-effect)
 [![Discord](https://img.shields.io/discord/632277896739946517.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/vpEv3HJ)
 
 <img align="right" width="256px" height="256px" src="images/cats-effect-logo.png"/>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Cats Effect
 
 [![Gitter](https://img.shields.io/gitter/room/typelevel/cats-effect.svg)](https://gitter.im/typelevel/cats-effect) [![Latest version](https://index.scala-lang.org/typelevel/cats-effect/cats-effect/latest.svg?color=orange)](https://index.scala-lang.org/typelevel/cats-effect/cats-effect)
+[![Discord](https://img.shields.io/discord/632277896739946517.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/vpEv3HJ)
 
 <img align="right" width="256px" height="256px" src="images/cats-effect-logo.png"/>
 


### PR DESCRIPTION
It might be a good idea to link people to Discord now that Typelevel has its own server, the way the badge is created is by the server id `632277896739946517`, see the result:
![Screen Shot 2021-05-09 at 17 59 39](https://user-images.githubusercontent.com/33580722/117578794-5b940900-b0f0-11eb-9945-86978ce248b0.png)
