### PR TITLE
Remove silencer from the build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,6 @@ ThisBuild / scmInfo := Some(
 
 val CatsVersion = "2.6.1"
 val DisciplineMunitVersion = "1.0.9"
-val SilencerVersion = "1.7.5"
 
 replaceCommandAlias(
   "ci",
@@ -248,20 +247,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       "org.typelevel" %%% "cats-core" % CatsVersion,
       "org.typelevel" %%% "cats-laws" % CatsVersion % Test,
       "org.typelevel" %%% "discipline-munit" % DisciplineMunitVersion % Test
-    ),
-    libraryDependencies ++= {
-      if (isDotty.value)
-        Seq(
-          // Only way to properly resolve this library
-          ("com.github.ghik" % "silencer-lib" % SilencerVersion % Provided)
-        ).map(_.cross(CrossVersion.for3Use2_13With("", s".${Scala213.split("\\.").last}")))
-      else
-        Seq(
-          compilerPlugin(("com.github.ghik" % "silencer-plugin" % SilencerVersion).cross(CrossVersion.full)),
-          ("com.github.ghik" % "silencer-lib" % SilencerVersion % "provided").cross(CrossVersion.full),
-          ("com.github.ghik" % "silencer-lib" % SilencerVersion % Test).cross(CrossVersion.full)
-        )
-    }
+    )
   )
   .jvmSettings(mimaSettings)
   .jvmSettings(

--- a/core/shared/src/main/scala/cats/effect/concurrent/MVar.scala
+++ b/core/shared/src/main/scala/cats/effect/concurrent/MVar.scala
@@ -20,7 +20,7 @@ package concurrent
 import cats.effect.concurrent.MVar.{TransformedMVar, TransformedMVar2}
 import cats.effect.internals.{MVarAsync, MVarConcurrent}
 import cats.~>
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 /**
  * @define mVarDescription A mutable location, that is either empty or contains a value of type `A`.
@@ -135,7 +135,7 @@ abstract class MVar[F[_], A] extends MVarDocumentation {
  * The `MVar2` is the successor of `MVar` with [[tryRead]] and [[swap]]. It was implemented separately only to maintain
  * binary compatibility with `MVar`.
  */
-@silent("deprecated")
+@nowarn("cat=deprecation")
 abstract class MVar2[F[_], A] extends MVar[F, A] {
 
   /**


### PR DESCRIPTION
All of our cross compiled Scala versions have native `nowarn` support.