### PR TITLE
Work stealing runtime queues tuning

### DIFF
--- a/core/jvm/src/main/java/cats/effect/unsafe/LocalQueueConstants.java
+++ b/core/jvm/src/main/java/cats/effect/unsafe/LocalQueueConstants.java
@@ -43,7 +43,8 @@ class LocalQueueConstants {
   static final int HalfLocalQueueCapacity = LocalQueueCapacity / 2;
 
   /**
-   * Overflow fiber batch size.
+   * Overflow fiber batch size. The runtime relies on the assumption that this
+   * number fully divides `HalfLocalQueueCapacity`.
    */
   static final int OverflowBatchSize = 32;
 

--- a/core/jvm/src/main/java/cats/effect/unsafe/LocalQueueConstants.java
+++ b/core/jvm/src/main/java/cats/effect/unsafe/LocalQueueConstants.java
@@ -47,7 +47,17 @@ class LocalQueueConstants {
    */
   static final int OverflowBatchSize = 32;
 
+  /**
+   * Number of batches that fit into one half of the local queue.
+   */
   static final int BatchesInHalfQueueCapacity = HalfLocalQueueCapacity / OverflowBatchSize;
+
+  /**
+   * The maximum current capacity of the local queue which can still accept a
+   * full batch to be added to the queue (remembering that one fiber from the
+   * batch is executed by directly and not enqueued on the local queue).
+   */
+  static final int LocalQueueCapacityMinusBatch = LocalQueueCapacity - OverflowBatchSize + 1;
 
   /**
    * Bitmask used to extract the 16 least significant bits of a 32 bit integer

--- a/core/jvm/src/main/java/cats/effect/unsafe/LocalQueueConstants.java
+++ b/core/jvm/src/main/java/cats/effect/unsafe/LocalQueueConstants.java
@@ -45,7 +45,7 @@ class LocalQueueConstants {
   /**
    * Overflow fiber batch size.
    */
-  static final int OverflowBatchSize = HalfLocalQueueCapacity + 1;
+  static final int OverflowBatchSize = HalfLocalQueueCapacity;
 
   /**
    * Bitmask used to extract the 16 least significant bits of a 32 bit integer

--- a/core/jvm/src/main/java/cats/effect/unsafe/LocalQueueConstants.java
+++ b/core/jvm/src/main/java/cats/effect/unsafe/LocalQueueConstants.java
@@ -45,7 +45,9 @@ class LocalQueueConstants {
   /**
    * Overflow fiber batch size.
    */
-  static final int OverflowBatchSize = HalfLocalQueueCapacity;
+  static final int OverflowBatchSize = 32;
+
+  static final int BatchesInHalfQueueCapacity = HalfLocalQueueCapacity / OverflowBatchSize;
 
   /**
    * Bitmask used to extract the 16 least significant bits of a 32 bit integer

--- a/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
@@ -368,7 +368,7 @@ private final class LocalQueue {
    *       this queue is '''empty'''.
    *
    * @note By convention, each batch of fibers contains exactly
-   * `LocalQueueConstants.OverflowBatchSize` number of fibers.
+   *       `LocalQueueConstants.OverflowBatchSize` number of fibers.
    *
    * @note The references inside the batch are not nulled out. It is important
    *       to never reference the batch after this usage, so that it can be
@@ -412,7 +412,7 @@ private final class LocalQueue {
       // described in the scaladoc for this class, this number will be equal to
       // `LocalQueueCapacity`.
       val len = unsignedShortSubtraction(tl, steal)
-      if (len <= LocalQueueCapacity - OverflowBatchSize + 1) {
+      if (len <= LocalQueueCapacityMinusBatch) {
         // It is safe to transfer the fibers from the batch to the queue.
         val startPos = tl - 1
         var i = 1
@@ -697,7 +697,7 @@ private final class LocalQueue {
 
       val real = lsb(hd)
 
-      if (unsignedShortSubtraction(tl, real) <= LocalQueueCapacity - OverflowBatchSize + 1) {
+      if (unsignedShortSubtraction(tl, real) <= LocalQueueCapacityMinusBatch) {
         // The current remaining capacity of the local queue is enough to
         // accommodate the new incoming batch. There is nothing more to be done.
         return

--- a/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
@@ -585,13 +585,15 @@ private final class LocalQueue {
         // announced. Proceed to transfer all of the fibers between the old
         // "steal" tag and the new "real" value, nulling out the references for
         // garbage collection purposes.
+        val dstBuffer = dst.bufferForwarder
+
         var i = 0
         while (i < n) {
           val srcIdx = index(steal + i)
           val dstIdx = index(dstTl + i)
           val fiber = buffer(srcIdx)
           buffer(srcIdx) = null
-          dst.bufferForwarder(dstIdx) = fiber
+          dstBuffer(dstIdx) = fiber
           i += 1
         }
 
@@ -613,8 +615,8 @@ private final class LocalQueue {
             n -= 1
             val newDstTl = unsignedShortAddition(dstTl, n)
             val idx = index(newDstTl)
-            val fiber = dst.bufferForwarder(idx)
-            dst.bufferForwarder(idx) = null
+            val fiber = dstBuffer(idx)
+            dstBuffer(idx) = null
 
             if (n == 0) {
               // Only 1 fiber has been stolen. No need for any memory

--- a/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
@@ -410,9 +410,10 @@ private final class LocalQueue {
       val len = unsignedShortSubtraction(tl, steal)
       if (len <= HalfLocalQueueCapacity) {
         // It is safe to transfer the fibers from the batch to the queue.
-        var i = 0
-        while (i < HalfLocalQueueCapacity) {
-          val idx = index(tl + i)
+        val startPos = tl - 1
+        var i = 1
+        while (i < OverflowBatchSize) {
+          val idx = index(startPos + i)
           buffer(idx) = batch(i)
           i += 1
         }
@@ -423,7 +424,7 @@ private final class LocalQueue {
         tail = newTl
         // Return a fiber to be directly executed, withouth enqueueing it first
         // on the local queue.
-        return batch(i)
+        return batch(0)
       }
     }
 

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -232,7 +232,7 @@ private final class WorkerThread(
      */
     var state = 0
 
-    var fairness: Int = 0
+    var checkOverflowQueue: Boolean = true
 
     def parkLoop(): Unit = {
       var cont = true
@@ -248,43 +248,30 @@ private final class WorkerThread(
     while (!isInterrupted()) {
       ((state & OverflowQueueTicksMask): @switch) match {
         case 0 =>
-          // Alternate between checking the overflow and batched queues with a
-          // 2:1 ration in favor of the overflow queue, for now.
-          (fairness: @switch) match {
-            case 0 =>
-              // Dequeue a fiber from the overflow queue.
-              val fiber = overflow.poll(rnd)
-              if (fiber ne null) {
-                // Run the fiber.
-                fiber.run()
-              }
-              fairness = 1
+          // Alternate between checking the overflow and batched queues.
+          if (checkOverflowQueue) {
+            // Dequeue a fiber from the overflow queue.
+            val fiber = overflow.poll(rnd)
+            if (fiber ne null) {
+              // Run the fiber.
+              fiber.run()
+            }
+          } else {
+            // Look into the batched queue for a batch of fibers.
+            val batch = batched.poll(rnd)
+            if (batch ne null) {
+              // Make room for the batch if the local queue cannot
+              // accommodate the batch as is.
+              queue.drainBatch(batched, rnd)
 
-            case 1 =>
-              // Look into the batched queue for a batch of fibers.
-              val batch = batched.poll(rnd)
-              if (batch ne null) {
-                // Make room for the batch if the local queue cannot
-                // accommodate the batch as is.
-                queue.drainBatch(batched, rnd)
-
-                // Enqueue the batch at the back of the local queue and execute
-                // the first fiber.
-                val fiber = queue.enqueueBatch(batch)
-                fiber.run()
-              }
-              fairness = 2
-
-            case 2 =>
-              // Dequeue a fiber from the overflow queue.
-              val fiber = overflow.poll(rnd)
-              if (fiber ne null) {
-                // Run the fiber.
-                fiber.run()
-              }
-              fairness = 0
+              // Enqueue the batch at the back of the local queue and execute
+              // the first fiber.
+              val fiber = queue.enqueueBatch(batch)
+              fiber.run()
+            }
           }
 
+          checkOverflowQueue = !checkOverflowQueue
           // Transition to executing fibers from the local queue.
           state = 7
 

--- a/tests/jvm/src/test/scala/cats/effect/unsafe/DrainBatchSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/DrainBatchSpec.scala
@@ -19,11 +19,7 @@ package unsafe
 
 import cats.effect.std.Queue
 
-import scala.concurrent.duration._
-
 class DrainBatchSpec extends BaseSpec with Runners {
-
-  override implicit val executionTimeout: FiniteDuration = 1.minute
 
   "Batch draining" should {
     "work correctly in the presence of concurrent stealers" in real {

--- a/tests/jvm/src/test/scala/cats/effect/unsafe/DrainBatchSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/DrainBatchSpec.scala
@@ -19,7 +19,11 @@ package unsafe
 
 import cats.effect.std.Queue
 
+import scala.concurrent.duration._
+
 class DrainBatchSpec extends BaseSpec with Runners {
+
+  override implicit val executionTimeout: FiniteDuration = 1.minute
 
   "Batch draining" should {
     "work correctly in the presence of concurrent stealers" in real {


### PR DESCRIPTION
The initial commits in this PR are a preparation for the main intended change, which is to halve the local queue on overflow, but instead of 1 big batch of 128 fibers, create 4 batches of 32 fibers. At another time, when the batched queue is checked for fibers, it won't cause spillage of the local queue because only a smaller batch of fibers will be enqueued, instead of half of the queue being replaced, as was the case previously.