### PR TITLE
Fix ordered list in GenSpawn scaladoc

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -65,11 +65,11 @@ import cats.effect.kernel.syntax.monadCancel._
  * The observed output of each execution is shown below:
  *
  *   1. A1, A2, B1, B2
- *   2. A1, B1, A2, B2
- *   3. A1, B1, B2, A2
- *   4. B1, B2, A1, A2
- *   5. B1, A1, B2, A2
- *   6. B1, A1, A2, B3
+ *   1. A1, B1, A2, B2
+ *   1. A1, B1, B2, A2
+ *   1. B1, B2, A1, A2
+ *   1. B1, A1, B2, A2
+ *   1. B1, A1, A2, B3
  *
  * Notice how every execution preserves sequential consistency of the effects
  * within each fiber: `A1` always prints before `A2`, and `B1` always prints


### PR DESCRIPTION
This is how it looks like if `1., 2., 3., etc` is used.
![Screen Shot 2021-06-26 at 13 28 30](https://user-images.githubusercontent.com/7115459/123511674-fdf95300-d682-11eb-8e68-af18dd6bf108.png)

The official documentation says to use `1., 1., 1., etc` [here](https://docs.scala-lang.org/overviews/scaladoc/for-library-authors.html).
