### PR TITLE
Replacing IOFiber#execute with IOFiber#scheduleFiber

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -616,7 +616,7 @@ private final class IOFiber[A](
                         resumeTag = AsyncContinueSuccessfulR
                         objectState.push(a.asInstanceOf[AnyRef])
                     }
-                    execute(ec)(this)
+                    scheduleFiber(ec)(this)
                   } else {
                     /*
                      * we were canceled, but since we have won the race on `suspended`
@@ -897,7 +897,7 @@ private final class IOFiber[A](
 
             resumeTag = EvalOnR
             resumeIO = cur.ioa
-            execute(ec)(this)
+            scheduleFiber(ec)(this)
           }
 
         case 21 =>
@@ -1102,14 +1102,6 @@ private final class IOFiber[A](
     }
   }
 
-  private[this] def execute(ec: ExecutionContext)(fiber: IOFiber[_]): Unit = {
-    if (ec.isInstanceOf[WorkStealingThreadPool]) {
-      ec.asInstanceOf[WorkStealingThreadPool].scheduleFiber(fiber)
-    } else {
-      scheduleOnForeignEC(ec)(fiber)
-    }
-  }
-
   private[this] def rescheduleFiber(ec: ExecutionContext)(fiber: IOFiber[_]): Unit = {
     if (ec.isInstanceOf[WorkStealingThreadPool]) {
       ec.asInstanceOf[WorkStealingThreadPool].rescheduleFiber(fiber)
@@ -1305,7 +1297,7 @@ private final class IOFiber[A](
     if (!shouldFinalize()) {
       resumeTag = AfterBlockingSuccessfulR
       objectState.push(result.asInstanceOf[AnyRef])
-      execute(ec)(this)
+      scheduleFiber(ec)(this)
     } else {
       asyncCancel(null)
     }
@@ -1319,7 +1311,7 @@ private final class IOFiber[A](
     if (!shouldFinalize()) {
       resumeTag = AfterBlockingFailedR
       objectState.push(t)
-      execute(ec)(this)
+      scheduleFiber(ec)(this)
     } else {
       asyncCancel(null)
     }


### PR DESCRIPTION
A tiny refactoring of IOFiber - replace *.execute method with *.scheduleFiber according to [this issue](https://github.com/typelevel/cats-effect/issues/2318)

