### PR TITLE
Do not alter the resume tag in `execR`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1150,8 +1150,6 @@ private final class IOFiber[A](
 
   private[this] def execR(): Unit = {
     // println(s"$name: starting at ${Thread.currentThread().getName} + ${suspended.get()}")
-
-    resumeTag = DoneR
     if (canceled) {
       done(IOFiber.OutcomeCanceled.asInstanceOf[OutcomeIO[A]])
     } else {


### PR DESCRIPTION
This is a remnant of the big debugging week leading up to the final `3.0.0` release.

`resumeTag` is set right before an asynchronous boundary and this removed line is not one.

It actually causes confusion when profiling. Yesterday, I was looking at a fiber which was executing an `IO.delay` thunk with blocking code, but it was carrying this `resumeTag` which sent me on a goose chase as to why the fiber state was not released after the fiber had presumably finished.