### PR TITLE
Radically slimmer parallel map2

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/instances/GenSpawnInstances.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/instances/GenSpawnInstances.scala
@@ -52,133 +52,71 @@ trait GenSpawnInstances {
 
       final override def map2[A, B, Z](fa: ParallelF[F, A], fb: ParallelF[F, B])(
           f: (A, B) => Z): ParallelF[F, Z] =
-        ParallelF(
+        ParallelF {
           F.uncancelable { poll =>
             for {
               fiberA <- F.start(ParallelF.value(fa))
-              fiberB <- F.start(ParallelF.value(fb))
-
-              // start a pair of supervisors to ensure that the opposite is canceled on error
-              _ <- F start {
-                fiberB.join flatMap {
-                  case Outcome.Succeeded(_) => F.unit
-                  case _ => fiberA.cancel
-                }
-              }
-
-              _ <- F start {
-                fiberA.join flatMap {
-                  case Outcome.Succeeded(_) => F.unit
-                  case _ => fiberB.cancel
-                }
-              }
+              fiberB <- F.start(F.guaranteeCase(ParallelF.value(fb)) {
+                case Outcome.Succeeded(_) => F.unit
+                case _ => fiberA.cancel
+              })
 
               a <- F
-                .onCancel(poll(fiberA.join), F.both(fiberA.cancel, fiberB.cancel).void)
+                .onCancel(poll(fiberA.join), F.map2(fiberA.cancel, fiberB.cancel)((_, _) => ()))
                 .flatMap[A] {
-                  case Outcome.Succeeded(fa) =>
-                    fa
-
-                  case Outcome.Errored(e) =>
-                    fiberB.cancel *> F.raiseError(e)
-
+                  case Outcome.Succeeded(fa) => fa
+                  case Outcome.Errored(e) => fiberB.cancel *> F.raiseError(e)
                   case Outcome.Canceled() =>
-                    fiberB.cancel *> poll {
-                      fiberB.join flatMap {
-                        case Outcome.Succeeded(_) | Outcome.Canceled() =>
-                          F.canceled *> F.never
-                        case Outcome.Errored(e) =>
-                          F.raiseError(e)
-                      }
+                    fiberB.cancel *> fiberB.join.flatMap {
+                      case Outcome.Errored(e) => F.raiseError(e)
+                      case _ => poll(F.canceled) *> F.never
                     }
                 }
 
-              z <- F.onCancel(poll(fiberB.join), fiberB.cancel).flatMap[Z] {
-                case Outcome.Succeeded(fb) =>
-                  fb.map(b => f(a, b))
-
-                case Outcome.Errored(e) =>
-                  F.raiseError(e)
-
-                case Outcome.Canceled() =>
-                  poll {
-                    fiberA.join flatMap {
-                      case Outcome.Succeeded(_) | Outcome.Canceled() =>
-                        F.canceled *> F.never
-                      case Outcome.Errored(e) =>
-                        F.raiseError(e)
-                    }
-                  }
+              b <- F.onCancel(poll(fiberB.join), fiberB.cancel).flatMap[B] {
+                case Outcome.Succeeded(fb) => fb
+                case Outcome.Errored(e) => F.raiseError(e)
+                case Outcome.Canceled() => poll(F.canceled) *> F.never
               }
-            } yield z
+            } yield f(a, b)
           }
-        )
+        }
 
       final override def map2Eval[A, B, Z](fa: ParallelF[F, A], fb: Eval[ParallelF[F, B]])(
           f: (A, B) => Z): Eval[ParallelF[F, Z]] =
-        Eval.now(
-          ParallelF(
+        Eval.now {
+          ParallelF {
             F.uncancelable { poll =>
               for {
                 fiberA <- F.start(ParallelF.value(fa))
-                fiberB <- F.start(ParallelF.value(fb.value))
-
-                // start a pair of supervisors to ensure that the opposite is canceled on error
-                _ <- F start {
-                  fiberB.join flatMap {
-                    case Outcome.Succeeded(_) => F.unit
-                    case _ => fiberA.cancel
-                  }
-                }
-
-                _ <- F start {
-                  fiberA.join flatMap {
-                    case Outcome.Succeeded(_) => F.unit
-                    case _ => fiberB.cancel
-                  }
-                }
+                fiberB <- F.start(F.guaranteeCase(ParallelF.value(fb.value)) {
+                  case Outcome.Succeeded(_) => F.unit
+                  case _ => fiberA.cancel
+                })
 
                 a <- F
-                  .onCancel(poll(fiberA.join), F.both(fiberA.cancel, fiberB.cancel).void)
+                  .onCancel(
+                    poll(fiberA.join),
+                    F.map2(fiberA.cancel, fiberB.cancel)((_, _) => ()))
                   .flatMap[A] {
-                    case Outcome.Succeeded(fa) =>
-                      fa
-
-                    case Outcome.Errored(e) =>
-                      fiberB.cancel *> F.raiseError(e)
-
+                    case Outcome.Succeeded(fa) => fa
+                    case Outcome.Errored(e) => fiberB.cancel *> F.raiseError(e)
                     case Outcome.Canceled() =>
-                      fiberB.cancel *> poll {
-                        fiberB.join flatMap {
-                          case Outcome.Succeeded(_) | Outcome.Canceled() =>
-                            F.canceled *> F.never
-                          case Outcome.Errored(e) =>
-                            F.raiseError(e)
-                        }
+                      fiberB.cancel *> fiberB.join.flatMap {
+                        case Outcome.Errored(e) => F.raiseError(e)
+                        case _ => poll(F.canceled) *> F.never
                       }
                   }
 
-                z <- F.onCancel(poll(fiberB.join), fiberB.cancel).flatMap[Z] {
-                  case Outcome.Succeeded(fb) =>
-                    fb.map(b => f(a, b))
-
-                  case Outcome.Errored(e) =>
-                    F.raiseError(e)
-
-                  case Outcome.Canceled() =>
-                    poll {
-                      fiberA.join flatMap {
-                        case Outcome.Succeeded(_) | Outcome.Canceled() =>
-                          F.canceled *> F.never
-                        case Outcome.Errored(e) =>
-                          F.raiseError(e)
-                      }
-                    }
+                b <- F.onCancel(poll(fiberB.join), fiberB.cancel).flatMap[B] {
+                  case Outcome.Succeeded(fb) => fb
+                  case Outcome.Errored(e) => F.raiseError(e)
+                  case Outcome.Canceled() => poll(F.canceled) *> F.never
                 }
-              } yield z
+              } yield f(a, b)
             }
-          )
-        )
+          }
+        }
 
       final override def ap[A, B](ff: ParallelF[F, A => B])(
           fa: ParallelF[F, A]): ParallelF[F, B] =

--- a/laws/shared/src/test/scala/cats/effect/laws/PureConcParSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/PureConcParSpec.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package laws
+
+import cats.effect.kernel.ParallelF
+import cats.effect.kernel.implicits._
+import cats.effect.kernel.testkit.{pure, ParallelFGenerators, PureConcGenerators}, pure._
+import cats.laws.discipline.CommutativeApplicativeTests
+import org.specs2.mutable.Specification
+import org.typelevel.discipline.specs2.mutable.Discipline
+
+class PureConcParSpec extends Specification with Discipline with BaseSpec {
+
+  import ParallelFGenerators._
+  import PureConcGenerators._
+
+  checkAll(
+    "CommutativeApplicative[ParallelF[PureConc]]",
+    CommutativeApplicativeTests[ParallelF[PureConc[Int, *], *]]
+      .commutativeApplicative[Int, Int, Int])
+}

--- a/tests/shared/src/test/scala/cats/effect/IOParSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOParSpec.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.laws.discipline.ApplicativeTests
+import cats.effect.implicits._
+import org.typelevel.discipline.specs2.mutable.Discipline
+
+class IOParSpec extends BaseSpec with Discipline {
+
+  sequential
+
+  {
+    implicit val ticker = Ticker()
+
+    checkAll("Applicative[IO.Par]", ApplicativeTests[IO.Par].applicative[Int, Int, Int])
+  }
+}


### PR DESCRIPTION
@armanbilge Please read the comments carefully and comment whether you agree with them. I may have overlooked something, it's very late and I apologize in advance.

The tests seem to be passing (the ones that we have in `series/3.x` in any case) with these changes, so this should be "compatible" with the previous implementation.

However, if you rebase the laws checks that you added about ParallelF on this branch, you will see the `???` paths being taken, and I believe this is a bug in the pure interpreter. I haven't tried the IO.Par laws.