### PR TITLE
Add tracing events to some of the `IO` combinators

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -488,7 +488,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
   def map[B](f: A => B): IO[B] = IO.Map(this, f, Tracing.calculateTracingEvent(f.getClass))
 
   def onCancel(fin: IO[Unit]): IO[A] =
-    IO.OnCancel(this, fin)
+    IO.OnCancel(this, fin, Tracing.calculateTracingEvent(fin.getClass))
 
   def onError(f: Throwable => IO[Unit]): IO[A] =
     handleErrorWith(t => f(t).attempt *> IO.raiseError(t))
@@ -1599,7 +1599,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def tag = 10
   }
 
-  private[effect] final case class OnCancel[+A](ioa: IO[A], fin: IO[Unit]) extends IO[A] {
+  private[effect] final case class OnCancel[+A](ioa: IO[A], fin: IO[Unit], event: TracingEvent) extends IO[A] {
     def tag = 11
   }
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1026,7 +1026,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
   def cont[K, R](body: Cont[IO, K, R]): IO[R] =
     IOCont[K, R](body, Tracing.calculateTracingEvent(body.getClass))
 
-  def executionContext: IO[ExecutionContext] = ReadEC
+  def executionContext: IO[ExecutionContext] = ReadEC(Tracing.calculateTracingEvent(this.getClass))
 
   def monotonic: IO[FiniteDuration] = Monotonic(Tracing.calculateTracingEvent(this.getClass))
 
@@ -1566,7 +1566,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def tag = 4
   }
 
-  private[effect] case object ReadEC extends IO[ExecutionContext] {
+  private[effect] final case class ReadEC(event: TracingEvent) extends IO[ExecutionContext] {
     def tag = 5
   }
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -366,7 +366,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    * @see [[IO.executionContext]] for obtaining the `ExecutionContext` on which
    *                              the current `IO` is being executed
    */
-  def evalOn(ec: ExecutionContext): IO[A] = IO.EvalOn(this, ec)
+  def evalOn(ec: ExecutionContext): IO[A] = IO.EvalOn(this, ec, Tracing.calculateTracingEvent(this.getClass))
 
   def startOn(ec: ExecutionContext): IO[FiberIO[A @uncheckedVariance]] = start.evalOn(ec)
 
@@ -1645,7 +1645,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def tag = 19
   }
 
-  private[effect] final case class EvalOn[+A](ioa: IO[A], ec: ExecutionContext) extends IO[A] {
+  private[effect] final case class EvalOn[+A](ioa: IO[A], ec: ExecutionContext, event: TracingEvent) extends IO[A] {
     def tag = 20
   }
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1560,6 +1560,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
   private[effect] case object RealTime extends IO[FiniteDuration] {
     def tag = 3
+    val event: TracingEvent = Tracing.calculateTracingEvent(this.getClass)
   }
 
   private[effect] case object Monotonic extends IO[FiniteDuration] {

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1014,7 +1014,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     IOCont(body, Tracing.calculateTracingEvent(k.getClass))
   }
 
-  def canceled: IO[Unit] = Canceled
+  def canceled: IO[Unit] = Canceled(Tracing.calculateTracingEvent(this.getClass))
 
   def cede: IO[Unit] = Cede(Tracing.calculateTracingEvent(this.getClass))
 
@@ -1595,7 +1595,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def tag = 9
   }
 
-  private[effect] case object Canceled extends IO[Unit] {
+  private[effect] final case class Canceled(event: TracingEvent) extends IO[Unit] {
     def tag = 10
   }
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1644,6 +1644,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
   private[effect] final case class Sleep(delay: FiniteDuration) extends IO[Unit] {
     def tag = 19
+    val event: TracingEvent = Tracing.calculateTracingEvent(this.getClass)
   }
 
   private[effect] final case class EvalOn[+A](ioa: IO[A], ec: ExecutionContext) extends IO[A] {

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1564,6 +1564,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
   private[effect] case object Monotonic extends IO[FiniteDuration] {
     def tag = 4
+    val event: TracingEvent = Tracing.calculateTracingEvent(this.getClass)
   }
 
   private[effect] case object ReadEC extends IO[ExecutionContext] {

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1630,6 +1630,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
   private[effect] case object Cede extends IO[Unit] {
     def tag = 16
+    val event: TracingEvent = Tracing.calculateTracingEvent(this.getClass)
   }
 
   private[effect] final case class Start[A](ioa: IO[A]) extends IO[FiberIO[A]] {

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -268,6 +268,9 @@ private final class IOFiber[A](
 
         /* Monotonic */
         case 4 =>
+          val cur = cur0.asInstanceOf[Monotonic.type]
+          pushTracingEvent(cur.event)
+
           runLoop(
             succeeded(runtime.scheduler.monotonicNanos().nanos, 0),
             nextCancelation,
@@ -332,6 +335,9 @@ private final class IOFiber[A](
               runLoop(next(realTime), nextCancelation - 1, nextAutoCede)
 
             case 4 =>
+              val cur = ioe.asInstanceOf[Monotonic.type]
+              pushTracingEvent(cur.event)
+
               val monotonic = runtime.scheduler.monotonicNanos().nanos
               runLoop(next(monotonic), nextCancelation - 1, nextAutoCede)
 
@@ -397,6 +403,9 @@ private final class IOFiber[A](
               runLoop(next(realTime), nextCancelation - 1, nextAutoCede)
 
             case 4 =>
+              val cur = ioe.asInstanceOf[Monotonic.type]
+              pushTracingEvent(cur.event)
+
               val monotonic = runtime.scheduler.monotonicNanos().nanos
               runLoop(next(monotonic), nextCancelation - 1, nextAutoCede)
 
@@ -463,6 +472,9 @@ private final class IOFiber[A](
               runLoop(succeeded(Right(realTime), 0), nextCancelation - 1, nextAutoCede)
 
             case 4 =>
+              val cur = ioa.asInstanceOf[Monotonic.type]
+              pushTracingEvent(cur.event)
+
               val monotonic = runtime.scheduler.monotonicNanos().nanos
               runLoop(succeeded(Right(monotonic), 0), nextCancelation - 1, nextAutoCede)
 

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -501,6 +501,7 @@ private final class IOFiber[A](
 
         case 11 =>
           val cur = cur0.asInstanceOf[OnCancel[Any]]
+          pushTracingEvent(cur.event)
 
           finalizers.push(EvalOn(cur.fin, currentCtx))
           // println(s"pushed onto finalizers: length = ${finalizers.unsafeIndex()}")

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -799,6 +799,9 @@ private final class IOFiber[A](
 
         /* Cede */
         case 16 =>
+          val cur = cur0.asInstanceOf[Cede.type]
+          pushTracingEvent(cur.event)
+
           resumeTag = CedeR
           rescheduleFiber(currentCtx)(this)
 

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -261,6 +261,9 @@ private final class IOFiber[A](
 
         /* RealTime */
         case 3 =>
+          val cur = cur0.asInstanceOf[RealTime.type]
+          pushTracingEvent(cur.event)
+
           runLoop(
             succeeded(runtime.scheduler.nowMillis().millis, 0),
             nextCancelation,
@@ -331,6 +334,9 @@ private final class IOFiber[A](
               runLoop(nextIO, nextCancelation - 1, nextAutoCede)
 
             case 3 =>
+              val cur = ioe.asInstanceOf[RealTime.type]
+              pushTracingEvent(cur.event)
+
               val realTime = runtime.scheduler.nowMillis().millis
               runLoop(next(realTime), nextCancelation - 1, nextAutoCede)
 
@@ -399,6 +405,9 @@ private final class IOFiber[A](
               runLoop(result, nextCancelation - 1, nextAutoCede)
 
             case 3 =>
+              val cur = ioe.asInstanceOf[RealTime.type]
+              pushTracingEvent(cur.event)
+
               val realTime = runtime.scheduler.nowMillis().millis
               runLoop(next(realTime), nextCancelation - 1, nextAutoCede)
 
@@ -468,6 +477,9 @@ private final class IOFiber[A](
               runLoop(next, nextCancelation - 1, nextAutoCede)
 
             case 3 =>
+              val cur = ioa.asInstanceOf[RealTime.type]
+              pushTracingEvent(cur.event)
+
               val realTime = runtime.scheduler.nowMillis().millis
               runLoop(succeeded(Right(realTime), 0), nextCancelation - 1, nextAutoCede)
 

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -542,7 +542,7 @@ private final class IOFiber[A](
           val cur = cur0.asInstanceOf[OnCancel[Any]]
           pushTracingEvent(cur.event)
 
-          finalizers.push(EvalOn(cur.fin, currentCtx))
+          finalizers.push(EvalOn(cur.fin, currentCtx, Tracing.calculateTracingEvent(cur.fin.getClass)))
           // println(s"pushed onto finalizers: length = ${finalizers.unsafeIndex()}")
 
           /*
@@ -929,6 +929,7 @@ private final class IOFiber[A](
 
         case 20 =>
           val cur = cur0.asInstanceOf[EvalOn[Any]]
+          pushTracingEvent(cur.event)
 
           /* fast-path when it's an identity transformation */
           if (cur.ec eq currentCtx) {

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -876,6 +876,7 @@ private final class IOFiber[A](
 
         case 19 =>
           val cur = cur0.asInstanceOf[Sleep]
+          pushTracingEvent(cur.event)
 
           val next = IO.async[Unit] { cb =>
             IO {

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -281,6 +281,9 @@ private final class IOFiber[A](
 
         /* ReadEC */
         case 5 =>
+          val cur = cur0.asInstanceOf[ReadEC]
+          pushTracingEvent(cur.event)
+
           runLoop(succeeded(currentCtx, 0), nextCancelation, nextAutoCede)
 
         case 6 =>
@@ -348,6 +351,9 @@ private final class IOFiber[A](
               runLoop(next(monotonic), nextCancelation - 1, nextAutoCede)
 
             case 5 =>
+              val cur = ioe.asInstanceOf[ReadEC]
+              pushTracingEvent(cur.event)
+
               val ec = currentCtx
               runLoop(next(ec), nextCancelation - 1, nextAutoCede)
 
@@ -419,6 +425,9 @@ private final class IOFiber[A](
               runLoop(next(monotonic), nextCancelation - 1, nextAutoCede)
 
             case 5 =>
+              val cur = ioe.asInstanceOf[ReadEC]
+              pushTracingEvent(cur.event)
+
               val ec = currentCtx
               runLoop(next(ec), nextCancelation - 1, nextAutoCede)
 
@@ -491,6 +500,9 @@ private final class IOFiber[A](
               runLoop(succeeded(Right(monotonic), 0), nextCancelation - 1, nextAutoCede)
 
             case 5 =>
+              val cur = ioa.asInstanceOf[ReadEC]
+              pushTracingEvent(cur.event)
+
               val ec = currentCtx
               runLoop(succeeded(Right(ec), 0), nextCancelation - 1, nextAutoCede)
 

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -527,6 +527,9 @@ private final class IOFiber[A](
 
         /* Canceled */
         case 10 =>
+          val cur = cur0.asInstanceOf[Canceled]
+          pushTracingEvent(cur.event)
+
           canceled = true
           if (isUnmasked()) {
             /* run finalizers immediately */

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -261,7 +261,7 @@ private final class IOFiber[A](
 
         /* RealTime */
         case 3 =>
-          val cur = cur0.asInstanceOf[RealTime.type]
+          val cur = cur0.asInstanceOf[RealTime]
           pushTracingEvent(cur.event)
 
           runLoop(
@@ -271,7 +271,7 @@ private final class IOFiber[A](
 
         /* Monotonic */
         case 4 =>
-          val cur = cur0.asInstanceOf[Monotonic.type]
+          val cur = cur0.asInstanceOf[Monotonic]
           pushTracingEvent(cur.event)
 
           runLoop(
@@ -334,14 +334,14 @@ private final class IOFiber[A](
               runLoop(nextIO, nextCancelation - 1, nextAutoCede)
 
             case 3 =>
-              val cur = ioe.asInstanceOf[RealTime.type]
+              val cur = ioe.asInstanceOf[RealTime]
               pushTracingEvent(cur.event)
 
               val realTime = runtime.scheduler.nowMillis().millis
               runLoop(next(realTime), nextCancelation - 1, nextAutoCede)
 
             case 4 =>
-              val cur = ioe.asInstanceOf[Monotonic.type]
+              val cur = ioe.asInstanceOf[Monotonic]
               pushTracingEvent(cur.event)
 
               val monotonic = runtime.scheduler.monotonicNanos().nanos
@@ -405,14 +405,14 @@ private final class IOFiber[A](
               runLoop(result, nextCancelation - 1, nextAutoCede)
 
             case 3 =>
-              val cur = ioe.asInstanceOf[RealTime.type]
+              val cur = ioe.asInstanceOf[RealTime]
               pushTracingEvent(cur.event)
 
               val realTime = runtime.scheduler.nowMillis().millis
               runLoop(next(realTime), nextCancelation - 1, nextAutoCede)
 
             case 4 =>
-              val cur = ioe.asInstanceOf[Monotonic.type]
+              val cur = ioe.asInstanceOf[Monotonic]
               pushTracingEvent(cur.event)
 
               val monotonic = runtime.scheduler.monotonicNanos().nanos
@@ -477,14 +477,14 @@ private final class IOFiber[A](
               runLoop(next, nextCancelation - 1, nextAutoCede)
 
             case 3 =>
-              val cur = ioa.asInstanceOf[RealTime.type]
+              val cur = ioa.asInstanceOf[RealTime]
               pushTracingEvent(cur.event)
 
               val realTime = runtime.scheduler.nowMillis().millis
               runLoop(succeeded(Right(realTime), 0), nextCancelation - 1, nextAutoCede)
 
             case 4 =>
-              val cur = ioa.asInstanceOf[Monotonic.type]
+              val cur = ioa.asInstanceOf[Monotonic]
               pushTracingEvent(cur.event)
 
               val monotonic = runtime.scheduler.monotonicNanos().nanos
@@ -824,7 +824,7 @@ private final class IOFiber[A](
 
         /* Cede */
         case 16 =>
-          val cur = cur0.asInstanceOf[Cede.type]
+          val cur = cur0.asInstanceOf[Cede]
           pushTracingEvent(cur.event)
 
           resumeTag = CedeR

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -71,12 +71,17 @@ private[effect] object Tracing extends ClassValue[TracingEvent] {
     val len = stackTrace.length
     var idx = 1
     while (idx < len) {
-      val methodSite = stackTrace(idx - 1)
       val callSite = stackTrace(idx)
       val callSiteClassName = callSite.getClassName
 
       if (!applyStackTraceFilter(callSiteClassName)) {
-        val methodSiteMethodName = methodSite.getMethodName
+        var mIdx = idx - 1
+        var methodSiteMethodName = stackTrace(mIdx).getMethodName
+        while ((methodSiteMethodName == "<init>" || methodSiteMethodName == "<clinit>") && mIdx > 0) {
+          mIdx -= 1
+          methodSiteMethodName = stackTrace(mIdx).getMethodName
+        }
+
         val op = NameTransformer.decode(methodSiteMethodName)
 
         return new StackTraceElement(

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -67,21 +67,16 @@ private[effect] object Tracing extends ClassValue[TracingEvent] {
   }
 
   private[this] def getOpAndCallSite(
-      stackTrace: Array[StackTraceElement]): StackTraceElement = {
+    stackTrace: Array[StackTraceElement]): StackTraceElement = {
     val len = stackTrace.length
     var idx = 1
     while (idx < len) {
+      val methodSite = stackTrace(idx - 1)
       val callSite = stackTrace(idx)
       val callSiteClassName = callSite.getClassName
 
       if (!applyStackTraceFilter(callSiteClassName)) {
-        var mIdx = idx - 1
-        var methodSiteMethodName = stackTrace(mIdx).getMethodName
-        while ((methodSiteMethodName == "<init>" || methodSiteMethodName == "<clinit>") && mIdx > 0) {
-          mIdx -= 1
-          methodSiteMethodName = stackTrace(mIdx).getMethodName
-        }
-
+        val methodSiteMethodName = methodSite.getMethodName
         val op = NameTransformer.decode(methodSiteMethodName)
 
         return new StackTraceElement(


### PR DESCRIPTION
This PR should help with the implementation for #2066.
Adds tracing for the following combinators:
- `monotonic`
- `realTime`
- `executionContext`
- `onCancel`
- `cancelled`
- `cede`
- `sleep`
- `evalOn`