### PR TITLE
Lazy initialization of array based stacks

### DIFF
--- a/core/shared/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/shared/src/main/scala/cats/effect/ArrayStack.scala
@@ -16,12 +16,15 @@
 
 package cats.effect
 
-private[effect] final class ArrayStack[A <: AnyRef](
-    private[this] var buffer: Array[AnyRef],
-    private[this] var index: Int) {
+private[effect] final class ArrayStack[A <: AnyRef] {
 
-  def this(initBound: Int) =
-    this(new Array[AnyRef](initBound), 0)
+  private[this] var buffer: Array[AnyRef] = _
+  private[this] var index: Int = _
+
+  def init(bound: Int): Unit = {
+    buffer = new Array(bound)
+    index = 0
+  }
 
   def push(a: A): Unit = {
     checkAndGrow()
@@ -58,18 +61,6 @@ private[effect] final class ArrayStack[A <: AnyRef](
   def invalidate(): Unit = {
     index = 0
     buffer = null
-  }
-
-  def copy(): ArrayStack[A] = {
-    val buffer2 = if (index == 0) {
-      new Array[AnyRef](buffer.length)
-    } else {
-      val buffer2 = new Array[AnyRef](buffer.length)
-      System.arraycopy(buffer, 0, buffer2, 0, buffer.length)
-      buffer2
-    }
-
-    new ArrayStack[A](buffer2, index)
   }
 
   private[this] def checkAndGrow(): Unit =

--- a/core/shared/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/shared/src/main/scala/cats/effect/ArrayStack.scala
@@ -16,10 +16,14 @@
 
 package cats.effect
 
-private[effect] final class ArrayStack[A <: AnyRef] {
+private[effect] final class ArrayStack[A <: AnyRef](
+    private[this] var buffer: Array[AnyRef],
+    private[this] var index: Int) {
 
-  private[this] var buffer: Array[AnyRef] = _
-  private[this] var index: Int = _
+  def this(initBound: Int) =
+    this(new Array[AnyRef](initBound), 0)
+
+  def this() = this(null, 0)
 
   def init(bound: Int): Unit = {
     buffer = new Array(bound)
@@ -61,6 +65,18 @@ private[effect] final class ArrayStack[A <: AnyRef] {
   def invalidate(): Unit = {
     index = 0
     buffer = null
+  }
+
+  def copy(): ArrayStack[A] = {
+    val buffer2 = if (index == 0) {
+      new Array[AnyRef](buffer.length)
+    } else {
+      val buffer2 = new Array[AnyRef](buffer.length)
+      System.arraycopy(buffer, 0, buffer2, 0, buffer.length)
+      buffer2
+    }
+
+    new ArrayStack[A](buffer2, index)
   }
 
   private[this] def checkAndGrow(): Unit =

--- a/core/shared/src/main/scala/cats/effect/ByteStack.scala
+++ b/core/shared/src/main/scala/cats/effect/ByteStack.scala
@@ -16,10 +16,14 @@
 
 package cats.effect
 
-private[effect] final class ByteStack {
+private[effect] final class ByteStack(
+    private[this] var buffer: Array[Byte],
+    private[this] var index: Int) {
 
-  private[this] var buffer: Array[Byte] = _
-  private[this] var index: Int = _
+  def this(initBound: Int) =
+    this(new Array[Byte](initBound), 0)
+
+  def this() = this(null, 0)
 
   def init(bound: Int): Unit = {
     buffer = new Array(bound)
@@ -52,6 +56,18 @@ private[effect] final class ByteStack {
   def invalidate(): Unit = {
     index = 0
     buffer = null
+  }
+
+  def copy(): ByteStack = {
+    val buffer2 = if (index == 0) {
+      new Array[Byte](buffer.length)
+    } else {
+      val buffer2 = new Array[Byte](buffer.length)
+      System.arraycopy(buffer, 0, buffer2, 0, buffer.length)
+      buffer2
+    }
+
+    new ByteStack(buffer2, index)
   }
 
   private[this] def checkAndGrow(): Unit =

--- a/core/shared/src/main/scala/cats/effect/ByteStack.scala
+++ b/core/shared/src/main/scala/cats/effect/ByteStack.scala
@@ -16,12 +16,15 @@
 
 package cats.effect
 
-private[effect] final class ByteStack(
-    private[this] var buffer: Array[Byte],
-    private[this] var index: Int) {
+private[effect] final class ByteStack {
 
-  def this(initBound: Int) =
-    this(new Array[Byte](initBound), 0)
+  private[this] var buffer: Array[Byte] = _
+  private[this] var index: Int = _
+
+  def init(bound: Int): Unit = {
+    buffer = new Array(bound)
+    index = 0
+  }
 
   def push(b: Byte): Unit = {
     checkAndGrow()
@@ -49,18 +52,6 @@ private[effect] final class ByteStack(
   def invalidate(): Unit = {
     index = 0
     buffer = null
-  }
-
-  def copy(): ByteStack = {
-    val buffer2 = if (index == 0) {
-      new Array[Byte](buffer.length)
-    } else {
-      val buffer2 = new Array[Byte](buffer.length)
-      System.arraycopy(buffer, 0, buffer2, 0, buffer.length)
-      buffer2
-    }
-
-    new ByteStack(buffer2, index)
   }
 
   private[this] def checkAndGrow(): Unit =

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -95,7 +95,7 @@ private final class IOFiber[A](
   private[this] var masks: Int = initMask
   private[this] var finalizing: Boolean = false
 
-  private[this] val finalizers = new ArrayStack[IO[Unit]](16)
+  private[this] var finalizers: ArrayStack[IO[Unit]] = _
 
   private[this] val callbacks = new CallbackStack[A](cb)
 
@@ -911,12 +911,11 @@ private final class IOFiber[A](
     if (conts != null) {
       conts.invalidate()
       objectState.invalidate()
+      finalizers.invalidate()
     }
 
     currentCtx = null
     ctxs = null
-
-    finalizers.invalidate()
   }
 
   private[this] def asyncCancel(cb: Either[Throwable, Unit] => Unit): Unit = {
@@ -1110,6 +1109,7 @@ private final class IOFiber[A](
       conts.push(RunTerminusK)
 
       objectState = new ArrayStack(16)
+      finalizers = new ArrayStack(16)
 
       ctxs = new ArrayStack[ExecutionContext](2)
       ctxs.push(currentCtx)

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -912,10 +912,10 @@ private final class IOFiber[A](
       conts.invalidate()
       objectState.invalidate()
       finalizers.invalidate()
+      ctxs.invalidate()
     }
 
     currentCtx = null
-    ctxs = null
   }
 
   private[this] def asyncCancel(cb: Either[Throwable, Unit] => Unit): Unit = {

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -97,7 +97,7 @@ private final class IOFiber[A](
 
   private[this] var finalizers: ArrayStack[IO[Unit]] = _
 
-  private[this] val callbacks = new CallbackStack[A](cb)
+  private[this] val callbacks: CallbackStack[A] = new CallbackStack(cb)
 
   private[this] var localState: IOLocalState = initLocalState
 
@@ -109,13 +109,13 @@ private final class IOFiber[A](
   private[this] var resumeIO: IO[Any] = startIO
 
   /* prefetch for Right(()) */
-  private[this] val RightUnit = IOFiber.RightUnit
+  private[this] val RightUnit: Either[Throwable, Unit] = IOFiber.RightUnit
 
   /* similar prefetch for EndFiber */
-  private[this] val IOEndFiber = IO.EndFiber
+  private[this] val IOEndFiber: IO.EndFiber.type = IO.EndFiber
 
-  private[this] val cancelationCheckThreshold = runtime.config.cancelationCheckThreshold
-  private[this] val autoYieldThreshold = runtime.config.autoYieldThreshold
+  private[this] val cancelationCheckThreshold: Int = runtime.config.cancelationCheckThreshold
+  private[this] val autoYieldThreshold: Int = runtime.config.autoYieldThreshold
 
   override def run(): Unit = {
     // insert a read barrier after every async boundary

--- a/core/shared/src/main/scala/cats/effect/SyncIO.scala
+++ b/core/shared/src/main/scala/cats/effect/SyncIO.scala
@@ -191,7 +191,8 @@ sealed abstract class SyncIO[+A] private () {
 
     val conts = new ByteStack()
     conts.init(16)
-    val objectState = new ArrayStack[AnyRef](16)
+    val objectState = new ArrayStack[AnyRef]()
+    objectState.init(16)
 
     conts.push(RunTerminusK)
 

--- a/core/shared/src/main/scala/cats/effect/SyncIO.scala
+++ b/core/shared/src/main/scala/cats/effect/SyncIO.scala
@@ -189,7 +189,8 @@ sealed abstract class SyncIO[+A] private () {
   def unsafeRunSync(): A = {
     import SyncIOConstants._
 
-    val conts = new ByteStack(16)
+    val conts = new ByteStack()
+    conts.init(16)
     val objectState = new ArrayStack[AnyRef](16)
 
     conts.push(RunTerminusK)

--- a/core/shared/src/main/scala/cats/effect/SyncIO.scala
+++ b/core/shared/src/main/scala/cats/effect/SyncIO.scala
@@ -189,10 +189,8 @@ sealed abstract class SyncIO[+A] private () {
   def unsafeRunSync(): A = {
     import SyncIOConstants._
 
-    val conts = new ByteStack()
-    conts.init(16)
-    val objectState = new ArrayStack[AnyRef]()
-    objectState.init(16)
+    val conts = new ByteStack(16)
+    val objectState = new ArrayStack[AnyRef](16)
 
     conts.push(RunTerminusK)
 


### PR DESCRIPTION
Some of the previous logic made sense when the cancelation code could run the fiber before it was even executed, but we blocked this entry right before the 3.0 release.

This PR lazily allocates all of the array backed stacks and unconditionally clears them in `done`, thus removing a branching instruction.