### PR TITLE
Choose an explicit Scala dialect

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,7 @@
 version = 3.0.4
 
+runner.dialect = Scala213Source3
+
 maxColumn = 96
 
 includeCurlyBraceInSelectChains = true


### PR DESCRIPTION
This resolves the following warning:

```
Default dialect is deprecated; use explicit: [Scala211,scala212,Scala212Source3,scala213,Scala213Source3,Sbt0137,Sbt1,scala3]
Also see https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects"
```