### PR TITLE
Add `trace` to `IO`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -37,8 +37,7 @@ import cats.data.Ior
 import cats.syntax.all._
 import cats.effect.instances.spawn
 import cats.effect.std.Console
-import cats.effect.tracing.{Tracing, TracingEvent}
-
+import cats.effect.tracing.{Trace, Tracing, TracingEvent}
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.{
   CancellationException,
@@ -1117,6 +1116,9 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
   def sleep(delay: FiniteDuration): IO[Unit] =
     Sleep(delay)
 
+  def trace: IO[Trace] =
+    IOTrace
+
   def uncancelable[A](body: Poll[IO] => IO[A]): IO[A] =
     Uncancelable(body, Tracing.calculateTracingEvent(body.getClass))
 
@@ -1467,6 +1469,9 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def sleep(time: FiniteDuration): IO[Unit] =
       IO.sleep(time)
 
+    def trace: IO[Trace] =
+      IO.trace
+
     override def timeoutTo[A](ioa: IO[A], duration: FiniteDuration, fallback: IO[A]): IO[A] =
       ioa.timeoutTo(duration, fallback)
 
@@ -1658,6 +1663,10 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
   private[effect] final case class Local[+A](f: IOLocalState => (IOLocalState, A))
       extends IO[A] {
     def tag = 22
+  }
+
+  private[effect] final case object IOTrace extends IO[Trace] {
+    def tag = 23
   }
 
   // INTERNAL, only created by the runloop itself as the terminal state of several operations

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1469,9 +1469,6 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def sleep(time: FiniteDuration): IO[Unit] =
       IO.sleep(time)
 
-    def trace: IO[Trace] =
-      IO.trace
-
     override def timeoutTo[A](ioa: IO[A], duration: FiniteDuration, fallback: IO[A]): IO[A] =
       ioa.timeoutTo(duration, fallback)
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -37,7 +37,7 @@ import cats.data.Ior
 import cats.syntax.all._
 import cats.effect.instances.spawn
 import cats.effect.std.Console
-import cats.effect.tracing.{Trace, Tracing, TracingEvent}
+import cats.effect.tracing.{Tracing, TracingEvent}
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.{
   CancellationException,

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -339,6 +339,10 @@ private final class IOFiber[A](
               val ec = currentCtx
               runLoop(next(ec), nextCancelation - 1, nextAutoCede)
 
+            case 23 =>
+              val trace = Trace(runtime.config.enhancedExceptions, tracingEvents)
+              runLoop(next(trace), nextCancelation - 1, nextAutoCede)
+
             case _ =>
               objectState.push(f)
               conts.push(MapK)
@@ -400,6 +404,10 @@ private final class IOFiber[A](
               val ec = currentCtx
               runLoop(next(ec), nextCancelation - 1, nextAutoCede)
 
+            case 23 =>
+              val trace = Trace(runtime.config.enhancedExceptions, tracingEvents)
+              runLoop(next(trace), nextCancelation - 1, nextAutoCede)
+
             case _ =>
               objectState.push(f)
               conts.push(FlatMapK)
@@ -451,6 +459,10 @@ private final class IOFiber[A](
             case 5 =>
               val ec = currentCtx
               runLoop(succeeded(Right(ec), 0), nextCancelation - 1, nextAutoCede)
+
+            case 23 =>
+              val trace = Trace(runtime.config.enhancedExceptions, tracingEvents)
+              runLoop(succeeded(Right(trace), 0), nextCancelation - 1, nextAutoCede)
 
             case _ =>
               conts.push(AttemptK)

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -898,6 +898,12 @@ private final class IOFiber[A](
           val (nextLocalState, value) = cur.f(localState)
           localState = nextLocalState
           runLoop(succeeded(value, 0), nextCancelation, nextAutoCede)
+
+        case 23 =>
+          runLoop(
+            succeeded(Trace(runtime.config.enhancedExceptions, tracingEvents), 0),
+            nextCancelation,
+            nextAutoCede)
       }
     }
   }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -340,7 +340,7 @@ private final class IOFiber[A](
               runLoop(next(ec), nextCancelation - 1, nextAutoCede)
 
             case 23 =>
-              val trace = Trace(runtime.config.enhancedExceptions, tracingEvents)
+              val trace = Trace(tracingEvents)
               runLoop(next(trace), nextCancelation - 1, nextAutoCede)
 
             case _ =>
@@ -405,7 +405,7 @@ private final class IOFiber[A](
               runLoop(next(ec), nextCancelation - 1, nextAutoCede)
 
             case 23 =>
-              val trace = Trace(runtime.config.enhancedExceptions, tracingEvents)
+              val trace = Trace(tracingEvents)
               runLoop(next(trace), nextCancelation - 1, nextAutoCede)
 
             case _ =>
@@ -461,7 +461,7 @@ private final class IOFiber[A](
               runLoop(succeeded(Right(ec), 0), nextCancelation - 1, nextAutoCede)
 
             case 23 =>
-              val trace = Trace(runtime.config.enhancedExceptions, tracingEvents)
+              val trace = Trace(tracingEvents)
               runLoop(succeeded(Right(trace), 0), nextCancelation - 1, nextAutoCede)
 
             case _ =>
@@ -912,10 +912,7 @@ private final class IOFiber[A](
           runLoop(succeeded(value, 0), nextCancelation, nextAutoCede)
 
         case 23 =>
-          runLoop(
-            succeeded(Trace(runtime.config.enhancedExceptions, tracingEvents), 0),
-            nextCancelation,
-            nextAutoCede)
+          runLoop(succeeded(Trace(tracingEvents), 0), nextCancelation, nextAutoCede)
       }
     }
   }

--- a/core/shared/src/main/scala/cats/effect/Trace.scala
+++ b/core/shared/src/main/scala/cats/effect/Trace.scala
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-package cats.effect.tracing
+package cats.effect
+
+import cats.effect.tracing.{RingBuffer, Tracing}
 
 final class Trace private (frames: List[StackTraceElement]) {
 

--- a/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
@@ -16,20 +16,9 @@
 
 package cats.effect.tracing
 
-import java.io.{ByteArrayOutputStream, PrintStream}
-import cats.effect.tracing.TracingEvent.StackTrace
+import cats.Show
 
-final class Trace private (events: RingBuffer) {
-  private[this] val collector = new StackTrace
-  Tracing.augmentThrowable(true, collector, events)
-
-  override def toString: String = {
-    val baos = new ByteArrayOutputStream()
-    val ps = new PrintStream(baos)
-    collector.printStackTrace(ps)
-    baos.toString
-  }
-}
+final class Trace private (private val events: RingBuffer)
 
 object Trace {
 
@@ -37,4 +26,6 @@ object Trace {
     new Trace(events)
   }
 
+  implicit val showForTrace: Show[Trace] =
+    Show.show(trace => Tracing.showFiberTrace(trace.events))
 }

--- a/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
@@ -45,7 +45,7 @@ final class Trace private (events: RingBuffer) {
     acc0 + acc1
   }
 
-  def compact: String = Tracing.getFrames(events).map(renderStackTraceElement).mkString
+  def compact: String = toList.map(renderStackTraceElement).mkString
 
   def toList: List[StackTraceElement] = Tracing.getFrames(events)
 

--- a/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
@@ -20,7 +20,7 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 import cats.effect.tracing.TracingEvent.StackTrace
 
 class Trace private (enhancedExceptions: Boolean, events: List[TracingEvent]) {
-  private val collector = new StackTrace
+  private[this] val collector = new StackTrace
   Tracing.augmentThrowable(enhancedExceptions, collector, events)
 
   override def toString: String = {

--- a/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
@@ -19,9 +19,9 @@ package cats.effect.tracing
 import java.io.{ByteArrayOutputStream, PrintStream}
 import cats.effect.tracing.TracingEvent.StackTrace
 
-final class Trace private (enhancedExceptions: Boolean, events: RingBuffer) {
+final class Trace private (events: RingBuffer) {
   private[this] val collector = new StackTrace
-  Tracing.augmentThrowable(enhancedExceptions, collector, events)
+  Tracing.augmentThrowable(true, collector, events)
 
   override def toString: String = {
     val baos = new ByteArrayOutputStream()
@@ -33,8 +33,8 @@ final class Trace private (enhancedExceptions: Boolean, events: RingBuffer) {
 
 object Trace {
 
-  private[effect] def apply(enhancedExceptions: Boolean, events: RingBuffer): Trace = {
-    new Trace(enhancedExceptions, events)
+  private[effect] def apply(events: RingBuffer): Trace = {
+    new Trace(events)
   }
 
 }

--- a/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
@@ -16,7 +16,7 @@
 
 package cats.effect.tracing
 
-final class Trace private (events: RingBuffer) {
+final class Trace private (frames: List[StackTraceElement]) {
 
   private[this] def renderStackTraceElement(ste: StackTraceElement): String = {
     s"${ste.getClassName}.${ste.getMethodName} (${ste.getFileName}:${ste.getLineNumber})"
@@ -26,7 +26,7 @@ final class Trace private (events: RingBuffer) {
     val TurnRight = "╰"
     val Junction = "├"
     var captured = 0
-    val indexedRenderedStackTrace = Tracing.getFrames(events).map { frame =>
+    val indexedRenderedStackTrace = frames.map { frame =>
       val res = renderStackTraceElement(frame) -> captured
       captured += 1
       res
@@ -45,9 +45,9 @@ final class Trace private (events: RingBuffer) {
     acc0 + acc1
   }
 
-  def compact: String = toList.map(renderStackTraceElement).mkString
+  def compact: String = frames.map(renderStackTraceElement).mkString
 
-  def toList: List[StackTraceElement] = Tracing.getFrames(events)
+  def toList: List[StackTraceElement] = frames
 
   override def toString: String = compact
 }
@@ -55,6 +55,6 @@ final class Trace private (events: RingBuffer) {
 object Trace {
 
   private[effect] def apply(events: RingBuffer): Trace = {
-    new Trace(events)
+    new Trace(Tracing.getFrames(events))
   }
 }

--- a/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
@@ -19,7 +19,7 @@ package cats.effect.tracing
 import java.io.{ByteArrayOutputStream, PrintStream}
 import cats.effect.tracing.TracingEvent.StackTrace
 
-class Trace private (enhancedExceptions: Boolean, events: List[TracingEvent]) {
+final class Trace private (enhancedExceptions: Boolean, events: RingBuffer) {
   private[this] val collector = new StackTrace
   Tracing.augmentThrowable(enhancedExceptions, collector, events)
 
@@ -33,8 +33,8 @@ class Trace private (enhancedExceptions: Boolean, events: List[TracingEvent]) {
 
 object Trace {
 
-  def apply(enhancedExceptions: Boolean, events: RingBuffer): Trace = {
-    new Trace(enhancedExceptions, events.toList.tail)
+  private[effect] def apply(enhancedExceptions: Boolean, events: RingBuffer): Trace = {
+    new Trace(enhancedExceptions, events)
   }
 
 }

--- a/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
@@ -16,31 +16,23 @@
 
 package cats.effect.tracing
 
+import java.io.{ByteArrayOutputStream, PrintStream}
 import cats.effect.tracing.TracingEvent.StackTrace
 
 class Trace private (enhancedExceptions: Boolean, events: List[TracingEvent]) {
   private val collector = new StackTrace
   Tracing.augmentThrowable(enhancedExceptions, collector, events)
 
-  def enhanceException(t: Throwable): Throwable = {
-    Tracing.augmentThrowable(enhancedExceptions, t, events)
-    t
-  }
-  def pretty: String = {
-    collector.getStackTrace.mkString("\n")
-  }
-
-  def oneline: String = {
-    collector.toString
-    collector.getStackTrace.mkString
-  }
-
   override def toString: String = {
-    collector.getStackTrace.mkString("\n")
+    val baos = new ByteArrayOutputStream()
+    val ps = new PrintStream(baos)
+    collector.printStackTrace(ps)
+    baos.toString
   }
 }
 
 object Trace {
+
   def apply(enhancedExceptions: Boolean, events: RingBuffer): Trace = {
     new Trace(enhancedExceptions, events.toList.tail)
   }

--- a/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.tracing
+
+import cats.effect.tracing.TracingEvent.StackTrace
+
+class Trace private (enhancedExceptions: Boolean, events: List[TracingEvent]) {
+  private val collector = new StackTrace
+  Tracing.augmentThrowable(enhancedExceptions, collector, events)
+
+  def enhanceException(t: Throwable): Throwable = {
+    Tracing.augmentThrowable(enhancedExceptions, t, events)
+    t
+  }
+  def pretty: String = {
+    collector.getStackTrace.mkString("\n")
+  }
+
+  def oneline: String = {
+    collector.toString
+    collector.getStackTrace.mkString
+  }
+
+  override def toString: String = {
+    collector.getStackTrace.mkString("\n")
+  }
+}
+
+object Trace {
+  def apply(enhancedExceptions: Boolean, events: RingBuffer): Trace = {
+    new Trace(enhancedExceptions, events.toList.tail)
+  }
+
+}

--- a/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Trace.scala
@@ -45,7 +45,7 @@ final class Trace private (frames: List[StackTraceElement]) {
     acc0 + acc1
   }
 
-  def compact: String = frames.map(renderStackTraceElement).mkString
+  def compact: String = frames.map(renderStackTraceElement).mkString(", ")
 
   def toList: List[StackTraceElement] = frames
 

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -139,7 +139,7 @@ private[effect] object Tracing extends ClassValue[TracingEvent] {
     }
   }
 
-  private[tracing] def getFrames(events: RingBuffer): List[StackTraceElement] =
+  def getFrames(events: RingBuffer): List[StackTraceElement] =
     events
       .toList
       .collect { case ev: TracingEvent.StackTrace => getOpAndCallSite(ev.getStackTrace) }

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -54,13 +54,6 @@ private[effect] object Tracing extends ClassValue[TracingEvent] {
   )
 
   def augmentThrowable(enhancedExceptions: Boolean, t: Throwable, events: RingBuffer): Unit = {
-    augmentThrowable(enhancedExceptions, t, events.toList)
-  }
-
-  def augmentThrowable(
-      enhancedExceptions: Boolean,
-      t: Throwable,
-      events: List[TracingEvent]): Unit = {
     def applyRunLoopFilter(ste: StackTraceElement): Boolean = {
       val name = ste.getClassName
       var i = 0
@@ -139,6 +132,7 @@ private[effect] object Tracing extends ClassValue[TracingEvent] {
         if (!augmented) {
           val prefix = dropRunLoopFrames(stackTrace)
           val suffix = events
+            .toList
             .collect { case ev: TracingEvent.StackTrace => getOpAndCallSite(ev.getStackTrace) }
             .filter(_ ne null)
             .toArray

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -139,7 +139,7 @@ private[effect] object Tracing extends ClassValue[TracingEvent] {
     }
   }
 
-  def getFrames(events: RingBuffer): List[StackTraceElement] =
+  private[tracing] def getFrames(events: RingBuffer): List[StackTraceElement] =
     events
       .toList
       .collect { case ev: TracingEvent.StackTrace => getOpAndCallSite(ev.getStackTrace) }

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -54,6 +54,13 @@ private[effect] object Tracing extends ClassValue[TracingEvent] {
   )
 
   def augmentThrowable(enhancedExceptions: Boolean, t: Throwable, events: RingBuffer): Unit = {
+    augmentThrowable(enhancedExceptions, t, events.toList)
+  }
+
+  def augmentThrowable(
+      enhancedExceptions: Boolean,
+      t: Throwable,
+      events: List[TracingEvent]): Unit = {
     def applyRunLoopFilter(ste: StackTraceElement): Boolean = {
       val name = ste.getClassName
       var i = 0
@@ -132,7 +139,6 @@ private[effect] object Tracing extends ClassValue[TracingEvent] {
         if (!augmented) {
           val prefix = dropRunLoopFrames(stackTrace)
           val suffix = events
-            .toList
             .collect { case ev: TracingEvent.StackTrace => getOpAndCallSite(ev.getStackTrace) }
             .filter(_ ne null)
             .toArray


### PR DESCRIPTION
This should close #2161 

- extended the `IO` run-loop with the `IOTrace` tag. (The name is ported from CE2 😄)
- wasn't quite sure about how the `Trace` API should look like, so at the moment there is only a `toString` method available (the implementation is copied from https://github.com/typelevel/cats-effect/commit/e41ade1e14ee4626eb65acd5cdd6aef85bc2d718)

I'm not sure if the following choices are the best way to go:
- in the `Trace` class I've eagerly augmented a **dummy** exception to use later on. Maybe this could be done on **request**?
- is it ok that I also extended the `Map`, `FlatMap` and `Attempt` run-loop to also consider the new tag?
- when constructing the `Trace` I drop the head of the `TracingEvent` list to avoid showing the call to access the tracing information