### PR TITLE
Use proper cats-effect versions in scalafix tests

### DIFF
--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -15,7 +15,7 @@ lazy val v2_4_0_input = project
   .in(file("v2_4_0/input"))
   .settings(
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats-effect" % "2.5.1"
+      "org.typelevel" %% "cats-effect" % "2.3.3"
     )
   )
 
@@ -25,7 +25,7 @@ lazy val v2_4_0_output = project
     libraryDependencies ++= Seq(
       // Ideally this would be a 2.4.0 release candidate or any other version
       // newer than 2.3.3.
-      "org.typelevel" %% "cats-effect" % "3.1.1"
+      "org.typelevel" %% "cats-effect" % "2.4.0"
     )
   )
 


### PR DESCRIPTION
I made a mistake when editing this configuration, the scalafix fixes are meant to be used between `cats-effect` `2.3.3` and `2.4.0` only.