### PR TITLE
Converted startup runtime collision into a warning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -361,7 +361,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.SyncIO$Delay"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#IOCont.apply"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#IOCont.copy"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#IOCont.this")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#IOCont.this"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("cats.effect.unsafe.IORuntimeCompanionPlatform.installGlobal")
     )
   )
   .jvmSettings(

--- a/core/js/src/main/scala/cats/effect/IOApp.scala
+++ b/core/js/src/main/scala/cats/effect/IOApp.scala
@@ -189,13 +189,20 @@ trait IOApp {
     if (runtime == null) {
       import unsafe.IORuntime
 
-      IORuntime installGlobal {
+      val installed = IORuntime installGlobal {
         IORuntime(
           IORuntime.defaultComputeExecutionContext,
           IORuntime.defaultComputeExecutionContext,
           IORuntime.defaultScheduler,
           () => (),
           runtimeConfig)
+      }
+
+      if (!installed) {
+        System
+          .err
+          .println(
+            "WARNING: Cats Effect global runtime already initialized; custom configurations will be ignored")
       }
 
       _runtime = IORuntime.global

--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -40,9 +40,13 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
 
   private[this] var _global: IORuntime = null
 
-  private[effect] def installGlobal(global: IORuntime): Unit = {
-    require(_global == null)
-    _global = global
+  private[effect] def installGlobal(global: => IORuntime): Boolean = {
+    if (_global == null) {
+      _global = global
+      true
+    } else {
+      false
+    }
   }
 
   private[effect] def resetGlobal(): Unit =

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -213,7 +213,7 @@ trait IOApp {
     if (runtime == null) {
       import unsafe.IORuntime
 
-      IORuntime installGlobal {
+      val installed = IORuntime installGlobal {
         val (compute, compDown) =
           IORuntime.createDefaultComputeThreadPool(runtime, threads = computeWorkerThreadCount)
 
@@ -233,6 +233,13 @@ trait IOApp {
             schedDown()
           },
           runtimeConfig)
+      }
+
+      if (!installed) {
+        System
+          .err
+          .println(
+            "WARNING: Cats Effect global runtime already initialized; custom configurations will be ignored")
       }
 
       _runtime = IORuntime.global

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -63,9 +63,13 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
 
   // we don't need to synchronize this with IOApp, because we control the main thread
   // so instead we just yolo it since the lazy val already synchronizes its own initialization
-  private[effect] def installGlobal(global: IORuntime): Unit = {
-    require(_global == null)
-    _global = global
+  private[effect] def installGlobal(global: => IORuntime): Boolean = {
+    if (_global == null) {
+      _global = global
+      true
+    } else {
+      false
+    }
   }
 
   private[effect] def resetGlobal(): Unit =

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -200,10 +200,13 @@ package examples {
 
   object GlobalRacingInit extends IOApp {
 
-    {
+    def foo(): Unit = {
       // touch the global runtime to force its initialization
       val _ = cats.effect.unsafe.implicits.global
+      ()
     }
+
+    foo()
 
     // indirect assertion that we *don't* use the custom config
     override def runtimeConfig = sys.error("boom")

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -113,6 +113,14 @@ class IOAppSpec extends Specification {
         val h = java(Canceled, List.empty)
         h.awaitStatus() mustEqual 1
       }
+
+      "warn on global runtime collision" in {
+        val h = java(GlobalRacingInit, List.empty)
+        h.awaitStatus() mustEqual 0
+        h.stderr() must contain(
+          "Cats Effect global runtime already initialized; custom configurations will be ignored")
+        h.stderr() must not(contain("boom"))
+      }
     }
   }
 
@@ -188,5 +196,19 @@ package examples {
   object Canceled extends IOApp {
     def run(args: List[String]): IO[ExitCode] =
       IO.canceled.as(ExitCode.Success)
+  }
+
+  object GlobalRacingInit extends IOApp {
+
+    {
+      // touch the global runtime to force its initialization
+      val _ = cats.effect.unsafe.implicits.global
+    }
+
+    // indirect assertion that we *don't* use the custom config
+    override def runtimeConfig = sys.error("boom")
+
+    def run(args: List[String]): IO[ExitCode] =
+      IO.pure(ExitCode.Success)
   }
 }


### PR DESCRIPTION
Fixes #1918 

When the global runtime is *already* initialized by the time `main` runs, we now treat this as a warning (which prints to stderr) rather than a fatal error (which is what we did previously). The warning is still important because the user really needs to know that we're ignoring their custom configurations.

We can probably do better than the text on this warning and give the user some actionable steps to track down *why* the warning is appearing.