### PR TITLE
PQueue respects FIFO for elements at the same priority

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/internal/BinomialHeap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/internal/BinomialHeap.scala
@@ -139,7 +139,7 @@ private[std] final case class BinomialTree[A](
    * Link two trees of rank r to produce a tree of rank r + 1
    */
   def link(other: BinomialTree[A])(implicit Ord: Order[A]): BinomialTree[A] = {
-    if (Ord.lteqv(value, other.value))
+    if (Ord.lt(value, other.value))
       BinomialTree(rank + 1, value, other :: children)
     else BinomialTree(rank + 1, other.value, this :: other.children)
   }

--- a/tests/shared/src/test/scala/cats/effect/std/PQueueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/PQueueSpec.scala
@@ -120,6 +120,22 @@ class UnboundedPQueueSpec extends BaseSpec with PQueueTests {
     unboundedPQueueTests(
       "UnboundedPQueue mapK",
       PQueue.unbounded[IO, Int].map(_.mapK(FunctionK.id)))
+
+    "degenerate to a normal queue if all priorities are the same" in real {
+      case class E(name: String, index: Int)
+      object E {
+        implicit val orderForE: Order[E] = Order.by(_.index)
+      }
+
+      val results = List(E("a", 0), E("b", 0), E("c", 0), E("d", 0))
+
+      PQueue.unbounded[IO, E].flatMap { q =>
+        results.traverse(q.offer) >>
+        q.take.replicateA(results.length).flatMap { out =>
+          IO(out must beEqualTo(results))
+        }
+      }
+    }
   }
 
   private def unboundedPQueueTests(


### PR DESCRIPTION
Currently elements at the same priority get dequeued in LIFO order, which is very weird for a queue. This PR fixes that.

I haven't delved too deeply into BinomialHeap so please double check the logic, worst case scenario there is an implementation strategy that only touches PQueue: keep track of the latest insertion in a Long and use a `Box[A: Order](a: A, insertedAt: Long)`, using `insertedAt` in `Order[Box[A]]` to break ties.


Targeting 3.2.x because I need this.