### PR TITLE
Remove redundant modifier `final` for `object`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1662,7 +1662,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def tag = 22
   }
 
-  private[effect] final case object IOTrace extends IO[Trace] {
+  private[effect] case object IOTrace extends IO[Trace] {
     def tag = 23
   }
 


### PR DESCRIPTION
Scala 3 helpfully warns of this.