### PR TITLE
Use Javascript-native map for polyfill on ES2015+

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/PolyfillExecutionContext.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/PolyfillExecutionContext.scala
@@ -18,6 +18,7 @@ package cats.effect.unsafe
 
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
+import scala.scalajs.LinkingInfo
 import scala.scalajs.js
 import scala.util.Random
 import scala.util.control.NonFatal
@@ -37,7 +38,11 @@ private[unsafe] object PolyfillExecutionContext extends ExecutionContext {
   private[this] val setImmediate: (() => Unit) => Unit = {
     if (js.typeOf(js.Dynamic.global.setImmediate) == Undefined) {
       var nextHandle = 1
-      val tasksByHandle = mutable.Map[Int, () => Unit]()
+      val tasksByHandle: mutable.Map[Int, () => Unit] =
+        if (LinkingInfo.esVersion >= LinkingInfo.ESVersion.ES2015)
+          js.Map[Int, () => Unit]()
+        else
+          mutable.Map[Int, () => Unit]()
       var currentlyRunningATask = false
 
       def canUsePostMessage(): Boolean = {


### PR DESCRIPTION
This uses a Javascript-native map in `PolyfillExecutionContext` if emitting ES2015 code (the default), otherwise falls back to a Scala mutable map. Actually, I benchmarked the different implementations individually and found no significant difference, but this is the pattern used in the [Scala.js standard library](https://github.com/scala-js/scala-js/blob/master/javalanglib/src/main/scala/java/lang/ClassValue.scala). In light of this, personally I don't feel strongly whether we merge this or not but also wanted a place to document these results.

Benchmarked in 6e34e9f on 2.13 / Firefox / `fullOptJS`.

`mutable.Map`
```
Starting suite: deep bind
[0/3] async 10000 : 3.996 ± 1.157 ops/s
[1/3] delay 10000 : 157.799 ± 26.372 ops/s
[2/3] pure  10000 : 261.437 ± 31.318 ops/s
Suite completed: deep bind
Starting suite: parallel
[ 0/10] parTraverse Params(100,100)   : 35.362 ± 2.896 ops/s
[ 1/10] traverse    Params(100,100)   : 79.168 ± 4.505 ops/s
[ 2/10] parTraverse Params(100,1000)  : 6.747 ± 0.239 ops/s
[ 3/10] traverse    Params(100,1000)  : 8.047 ± 1.108 ops/s
[ 4/10] parTraverse Params(100,10000) : 0.799 ± 0.059 ops/s
[ 5/10] traverse    Params(100,10000) : 0.815 ± 0.080 ops/s
[ 6/10] parTraverse Params(1000,100)  : 3.636 ± 0.303 ops/s
[ 7/10] traverse    Params(1000,100)  : 7.770 ± 0.668 ops/s
[ 8/10] parTraverse Params(1000,1000) : 0.684 ± 0.035 ops/s
[ 9/10] traverse    Params(1000,1000) : 0.823 ± 0.057 ops/s
Suite completed: parallel
Starting suite: shallow bind
[0/3] async 10000 : 3.930 ± 0.387 ops/s
[1/3] delay 10000 : 163.924 ± 19.340 ops/s
[2/3] pure  10000 : 246.070 ± 24.724 ops/s
Suite completed: shallow bind
```

`js.Map`
```
Starting suite: deep bind
[0/3] async 10000 : 4.004 ± 0.983 ops/s
[1/3] delay 10000 : 156.239 ± 17.203 ops/s
[2/3] pure  10000 : 238.051 ± 26.472 ops/s
Suite completed: deep bind
Starting suite: parallel
[ 0/10] parTraverse Params(100,100)   : 30.292 ± 5.989 ops/s
[ 1/10] traverse    Params(100,100)   : 67.707 ± 9.289 ops/s
[ 2/10] parTraverse Params(100,1000)  : 6.242 ± 1.173 ops/s
[ 3/10] traverse    Params(100,1000)  : 7.567 ± 1.166 ops/s
[ 4/10] parTraverse Params(100,10000) : 0.758 ± 0.054 ops/s
[ 5/10] traverse    Params(100,10000) : 0.780 ± 0.088 ops/s
[ 6/10] parTraverse Params(1000,100)  : 3.061 ± 0.467 ops/s
[ 7/10] traverse    Params(1000,100)  : 7.450 ± 0.720 ops/s
[ 8/10] parTraverse Params(1000,1000) : 0.627 ± 0.079 ops/s
[ 9/10] traverse    Params(1000,1000) : 0.692 ± 0.162 ops/s
Suite completed: parallel
Starting suite: shallow bind
[0/3] async 10000 : 3.721 ± 0.565 ops/s
[1/3] delay 10000 : 140.091 ± 28.923 ops/s
[2/3] pure  10000 : 207.703 ± 62.856 ops/s
Suite completed: shallow bind
```

`js.Dictionary`
```
Starting suite: deep bind
[0/3] async 10000 : 3.591 ± 0.783 ops/s
[1/3] delay 10000 : 150.879 ± 20.873 ops/s
[2/3] pure  10000 : 241.148 ± 16.406 ops/s
Suite completed: deep bind
Starting suite: parallel
[ 0/10] parTraverse Params(100,100)   : 31.700 ± 2.699 ops/s
[ 1/10] traverse    Params(100,100)   : 76.924 ± 5.736 ops/s
[ 2/10] parTraverse Params(100,1000)  : 6.082 ± 0.518 ops/s
[ 3/10] traverse    Params(100,1000)  : 7.720 ± 1.214 ops/s
[ 4/10] parTraverse Params(100,10000) : 0.791 ± 0.065 ops/s
[ 5/10] traverse    Params(100,10000) : 0.836 ± 0.042 ops/s
[ 6/10] parTraverse Params(1000,100)  : 3.235 ± 0.253 ops/s
[ 7/10] traverse    Params(1000,100)  : 8.029 ± 0.444 ops/s
[ 8/10] parTraverse Params(1000,1000) : 0.651 ± 0.034 ops/s
[ 9/10] traverse    Params(1000,1000) : 0.799 ± 0.069 ops/s
Suite completed: parallel
Starting suite: shallow bind
[0/3] async 10000 : 3.222 ± 0.318 ops/s
[1/3] delay 10000 : 142.883 ± 21.728 ops/s
[2/3] pure  10000 : 227.520 ± 34.122 ops/s
Suite completed: shallow bind
```