### PR TITLE
WIP: Adding the Parallel instance for Eval

### DIFF
--- a/core/shared/src/main/scala/cats/effect/instances/AllInstances.scala
+++ b/core/shared/src/main/scala/cats/effect/instances/AllInstances.scala
@@ -17,4 +17,4 @@
 package cats.effect
 package instances
 
-trait AllInstances extends kernel.instances.GenSpawnInstances
+trait AllInstances extends kernel.instances.GenSpawnInstances with ParEval

--- a/core/shared/src/main/scala/cats/effect/instances/ParEval.scala
+++ b/core/shared/src/main/scala/cats/effect/instances/ParEval.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.instances
+
+import cats.{Applicative, Eval, Monad, Parallel, ~>}
+import cats.arrow.FunctionK
+import cats.effect.IO
+import cats.effect.kernel.Par.ParallelF
+import cats.effect.unsafe.implicits.global
+
+trait ParEval {
+  implicit final val parEvalInstance: Parallel[Eval] =
+    new Parallel[Eval] {
+      override final type F[x] = IO.Par[x]
+
+      override final val applicative: Applicative[F] =
+        all.commutativeApplicativeForParallelF[IO, Throwable]
+
+      override final val monad: Monad[Eval] =
+        Eval.catsBimonadForEval
+
+      override final val sequential: IO.Par ~> Eval =
+        new FunctionK[IO.Par, Eval] {
+          override final def apply[A](ioPar: IO.Par[A]): Eval[A] =
+            Eval.later(ParallelF.value(ioPar).unsafeRunSync())
+        }
+
+      override final val parallel: Eval ~> IO.Par =
+        new FunctionK[Eval, IO.Par] {
+          override final def apply[A](eval: Eval[A]): IO.Par[A] =
+            ParallelF(IO(eval.value))
+        }
+    }
+}


### PR DESCRIPTION
The other day in the **Discord** server there was a quick discussion on #general about if it would be better to use `Future` over `IO` for parallelizing **CPU** only work.
During the discussion, there was also evaluated the possibility of adding a `LazyFuture` type as just an alias / wrapper over `IO` or adding a `Parallel` instance for `Eval`.
The main argument about using something different than `IO` was that such type should imply that the computation should not produce _"side-effects"_ but just **CPU** work and parallelization.

This PR attempts to revive such discussion and see if people find this _(or a similar approach)_ useful enough to be included.

I decided to start with the `Parallel` for `Eval` route using `IO.Par` under the hood; I kind of like the simplicity of the change, but dislike that users need to import `cats.effect.implicits._` and not sure how the direct usage of `IORuntime` would interact if the user is also using `IO` for other parts of the application.
Rather I think it would be better to add another type `LazyFuture` that may be a simple wrapper over `IO` so users can keep composing the result if they want or just run it there.

Anyways, what do you all think?

-----

PS: I know I am missing tests and that the naming is not the best, I just wanted to have something working to show and start the discussion since I feel is very possible this won't be merged.