### PR TITLE
Grow and shrink the callback hashtable

### DIFF
--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -148,11 +148,16 @@ private[effect] final class ThreadSafeHashtable(private[this] val initialCapacit
 
   def unsafeHashtable(): Array[Throwable => Unit] = hashtable
 
-  /**
+  /*
    * Only used in testing.
    */
+
   private[unsafe] def isEmpty: Boolean =
     size == 0 && hashtable.forall(cb => (cb eq null) || (cb eq Tombstone))
+
+  private[unsafe] def unsafeCapacity(): Int = capacity
+
+  private[unsafe] def unsafeInitialCapacity(): Int = initialCapacity
 }
 
 private object ThreadSafeHashtable {

--- a/tests/js/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
+++ b/tests/js/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
@@ -57,7 +57,11 @@ class StripedHashtableSpec extends BaseSpec with Runners {
             .flatMap { _ =>
               IO.blocking {
                 rt.fiberErrorCbs.synchronized {
-                  rt.fiberErrorCbs.tables.forall(_.isEmpty) mustEqual true
+                  rt.fiberErrorCbs.tables.forall { table =>
+                    // check that each component hashtable of the larger striped
+                    // hashtable is empty and has shrunk to its initial capacity
+                    table.isEmpty && table.unsafeCapacity() == table.unsafeInitialCapacity()
+                  } mustEqual true
                 }
               }
             }

--- a/tests/jvm/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
@@ -77,7 +77,11 @@ class StripedHashtableSpec extends BaseSpec with Runners {
             .flatMap { _ =>
               IO.blocking {
                 rt.fiberErrorCbs.synchronized {
-                  rt.fiberErrorCbs.tables.forall(_.isEmpty) mustEqual true
+                  rt.fiberErrorCbs.tables.forall { table =>
+                    // check that each component hashtable of the larger striped
+                    // hashtable is empty and has shrunk to its initial capacity
+                    table.isEmpty && table.unsafeCapacity() == table.unsafeInitialCapacity()
+                  } mustEqual true
                 }
               }
             }


### PR DESCRIPTION
Recently I've done a lot of interview preparations and I was revising algorithms and data structures, so I figured why not fiddle with the custom hashtable that we have, make it slightly better.