### PR TITLE
Fix `ApplicativeForParallelF` and friends

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/instances/GenSpawnInstances.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/instances/GenSpawnInstances.scala
@@ -58,39 +58,14 @@ trait GenSpawnInstances {
               fiberA <- F.start(ParallelF.value(fa).attempt)
               fiberB <- F.start(ParallelF.value(fb).attempt)
 
-              // start a pair of supervisors to ensure that the opposite is canceled on error
-              // _ <- F start {
-              //   fiberB.join flatMap {
-              //     case Outcome.Succeeded(_) => F.unit
-              //     case _ => fiberA.cancel
-              //   }
-              // }
-
-              // _ <- F start {
-              //   fiberA.join flatMap {
-              //     case Outcome.Succeeded(_) => F.unit
-              //     case _ => fiberB.cancel
-              //   }
-              // }
-
               a <- F
                 .onCancel(poll(fiberA.join), F.both(fiberA.cancel, fiberB.cancel).void)
                 .flatMap[Either[E, A]] {
                   case Outcome.Succeeded(fa) =>
                     fa
 
-                  case Outcome.Errored(_) => ???
-                  // fiberB.cancel *> F.raiseError(e)
-
-                  case Outcome.Canceled() =>
-                    fiberB.cancel *> poll {
-                      fiberB.join flatMap {
-                        case Outcome.Succeeded(_) | Outcome.Canceled() =>
-                          F.canceled *> F.never
-                        case Outcome.Errored(e) =>
-                          F.raiseError(e)
-                      }
-                    }
+                  case Outcome.Errored(_) | Outcome.Canceled() =>
+                    fiberB.cancel *> poll(F.canceled *> F.never)
                 }
 
               z <- F.onCancel(poll(fiberB.join), fiberB.cancel).flatMap[Z] {
@@ -103,18 +78,8 @@ trait GenSpawnInstances {
                     }
                   }
 
-                case Outcome.Errored(_) => ???
-                // F.raiseError(e)
-
-                case Outcome.Canceled() =>
-                  poll {
-                    fiberA.join flatMap {
-                      case Outcome.Succeeded(_) | Outcome.Canceled() =>
-                        F.canceled *> F.never
-                      case Outcome.Errored(e) =>
-                        F.raiseError(e)
-                    }
-                  }
+                case Outcome.Errored(_) | Outcome.Canceled() =>
+                  poll(F.canceled *> F.never)
               }
             } yield z
           }

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1387,7 +1387,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
 
     checkAll(
       "IO.Par",
-      CommutativeApplicativeTests[IO.Par].commutativeApplicative[Int, Int, Int]
+      CommutativeApplicativeTests[IO.Par].applicative[Int, Int, Int]
     )
   }
 

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -17,7 +17,12 @@
 package cats.effect
 
 import cats.kernel.laws.discipline.MonoidTests
-import cats.laws.discipline.{AlignTests, CommutativeApplicativeTests, SemigroupKTests}
+import cats.laws.discipline.{
+  AlignTests,
+  CommutativeApplicativeTests,
+  ParallelTests,
+  SemigroupKTests
+}
 import cats.laws.discipline.arbitrary._
 
 import cats.effect.implicits._
@@ -1373,7 +1378,25 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
 
     checkAll(
       "IO.Par",
+      ParallelTests[IO, IO.Par].parallel[Int, Int]
+    )
+  }
+
+  {
+    implicit val ticker = Ticker()
+
+    checkAll(
+      "IO.Par",
       CommutativeApplicativeTests[IO.Par].commutativeApplicative[Int, Int, Int]
+    )
+  }
+
+  {
+    implicit val ticker = Ticker()
+
+    checkAll(
+      "IO.Par",
+      AlignTests[IO.Par].align[Int, Int, Int, Int]
     )
   }
 

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -17,7 +17,7 @@
 package cats.effect
 
 import cats.kernel.laws.discipline.MonoidTests
-import cats.laws.discipline.{AlignTests, SemigroupKTests}
+import cats.laws.discipline.{AlignTests, CommutativeApplicativeTests, SemigroupKTests}
 import cats.laws.discipline.arbitrary._
 
 import cats.effect.implicits._
@@ -1365,6 +1365,15 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
     checkAll(
       "IO",
       AlignTests[IO].align[Int, Int, Int, Int]
+    )
+  }
+
+  {
+    implicit val ticker = Ticker()
+
+    checkAll(
+      "IO.Par",
+      CommutativeApplicativeTests[IO.Par].commutativeApplicative[Int, Int, Int]
     )
   }
 

--- a/tests/shared/src/test/scala/cats/effect/kernel/ParallelFSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/ParallelFSpec.scala
@@ -28,18 +28,17 @@ import org.typelevel.discipline.specs2.mutable.Discipline
 
 class ParallelFSpec extends BaseSpec with Discipline {
 
-  checkAll("Parallel[F, ParallelF]",
-    ParallelTests[PureConc[Throwable, *], ParallelF[PureConc[Throwable, *], *]].parallel[Int, Int]
-  )
+  checkAll(
+    "Parallel[F, ParallelF]",
+    ParallelTests[PureConc[Int, *], ParallelF[PureConc[Int, *], *]].parallel[Int, Int])
 
   checkAll(
     "CommutativeApplicative[ParallelF]",
-    CommutativeApplicativeTests[ParallelF[PureConc[Throwable, *], *]]
+    CommutativeApplicativeTests[ParallelF[PureConc[Int, *], *]]
       .commutativeApplicative[Int, Int, Int])
 
   checkAll(
     "Align[ParallelF]",
-    AlignTests[ParallelF[PureConc[Throwable, *], *]]
-      .align[Int, Int, Int, Int])
+    AlignTests[ParallelF[PureConc[Int, *], *]].align[Int, Int, Int, Int])
 
 }

--- a/tests/shared/src/test/scala/cats/effect/kernel/ParallelFSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/ParallelFSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package kernel
+
+import cats.effect.kernel.instances.all._
+import cats.effect.kernel.testkit.PureConcGenerators._
+import cats.effect.kernel.testkit.pure._
+import cats.laws.discipline.CommutativeApplicativeTests
+import org.typelevel.discipline.specs2.mutable.Discipline
+
+class ParallelFSpec extends BaseSpec with Discipline {
+
+  checkAll(
+    "CommutativeApplicative[ParallelF]",
+    CommutativeApplicativeTests[ParallelF[PureConc[Throwable, *], *]]
+      .commutativeApplicative[Int, Int, Int])
+
+}

--- a/tests/shared/src/test/scala/cats/effect/kernel/ParallelFSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/ParallelFSpec.scala
@@ -20,14 +20,26 @@ package kernel
 import cats.effect.kernel.instances.all._
 import cats.effect.kernel.testkit.PureConcGenerators._
 import cats.effect.kernel.testkit.pure._
+import cats.laws.discipline.AlignTests
 import cats.laws.discipline.CommutativeApplicativeTests
+import cats.laws.discipline.ParallelTests
+import cats.laws.discipline.arbitrary.catsLawsCogenForIor
 import org.typelevel.discipline.specs2.mutable.Discipline
 
 class ParallelFSpec extends BaseSpec with Discipline {
+
+  checkAll("Parallel[F, ParallelF]",
+    ParallelTests[PureConc[Throwable, *], ParallelF[PureConc[Throwable, *], *]].parallel[Int, Int]
+  )
 
   checkAll(
     "CommutativeApplicative[ParallelF]",
     CommutativeApplicativeTests[ParallelF[PureConc[Throwable, *], *]]
       .commutativeApplicative[Int, Int, Int])
+
+  checkAll(
+    "Align[ParallelF]",
+    AlignTests[ParallelF[PureConc[Throwable, *], *]]
+      .align[Int, Int, Int, Int])
 
 }

--- a/tests/shared/src/test/scala/cats/effect/kernel/ParallelFSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/ParallelFSpec.scala
@@ -34,8 +34,7 @@ class ParallelFSpec extends BaseSpec with Discipline {
 
   checkAll(
     "CommutativeApplicative[ParallelF]",
-    CommutativeApplicativeTests[ParallelF[PureConc[Int, *], *]]
-      .commutativeApplicative[Int, Int, Int])
+    CommutativeApplicativeTests[ParallelF[PureConc[Int, *], *]].applicative[Int, Int, Int])
 
   checkAll(
     "Align[ParallelF]",


### PR DESCRIPTION
The first goal is getting the `ParallelFSpec` introduced in #2375 to pass, which is accomplished in 6032cf2. 

Note I relaxed the tests from `CommutativeApplicative` to just `Applicative` since atm I do not believe commutativity is feasible without an additional constraint on `E`, h/t to @Baccata for pointing this out.

Currently laws are still not passing for `IO.Par` and in addition these changes also fail the `parallel should short-circuit on error` in `IOSpec`. I don't think it's possible to pass the laws for `Applicative` _and_ short-circuit both the left and right. See also https://github.com/typelevel/cats-effect/pull/2376#discussion_r716312564. Possible compromises:
1. Only short-circuit the right, if an error occurs on the left. Don't short-circuit the left even if the right errors. This effectively left-biases the error channel.
2. Relax the equivalence of errors to something like "all errors are equivalent".