### PR TITLE
Fix error and clarify wording in `MonadCancel` documentation

### DIFF
--- a/docs/typeclasses/monadcancel.md
+++ b/docs/typeclasses/monadcancel.md
@@ -135,12 +135,14 @@ The use of the `outer` poll within the inner `uncancelable` is simply ignored un
 ```scala
 MonadCancel[F] uncancelable { outer =>
   MonadCancel[F] uncancelable { inner =>
-    outer(inner(fa))
+    inner(outer(fa))
   }
 }
 ```
 
 This is simply equivalent to writing `fa`. Which is to say, `poll` composes in the way you would expect.
+
+They are applied to `fa` outermost-first as when the program is interpreted this order is reversed: the `inner` `poll` will be evaluated first, which removes the inner `uncancelable`, followed by the `outer` `poll`, which removes the outer `uncancelable` and allows cancelation. 
 
 ### Self-Cancelation
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -257,8 +257,8 @@ trait MonadCancel[F[_], E] extends MonadError[F, E] {
    *
    * Masks can also be stacked or nested within each other. If multiple masks are active, all
    * masks must be undone so that cancelation can be observed. In order to completely unmask
-   * within a multi-masked region, the poll corresponding to each mask must be applied,
-   * innermost-first.
+   * within a multi-masked region the poll corresponding to each mask must be applied to the
+   * effect, outermost-first.
    *
    * {{{
    *
@@ -273,7 +273,8 @@ trait MonadCancel[F[_], E] extends MonadError[F, E] {
    * The following operations are no-ops:
    *
    *   1. Polling in the wrong order
-   *   1. Applying the same poll more than once: `poll(poll(fa))`
+   *   1. Subsequent polls when applying the same poll more than once: `poll(poll(fa))` is
+   *      equivalent to `poll(fa)`
    *   1. Applying a poll bound to one fiber within another fiber
    *
    * @param body


### PR DESCRIPTION
This was prompted by a [discussion on discord](https://discord.com/channels/632277896739946517/632278585700384799/890606516380512296).

The `MonadCancel` documentation applied nested
`uncancelable` `Poll`s in the incorrect order.

In addition the `MonadCancel.uncancelable` docstring
is slightly ambiguous about what order nested masks should
be applied. I've tried to clarify this...