### PR TITLE
Check `WorkerThread` ownership before scheduling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -352,7 +352,11 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#IOCont.copy"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#IOCont.this"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
-        "cats.effect.unsafe.IORuntimeCompanionPlatform.installGlobal")
+        "cats.effect.unsafe.IORuntimeCompanionPlatform.installGlobal"),
+      // introduced by #, Check `WorkerThread` ownership before scheduling
+      // changes to `cats.effect.unsafe` package private code
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "cats.effect.unsafe.WorkStealingThreadPool.executeFiber")
     )
   )
   .jvmSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -353,7 +353,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#IOCont.this"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
         "cats.effect.unsafe.IORuntimeCompanionPlatform.installGlobal"),
-      // introduced by #, Check `WorkerThread` ownership before scheduling
+      // introduced by #2254, Check `WorkerThread` ownership before scheduling
       // changes to `cats.effect.unsafe` package private code
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "cats.effect.unsafe.WorkStealingThreadPool.executeFiber")

--- a/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -26,7 +26,6 @@ private[effect] sealed abstract class WorkStealingThreadPool private ()
     extends ExecutionContext {
   def execute(runnable: Runnable): Unit
   def reportFailure(cause: Throwable): Unit
-  private[effect] def executeFiber(fiber: IOFiber[_]): Unit
   private[effect] def rescheduleFiber(fiber: IOFiber[_]): Unit
   private[effect] def scheduleFiber(fiber: IOFiber[_]): Unit
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/HelperThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/HelperThread.scala
@@ -102,7 +102,7 @@ private final class HelperThread(
    * and is returning to normal operation. The [[HelperThread]] should finalize
    * and die.
    */
-  private[unsafe] def setSignal(): Unit = {
+  def setSignal(): Unit = {
     signal.lazySet(true)
   }
 
@@ -116,6 +116,20 @@ private final class HelperThread(
     overflow.offer(fiber, random)
     ()
   }
+
+  /**
+   * Checks whether this [[HelperThread]] operates within the
+   * [[WorkStealingThreadPool]] provided as an argument to this method. The
+   * implementation checks whether the provided [[WorkStealingThreadPool]]
+   * matches the reference of the pool provided when this [[HelperThread]] was
+   * constructed.
+   *
+   * @param threadPool a work stealing thread pool reference
+   * @return `true` if this helper thread is owned by the provided work stealing
+   *         thread pool, `false` otherwise
+   */
+  def isOwnedBy(threadPool: WorkStealingThreadPool): Boolean =
+    pool eq threadPool
 
   /**
    * The run loop of the [[HelperThread]]. A loop iteration consists of

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -373,11 +373,19 @@ private[effect] final class WorkStealingThreadPool(
    * `WorkerThread`.
    */
   private[effect] def rescheduleFiber(fiber: IOFiber[_]): Unit = {
-    val thread = Thread.currentThread()
-    if (thread.isInstanceOf[WorkerThread]) {
-      thread.asInstanceOf[WorkerThread].reschedule(fiber)
-    } else {
-      thread.asInstanceOf[HelperThread].schedule(fiber)
+    val pool = this
+    Thread.currentThread() match {
+      case worker: WorkerThread if worker.isOwnedBy(pool) =>
+        worker.reschedule(fiber)
+
+      case helper: HelperThread if helper.isOwnedBy(pool) =>
+        helper.schedule(fiber)
+
+      case _ =>
+        val random = ThreadLocalRandom.current()
+        overflowQueue.offer(fiber, random)
+        notifyParked(random)
+        ()
     }
   }
 

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -126,6 +126,20 @@ private final class WorkerThread(
   }
 
   /**
+   * Checks whether this [[WorkerThread]] operates within the
+   * [[WorkStealingThreadPool]] provided as an argument to this method. The
+   * implementation checks whether the provided [[WorkStealingThreadPool]]
+   * matches the reference of the pool provided when this [[WorkerThread]] was
+   * constructed.
+   *
+   * @param threadPool a work stealing thread pool reference
+   * @return `true` if this worker thread is owned by the provided work stealing
+   *         thread pool, `false` otherwise
+   */
+  def isOwnedBy(threadPool: WorkStealingThreadPool): Boolean =
+    pool eq threadPool
+
+  /**
    * The run loop of the [[WorkerThread]].
    */
   override def run(): Unit = {

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1101,7 +1101,7 @@ private final class IOFiber[A](
 
   private[this] def execute(ec: ExecutionContext)(fiber: IOFiber[_]): Unit = {
     if (ec.isInstanceOf[WorkStealingThreadPool]) {
-      ec.asInstanceOf[WorkStealingThreadPool].executeFiber(fiber)
+      ec.asInstanceOf[WorkStealingThreadPool].scheduleFiber(fiber)
     } else {
       scheduleOnForeignEC(ec)(fiber)
     }


### PR DESCRIPTION
This covers the interleaving between two instances of `WorkStealingThreadPool`. I did not have a chance to test the performance impact thoroughly, but in the quick benchmark run I did, the new code was faster, which, I'm not sure whether to trust. I will repeat the run when I have the time.

`series/3.x`:
```
Benchmark                          (size)   Mode  Cnt   Score   Error    Units
WorkStealingBenchmark.scheduling  1000000  thrpt   10  13.270 ± 1.109  ops/min
```

`This PR`:
```
Benchmark                          (size)   Mode  Cnt   Score   Error    Units
WorkStealingBenchmark.scheduling  1000000  thrpt   10  13.981 ± 1.537  ops/min
```