### PR TITLE
Fix #2236 implement Async.fromThenable (take 2)

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -18,7 +18,7 @@ package cats.effect
 
 import scalajs.js
 
-import scala.scalajs.js.Promise
+import scala.scalajs.js.{Promise, Thenable}
 
 private[effect] abstract class IOCompanionPlatform { this: IO.type =>
 
@@ -34,6 +34,9 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
     val _ = hint
     apply(thunk)
   }
+
+  def fromThenable[A](iot: IO[Thenable[A]]): IO[A] =
+    asyncForIO.fromThenable(iot)
 
   def fromPromise[A](iop: IO[Promise[A]]): IO[A] =
     asyncForIO.fromPromise(iop)


### PR DESCRIPTION
Cherry-picks 8e0cc4efb317fca700ce189e3c32f38e8c429693 which implements `fromThenable` as a separate method to avoid problems like #2271.