### PR TITLE
Add syntax for Supervisor

### DIFF
--- a/core/shared/src/main/scala/cats/effect/syntax/AllSyntax.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/AllSyntax.scala
@@ -17,4 +17,4 @@
 package cats.effect
 package syntax
 
-trait AllSyntax extends kernel.syntax.AllSyntax
+trait AllSyntax extends kernel.syntax.AllSyntax with std.syntax.AllSyntax

--- a/core/shared/src/main/scala/cats/effect/syntax/package.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/package.scala
@@ -27,4 +27,6 @@ package object syntax {
   object async extends kernel.syntax.AsyncSyntax
   object resource extends kernel.syntax.ResourceSyntax
   object clock extends kernel.syntax.ClockSyntax
+
+  object supervisor extends std.syntax.SupervisorSyntax
 }

--- a/std/shared/src/main/scala/cats/effect/std/syntax/AllSyntax.scala
+++ b/std/shared/src/main/scala/cats/effect/std/syntax/AllSyntax.scala
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-package cats.effect.std
+package cats.effect
+package std.syntax
 
-package object syntax {
-
-  object all extends AllSyntax
-  
-  object supervisor extends SupervisorSyntax
-
-}
+trait AllSyntax extends SupervisorSyntax

--- a/std/shared/src/main/scala/cats/effect/std/syntax/SupervisorSyntax.scala
+++ b/std/shared/src/main/scala/cats/effect/std/syntax/SupervisorSyntax.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.std.syntax
+
+import cats.effect.std.Supervisor
+import cats.effect.kernel.Fiber
+
+trait SupervisorSyntax {
+  implicit def supervisorOps[F[_], A](wrapped: F[A]): SupervisorOps[F, A] =
+    new SupervisorOps(wrapped)
+}
+
+final class SupervisorOps[F[_], A] private[syntax] (private[syntax] val wrapped: F[A])
+    extends AnyVal {
+  def supervise(supervisor: Supervisor[F]): F[Fiber[F, Throwable, A]] =
+    supervisor.supervise(wrapped)
+}

--- a/std/shared/src/main/scala/cats/effect/std/syntax/package.scala
+++ b/std/shared/src/main/scala/cats/effect/std/syntax/package.scala
@@ -19,7 +19,7 @@ package cats.effect.std
 package object syntax {
 
   object all extends AllSyntax
-  
+
   object supervisor extends SupervisorSyntax
 
 }

--- a/std/shared/src/main/scala/cats/effect/std/syntax/package.scala
+++ b/std/shared/src/main/scala/cats/effect/std/syntax/package.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.std
+
+package object syntax {
+
+  object supervisor extends SupervisorSyntax
+
+}


### PR DESCRIPTION
Following up on #2068, add syntax for `fa.supervise(supervisor)`