### PR TITLE
Docs typo

### DIFF
--- a/docs/std/deferred.md
+++ b/docs/std/deferred.md
@@ -10,7 +10,7 @@ When created, a `Deferred` is empty. It can then be completed exactly once, and 
 ```scala mdoc:silent
 abstract class Deferred[F[_], A] {
   def get: F[A]
-  def complete(a: A): F[Unit]
+  def complete(a: A): F[Boolean]
 }
 ```
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -623,7 +623,7 @@ the output of each fiber and and applies a given function to them. In our case
 both producer and consumer shall run forever until user presses CTRL-C which
 will trigger a cancelation.
 
-Alternatively we could have used `start` method to explicitely create new
+Alternatively we could have used `start` method to explicitly create new
 `Fiber` instances that will run the producer and consumer, then use `join` to
 wait for them to finish, something like:
 


### PR DESCRIPTION
Fix incorrect type in `Deferred` docs