### PR TITLE
Add ParallelBenchmark

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/ParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/ParallelBenchmark.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.benchmarks
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.implicits.{catsSyntaxParallelTraverse1, toTraverseOps}
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * To do comparative benchmarks between versions:
+ *
+ *     benchmarks/run-benchmark ParallelBenchmark
+ *
+ * This will generate results in `benchmarks/results`.
+ *
+ * Or to run the benchmark from within sbt:
+ *
+ *     jmh:run -i 10 -wi 10 -f 2 -t 4 cats.effect.benchmarks.ParallelBenchmark
+ *
+ * Which means "10 iterations", "10 warm-up iterations", "2 forks", "4 thread".
+ * Please note that benchmarks should be usually executed at least in
+ * 10 iterations (as a rule of thumb), but more is better.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class ParallelBenchmark {
+
+  @Param(Array("10000"))
+  var size: Int = _
+
+  @Benchmark
+  def parTraverseCpuTokens100(): Unit =
+    1.to(size).toList.parTraverse(_ => IO(Blackhole.consumeCPU(100L))).void.unsafeRunSync()
+
+  @Benchmark
+  def parTraverseCpuTokens1000(): Unit =
+    1.to(size).toList.parTraverse(_ => IO(Blackhole.consumeCPU(1000L))).void.unsafeRunSync()
+
+  @Benchmark
+  def parTraverseCpuTokens10000(): Unit =
+    1.to(size).toList.parTraverse(_ => IO(Blackhole.consumeCPU(10000L))).void.unsafeRunSync()
+
+  @Benchmark
+  def traverseCpuTokens100(): Unit =
+    1.to(size).toList.traverse(_ => IO(Blackhole.consumeCPU(100L))).void.unsafeRunSync()
+
+  @Benchmark
+  def traverseCpuTokens1000(): Unit =
+    1.to(size).toList.traverse(_ => IO(Blackhole.consumeCPU(1000L))).void.unsafeRunSync()
+
+  @Benchmark
+  def traverseCpuTokens10000(): Unit =
+    1.to(size).toList.traverse(_ => IO(Blackhole.consumeCPU(10000L))).void.unsafeRunSync()
+}

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/ParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/ParallelBenchmark.scala
@@ -45,30 +45,17 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.SECONDS)
 class ParallelBenchmark {
 
-  @Param(Array("10000"))
+  @Param(Array("100", "1000", "10000"))
   var size: Int = _
 
-  @Benchmark
-  def parTraverseCpuTokens100(): Unit =
-    1.to(size).toList.parTraverse(_ => IO(Blackhole.consumeCPU(100L))).void.unsafeRunSync()
+  @Param(Array("100", "1000", "10000", "100000", "1000000"))
+  var cpuTokens: Long = _
 
   @Benchmark
-  def parTraverseCpuTokens1000(): Unit =
-    1.to(size).toList.parTraverse(_ => IO(Blackhole.consumeCPU(1000L))).void.unsafeRunSync()
+  def parTraverse(): Unit =
+    1.to(size).toList.parTraverse(_ => IO(Blackhole.consumeCPU(cpuTokens))).void.unsafeRunSync()
 
   @Benchmark
-  def parTraverseCpuTokens10000(): Unit =
-    1.to(size).toList.parTraverse(_ => IO(Blackhole.consumeCPU(10000L))).void.unsafeRunSync()
-
-  @Benchmark
-  def traverseCpuTokens100(): Unit =
-    1.to(size).toList.traverse(_ => IO(Blackhole.consumeCPU(100L))).void.unsafeRunSync()
-
-  @Benchmark
-  def traverseCpuTokens1000(): Unit =
-    1.to(size).toList.traverse(_ => IO(Blackhole.consumeCPU(1000L))).void.unsafeRunSync()
-
-  @Benchmark
-  def traverseCpuTokens10000(): Unit =
-    1.to(size).toList.traverse(_ => IO(Blackhole.consumeCPU(10000L))).void.unsafeRunSync()
+  def traverse(): Unit =
+    1.to(size).toList.traverse(_ => IO(Blackhole.consumeCPU(cpuTokens))).void.unsafeRunSync()
 }


### PR DESCRIPTION
As requested by @vasilmkd, moved the `ParallelBenchmark` to a new PR. The reason for the 6 benchmarks is to compare the performance of `parTraverse` vs `traverse` under different CPU load.

Posted the benchmarks for the `series/3.x`:

```sbt
[info] Benchmark                                    (size)   Mode  Cnt    Score   Error  Units
[info] ParallelBenchmark.parTraverseCpuTokens100     10000  thrpt   20   52.561 ± 1.691  ops/s
[info] ParallelBenchmark.parTraverseCpuTokens1000    10000  thrpt   20   44.141 ± 1.213  ops/s
[info] ParallelBenchmark.parTraverseCpuTokens10000   10000  thrpt   20   18.174 ± 0.254  ops/s
[info] ParallelBenchmark.traverseCpuTokens100        10000  thrpt   20  741.288 ± 9.223  ops/s
[info] ParallelBenchmark.traverseCpuTokens1000       10000  thrpt   20  134.859 ± 5.774  ops/s
[info] ParallelBenchmark.traverseCpuTokens10000      10000  thrpt   20   15.097 ± 0.458  ops/s
```

LE:

### Executing Machine Details

```
Processor Name:         Quad-Core Intel Core i7
Processor Speed:        2,2 GHz
Number of Processors:   1
Total Number of Cores:  4
```
