### PR TITLE
Update setup-node action to v2.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Setup NodeJS v14 LTS
         if: matrix.ci == 'ciJS' || matrix.ci == 'ciJSDOMNodeJS'
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v2.4.0
         with:
           node-version: 14
 

--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,7 @@ ThisBuild / githubWorkflowOSes := Seq(PrimaryOS, Windows)
 
 ThisBuild / githubWorkflowBuildPreamble ++= Seq(
   WorkflowStep.Use(
-    UseRef.Public("actions", "setup-node", "v2.1.2"),
+    UseRef.Public("actions", "setup-node", "v2.4.0"),
     name = Some("Setup NodeJS v14 LTS"),
     params = Map("node-version" -> "14"),
     cond = Some("matrix.ci == 'ciJS' || matrix.ci == 'ciJSDOMNodeJS'")


### PR DESCRIPTION
I don't think this update is critical to the [reported security vulnerability](https://github.blog/2021-09-08-github-security-update-vulnerabilities-tar-npmcli-arborist/) but can't hurt.