### PR TITLE
Documentation of bracket is unclear?

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -248,7 +248,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    * termination and cancelation.
    *
    * '''NOTE on error handling''': in case both the `release`
-   * function and the `use` function throws, the error raised by `use`
+   * function and the `use` function throws, the error raised by `release`
    * gets signaled.
    *
    * For example:

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -248,24 +248,28 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    * termination and cancelation.
    *
    * '''NOTE on error handling''': in case both the `release`
-   * function and the `use` function throws, the error raised by `release`
+   * function and the `use` function throws, the error raised by `use`
    * gets signaled.
    *
    * For example:
    *
    * {{{
+   *   val foo = new RuntimeException("Foo")
+   *   val bar = new RuntimeException("Bar")
    *   IO("resource").bracket { _ =>
    *     // use
-   *     IO.raiseError(new RuntimeException("Foo"))
+   *     IO.raiseError(foo)
    *   } { _ =>
    *     // release
-   *     IO.raiseError(new RuntimeException("Bar"))
+   *     IO.raiseError(bar)
    *   }
    * }}}
    *
-   * In this case the error signaled downstream is `"Bar"`, while the
-   * `"Foo"` error gets reported on a side-channel. This is consistent
-   * with the behavior `try {} finally {}`.
+   * In this case the resulting `IO` will raise error `foo`, while the
+   * `bar` error gets reported on a side-channel. This is consistent
+   * with the behavior of Java's "Try with resources" except that no
+   * involved exceptions are mutated (i.e., in contrast to Java, `bar`
+   * isn't added as a suppressed exception to `foo`).
    *
    * @see [[bracketCase]]
    *


### PR DESCRIPTION
Looking at CE 3.1.1's unit test

https://github.com/typelevel/cats-effect/blob/ffcd1dbaf455bc3dc86dff7884375917738b0b08/tests/shared/src/test/scala/cats/effect/IOSpec.scala#L188-L198

I found the documentation of `bracket()` slightly confusing in its use of "signaling" and "side-channel reporting". I'm suggestion a rewording in the hope it makes things clearer. WDYT?
