### PR TITLE
Configurable inheritance for `IOLocal`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -306,7 +306,10 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Map.this"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Uncancelable.apply"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Uncancelable.copy"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Uncancelable.this")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Uncancelable.this"),
+      // introduced by #2066, configurable inheritance for IOLocal
+      // IOLocal is a sealed trait
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("cats.effect.IOLocal.inherit")
     )
   )
   .jvmSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -309,7 +309,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Uncancelable.this"),
       // introduced by #2067, configurable inheritance for IOLocal
       // IOLocal is a sealed trait
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("cats.effect.IOLocal.inherit")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("cats.effect.IOLocal.inheritable")
     )
   )
   .jvmSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -307,7 +307,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Uncancelable.apply"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Uncancelable.copy"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Uncancelable.this"),
-      // introduced by #2066, configurable inheritance for IOLocal
+      // introduced by #2067, configurable inheritance for IOLocal
       // IOLocal is a sealed trait
       ProblemFilters.exclude[ReversedMissingMethodProblem]("cats.effect.IOLocal.inherit")
     )

--- a/build.sbt
+++ b/build.sbt
@@ -309,7 +309,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#Uncancelable.this"),
       // introduced by #2067, configurable inheritance for IOLocal
       // IOLocal is a sealed trait
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("cats.effect.IOLocal.inheritable")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("cats.effect.IOLocal.inherit")
     )
   )
   .jvmSettings(

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -781,10 +781,18 @@ private final class IOFiber[A](
           val cur = cur0.asInstanceOf[Start[Any]]
 
           val childMask = initMask + ChildMaskOffset
+          val childState =
+            if (localState.isEmpty)
+              localState
+            else
+              localState.map {
+                case (k: IOLocal[Any], v) =>
+                  (k, k.inherit(v))
+              }: IOLocalState
           val ec = currentCtx
           val fiber = new IOFiber[Any](
             childMask,
-            localState.filter(_._1.inheritable),
+            childState,
             null,
             cur.ioa,
             ec,

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -784,7 +784,7 @@ private final class IOFiber[A](
           val ec = currentCtx
           val fiber = new IOFiber[Any](
             childMask,
-            localState.filter(_._1.inherit),
+            localState.filter(_._1.inheritable),
             null,
             cur.ioa,
             ec,

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -781,18 +781,10 @@ private final class IOFiber[A](
           val cur = cur0.asInstanceOf[Start[Any]]
 
           val childMask = initMask + ChildMaskOffset
-          val childState =
-            if (localState.isEmpty)
-              localState
-            else
-              localState.map {
-                case (k: IOLocal[Any], v) =>
-                  (k, k.inherit(v))
-              }: IOLocalState
           val ec = currentCtx
           val fiber = new IOFiber[Any](
             childMask,
-            childState,
+            localState.filter(_._1.inheritable),
             null,
             cur.ioa,
             ec,

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -784,7 +784,7 @@ private final class IOFiber[A](
           val ec = currentCtx
           val fiber = new IOFiber[Any](
             childMask,
-            localState,
+            localState.filter(_._1.inherit),
             null,
             cur.ioa,
             ec,

--- a/core/shared/src/main/scala/cats/effect/IOLocal.scala
+++ b/core/shared/src/main/scala/cats/effect/IOLocal.scala
@@ -32,7 +32,7 @@ sealed trait IOLocal[A] {
 
   def getAndReset: IO[A]
 
-  def inherit: A => A
+  def inheritable: Boolean
 
 }
 
@@ -42,11 +42,8 @@ object IOLocal {
     apply(default: A, inheritable = true)
 
   def apply[A](default: A, inheritable: Boolean): IO[IOLocal[A]] =
-    apply(default, if (inheritable) identity[A](_) else (_: A) => default)
-
-  def apply[A](default: A, inherit: A => A): IO[IOLocal[A]] =
     IO {
-      val _inherit = inherit
+      val _inheritable = inheritable
       new IOLocal[A] { self =>
         override def get: IO[A] =
           IO.Local(state => (state, state.get(self).map(_.asInstanceOf[A]).getOrElse(default)))
@@ -72,7 +69,7 @@ object IOLocal {
         override def getAndReset: IO[A] =
           get <* reset
 
-        override val inherit: A => A = _inherit
+        override val inheritable: Boolean = _inheritable
 
       }
     }

--- a/core/shared/src/main/scala/cats/effect/IOLocal.scala
+++ b/core/shared/src/main/scala/cats/effect/IOLocal.scala
@@ -32,12 +32,18 @@ sealed trait IOLocal[A] {
 
   def getAndReset: IO[A]
 
+  def inherit: Boolean
+
 }
 
 object IOLocal {
 
   def apply[A](default: A): IO[IOLocal[A]] =
+    apply(default: A, inherit = true)
+
+  def apply[A](default: A, inherit: Boolean): IO[IOLocal[A]] =
     IO {
+      val _inherit = inherit
       new IOLocal[A] { self =>
         override def get: IO[A] =
           IO.Local(state => (state, state.get(self).map(_.asInstanceOf[A]).getOrElse(default)))
@@ -62,6 +68,8 @@ object IOLocal {
 
         override def getAndReset: IO[A] =
           get <* reset
+
+        override val inherit: Boolean = _inherit
 
       }
     }

--- a/core/shared/src/main/scala/cats/effect/IOLocal.scala
+++ b/core/shared/src/main/scala/cats/effect/IOLocal.scala
@@ -32,18 +32,18 @@ sealed trait IOLocal[A] {
 
   def getAndReset: IO[A]
 
-  def inherit: Boolean
+  def inheritable: Boolean
 
 }
 
 object IOLocal {
 
   def apply[A](default: A): IO[IOLocal[A]] =
-    apply(default: A, inherit = true)
+    apply(default: A, inheritable = true)
 
-  def apply[A](default: A, inherit: Boolean): IO[IOLocal[A]] =
+  def apply[A](default: A, inheritable: Boolean): IO[IOLocal[A]] =
     IO {
-      val _inherit = inherit
+      val _inheritable = inheritable
       new IOLocal[A] { self =>
         override def get: IO[A] =
           IO.Local(state => (state, state.get(self).map(_.asInstanceOf[A]).getOrElse(default)))
@@ -69,7 +69,7 @@ object IOLocal {
         override def getAndReset: IO[A] =
           get <* reset
 
-        override val inherit: Boolean = _inherit
+        override val inheritable: Boolean = _inheritable
 
       }
     }

--- a/tests/shared/src/test/scala/cats/effect/IOLocalSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOLocalSpec.scala
@@ -69,17 +69,6 @@ class IOLocalSpec extends BaseSpec {
       io must completeAs(0)
     }
 
-    "transform locals inherited by children fibers" in ticked { implicit ticker =>
-      val io = for {
-        local <- IOLocal(0, (_: Int) * 2)
-        _ <- local.set(10)
-        f <- local.get.start
-        value <- f.joinWithNever
-      } yield value
-
-      io must completeAs(20)
-    }
-
     "child local manipulation is invisible to parents" in ticked { implicit ticker =>
       val io = for {
         local <- IOLocal(10)

--- a/tests/shared/src/test/scala/cats/effect/IOLocalSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOLocalSpec.scala
@@ -69,6 +69,17 @@ class IOLocalSpec extends BaseSpec {
       io must completeAs(0)
     }
 
+    "transform locals inherited by children fibers" in ticked { implicit ticker =>
+      val io = for {
+        local <- IOLocal(0, (_: Int) * 2)
+        _ <- local.set(10)
+        f <- local.get.start
+        value <- f.joinWithNever
+      } yield value
+
+      io must completeAs(20)
+    }
+
     "child local manipulation is invisible to parents" in ticked { implicit ticker =>
       val io = for {
         local <- IOLocal(10)

--- a/tests/shared/src/test/scala/cats/effect/IOLocalSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOLocalSpec.scala
@@ -47,7 +47,7 @@ class IOLocalSpec extends BaseSpec {
       io must completeAs(10)
     }
 
-    "copy locals to children fibers" in ticked { implicit ticker =>
+    "copy inherited locals to children fibers" in ticked { implicit ticker =>
       val io = for {
         local <- IOLocal(0)
         _ <- local.set(10)
@@ -56,6 +56,17 @@ class IOLocalSpec extends BaseSpec {
       } yield value
 
       io must completeAs(10)
+    }
+
+    "not copy non-inherited locals to children fibers" in ticked { implicit ticker =>
+      val io = for {
+        local <- IOLocal(0, inherit = false)
+        _ <- local.set(10)
+        f <- local.get.start
+        value <- f.joinWithNever
+      } yield value
+
+      io must completeAs(0)
     }
 
     "child local manipulation is invisible to parents" in ticked { implicit ticker =>

--- a/tests/shared/src/test/scala/cats/effect/IOLocalSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOLocalSpec.scala
@@ -47,7 +47,7 @@ class IOLocalSpec extends BaseSpec {
       io must completeAs(10)
     }
 
-    "copy inherited locals to children fibers" in ticked { implicit ticker =>
+    "copy inheritable locals to children fibers" in ticked { implicit ticker =>
       val io = for {
         local <- IOLocal(0)
         _ <- local.set(10)
@@ -58,9 +58,9 @@ class IOLocalSpec extends BaseSpec {
       io must completeAs(10)
     }
 
-    "not copy non-inherited locals to children fibers" in ticked { implicit ticker =>
+    "not copy non-inheritable locals to children fibers" in ticked { implicit ticker =>
       val io = for {
-        local <- IOLocal(0, inherit = false)
+        local <- IOLocal(0, inheritable = false)
         _ <- local.set(10)
         f <- local.get.start
         value <- f.joinWithNever


### PR DESCRIPTION
A small change to `IOLocal` that adds an option to disable "inheritance" such that its value is not copied to child fibers. This provides semantics matching a `ThreadLocal`; the current `IOLocal` implementation is like an [`InheritableThreadLocal`](https://docs.oracle.com/javase/8/docs/api/java/lang/InheritableThreadLocal.html).*

\* for `InheritableThreadLocal` "the child's value can be made an arbitrary function of the parent's". Any interest in adding this functionality to `IOLocal`? Actually, I would find this quite useful.

Edit/update: I implemented the full-blown inheritable via an arbitrary transformation `A => A`, but this has the biggest performance implications. Found some discussion at https://github.com/typelevel/cats-effect/pull/1393#discussion_r571985239