### PR TITLE
Binpack continuations stack to improve memory density

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/ParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/ParallelBenchmark.scala
@@ -45,10 +45,10 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.SECONDS)
 class ParallelBenchmark {
 
-  @Param(Array("100", "1000", "10000"))
+  @Param(Array(/*"100", */"1000"/*, "10000"*/))
   var size: Int = _
 
-  @Param(Array("100", "1000", "10000", "100000", "1000000"))
+  @Param(Array(/*"100", "1000", */"10000"/*, "100000", "1000000"*/))
   var cpuTokens: Long = _
 
   @Benchmark

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/ParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/ParallelBenchmark.scala
@@ -45,10 +45,10 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.SECONDS)
 class ParallelBenchmark {
 
-  @Param(Array(/*"100", */"1000"/*, "10000"*/))
+  @Param(Array( /*"100", */ "1000" /*, "10000"*/ ))
   var size: Int = _
 
-  @Param(Array(/*"100", "1000", */"10000"/*, "100000", "1000000"*/))
+  @Param(Array( /*"100", "1000", */ "10000" /*, "100000", "1000000"*/ ))
   var cpuTokens: Long = _
 
   @Benchmark

--- a/build.sbt
+++ b/build.sbt
@@ -352,7 +352,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#IOCont.copy"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#IOCont.this"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
-        "cats.effect.unsafe.IORuntimeCompanionPlatform.installGlobal")
+        "cats.effect.unsafe.IORuntimeCompanionPlatform.installGlobal"),
+      ProblemFilters.exclude[Problem]("cats.effect.ByteStack.*")
     )
   )
   .jvmSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -441,7 +441,9 @@ lazy val example = crossProject(JSPlatform, JVMPlatform)
 lazy val benchmarks = project
   .in(file("benchmarks"))
   .dependsOn(core.jvm)
-  .settings(name := "cats-effect-benchmarks")
+  .settings(
+    name := "cats-effect-benchmarks",
+    javaOptions ++= Seq("-Dcats.effect.tracing.mode=none", "-Dcats.effect.tracing.exceptions.enhanced=false"))
   .enablePlugins(NoPublishPlugin, JmhPlugin)
 
 lazy val docs = project.in(file("site-docs")).dependsOn(core.jvm).enablePlugins(MdocPlugin)

--- a/core/shared/src/main/scala/cats/effect/ByteStack.scala
+++ b/core/shared/src/main/scala/cats/effect/ByteStack.scala
@@ -20,15 +20,20 @@ private[effect] object ByteStack {
 
   final def toDebugString(stack: Array[Int], translate: Byte => String = _.toString): String = {
     val count = size(stack)
-    ((count - 1) to 0 by -1).foldLeft(
-      new StringBuilder()
-      .append("Stack:")
-      .append(" capacity = ").append((stack.length - 1) * 8).append(',')
-      .append(" count = ").append(count).append(',')
-      .append(" content (top-first) = [ ")
-    ){
-      (b, i) =>  b.append(translate(ByteStack.read(stack, i))).append(' ')
-    }.append(']').toString
+    ((count - 1) to 0 by -1)
+      .foldLeft(
+        new StringBuilder()
+          .append("Stack:")
+          .append(" capacity = ")
+          .append((stack.length - 1) * 8)
+          .append(',')
+          .append(" count = ")
+          .append(count)
+          .append(',')
+          .append(" content (top-first) = [ ")
+      ) { (b, i) => b.append(translate(ByteStack.read(stack, i))).append(' ') }
+      .append(']')
+      .toString
   }
 
   final def create(initialMaxOps: Int): Array[Int] =
@@ -45,12 +50,12 @@ private[effect] object ByteStack {
   }
 
   final def push(stack: Array[Int], op: Byte): Array[Int] = {
-    val c = stack(0)                                           // current count of elements
-    val use = growIfNeeded(stack, c)                           // alias so we add to the right place
-    val s = (c >> 3) + 1                                       // current slot in `use`
-    val shift = (c & 7) << 2                                   // BEGIN MAGIC
-    use(s) = (use(s) & ~(0xFFFFFFFF << shift)) | (op << shift) // END MAGIC
-    use(0) += 1                                                // write the new count
+    val c = stack(0) // current count of elements
+    val use = growIfNeeded(stack, c) // alias so we add to the right place
+    val s = (c >> 3) + 1 // current slot in `use`
+    val shift = (c & 7) << 2 // BEGIN MAGIC
+    use(s) = (use(s) & ~(0xffffffff << shift)) | (op << shift) // END MAGIC
+    use(0) += 1 // write the new count
     use
   }
 
@@ -62,13 +67,13 @@ private[effect] object ByteStack {
 
   final def read(stack: Array[Int], pos: Int): Byte = {
     if (pos < 0 || pos >= stack(0)) throw new ArrayIndexOutOfBoundsException()
-      ((stack((pos >> 3) + 1) >>> ((pos & 7) << 2)) & 0x0000000F).toByte
+    ((stack((pos >> 3) + 1) >>> ((pos & 7) << 2)) & 0x0000000f).toByte
   }
 
   final def peek(stack: Array[Int]): Byte = {
     val c = stack(0) - 1
     if (c < 0) throw new ArrayIndexOutOfBoundsException()
-      ((stack((c >> 3) + 1) >>> ((c & 7) << 2)) & 0x0000000F).toByte
+    ((stack((c >> 3) + 1) >>> ((c & 7) << 2)) & 0x0000000f).toByte
   }
 
   final def pop(stack: Array[Int]): Byte = {

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -85,7 +85,7 @@ private final class IOFiber[A](
    * Ideally these would be on the stack, but they can't because we sometimes need to
    * relocate our runloop to another fiber.
    */
-  private[this] var conts = ByteStack.create(16)   // use ByteStack to interact
+  private[this] var conts = ByteStack.create(16) // use ByteStack to interact
   private[this] val objectState: ArrayStack[AnyRef] = new ArrayStack()
 
   /* fast-path to head */

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -85,7 +85,7 @@ private final class IOFiber[A](
    * Ideally these would be on the stack, but they can't because we sometimes need to
    * relocate our runloop to another fiber.
    */
-  private[this] var conts = ByteStack.create(8)   // use ByteStack to interact
+  private[this] var conts = ByteStack.create(16)   // use ByteStack to interact
   private[this] val objectState: ArrayStack[AnyRef] = new ArrayStack()
 
   /* fast-path to head */

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -85,7 +85,7 @@ private final class IOFiber[A](
    * Ideally these would be on the stack, but they can't because we sometimes need to
    * relocate our runloop to another fiber.
    */
-  private[this] val conts: ByteStack = new ByteStack()
+  private[this] var conts = ByteStack.create(8)   // use ByteStack to interact
   private[this] val objectState: ArrayStack[AnyRef] = new ArrayStack()
 
   /* fast-path to head */
@@ -345,7 +345,7 @@ private final class IOFiber[A](
 
             case _ =>
               objectState.push(f)
-              conts.push(MapK)
+              conts = ByteStack.push(conts, MapK)
               runLoop(ioe, nextCancelation, nextAutoCede)
           }
 
@@ -410,7 +410,7 @@ private final class IOFiber[A](
 
             case _ =>
               objectState.push(f)
-              conts.push(FlatMapK)
+              conts = ByteStack.push(conts, FlatMapK)
               runLoop(ioe, nextCancelation, nextAutoCede)
           }
 
@@ -475,7 +475,7 @@ private final class IOFiber[A](
               runLoop(succeeded(Right(trace), 0), nextCancelation - 1, nextAutoCede)
 
             case _ =>
-              conts.push(AttemptK)
+              conts = ByteStack.push(conts, AttemptK)
               runLoop(ioa, nextCancelation, nextAutoCede)
           }
 
@@ -485,7 +485,7 @@ private final class IOFiber[A](
           pushTracingEvent(cur.event)
 
           objectState.push(cur.f)
-          conts.push(HandleErrorWithK)
+          conts = ByteStack.push(conts, HandleErrorWithK)
 
           runLoop(cur.ioa, nextCancelation, nextAutoCede)
 
@@ -509,7 +509,7 @@ private final class IOFiber[A](
            * the OnCancelK marker is used by `succeeded` to remove the
            * finalizer when `ioa` completes uninterrupted.
            */
-          conts.push(OnCancelK)
+          conts = ByteStack.push(conts, OnCancelK)
           runLoop(cur.ioa, nextCancelation, nextAutoCede)
 
         case 12 =>
@@ -527,7 +527,7 @@ private final class IOFiber[A](
            * The uncancelableK marker is used by `succeeded` and `failed`
            * to unmask once body completes.
            */
-          conts.push(UncancelableK)
+          conts = ByteStack.push(conts, UncancelableK)
           runLoop(cur.body(poll), nextCancelation, nextAutoCede)
 
         case 13 =>
@@ -543,7 +543,7 @@ private final class IOFiber[A](
              * The UnmaskK marker gets used by `succeeded` and `failed`
              * to restore masking state after `cur.ioa` has finished
              */
-            conts.push(UnmaskK)
+            conts = ByteStack.push(conts, UnmaskK)
           }
 
           runLoop(cur.ioa, nextCancelation, nextAutoCede)
@@ -708,7 +708,7 @@ private final class IOFiber[A](
             ()
           }
           finalizers.push(fin)
-          conts.push(OnCancelK)
+          conts = ByteStack.push(conts, OnCancelK)
 
           if (state.compareAndSet(ContStateInitial, ContStateWaiting)) {
             /*
@@ -893,7 +893,7 @@ private final class IOFiber[A](
             val ec = cur.ec
             currentCtx = ec
             ctxs.push(ec)
-            conts.push(EvalOnK)
+            conts = ByteStack.push(conts, EvalOnK)
 
             resumeTag = EvalOnR
             resumeIO = cur.ioa
@@ -956,7 +956,7 @@ private final class IOFiber[A](
 
     /* clear out literally everything to avoid any possible memory leaks */
 
-    conts.invalidate()
+    conts = null
     objectState.invalidate()
     finalizers.invalidate()
     ctxs.invalidate()
@@ -968,8 +968,8 @@ private final class IOFiber[A](
     finalizing = true
 
     if (!finalizers.isEmpty()) {
-      conts.init(16)
-      conts.push(CancelationLoopK)
+      conts = ByteStack.create(8)
+      conts = ByteStack.push(conts, CancelationLoopK)
 
       objectState.init(16)
       objectState.push(cb)
@@ -1043,7 +1043,7 @@ private final class IOFiber[A](
 
   @tailrec
   private[this] def succeeded(result: Any, depth: Int): IO[Any] =
-    (conts.pop(): @switch) match {
+    (ByteStack.pop(conts): @switch) match {
       case 0 => mapK(result, depth)
       case 1 => flatMapK(result, depth)
       case 2 => cancelationLoopSuccessK()
@@ -1064,16 +1064,16 @@ private final class IOFiber[A](
     Tracing.augmentThrowable(runtime.config.enhancedExceptions, error, tracingEvents)
 
     // println(s"<$name> failed() with $error")
-    val buffer = conts.unsafeBuffer()
+    /*val buffer = conts.unsafeBuffer()
 
     var i = conts.unsafeIndex() - 1
     val orig = i
     var k: Byte = -1
 
-    /*
+
      * short circuit on error by dropping map and flatMap continuations
      * until we hit a continuation that needs to deal with errors.
-     */
+
     while (i >= 0 && k < 0) {
       if (buffer(i) <= FlatMapK)
         i -= 1
@@ -1082,12 +1082,15 @@ private final class IOFiber[A](
     }
 
     conts.unsafeSet(i)
-    objectState.unsafeSet(objectState.unsafeIndex() - (orig - i))
+    objectState.unsafeSet(objectState.unsafeIndex() - (orig - i))*/
 
     /* has to be duplicated from succeeded to ensure call-site monomorphism */
-    (k: @switch) match {
+    (ByteStack.pop(conts): @switch) match {
       /* (case 0) will never continue to mapK */
       /* (case 1) will never continue to flatMapK */
+      case 0 | 1 =>
+        objectState.pop()
+        failed(error, depth)
       case 2 => cancelationLoopFailureK(error)
       case 3 => runTerminusFailureK(error)
       case 4 => evalOnFailureK(error)
@@ -1152,8 +1155,8 @@ private final class IOFiber[A](
     if (canceled) {
       done(IOFiber.OutcomeCanceled.asInstanceOf[OutcomeIO[A]])
     } else {
-      conts.init(16)
-      conts.push(RunTerminusK)
+      conts = ByteStack.create(8)
+      conts = ByteStack.push(conts, RunTerminusK)
 
       objectState.init(16)
       finalizers.init(16)
@@ -1267,7 +1270,7 @@ private final class IOFiber[A](
 
   private[this] def cancelationLoopSuccessK(): IO[Any] = {
     if (!finalizers.isEmpty()) {
-      conts.push(CancelationLoopK)
+      conts = ByteStack.push(conts, CancelationLoopK)
       runLoop(finalizers.pop(), cancelationCheckThreshold, autoYieldThreshold)
     } else {
       /* resume external canceller */


### PR DESCRIPTION
This removes the old implementation of `ByteStack` and replaces it with a branchless version which binpacks the four bits required for our continuation flags into an `Array[Int]`, as well as pulling the max offset into that same array. This allows us to allocate much smaller continuation stacks which also grow more slowly, as well as slightly lightening up the allocation costs for `IOFiber` itself. The downside is we had to throw away the `failure` fast-path scan (more notes on that later). The main win here is that the memory pressure is dramatically lower. Lots of numbers below…

---

This is a bit of a complex one to analyze. First off, the continuations stack is not at all the bottleneck on `IO`, so these kinds of optimizations are mostly lost in the noise. Despite that, there is a *slight* difference before and after in terms of total run time:

Before:

```
[info] Benchmark                         (cpuTokens)  (size)   Mode  Cnt     Score     Error  Units
[info] DeepBindBenchmark.async                   N/A   10000  thrpt    5  3230.317 ±  50.599  ops/s
[info] DeepBindBenchmark.delay                   N/A   10000  thrpt    5  9334.381 ± 255.966  ops/s
[info] DeepBindBenchmark.pure                    N/A   10000  thrpt    5  9963.281 ± 381.715  ops/s
[info] HandleErrorBenchmark.errorRaised          N/A   10000  thrpt    5  3135.114 ±  35.408  ops/s
[info] HandleErrorBenchmark.happyPath            N/A   10000  thrpt    5  3754.813 ±  50.927  ops/s
[info] ParallelBenchmark.parTraverse           10000    1000  thrpt    5   509.352 ±  55.933  ops/s
[info] ParallelBenchmark.traverse              10000    1000  thrpt    5    63.182 ±   2.599  ops/s
[info] ShallowBindBenchmark.async                N/A   10000  thrpt    5  2490.175 ±  50.183  ops/s
[info] ShallowBindBenchmark.delay                N/A   10000  thrpt    5  9316.155 ± 198.293  ops/s
[info] ShallowBindBenchmark.pure                 N/A   10000  thrpt    5  9532.402 ± 419.648  ops/s

[info] Benchmark                          (size)   Mode  Cnt   Score   Error    Units
[info] WorkStealingBenchmark.scheduling  1000000  thrpt    5  23.424 ± 4.094  ops/min
```

After:

```
[info] Benchmark                         (cpuTokens)  (size)   Mode  Cnt     Score     Error  Units
[info] DeepBindBenchmark.async                   N/A   10000  thrpt    5  2886.952 ± 209.338  ops/s
[info] DeepBindBenchmark.delay                   N/A   10000  thrpt    5  9159.002 ± 671.254  ops/s
[info] DeepBindBenchmark.pure                    N/A   10000  thrpt    5  9934.367 ± 344.390  ops/s
[info] HandleErrorBenchmark.errorRaised          N/A   10000  thrpt    5  3007.812 ±  51.022  ops/s
[info] HandleErrorBenchmark.happyPath            N/A   10000  thrpt    5  3302.089 ±  98.346  ops/s
[info] ParallelBenchmark.parTraverse           10000    1000  thrpt    5   498.043 ±  51.942  ops/s
[info] ParallelBenchmark.traverse              10000    1000  thrpt    5    62.830 ±   3.086  ops/s
[info] ShallowBindBenchmark.async                N/A   10000  thrpt    5  2262.803 ±  30.562  ops/s
[info] ShallowBindBenchmark.delay                N/A   10000  thrpt    5  9343.042 ± 197.581  ops/s
[info] ShallowBindBenchmark.pure                 N/A   10000  thrpt    5  9338.564 ± 490.507  ops/s

[info] Benchmark                          (size)   Mode  Cnt   Score   Error    Units
[info] WorkStealingBenchmark.scheduling  1000000  thrpt    5  25.186 ± 1.621  ops/min
```

This also appears to suggest that the external scanning optimization in `failed` isn't really helping anything.

Notice that almost everything is within the margin for error. The most statistically significant changes are in `errorRaised` and `scheduling`, with the former degrading slightly while the latter improves significantly. All in all, this change is *nearly* a wash outside of memory pressure:

Before:

```
[info] Benchmark                                                           (size)   Mode  Cnt            Score            Error    Units
[info] WorkStealingBenchmark.scheduling                                   1000000  thrpt    5           18.834 ±          6.682  ops/min
[info] WorkStealingBenchmark.scheduling:·gc.alloc.rate                    1000000  thrpt    5         3090.101 ±       1117.344   MB/sec
[info] WorkStealingBenchmark.scheduling:·gc.alloc.rate.norm               1000000  thrpt    5  10775591876.933 ±     357261.592     B/op
[info] WorkStealingBenchmark.scheduling:·gc.churn.PS_Eden_Space           1000000  thrpt    5         3121.574 ±       1264.144   MB/sec
[info] WorkStealingBenchmark.scheduling:·gc.churn.PS_Eden_Space.norm      1000000  thrpt    5  10878006067.200 ± 1003154019.356     B/op
[info] WorkStealingBenchmark.scheduling:·gc.churn.PS_Old_Gen              1000000  thrpt    5           52.054 ±        156.868   MB/sec
[info] WorkStealingBenchmark.scheduling:·gc.churn.PS_Old_Gen.norm         1000000  thrpt    5    180311766.400 ±  551143294.535     B/op
[info] WorkStealingBenchmark.scheduling:·gc.churn.PS_Survivor_Space       1000000  thrpt    5           50.178 ±         28.841   MB/sec
[info] WorkStealingBenchmark.scheduling:·gc.churn.PS_Survivor_Space.norm  1000000  thrpt    5    177866898.933 ±  165077416.099     B/op
[info] WorkStealingBenchmark.scheduling:·gc.count                         1000000  thrpt    5           93.000                    counts
[info] WorkStealingBenchmark.scheduling:·gc.time                          1000000  thrpt    5         6307.000                        ms
```

After:

```
[info] Benchmark                                                           (size)   Mode  Cnt            Score            Error    Units
[info] WorkStealingBenchmark.scheduling                                   1000000  thrpt    5           14.375 ±         11.017  ops/min
[info] WorkStealingBenchmark.scheduling:·gc.alloc.rate                    1000000  thrpt    5         2352.774 ±       1799.100   MB/sec
[info] WorkStealingBenchmark.scheduling:·gc.alloc.rate.norm               1000000  thrpt    5  10775798612.800 ±     931296.668     B/op
[info] WorkStealingBenchmark.scheduling:·gc.churn.PS_Eden_Space           1000000  thrpt    5         2378.270 ±       1751.656   MB/sec
[info] WorkStealingBenchmark.scheduling:·gc.churn.PS_Eden_Space.norm      1000000  thrpt    5  10906725502.667 ± 1287186881.000     B/op
[info] WorkStealingBenchmark.scheduling:·gc.churn.PS_Old_Gen              1000000  thrpt    5           24.499 ±        100.341   MB/sec
[info] WorkStealingBenchmark.scheduling:·gc.churn.PS_Old_Gen.norm         1000000  thrpt    5    113354916.000 ±  458602258.928     B/op
[info] WorkStealingBenchmark.scheduling:·gc.churn.PS_Survivor_Space       1000000  thrpt    5           42.071 ±         50.457   MB/sec
[info] WorkStealingBenchmark.scheduling:·gc.churn.PS_Survivor_Space.norm  1000000  thrpt    5    189144549.333 ±   99755404.342     B/op
[info] WorkStealingBenchmark.scheduling:·gc.count                         1000000  thrpt    5           71.000                    counts
[info] WorkStealingBenchmark.scheduling:·gc.time                          1000000  thrpt    5         6611.000                        ms
```

Notice how the allocation rate is dramatically better. This change lowers the footprint on fibers quite noticeably and improves the probability that other (more meaningful) data is included within the cache line. Thus, in practice, this change should result in gains that are hard to measure in microbenchmarks.

All credit for everything clever here goes to @viktorklang. :-)