### PR TITLE
Prevent eager creation of TimeoutException in IO.timeout

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -585,7 +585,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    *        the source completing, a `TimeoutException` is raised
    */
   def timeout[A2 >: A](duration: FiniteDuration): IO[A2] =
-    timeoutTo(duration, IO.pure(duration).flatMap(d => IO.raiseError(new TimeoutException(d.toString))))
+    timeoutTo(duration, IO.defer(IO.raiseError(new TimeoutException(duration.toString))))
 
   /**
    * Returns an IO that either completes with the result of the source within

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -585,7 +585,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    *        the source completing, a `TimeoutException` is raised
    */
   def timeout[A2 >: A](duration: FiniteDuration): IO[A2] =
-    timeoutTo(duration, IO.raiseError(new TimeoutException(duration.toString)))
+    timeoutTo(duration, IO.pure(duration).flatMap(d => IO.raiseError(new TimeoutException(d.toString))))
 
   /**
    * Returns an IO that either completes with the result of the source within

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1441,6 +1441,11 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     override def handleError[A](fa: IO[A])(f: Throwable => A): IO[A] =
       fa.handleError(f)
 
+    override def timeout[A](fa: IO[A], duration: FiniteDuration)(
+        implicit ev: TimeoutException <:< Throwable): IO[A] = {
+      fa.timeout(duration)
+    }
+
     def handleErrorWith[A](fa: IO[A])(f: Throwable => IO[A]): IO[A] =
       fa.handleErrorWith(f)
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenTemporal.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenTemporal.scala
@@ -92,8 +92,10 @@ trait GenTemporal[F[_], E] extends GenConcurrent[F, E] with Clock[F] {
    */
   def timeout[A](fa: F[A], duration: FiniteDuration)(
       implicit ev: TimeoutException <:< E): F[A] = {
-    val timeoutException = raiseError[A](ev(new TimeoutException(duration.toString)))
-    timeoutTo(fa, duration, timeoutException)
+    flatMap(race(fa, sleep(duration))) {
+      case Left(a)  => pure(a)
+      case Right(_) => raiseError[A](ev(new TimeoutException(duration.toString())))
+    }
   }
 }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenTemporal.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenTemporal.scala
@@ -93,7 +93,7 @@ trait GenTemporal[F[_], E] extends GenConcurrent[F, E] with Clock[F] {
   def timeout[A](fa: F[A], duration: FiniteDuration)(
       implicit ev: TimeoutException <:< E): F[A] = {
     flatMap(race(fa, sleep(duration))) {
-      case Left(a)  => pure(a)
+      case Left(a) => pure(a)
       case Right(_) => raiseError[A](ev(new TimeoutException(duration.toString())))
     }
   }


### PR DESCRIPTION
This PR addresses #2244 by delaying the construction of a `TimeoutException` until it is really needed (or never)