### PR TITLE
Document outcome

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -718,7 +718,24 @@ Enjoy using Cats Effect 3!
 
 ## FAQ / Examples
 
-This section will include examples of typical errors encountered during the migration and their solutions.
+### Why does `Outcome#Succeeded` contain a value of type `F[A]` rather than type `A`?
+
+This is to support monad transformers. Consider
+
+```scala
+val oc: OutcomeIO[Int] =
+  for {
+    fiber <- Spawn[OptionT[IO, *]].start(OptionT.none[IO, Int])
+    oc <- fiber.join
+  } yield oc
+```
+
+If the fiber succeeds then there is no value of type `Int` to be wrapped in `Succeeded`,
+hence `Succeeded` contains a value of type `OptionT[IO, Int]` instead.
+
+In general you can assume that binding on the value of type `F[A]` contained in
+`Succeeded` does not force further execution. In the case of `OutcomeIO` that means
+that the outcome has been constructed as `Outcome.Succeeded(IO.pure(result))`.
 
 [sbt]: https://scala-sbt.org
 [scalafix]: https://scalacenter.github.io/scalafix/

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -734,7 +734,7 @@ If the fiber succeeds then there is no value of type `Int` to be wrapped in `Suc
 hence `Succeeded` contains a value of type `OptionT[IO, Int]` instead.
 
 In general you can assume that binding on the value of type `F[A]` contained in
-`Succeeded` does not force further execution. In the case of `OutcomeIO` that means
+`Succeeded` does not perform further effects. In the case of `IO` that means
 that the outcome has been constructed as `Outcome.Succeeded(IO.pure(result))`.
 
 [sbt]: https://scala-sbt.org

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -37,7 +37,7 @@ import cats.effect.kernel.syntax.monadCancel._
  * safely interact with each other via three special functions.
  * [[GenSpawn!.start start]] spawns a fiber that executes concurrently with the
  * spawning fiber. [[Fiber!.join join]] semantically blocks the joining fiber
- * until the joinee fiber terminates, after which the outcome of the joinee is
+ * until the joinee fiber terminates, after which the [[Outcome]] of the joinee is
  * returned. [[Fiber!.cancel cancel]] requests a fiber to abnormally terminate,
  * and semantically blocks the canceller until the cancellee has completed
  * finalization.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
@@ -23,6 +23,34 @@ import cats.syntax.all._
 import scala.annotation.tailrec
 import scala.util.{Either, Left, Right}
 
+/**
+ * Represents the result of the execution of a fiber. It may terminate in one of 3 states:
+ * 1. Succeeded(fa)
+ *    The fiber completed with a value. A commonly asked question is why this wraps a
+ *    value of type `F[A]` rather than one of type `A`. This is to support monad
+ *    transformers. Consider
+ *
+ *    ```scala
+ *    val oc: OutcomeIO[Int] =
+ *      for {
+ *        fiber <- Spawn[OptionT[IO, *]].start(OptionT.none[IO, Int])
+ *        oc <- fiber.join
+ *      } yield oc
+ *    ```
+ *
+ *    If the fiber succeeds then there is no value of type `Int` to be wrapped in `Succeeded`,
+ *    hence `Succeeded` contains a value of type `OptionT[IO, Int]` instead.
+ *
+ *    In general you can assume that binding on the value of type `F[A]` contained in
+ *    `Succeeded` does not force further execution. In the case of `OutcomeIO` that means
+ *    that the outcome has been constructed as `Outcome.Succeeded(IO.pure(result))`.
+ *    
+ * 2. Errored(e)
+ *    The fiber exited with an error.
+ *
+ * 3. Canceled()
+ *    The fiber was canceled, either externally or self-canceled via `MonadCancel[F]#canceled`.
+ */
 sealed trait Outcome[F[_], E, A] extends Product with Serializable {
   import Outcome._
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
@@ -45,7 +45,7 @@ import scala.util.{Either, Left, Right}
  *    In general you can assume that binding on the value of type `F[A]` contained in
  *    `Succeeded` does not perform further effects. In the case of `IO` that means
  *    that the outcome has been constructed as `Outcome.Succeeded(IO.pure(result))`.
- *    
+ *
  * 2. Errored(e)
  *    The fiber exited with an error.
  *

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
@@ -26,9 +26,10 @@ import scala.util.{Either, Left, Right}
 /**
  * Represents the result of the execution of a fiber. It may terminate in one of 3 states:
  * 1. Succeeded(fa)
- *    The fiber completed with a value. A commonly asked question is why this wraps a
- *    value of type `F[A]` rather than one of type `A`. This is to support monad
- *    transformers. Consider
+ *    The fiber completed with a value.
+ *
+ *    A commonly asked question is why this wraps a value of type `F[A]` rather
+ *    than one of type `A`. This is to support monad transformers. Consider
  *
  *    ```scala
  *    val oc: OutcomeIO[Int] =
@@ -42,7 +43,7 @@ import scala.util.{Either, Left, Right}
  *    hence `Succeeded` contains a value of type `OptionT[IO, Int]` instead.
  *
  *    In general you can assume that binding on the value of type `F[A]` contained in
- *    `Succeeded` does not force further execution. In the case of `OutcomeIO` that means
+ *    `Succeeded` does not perform further effects. In the case of `IO` that means
  *    that the outcome has been constructed as `Outcome.Succeeded(IO.pure(result))`.
  *    
  * 2. Errored(e)


### PR DESCRIPTION
Document `Outcome` and in particular why `Outcome#Succeeded` contains a value of type `F[A]` rather than one of type `A`.