### PR TITLE
Added private functions for resetting the global runtime

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -45,6 +45,9 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
     _global = global
   }
 
+  private[effect] def resetGlobal(): Unit =
+    _global = null
+
   lazy val global: IORuntime = {
     if (_global == null) {
       installGlobal {

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -68,6 +68,9 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
     _global = global
   }
 
+  private[effect] def resetGlobal(): Unit =
+    _global = null
+
   lazy val global: IORuntime = {
     if (_global == null) {
       installGlobal {


### PR DESCRIPTION
This is one attempt to (somewhat) address #1959. Would love some thoughts on it. I basically want to make the most narrowly-scoped thing possible. You could get at this by calling `IORuntime.asInstanceOf[{ def resetGlobal(): Unit }].resetGlobal()`.