### PR TITLE
Make JS IORuntime externally configurable

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOApp.scala
+++ b/core/js/src/main/scala/cats/effect/IOApp.scala
@@ -205,12 +205,7 @@ trait IOApp {
     lazy val keepAlive: IO[Nothing] =
       IO.sleep(1.hour) >> keepAlive
 
-    val argList =
-      if (js.typeOf(js.Dynamic.global.process) != "undefined" && js.typeOf(
-          js.Dynamic.global.process.argv) != "undefined")
-        js.Dynamic.global.process.argv.asInstanceOf[js.Array[String]].toList.drop(2)
-      else
-        args.toList
+    val argList = process.argv.getOrElse(args.toList)
 
     Spawn[IO]
       .raceOutcome[ExitCode, Nothing](run(argList), keepAlive)

--- a/core/js/src/main/scala/cats/effect/process.scala
+++ b/core/js/src/main/scala/cats/effect/process.scala
@@ -16,6 +16,8 @@
 
 package cats.effect
 
+import cats.syntax.all._
+
 import scala.scalajs.js
 import scala.util.Try
 
@@ -27,7 +29,8 @@ private[effect] object process {
   def env(key: String): Option[String] =
     Try(js.Dynamic.global.process.env.selectDynamic(key))
       .orElse(Try(js.Dynamic.global.process.env.selectDynamic(s"REACT_APP_$key")))
+      .widen[Any]
+      .collect { case v: String if !js.isUndefined(v) => v }
       .toOption
-      .filterNot(js.isUndefined)
-      .flatMap(x => Try(x.asInstanceOf[String]).toOption)
+
 }

--- a/core/js/src/main/scala/cats/effect/process.scala
+++ b/core/js/src/main/scala/cats/effect/process.scala
@@ -27,7 +27,7 @@ private[effect] object process {
   def env(key: String): Option[String] =
     Try(js.Dynamic.global.process.env.selectDynamic(key))
       .orElse(Try(js.Dynamic.global.process.env.selectDynamic(s"REACT_APP_$key")))
-      .map(_.asInstanceOf[String])
       .toOption
       .filterNot(js.isUndefined)
+      .flatMap(x => Try(x.asInstanceOf[String]).toOption)
 }

--- a/core/js/src/main/scala/cats/effect/process.scala
+++ b/core/js/src/main/scala/cats/effect/process.scala
@@ -15,17 +15,19 @@
  */
 
 package cats.effect
-package tracing
 
-private object TracingConstants {
+import scala.scalajs.js
+import scala.util.Try
 
-  private[this] val stackTracingMode: String =
-    process.env("CATS_EFFECT_TRACING_MODE").filterNot(_.isEmpty).getOrElse("cached")
+private[effect] object process {
 
-  val isCachedStackTracing: Boolean = stackTracingMode.equalsIgnoreCase("cached")
+  def argv: Option[List[String]] = Try(
+    js.Dynamic.global.process.argv.asInstanceOf[js.Array[String]].toList.drop(2)).toOption
 
-  val isFullStackTracing: Boolean = stackTracingMode.equalsIgnoreCase("full")
-
-  val isStackTracing: Boolean = isFullStackTracing || isCachedStackTracing
-
+  def env(key: String): Option[String] =
+    Try(js.Dynamic.global.process.env.selectDynamic(key))
+      .toOption
+      .orElse(Try(js.Dynamic.global.process.env.selectDynamic(s"REACT_APP_$key")).toOption)
+      .filterNot(js.isUndefined)
+      .flatMap(x => Try(x.asInstanceOf[String]).toOption)
 }

--- a/core/js/src/main/scala/cats/effect/process.scala
+++ b/core/js/src/main/scala/cats/effect/process.scala
@@ -26,8 +26,8 @@ private[effect] object process {
 
   def env(key: String): Option[String] =
     Try(js.Dynamic.global.process.env.selectDynamic(key))
+      .orElse(Try(js.Dynamic.global.process.env.selectDynamic(s"REACT_APP_$key")))
+      .map(_.asInstanceOf[String])
       .toOption
-      .orElse(Try(js.Dynamic.global.process.env.selectDynamic(s"REACT_APP_$key")).toOption)
       .filterNot(js.isUndefined)
-      .flatMap(x => Try(x.asInstanceOf[String]).toOption)
 }

--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
@@ -17,27 +17,29 @@
 package cats.effect
 package unsafe
 
+import scala.util.Try
+
 private[unsafe] abstract class IORuntimeConfigCompanionPlatform { this: IORuntimeConfig.type =>
   // TODO make the cancelation and auto-yield properties have saner names
   protected final val Default: IORuntimeConfig = {
     val cancelationCheckThreshold = process
       .env("CATS_EFFECT_CANCELATION_CHECK_THRESHOLD")
-      .flatMap(_.toIntOption)
+      .flatMap(x => Try(x.toInt).toOption)
       .getOrElse(512)
 
     val autoYieldThreshold = process
       .env("CATS_EFFECT_AUTO_YIELD_THRESHOLD_MULTIPLIER")
-      .flatMap(_.toIntOption)
+      .flatMap(x => Try(x.toInt).toOption)
       .getOrElse(2) * cancelationCheckThreshold
 
     val enhancedExceptions = process
       .env("CATS_EFFECT_TRACING_EXCEPTIONS_ENHANCED")
-      .flatMap(_.toBooleanOption)
+      .flatMap(x => Try(x.toBoolean).toOption)
       .getOrElse(DefaultEnhancedExceptions)
 
     val traceBufferSize = process
       .env("CATS_EFFECT_TRACING_BUFFER_SIZE")
-      .flatMap(_.toIntOption)
+      .flatMap(x => Try(x.toInt).toOption)
       .getOrElse(DefaultTraceBufferSize)
 
     apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize)

--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
@@ -18,6 +18,28 @@ package cats.effect
 package unsafe
 
 private[unsafe] abstract class IORuntimeConfigCompanionPlatform { this: IORuntimeConfig.type =>
-  protected final val Default: IORuntimeConfig =
-    apply(512, 1024)
+  // TODO make the cancelation and auto-yield properties have saner names
+  protected final val Default: IORuntimeConfig = {
+    val cancelationCheckThreshold = process
+      .env("CATS_EFFECT_CANCELATION_CHECK_THRESHOLD")
+      .flatMap(_.toIntOption)
+      .getOrElse(512)
+
+    val autoYieldThreshold = process
+      .env("CATS_EFFECT_AUTO_YIELD_THRESHOLD_MULTIPLIER")
+      .flatMap(_.toIntOption)
+      .getOrElse(2) * cancelationCheckThreshold
+
+    val enhancedExceptions = process
+      .env("CATS_EFFECT_TRACING_EXCEPTIONS_ENHANCED")
+      .flatMap(_.toBooleanOption)
+      .getOrElse(DefaultEnhancedExceptions)
+
+    val traceBufferSize = process
+      .env("CATS_EFFECT_TRACING_BUFFER_SIZE")
+      .flatMap(_.toIntOption)
+      .getOrElse(DefaultTraceBufferSize)
+
+    apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize)
+  }
 }


### PR DESCRIPTION
Should put JS in lock-step with JVM. Relies on `process.env` instead of system properties.