### PR TITLE
Tracing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -286,7 +286,27 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       // introduced by #2041, Rewrite and improve `ThreadSafeHashtable`
       // changes to `cats.effect.unsafe` package private code
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.unsafe.ThreadSafeHashtable.hashtable"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.unsafe.ThreadSafeHashtable.hashtable_=")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.unsafe.ThreadSafeHashtable.hashtable_="),
+      // introduced by #2051, Tracing
+      // changes to package private code
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Blocking.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Blocking.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Blocking.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Delay.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Delay.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Delay.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#FlatMap.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#FlatMap.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#FlatMap.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#HandleErrorWith.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#HandleErrorWith.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#HandleErrorWith.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Map.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Map.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Map.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Uncancelable.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Uncancelable.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Uncancelable.this")
     )
   )
   .jvmSettings(

--- a/core/js/src/main/scala/cats/effect/tracing/TracingConstants.scala
+++ b/core/js/src/main/scala/cats/effect/tracing/TracingConstants.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.tracing
+
+private object TracingConstants {
+
+  final val isCachedStackTracing: Boolean = false
+
+  final val isFullStackTracing: Boolean = false
+
+  final val isStackTracing: Boolean = false
+
+  final val traceBufferLogSize: Int = 0
+
+  final val enhancedExceptions: Boolean = false
+}

--- a/core/jvm/src/main/java/cats/effect/tracing/TracingConstants.java
+++ b/core/jvm/src/main/java/cats/effect/tracing/TracingConstants.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.tracing;
+
+import java.util.Optional;
+
+class TracingConstants {
+
+  /**
+   * Sets stack tracing mode for a JVM process, which controls how much stack
+   * trace information is captured. Acceptable values are: NONE, CACHED, FULL.
+   */
+  private static final String stackTracingMode = Optional.ofNullable(System.getProperty("cats.effect.stackTracingMode"))
+      .filter(x -> !x.isEmpty()).orElse("cached");
+
+  static final boolean isCachedStackTracing = stackTracingMode.equalsIgnoreCase("cached");
+
+  static final boolean isFullStackTracing = stackTracingMode.equalsIgnoreCase("full");
+
+  static final boolean isStackTracing = isFullStackTracing || isCachedStackTracing;
+
+  /**
+   * The number of trace lines to retain during tracing. If more trace lines are
+   * produced, then the oldest trace lines will be discarded. Automatically
+   * rounded up to the nearest power of 2.
+   */
+  static final int traceBufferLogSize = Optional.ofNullable(System.getProperty("cats.effect.traceBufferLogSize"))
+      .filter(x -> !x.isEmpty()).flatMap(x -> {
+        try {
+          return Optional.of(Integer.valueOf(x));
+        } catch (Exception e) {
+          return Optional.empty();
+        }
+      }).orElse(4);
+
+  /**
+   * Sets the enhanced exceptions flag, which controls whether or not the stack
+   * traces of IO exceptions are augmented to include async stack trace
+   * information. Stack tracing must be enabled in order to use this feature. This
+   * flag is enabled by default.
+   */
+  static final boolean enhancedExceptions = Optional.ofNullable(System.getProperty("cats.effect.enhancedExceptions"))
+      .map(Boolean::valueOf).orElse(true);
+}

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -409,7 +409,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    * Implements `ApplicativeError.handleErrorWith`.
    */
   def handleErrorWith[B >: A](f: Throwable => IO[B]): IO[B] =
-    IO.HandleErrorWith(this, f)
+    IO.HandleErrorWith(this, f, Tracing.calculateTracingEvent(f.getClass))
 
   def ifM[B](ifTrue: => IO[B], ifFalse: => IO[B])(implicit ev: A <:< Boolean): IO[B] =
     flatMap(a => if (ev(a)) ifTrue else ifFalse)
@@ -1443,7 +1443,10 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def tag = 8
   }
 
-  private[effect] final case class HandleErrorWith[+A](ioa: IO[A], f: Throwable => IO[A])
+  private[effect] final case class HandleErrorWith[+A](
+      ioa: IO[A],
+      f: Throwable => IO[A],
+      event: TracingEvent)
       extends IO[A] {
     def tag = 9
   }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1504,7 +1504,11 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def tag = 20
   }
 
-  private[effect] final case class Blocking[+A](hint: Sync.Type, thunk: () => A) extends IO[A] {
+  private[effect] final case class Blocking[+A](
+      hint: Sync.Type,
+      thunk: () => A,
+      event: TracingEvent)
+      extends IO[A] {
     def tag = 21
   }
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -423,7 +423,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    * failures would be completely silent and `IO` references would
    * never terminate on evaluation.
    */
-  def map[B](f: A => B): IO[B] = IO.Map(this, f)
+  def map[B](f: A => B): IO[B] = IO.Map(this, f, Tracing.calculateTracingEvent(f.getClass))
 
   def onCancel(fin: IO[Unit]): IO[A] =
     IO.OnCancel(this, fin)
@@ -1425,7 +1425,8 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def tag = 5
   }
 
-  private[effect] final case class Map[E, +A](ioe: IO[E], f: E => A) extends IO[A] {
+  private[effect] final case class Map[E, +A](ioe: IO[E], f: E => A, event: TracingEvent)
+      extends IO[A] {
     def tag = 6
   }
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -971,7 +971,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     Sleep(delay)
 
   def uncancelable[A](body: Poll[IO] => IO[A]): IO[A] =
-    Uncancelable(body)
+    Uncancelable(body, Tracing.calculateTracingEvent(body.getClass))
 
   private[this] val _unit: IO[Unit] = Pure(())
 
@@ -1459,7 +1459,10 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def tag = 11
   }
 
-  private[effect] final case class Uncancelable[+A](body: Poll[IO] => IO[A]) extends IO[A] {
+  private[effect] final case class Uncancelable[+A](
+      body: Poll[IO] => IO[A],
+      event: TracingEvent)
+      extends IO[A] {
     def tag = 12
   }
   private[effect] object Uncancelable {

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -343,7 +343,8 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    * failures would be completely silent and `IO` references would
    * never terminate on evaluation.
    */
-  def flatMap[B](f: A => IO[B]): IO[B] = IO.FlatMap(this, f)
+  def flatMap[B](f: A => IO[B]): IO[B] =
+    IO.FlatMap(this, f, Tracing.calculateTracingEvent(f.getClass))
 
   def flatten[B](implicit ev: A <:< IO[B]): IO[B] = flatMap(ev)
 
@@ -1430,7 +1431,11 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def tag = 6
   }
 
-  private[effect] final case class FlatMap[E, +A](ioe: IO[E], f: E => IO[A]) extends IO[A] {
+  private[effect] final case class FlatMap[E, +A](
+      ioe: IO[E],
+      f: E => IO[A],
+      event: TracingEvent)
+      extends IO[A] {
     def tag = 7
   }
 

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1264,6 +1264,7 @@ private final class IOFiber[A](
   }
 
   private[this] def runTerminusFailureK(t: Throwable): IO[Any] = {
+    Tracing.augmentThrowable(t, tracingEvents)
     done(Outcome.Errored(t))
     IOEndFiber
   }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -16,6 +16,7 @@
 
 package cats.effect
 
+import cats.effect.tracing._
 import cats.effect.unsafe._
 
 import cats.arrow.FunctionK
@@ -116,6 +117,8 @@ private final class IOFiber[A](
 
   private[this] val cancelationCheckThreshold: Int = runtime.config.cancelationCheckThreshold
   private[this] val autoYieldThreshold: Int = runtime.config.autoYieldThreshold
+
+  private[this] val tracingEvents: RingBuffer = RingBuffer.empty
 
   override def run(): Unit = {
     // insert a read barrier after every async boundary
@@ -237,6 +240,8 @@ private final class IOFiber[A](
         case 2 =>
           val cur = cur0.asInstanceOf[Delay[Any]]
 
+          pushTracingEvent(cur.event)
+
           var error: Throwable = null
           val r =
             try cur.thunk()
@@ -274,6 +279,8 @@ private final class IOFiber[A](
         case 6 =>
           val cur = cur0.asInstanceOf[Map[Any, Any]]
 
+          pushTracingEvent(cur.event)
+
           val ioe = cur.ioe
           val f = cur.f
 
@@ -302,6 +309,8 @@ private final class IOFiber[A](
 
             case 2 =>
               val delay = ioe.asInstanceOf[Delay[Any]]
+
+              pushTracingEvent(delay.event)
 
               // this code is inlined in order to avoid two `try` blocks
               var error: Throwable = null
@@ -338,6 +347,8 @@ private final class IOFiber[A](
         case 7 =>
           val cur = cur0.asInstanceOf[FlatMap[Any, Any]]
 
+          pushTracingEvent(cur.event)
+
           val ioe = cur.ioe
           val f = cur.f
 
@@ -361,6 +372,8 @@ private final class IOFiber[A](
 
             case 2 =>
               val delay = ioe.asInstanceOf[Delay[Any]]
+
+              pushTracingEvent(delay.event)
 
               // this code is inlined in order to avoid two `try` blocks
               val result =
@@ -409,6 +422,8 @@ private final class IOFiber[A](
             case 2 =>
               val delay = ioa.asInstanceOf[Delay[Any]]
 
+              pushTracingEvent(delay.event)
+
               // this code is inlined in order to avoid two `try` blocks
               var error: Throwable = null
               val result =
@@ -444,6 +459,8 @@ private final class IOFiber[A](
         case 9 =>
           val cur = cur0.asInstanceOf[HandleErrorWith[Any]]
 
+          pushTracingEvent(cur.event)
+
           objectState.push(cur.f)
           conts.push(HandleErrorWithK)
 
@@ -474,6 +491,8 @@ private final class IOFiber[A](
 
         case 12 =>
           val cur = cur0.asInstanceOf[Uncancelable[Any]]
+
+          pushTracingEvent(cur.event)
 
           masks += 1
           val id = masks
@@ -859,6 +878,8 @@ private final class IOFiber[A](
         case 21 =>
           val cur = cur0.asInstanceOf[Blocking[Any]]
           /* we know we're on the JVM here */
+
+          pushTracingEvent(cur.event)
 
           if (cur.hint eq IOFiber.TypeBlocking) {
             resumeTag = BlockingR
@@ -1317,6 +1338,12 @@ private final class IOFiber[A](
   private[this] def unmaskFailureK(t: Throwable, depth: Int): IO[Any] = {
     masks += 1
     failed(t, depth + 1)
+  }
+
+  private[this] def pushTracingEvent(te: TracingEvent): Unit = {
+    if (te ne null) {
+      tracingEvents.push(te)
+    }
   }
 
   private[this] def onFatalFailure(t: Throwable): Null = {

--- a/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
@@ -16,7 +16,7 @@
 
 package cats.effect.tracing
 
-private[effect] final class RingBuffer(logSize: Int) {
+private[effect] final class RingBuffer private (logSize: Int) {
 
   private[this] val length = 1 << logSize
   private[this] val mask = length - 1
@@ -46,4 +46,10 @@ private[effect] final class RingBuffer(logSize: Int) {
     }
     result
   }
+}
+
+private[effect] object RingBuffer {
+  import TracingConstants.traceBufferLogSize
+
+  def empty: RingBuffer = new RingBuffer(traceBufferLogSize)
 }

--- a/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.tracing
+
+private[effect] final class RingBuffer(logSize: Int) {
+
+  private[this] val length = 1 << logSize
+  private[this] val mask = length - 1
+
+  private[this] val buffer: Array[TracingEvent] = new Array(length)
+  private[this] var index: Int = 0
+
+  def push(te: TracingEvent): Unit = {
+    val idx = index & mask
+    buffer(idx) = te
+    index += 1
+  }
+
+  /**
+   * Returns a list in reverse order of insertion.
+   */
+  def toList: List[TracingEvent] = {
+    var result = List.empty[TracingEvent]
+    val msk = mask
+    val idx = index
+    val start = math.max(idx - length, 0)
+    val end = idx
+    var i = start
+    while (i < end) {
+      result ::= buffer(i & msk)
+      i += 1
+    }
+    result
+  }
+}

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -136,6 +136,7 @@ private[effect] object Tracing extends ClassValue[TracingEvent] {
             .collect {
               case ev: TracingEvent.StackTrace => getOpAndCallSite(ev.stackTrace.getStackTrace)
             }
+            .filter(_ ne null)
             .toArray
           t.setStackTrace(prefix ++ suffix)
         }

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.tracing
+
+import java.util.concurrent.ConcurrentHashMap
+
+private[effect] object Tracing {
+
+  import TracingConstants._
+
+  /**
+   * Global cache for trace frames. Keys are references to lambda classes.
+   * Should converge to the working set of traces very quickly for hot code paths.
+   */
+  private[this] val frameCache: ConcurrentHashMap[Class[_], TracingEvent] =
+    new ConcurrentHashMap()
+
+  def calculateTracingEvent(cls: Class[_]): TracingEvent = {
+    if (isCachedStackTracing) {
+      val currentFrame = frameCache.get(cls)
+      if (currentFrame eq null) {
+        val event = buildEvent()
+        frameCache.put(cls, event)
+        event
+      } else {
+        currentFrame
+      }
+    } else if (isFullStackTracing) {
+      buildEvent()
+    } else {
+      null
+    }
+  }
+
+  private[this] def buildEvent(): TracingEvent = {
+    TracingEvent.StackTrace(new Throwable())
+  }
+}

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -86,17 +86,19 @@ private[effect] object Tracing {
       buffer.toArray
     }
 
-    val stackTrace = t.getStackTrace
-    if (!stackTrace.isEmpty) {
-      val augmented = stackTrace.last.getClassName.indexOf('@') != -1
-      if (!augmented) {
-        val prefix = dropRunLoopFrames(stackTrace)
-        val suffix = events
-          .toList
-          .collect { case ev: TracingEvent.StackTrace => ev.stackTrace.getStackTrace }
-          .flatten
-          .toArray
-        t.setStackTrace(prefix ++ suffix)
+    if (isStackTracing && enhancedExceptions) {
+      val stackTrace = t.getStackTrace
+      if (!stackTrace.isEmpty) {
+        val augmented = stackTrace.last.getClassName.indexOf('@') != -1
+        if (!augmented) {
+          val prefix = dropRunLoopFrames(stackTrace)
+          val suffix = events
+            .toList
+            .collect { case ev: TracingEvent.StackTrace => ev.stackTrace.getStackTrace }
+            .flatten
+            .toArray
+          t.setStackTrace(prefix ++ suffix)
+        }
       }
     }
   }

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -18,30 +18,19 @@ package cats.effect.tracing
 
 import scala.collection.mutable.ArrayBuffer
 
-import java.util.concurrent.ConcurrentHashMap
 import scala.reflect.NameTransformer
 
-private[effect] object Tracing {
+private[effect] object Tracing extends ClassValue[TracingEvent] {
 
   import TracingConstants._
 
-  /**
-   * Global cache for trace frames. Keys are references to lambda classes.
-   * Should converge to the working set of traces very quickly for hot code paths.
-   */
-  private[this] val frameCache: ConcurrentHashMap[Class[_], TracingEvent] =
-    new ConcurrentHashMap()
+  override protected def computeValue(cls: Class[_]): TracingEvent = {
+    buildEvent()
+  }
 
   def calculateTracingEvent(cls: Class[_]): TracingEvent = {
     if (isCachedStackTracing) {
-      val currentFrame = frameCache.get(cls)
-      if (currentFrame eq null) {
-        val event = buildEvent()
-        frameCache.put(cls, event)
-        event
-      } else {
-        currentFrame
-      }
+      get(cls)
     } else if (isFullStackTracing) {
       buildEvent()
     } else {

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -39,7 +39,7 @@ private[effect] object Tracing extends ClassValue[TracingEvent] {
   }
 
   private[this] def buildEvent(): TracingEvent = {
-    TracingEvent.StackTrace(new Throwable())
+    new TracingEvent.StackTrace()
   }
 
   private[this] final val runLoopFilter: Array[String] = Array("cats.effect.", "scala.runtime.")
@@ -133,9 +133,7 @@ private[effect] object Tracing extends ClassValue[TracingEvent] {
           val prefix = dropRunLoopFrames(stackTrace)
           val suffix = events
             .toList
-            .collect {
-              case ev: TracingEvent.StackTrace => getOpAndCallSite(ev.stackTrace.getStackTrace)
-            }
+            .collect { case ev: TracingEvent.StackTrace => getOpAndCallSite(ev.getStackTrace) }
             .filter(_ ne null)
             .toArray
           t.setStackTrace(prefix ++ suffix)

--- a/core/shared/src/main/scala/cats/effect/tracing/TracingEvent.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/TracingEvent.scala
@@ -19,5 +19,5 @@ package cats.effect.tracing
 private[effect] sealed trait TracingEvent
 
 private[effect] object TracingEvent {
-  final case class StackTrace(stackTrace: Throwable) extends TracingEvent
+  final class StackTrace extends Throwable with TracingEvent
 }

--- a/core/shared/src/main/scala/cats/effect/tracing/TracingEvent.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/TracingEvent.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.tracing
+
+private[effect] sealed trait TracingEvent
+
+private[effect] object TracingEvent {
+  final case class StackTrace(stackTrace: Throwable) extends TracingEvent
+}


### PR DESCRIPTION
Building on the work of @RaasAhsan and after several rounds of experimentation, I bring you the production ready initial support for tracing on CE3.

Features:
1. Tracing is available for the following `IO` constructors and combinators:
  - `IO.delay`
  - `IO#map`
  - `IO#flatMap`
  - `IO#handleErrorWith`
  - `IO.uncancelable`
  - `IO.blocking`

2. Noticeable performance improvements to _full_ stack tracing. In practice, this is a slow, tracing mode for debugging, unsuitable for use in production, but still results in an improved developer experience.
  - For those interested, stack trace information on the JVM is usually collected by constructing (but not throwing) new `Throwable` instances. This operation collects a stack trace of the current thread in a JVM specific, binary format. The `Throwable#getStackTrace()` call then parses and transforms this binary representation to the format we know and love from Java Exceptions. Both of these operations are costly. In CE2, we used to eagerly call the `Throwable#getStackTrace()` method on every tracing event, but it was in fact unnecessary. Now, the parsing of the binary format is done only on the necessary tracing information and only when this information is actually necessary for displaying, not earlier.

3. For the first time ever, Cats Effect brings tracing with improved application and memory safety on the modern JVM landscape. Tracing information is usually tied to references of specific `java.lang.Class[_]` objects. Keeping hard references to `Class` objects is generally unsafe on the JVM because it prevents the runtime from unloading those classes, should they become unused. This is not only a memory leak, but also a security issue. By using the `java.lang.ClassValue[_]` API, Cats Effect can be notified by the runtime when certain classes are unloaded, which in turn deletes the tracing information associated to them, freeing memory and improving application safety. This change should have an immediate impact on Cats Effect applications running in `sbt`, which uses complex class loading and unloading to control applications when executing `sbt run`. This change also brought performance improvements over the old `ConcurrentHashMap` based caching approach, due to relying on atomic operations in default JVM internal code, which is heavily optimized by the JVM itself. There are concrete plans to continue experimenting and improving upon this implementation.