### PR TITLE
Fix Hotswap example in docs

### DIFF
--- a/docs/std/hotswap.md
+++ b/docs/std/hotswap.md
@@ -31,7 +31,7 @@ A rotating logger would then look something like this:
 def rotating(n: Int): Resource[IO, Logger[IO]] =
   Hotswap.create[IO, File].flatMap { hs =>
     def file(name: String): Resource[IO, File] = ???
-    def write(file: File): IO[Unit] = ???
+    def write(file: File, msg: String): IO[Unit] = ???
 
     Resource.eval {
       for {

--- a/docs/std/hotswap.md
+++ b/docs/std/hotswap.md
@@ -31,6 +31,7 @@ A rotating logger would then look something like this:
 def rotating(n: Int): Resource[IO, Logger[IO]] =
   Hotswap.create[IO, File].flatMap { hs =>
     def file(name: String): Resource[IO, File] = ???
+    def write(file: File): IO[Unit] = ???
 
     Resource.eval {
       for {


### PR DESCRIPTION
Previously there were a few errors:
 - Missing for-comprehension block meaning the syntax was invalid
 - Overloaded names in scope meaning it would not compile
 - A `Ref` was "subtracted" from an int as the ref was not accessed
 - Not very important but I think the implementation would use the
   `0.log` filename twice!