### PR TITLE
More efficient IO.foreverM

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -813,7 +813,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
     interpret(this)
   }
 
-  def foreverM: IO[Nothing] = Monad[IO].foreverM[A, Nothing](this)
+  def foreverM: IO[Nothing] = IO.asyncForIO.foreverM[A, Nothing](this)
 
   def whileM[G[_]: Alternative, B >: A](p: IO[Boolean]): IO[G[B]] =
     Monad[IO].whileM[G, B](p)(this)


### PR DESCRIPTION
Following up on https://github.com/typelevel/cats-effect/pull/2132#discussion_r672691004