### PR TITLE
Hide the silent throwable arbitrary instance

### DIFF
--- a/laws/shared/src/main/scala/cats/effect/laws/discipline/arbitrary.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/discipline/arbitrary.scala
@@ -31,7 +31,7 @@ object arbitrary {
     override def printStackTrace(): Unit = ()
   }
 
-  implicit def arbitrarySilentThrowable: Arbitrary[Throwable] =
+  implicit private[effect] def arbitrarySilentThrowable: Arbitrary[Throwable] =
     Arbitrary(Gen.const(SilentThrowable))
 
   implicit def catsEffectLawsArbitraryForIO[A: Arbitrary: Cogen]: Arbitrary[IO[A]] =

--- a/laws/shared/src/test/scala/cats/effect/IOTests.scala
+++ b/laws/shared/src/test/scala/cats/effect/IOTests.scala
@@ -36,6 +36,8 @@ import scala.util.{Failure, Success, Try}
 import scala.concurrent.duration._
 
 class IOTests extends BaseTestsSuite {
+  import cats.effect.laws.discipline.arbitrary.arbitrarySilentThrowable
+
   checkAllAsync("IO", implicit ec => {
     implicit val cs: ContextShift[IO] = ec.ioContextShift
     ConcurrentEffectTests[IO].concurrentEffect[Int, Int, Int]


### PR DESCRIPTION
Fix for https://github.com/scala/community-build/pull/1418

@SethTisue