### PR TITLE
Playing with the memory of CI workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,24 @@ jobs:
         shell: bash
         run: npm install
 
+      - name: Let sbt use all available memory
+        if: matrix.ci == 'ciJVM' && matrix.os != 'windows-latest'
+        shell: bash
+        run: |
+          cat > .jvmopts <<EOF
+          -Xmx7G
+          -XX:+UseG1GC
+          EOF
+
+      - name: Let browsers and node use more memory
+        if: matrix.ci != 'ciJVM'
+        shell: bash
+        run: |
+          cat > .jvmopts <<EOF
+          -Xmx3G
+          -XX:+UseG1GC
+          EOF
+
       - name: Check that workflows are up to date
         shell: bash
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck

--- a/build.sbt
+++ b/build.sbt
@@ -78,6 +78,22 @@ ThisBuild / githubWorkflowBuildPreamble ++= Seq(
     List("npm install"),
     name = Some("Install jsdom"),
     cond = Some("matrix.ci == 'ciJSDOMNodeJS'")
+  ),
+  WorkflowStep.Run(
+    List(s"""cat > .jvmopts <<EOF
+            |-Xmx7G
+            |-XX:+UseG1GC
+            |EOF""".stripMargin),
+    name = Some("Let sbt use all available memory"),
+    cond = Some(s"matrix.ci == 'ciJVM' && matrix.os != '$Windows'")
+  ),
+  WorkflowStep.Run(
+    List(s"""cat > .jvmopts <<EOF
+            |-Xmx3G
+            |-XX:+UseG1GC
+            |EOF""".stripMargin),
+    name = Some("Let browsers and node use more memory"),
+    cond = Some("matrix.ci != 'ciJVM'")
   )
 )
 


### PR DESCRIPTION
Running `sbt ciFirefox/ciChrome` on this branch only executes `IOSpec`.

`IOSpec` on my machine takes around 48 seconds to execute on Chrome. It takes 2 minutes and 40 seconds to execute on Firefox.

Making every browser use `setTimeout` slows down the Chrome run to around 70 seconds, however the Firefox run stays within margin of error.

Either postMessage is not optimized on Firefox at all, or we have some slow section (which trips up Firefox) in the code. I'm pretty sure, but not 100% certain, that both Chrome and Firefox end up executing the same code (postMessage).