### PR TITLE
GC fiber bag dirty demonstration

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -28,4 +28,5 @@ private[effect] sealed abstract class WorkStealingThreadPool private ()
   def reportFailure(cause: Throwable): Unit
   private[effect] def rescheduleFiber(fiber: IOFiber[_]): Unit
   private[effect] def scheduleFiber(fiber: IOFiber[_]): Unit
+  private[effect] def monitor(key: AnyRef, fiber: IOFiber[_]): Unit
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -468,6 +468,20 @@ private[effect] final class WorkStealingThreadPool(
     }
   }
 
+  private[effect] def monitor(key: AnyRef, fiber: IOFiber[_]): Unit = {
+    val pool = this
+    val thread = Thread.currentThread()
+
+    if (thread.isInstanceOf[WorkerThread]) {
+      val worker = thread.asInstanceOf[WorkerThread]
+      if (worker.isOwnedBy(pool)) {
+        worker.monitor(key, fiber)
+      }
+    } else {
+      // demonstration, do nothing for now
+    }
+  }
+
   /**
    * Schedules a fiber for execution on this thread pool originating from an external thread (a
    * thread which is not owned by this thread pool).

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -122,7 +122,7 @@ private final class IOFiber[A](
     RingBuffer.empty(runtime.config.traceBufferLogSize)
 
   // GC fiber bag bookkeeping
-  private[this] var bagKey: AnyRef = _
+  // private[this] var bagKey: AnyRef = _
 
   override def run(): Unit = {
     // insert a read barrier after every async boundary
@@ -1026,13 +1026,13 @@ private final class IOFiber[A](
   private[this] def monitor(key: AnyRef): Unit = {
     val ec = currentCtx
     if (ec.isInstanceOf[WorkStealingThreadPool]) {
-      bagKey = key
+      // bagKey = key
       ec.asInstanceOf[WorkStealingThreadPool].monitor(key, this)
     }
   }
 
   private[this] def unmonitor(): Unit = {
-    bagKey = null
+    // bagKey = null
   }
 
   /* returns the *new* context, not the old */

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -736,7 +736,7 @@ private final class IOFiber[A](
              * which ensures we will always see the most up-to-date value
              * for `canceled` in `shouldFinalize`, ensuring no finalisation leaks
              */
-            monitor()
+            monitor(state)
             suspended.getAndSet(true)
 
             /*
@@ -1023,10 +1023,9 @@ private final class IOFiber[A](
   private[this] def suspend(): Unit =
     suspended.set(true)
 
-  private[this] def monitor(): Unit = {
+  private[this] def monitor(key: AnyRef): Unit = {
     val ec = currentCtx
     if (ec.isInstanceOf[WorkStealingThreadPool]) {
-      val key = new AnyRef()
       bagKey = key
       ec.asInstanceOf[WorkStealingThreadPool].monitor(key, this)
     }


### PR DESCRIPTION
Content warning: I'm not trolling at all in the following text, but it is supposed to be taken with a light heart. It's not a serious proposal (yet), but it is supposed to show people that trial-and-error and innovation should not be taken too seriously. Read on if you're interested in finding out if we can make the JDK GC to do our dirty work, there are some informative bits as well. I hope you have fun reading it.

An alternative to #2258, but not necessarily a replacement (depends on how much we want to promote the default runtime versus custom user runtimes with a different compute pool).

Here's how this works:
1. Instead of being a global data structure, we have a worker-thread-local one instead. What this means in practice when it comes to gathering the fiber dump is just that we need to query all worker threads when the signal is dispatched and aggregate the results together.
2. What having a thread-local data structure also allows is no synchronization points. To utilize this, the following observation is made. Each fiber which runs on our runtime has a carrier worker thread (this concept can be taken further in the future and it can help remove branches when scheduling, especially after we remove the helper thread type). Right before an asynchronous suspension point is hit, the fiber registers itself on the carrier thread. That carrier thread then has a reference to the suspended fiber which can be queried (more on the type of reference in the next point).
3. Now, the carrier thread cannot just hold a strong reference to the fiber because that would make the fiber be ignored by the GC. This is bad for fibers like `IO.never`. So, the carrier thread holds a weak reference to the fiber.
4. However, to have a useful fiber dump feature, we cannot just have a mechanism of registering the fibers to be monitored, we also need to have a mechanism for unregistering them when they are resumed. This seems simpler when there is a single global data structure, but is problematic when we have a thread-local one which we want to operate without synchronization. The big issue is the following observation, asynchronously suspended fibers can be resumed on any worker thread, not necessarily the previous carrier (because the async callback can be executed by any thread, including threads external to the pool). And this is where the magic happens (I'm not trolling). We let the GC remove the registration entries for us, automagically. How? `WeakHashMap`.
5. `WeakHashMap` is a hash table implementation by the JDK which keeps weak references to keys and strong references to values (I will go in more depth in a second). Essentially, when a key in the hash table is no longer referenced by the runtime, the GC will remove it and the hash table entry of both the key and the value will be released. The question now becomes, what to choose as our hashtable key.
6. A first guess might be the `IOFiber` instance itself. Let's see how far that takes us. Remember, the goal is for the GC to remove the entries from our map of _suspended_ fibers. However, the GC would be unable to assist us in this case, because after a fiber is resumed, it exists and the weak reference to it will not be cleared. So, we need a different type of key.
7. Remember that every asynchronously suspended fiber is accompanied by a callback function that would resume it. Let's see if we can use that function as the key. It seems reasonable at first, as soon as the callback is executed, the fiber will be resumed, the callback will be unreferenced, the GC will kick in and remove our suspended fiber from the data structure. However, we're passing this asynchronous callback into untrusted territory, there is no guarantee that users won't leak it and store it forever, so we cannot really rely on that.
8. Which is where we come to the solution, we will create a custom object per fiber which we will use as a key. However, we are immediately faced with a challenge, we cannot just create an object, give it to the thread-local fiber bag data structure and call it a day. Remember, the `WeakHashMap` holds weak references to the keys, so any unreferenced objects will be collected by the GC and therefore our references to the suspended fibers go bye bye as well. So, we need to hold a strong reference to this key object, and `null` it out when a fiber is resumed. Next question, where to store this reference? Well, every suspended fiber needs a unique key, so in the `IOFiber` object header is the natural solution. However, remember how I said that `WeakHashMap` keeps strong references to values, and our values are `IOFiber` instances. Well, if our values in turn hold strong references to our keys, the GC will refuse to help us (we're essentially shooting ourselves in the foot). This isn't _too_ terrible in practice, if we assume that all fibers will be eventually resumed. Unfortunately,  `IO.never` bites us again. We need those fibers to be collectable by the GC. Luckily, the [documentation](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/WeakHashMap.html) for `WeakHashMap` helps us here &ndash; just use `WeakReference` for the value. So, we do that. Now, `IO.never` fibers can be collected, as soon as the reference to the fiber object instance expires. This will expire the `WeakHashMap` entry _value_ _and_ allow the fiber to be collected (remember, `WeakReference`). The GC collection of the fiber then makes the reference to the key unreachable, and so the whole entry is then deleted from the data structure by the GC. All is well in the world.
9. Marking the fiber as resumed (unmonitoring it) is as easy as `null`ing out the reference to the key. The GC takes care of the rest. This does mean that there can be some lag in the removal from the suspended fiber data structure. However, I envision the fiber dump feature to be a fairly infrequent action (and understood by users as expensive), so we could even call `System.gc()` right before we dump the fibers. In any case, since we have references to fibers and we control the code in `IOFiber`, we can add a suspension check like we do in `toString()`, so essentially, any false positives can be easily removed from the output.
10. I haven't tested how this affects performance. I can do that. This is mostly me having fun. I don't really expect this to land, ever. If you read up to here, I thank you for your patience and perseverence and I hope you at least found it amusing. I know I did, I must admit this is pretty out-there, as far as thinking outside the box goes.
11. Caveat, this doesn't work with the `epsilon` GC, duh. https://blogs.oracle.com/javamagazine/post/epsilon-the-jdks-do-nothing-garbage-collector