### PR TITLE
Override `map2Eval` for `IO`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1396,6 +1396,14 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     override def ref[A](a: A): IO[Ref[IO, A]] = IO.ref(a)
 
     override def deferred[A]: IO[Deferred[IO, A]] = IO.deferred
+
+    override def map2Eval[A, B, C](fa: IO[A], fb: Eval[IO[B]])(fn: (A, B) => C): Eval[IO[C]] =
+      Eval.now(
+        for {
+          a <- fa
+          b <- fb.value
+        } yield fn(a, b)
+      )
   }
 
   implicit def asyncForIO: kernel.Async[IO] = _asyncForIO

--- a/tests/shared/src/test/scala/cats/effect/KleisliIOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/KleisliIOSpec.scala
@@ -22,6 +22,7 @@ import cats.effect.laws.AsyncTests
 import cats.laws.discipline.MiniInt
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
+import cats.syntax.all._
 
 import org.scalacheck.Prop
 
@@ -41,6 +42,16 @@ class KleisliIOSpec
 
   // we just need this because of the laws testing, since the prop runs can interfere with each other
   sequential
+
+  "Kleisli[IO, R, *]" >> {
+    "should be stack safe in long traverse chains" in ticked { implicit ticker =>
+      val N = 10000
+      var i = 0
+
+      List.fill(N)(0).traverse_(_ => Kleisli.liftF(IO(i += 1))).run("Go...") *>
+        IO(i) must completeAs(N)
+    }
+  }
 
   implicit def kleisliEq[F[_], A, B](implicit ev: Eq[A => F[B]]): Eq[Kleisli[F, A, B]] =
     Eq.by[Kleisli[F, A, B], A => F[B]](_.run)


### PR DESCRIPTION
Resolves #2095.