### PR TITLE
Add syntax for Supervisor

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/syntax/SupervisorSyntax.scala
+++ b/std/shared/src/main/scala/cats/effect/std/syntax/SupervisorSyntax.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.std.syntax
+
+import cats.effect.std.Supervisor
+import cats.effect.kernel.Fiber
+
+trait SupervisorSyntax {
+  implicit def supervisorOps[F[_], A](wrapped: F[A]): SupervisorOps[F, A] =
+    new SupervisorOps(wrapped)
+}
+
+final class SupervisorOps[F[_], A] private[syntax] (private[syntax] val wrapped: F[A])
+    extends AnyVal {
+  def supervise(implicit F: Supervisor[F]): F[Fiber[F, Throwable, A]] =
+    F.supervise(wrapped)
+}

--- a/std/shared/src/main/scala/cats/effect/std/syntax/package.scala
+++ b/std/shared/src/main/scala/cats/effect/std/syntax/package.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.std
+
+package object syntax {
+
+  object supervisor extends SupervisorSyntax
+
+}


### PR DESCRIPTION
I am quite lazy. This PR adds syntax `F[A]#supervise` equivalent to `Supervisor[F]#supervise(fa: F[A])` which is available whenever an implicit `Supervisor[F]` is in scope. Not sure where this would go, so I created a syntax package in `std`.