### PR TITLE
Rewrite and improve `ThreadSafeHashtable`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -282,7 +282,11 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.unsafe.IORuntime.<init>$default$6"),
       // introduced by #1928, wake up a worker thread before spawning a helper thread when blocking
       // changes to `cats.effect.unsafe` package private code
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.unsafe.WorkStealingThreadPool.notifyParked")
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.unsafe.WorkStealingThreadPool.notifyParked"),
+      // introduced by #2041, re-hash and insert callbacks when resizing the `ThreadSafeHashtable`
+      // changes to `cats.effect.unsafe` package private code
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.unsafe.ThreadSafeHashtable.hashtable"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.unsafe.ThreadSafeHashtable.hashtable_=")
     )
   )
   .jvmSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -283,7 +283,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       // introduced by #1928, wake up a worker thread before spawning a helper thread when blocking
       // changes to `cats.effect.unsafe` package private code
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.unsafe.WorkStealingThreadPool.notifyParked"),
-      // introduced by #2041, re-hash and insert callbacks when resizing the `ThreadSafeHashtable`
+      // introduced by #2041, Rewrite and improve `ThreadSafeHashtable`
       // changes to `cats.effect.unsafe` package private code
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.unsafe.ThreadSafeHashtable.hashtable"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.unsafe.ThreadSafeHashtable.hashtable_=")

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1324,6 +1324,9 @@ private final class IOFiber[A](
     currentCtx.reportFailure(t)
     runtime.shutdown()
 
+    // Make sure the shutdown did not interrupt this thread.
+    Thread.interrupted()
+
     var idx = 0
     val tables = runtime.fiberErrorCbs.tables
     val numTables = runtime.fiberErrorCbs.numTables

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1328,12 +1328,13 @@ private final class IOFiber[A](
     val tables = runtime.fiberErrorCbs.tables
     val numTables = runtime.fiberErrorCbs.numTables
     while (idx < numTables) {
-      val table = tables(idx).unsafeHashtable()
-      val len = table.length
+      val table = tables(idx)
       table.synchronized {
+        val hashtable = table.unsafeHashtable()
+        val len = hashtable.length
         var i = 0
         while (i < len) {
-          val cb = table(i)
+          val cb = hashtable(i)
           if (cb ne null) {
             cb(t)
           }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1328,7 +1328,7 @@ private final class IOFiber[A](
     val tables = runtime.fiberErrorCbs.tables
     val numTables = runtime.fiberErrorCbs.numTables
     while (idx < numTables) {
-      val table = tables(idx).hashtable
+      val table = tables(idx).unsafeHashtable()
       val len = table.length
       table.synchronized {
         var i = 0

--- a/core/shared/src/main/scala/cats/effect/unsafe/StripedHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/StripedHashtable.scala
@@ -23,19 +23,7 @@ package cats.effect.unsafe
  * hash table.
  */
 private[effect] final class StripedHashtable {
-
-  // we expect to have at least this many tables (it will be rounded up to a power of two by the log2NumTables computation)
-  private[this] def minNumTables: Int = Runtime.getRuntime().availableProcessors() * 4
-
-  private[this] val log2NumTables = {
-    var result = 0
-    var x = minNumTables
-    while (x != 0) {
-      result += 1
-      x >>= 1
-    }
-    result
-  }
+  private[this] val log2NumTables: Int = StripedHashtable.log2NumTables
 
   def numTables: Int = 1 << log2NumTables
 
@@ -63,5 +51,20 @@ private[effect] final class StripedHashtable {
     val hash = System.identityHashCode(cb)
     val idx = hash & mask
     tables(idx).remove(cb, hash >> log2NumTables)
+  }
+}
+
+private object StripedHashtable {
+  // we expect to have at least this many tables (it will be rounded up to a power of two by the log2NumTables computation)
+  private[this] def minNumTables: Int = Runtime.getRuntime().availableProcessors() * 4
+
+  final val log2NumTables: Int = {
+    var result = 0
+    var x = minNumTables
+    while (x != 0) {
+      result += 1
+      x >>= 1
+    }
+    result
   }
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -97,7 +97,9 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
     val init = hash & mask
     var idx = init
     val table = hashtable
-    while (true) {
+    var remaining = mask
+
+    while (remaining >= 0) {
       val cur = table(idx)
       if (cb eq cur) {
         // Mark the removed callback with the `Tombstone` reference.
@@ -107,13 +109,11 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
       } else if (cur ne null) {
         // Skip over references of other callbacks and `Tombstone` objects.
         idx = (idx + 1) & mask
-        if (idx == init) {
-          return
-        }
       } else {
         // Reached a `null` reference. The callback was not in the hash table.
         return
       }
+      remaining -= 1
     }
   }
 

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -104,7 +104,7 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
   def unsafeHashtable(): Array[Throwable => Unit] = hashtable
 
   def isEmpty: Boolean =
-    size == 0
+    size == 0 && hashtable.forall(_ eq null)
 }
 
 private object ThreadSafeHashtable {

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -79,8 +79,7 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
         table(idx) = cb
         return
       } else {
-        idx += 1
-        idx &= mask
+        idx = (idx + 1) & mask
       }
     }
   }
@@ -95,8 +94,7 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
         size -= 1
         return
       } else {
-        idx += 1
-        idx &= mask
+        idx = (idx + 1) & mask
         if (idx == init) {
           return
         }

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -41,6 +41,7 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
     val cap = capacity
     if ((size << 1) >= cap) { // the << 1 ensures that the load factor will remain between 0.25 and 0.5
       val newCap = cap << 1
+      val newMask = newCap - 1
       val newHashtable = new Array[Throwable => Unit](newCap)
 
       val table = hashtable
@@ -48,7 +49,7 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
       while (i < cap) {
         val cur = table(i)
         if (cur ne null) {
-          insert(newHashtable, cur, System.identityHashCode(cur) >> log2NumTables)
+          insert(newHashtable, newMask, cur, System.identityHashCode(cur) >> log2NumTables)
         }
         i += 1
       }
@@ -58,7 +59,7 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
       capacity = newCap
     }
 
-    insert(hashtable, cb, hash)
+    insert(hashtable, mask, cb, hash)
     size += 1
   }
 
@@ -69,6 +70,7 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
    */
   private[this] def insert(
       table: Array[Throwable => Unit],
+      mask: Int,
       cb: Throwable => Unit,
       hash: Int): Unit = {
     var idx = hash & mask

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -77,7 +77,9 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
       cb: Throwable => Unit,
       hash: Int): Unit = {
     var idx = hash & mask
-    while (true) {
+    var remaining = mask
+
+    while (remaining >= 0) {
       val cur = table(idx)
       if ((cur eq null) || (cur eq Tombstone)) {
         // Both null and `Tombstone` references are considered empty and new
@@ -87,6 +89,7 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
       } else {
         idx = (idx + 1) & mask
       }
+      remaining -= 1
     }
   }
 

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -32,9 +32,9 @@ package unsafe
  */
 private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
   var hashtable: Array[Throwable => Unit] = new Array(initialCapacity)
-  private[this] var size = 0
-  private[this] var mask = initialCapacity - 1
-  private[this] var capacity = initialCapacity
+  private[this] var size: Int = 0
+  private[this] var mask: Int = initialCapacity - 1
+  private[this] var capacity: Int = initialCapacity
 
   def put(cb: Throwable => Unit, hash: Int): Unit = this.synchronized {
     val cap = capacity

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -103,3 +103,7 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
 
   def unsafeHashtable(): Array[Throwable => Unit] = hashtable
 }
+
+private object ThreadSafeHashtable {
+  private[ThreadSafeHashtable] final val Tombstone: Throwable => Unit = _ => ()
+}

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -42,6 +42,7 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
       val newCap = cap << 1
       val newHashtable = new Array[Throwable => Unit](newCap)
 
+      val sz = size
       val table = hashtable
       var i = 0
       while (i < cap) {
@@ -52,6 +53,7 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
         i += 1
       }
 
+      size = sz
       hashtable = newHashtable
       mask = newCap - 1
       capacity = newCap
@@ -102,6 +104,9 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
   }
 
   def unsafeHashtable(): Array[Throwable => Unit] = hashtable
+
+  def isEmpty: Boolean =
+    size == 0
 }
 
 private object ThreadSafeHashtable {

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -47,17 +47,19 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
       capacity = newCap
     }
 
-    insert(cb, hash)
+    insert(hashtable, cb, hash)
   }
 
   /**
    * ''Must'' be called with the lock on the whole `ThreadSafeHashtable` object
-   * already held. The `hashtable` should contain at least one empty space to
+   * already held. The `table` should contain at least one empty space to
    * place the callback in.
    */
-  private[this] def insert(cb: Throwable => Unit, hash: Int): Unit = {
+  private[this] def insert(
+      table: Array[Throwable => Unit],
+      cb: Throwable => Unit,
+      hash: Int): Unit = {
     var idx = hash & mask
-    val table = hashtable
     while (true) {
       if (table(idx) eq null) {
         table(idx) = cb

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -85,9 +85,10 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
   def remove(cb: Throwable => Unit, hash: Int): Unit = this.synchronized {
     val init = hash & mask
     var idx = init
+    val table = hashtable
     while (true) {
-      if (cb eq hashtable(idx)) {
-        hashtable(idx) = null
+      if (cb eq table(idx)) {
+        table(idx) = null
         size -= 1
         return
       } else {

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -45,9 +45,9 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
       val table = hashtable
       var i = 0
       while (i < cap) {
-        val cb = table(i)
-        if (cb ne null) {
-          insert(newHashtable, cb, System.identityHashCode(cb))
+        val cur = table(i)
+        if (cur ne null) {
+          insert(newHashtable, cur, System.identityHashCode(cur))
         }
         i += 1
       }

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -31,7 +31,7 @@ package unsafe
  *                        power of 2
  */
 private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
-  var hashtable: Array[Throwable => Unit] = new Array(initialCapacity)
+  private[this] var hashtable: Array[Throwable => Unit] = new Array(initialCapacity)
   private[this] var size: Int = 0
   private[this] var mask: Int = initialCapacity - 1
   private[this] var capacity: Int = initialCapacity
@@ -99,4 +99,6 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
       }
     }
   }
+
+  def unsafeHashtable(): Array[Throwable => Unit] = hashtable
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -119,7 +119,10 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
 
   def unsafeHashtable(): Array[Throwable => Unit] = hashtable
 
-  def isEmpty: Boolean =
+  /**
+   * Only used in testing.
+   */
+  private[unsafe] def isEmpty: Boolean =
     size == 0 && hashtable.forall(cb => (cb eq null) || (cb eq Tombstone))
 }
 

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -47,10 +47,20 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
       capacity = newCap
     }
 
+    insert(cb, hash)
+  }
+
+  /**
+   * ''Must'' be called with the lock on the whole `ThreadSafeHashtable` object
+   * already held. The `hashtable` should contain at least one empty space to
+   * place the callback in.
+   */
+  private[this] def insert(cb: Throwable => Unit, hash: Int): Unit = {
     var idx = hash & mask
+    val table = hashtable
     while (true) {
-      if (hashtable(idx) == null) {
-        hashtable(idx) = cb
+      if (table(idx) eq null) {
+        table(idx) = cb
         size += 1
         return
       } else {

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -42,7 +42,6 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
       val newCap = cap << 1
       val newHashtable = new Array[Throwable => Unit](newCap)
 
-      val sz = size
       val table = hashtable
       var i = 0
       while (i < cap) {
@@ -53,13 +52,13 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
         i += 1
       }
 
-      size = sz
       hashtable = newHashtable
       mask = newCap - 1
       capacity = newCap
     }
 
     insert(hashtable, cb, hash)
+    size += 1
   }
 
   /**
@@ -75,7 +74,6 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
     while (true) {
       if (table(idx) eq null) {
         table(idx) = cb
-        size += 1
         return
       } else {
         idx += 1

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -41,7 +41,17 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
     if (size << 1 >= cap) { // the << 1 ensures that the load factor will remain between 0.25 and 0.5
       val newCap = cap * 2
       val newHashtable = new Array[Throwable => Unit](newCap)
-      System.arraycopy(hashtable, 0, newHashtable, 0, cap)
+
+      val table = hashtable
+      var i = 0
+      while (i < cap) {
+        val cb = table(i)
+        if (cb ne null) {
+          insert(newHashtable, cb, System.identityHashCode(cb))
+        }
+        i += 1
+      }
+
       hashtable = newHashtable
       mask = newCap - 1
       capacity = newCap

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -38,8 +38,8 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
 
   def put(cb: Throwable => Unit, hash: Int): Unit = this.synchronized {
     val cap = capacity
-    if (size << 1 >= cap) { // the << 1 ensures that the load factor will remain between 0.25 and 0.5
-      val newCap = cap * 2
+    if ((size << 1) >= cap) { // the << 1 ensures that the load factor will remain between 0.25 and 0.5
+      val newCap = cap << 1
       val newHashtable = new Array[Throwable => Unit](newCap)
 
       val table = hashtable

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -35,6 +35,7 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
   private[this] var size: Int = 0
   private[this] var mask: Int = initialCapacity - 1
   private[this] var capacity: Int = initialCapacity
+  private[this] val log2NumTables: Int = StripedHashtable.log2NumTables
 
   def put(cb: Throwable => Unit, hash: Int): Unit = this.synchronized {
     val cap = capacity
@@ -47,7 +48,7 @@ private[effect] final class ThreadSafeHashtable(initialCapacity: Int) {
       while (i < cap) {
         val cur = table(i)
         if (cur ne null) {
-          insert(newHashtable, cur, System.identityHashCode(cur))
+          insert(newHashtable, cur, System.identityHashCode(cur) >> log2NumTables)
         }
         i += 1
       }

--- a/tests/jvm/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
@@ -77,7 +77,9 @@ class StripedHashtableSpec extends BaseSpec with Runners {
             .flatMap { _ =>
               IO.blocking {
                 rt.fiberErrorCbs.synchronized {
-                  rt.fiberErrorCbs.tables.forall(_.hashtable.forall(_ eq null)) mustEqual true
+                  rt.fiberErrorCbs
+                    .tables
+                    .forall(_.unsafeHashtable().forall(_ eq null)) mustEqual true
                 }
               }
             }

--- a/tests/jvm/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
@@ -79,7 +79,7 @@ class StripedHashtableSpec extends BaseSpec with Runners {
                 rt.fiberErrorCbs.synchronized {
                   rt.fiberErrorCbs
                     .tables
-                    .forall(_.unsafeHashtable().forall(_ eq null)) mustEqual true
+                    .forall(_.isEmpty) mustEqual true
                 }
               }
             }

--- a/tests/jvm/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
@@ -77,9 +77,7 @@ class StripedHashtableSpec extends BaseSpec with Runners {
             .flatMap { _ =>
               IO.blocking {
                 rt.fiberErrorCbs.synchronized {
-                  rt.fiberErrorCbs
-                    .tables
-                    .forall(_.isEmpty) mustEqual true
+                  rt.fiberErrorCbs.tables.forall(_.isEmpty) mustEqual true
                 }
               }
             }


### PR DESCRIPTION
I realized that copying the elements of the old array to the beginning of the new array messes up the hashing.

For this one, I dug deep into my Data Structures university course, I think the hash table is finally what it was honestly supposed to be from day 1.