### PR TITLE
Cross-build kernel+std for Scala Native

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           - adopt@1.11
           - adopt@1.16
           - graalvm-ce-java8@21.1
-        ci: [ciJVM, ciJS, ciFirefox]
+        ci: [ciJVM, ciJS, ciFirefox, ciNative]
         exclude:
           - ci: ciJS
             java: adopt@1.11
@@ -40,6 +40,8 @@ jobs:
             scala: 3.0.1
           - os: windows-latest
             scala: 2.12.14
+          - ci: ciNative
+            scala: 3.0.1
           - os: windows-latest
             ci: ciJS
           - ci: ciFirefox
@@ -52,8 +54,24 @@ jobs:
             scala: 3.0.1
           - os: windows-latest
             scala: 2.12.14
+          - ci: ciNative
+            scala: 3.0.1
           - os: windows-latest
             ci: ciFirefox
+          - ci: ciNative
+            java: adopt@1.11
+          - ci: ciNative
+            java: adopt@1.16
+          - ci: ciNative
+            java: graalvm-ce-java8@21.1
+          - os: windows-latest
+            scala: 3.0.1
+          - os: windows-latest
+            scala: 2.12.14
+          - ci: ciNative
+            scala: 3.0.1
+          - os: windows-latest
+            ci: ciNative
           - java: adopt@1.16
             os: windows-latest
     runs-on: ${{ matrix.os }}

--- a/build.sbt
+++ b/build.sbt
@@ -250,7 +250,7 @@ lazy val kernel = crossProject(JSPlatform, JVMPlatform, NativePlatform)
  * Reference implementations (including a pure ConcurrentBracket), generic ScalaCheck
  * generators, and useful tools for testing code written against Cats Effect.
  */
-lazy val kernelTestkit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+lazy val kernelTestkit = crossProject(JSPlatform, JVMPlatform)
   .in(file("kernel-testkit"))
   .dependsOn(kernel)
   .settings(
@@ -266,7 +266,7 @@ lazy val kernelTestkit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
  * jar file and dependency issues. As a consequence of this split, some things
  * which are defined in kernelTestkit are *tested* in the Test scope of this project.
  */
-lazy val laws = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+lazy val laws = crossProject(JSPlatform, JVMPlatform)
   .in(file("laws"))
   .dependsOn(kernel, kernelTestkit % Test)
   .settings(

--- a/kernel/native/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
+++ b/kernel/native/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.kernel
+
+private[kernel] trait AsyncPlatform[F[_]] { this: Async[F] => }

--- a/kernel/native/src/main/scala/cats/effect/kernel/ClockPlatform.scala
+++ b/kernel/native/src/main/scala/cats/effect/kernel/ClockPlatform.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.kernel
+
+private[effect] trait ClockPlatform[F[_]] { self: Clock[F] => }

--- a/kernel/native/src/main/scala/cats/effect/kernel/ResourcePlatform.scala
+++ b/kernel/native/src/main/scala/cats/effect/kernel/ResourcePlatform.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.kernel
+
+private[effect] trait ResourcePlatform

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,9 @@ libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "1.1.0"
 
 addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.21.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.6.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.1.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.22")

--- a/std/native/src/main/scala/cats/effect/std/DispatcherPlatform.scala
+++ b/std/native/src/main/scala/cats/effect/std/DispatcherPlatform.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.std
+
+private[std] trait DispatcherPlatform[F[_]] { this: Dispatcher[F] => }


### PR DESCRIPTION
As proposed in https://github.com/typelevel/cats-effect/issues/1302#issuecomment-882643273. Note: there is currently no laws or testkit support, this will require coop and MTL to join us on Native (probably doable). ~Also there is no specs2 for Native, probably the best fix here is for CE to migrate to munit :(~