### PR TITLE
Fix typo in test-suite name in `TestControlSpec`

### DIFF
--- a/tests/shared/src/test/scala/cats/effect/testkit/TestControlSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/testkit/TestControlSpec.scala
@@ -114,7 +114,7 @@ class TestControlSpec extends BaseSpec {
     }
   }
 
-  "executeFully" should {
+  "executeEmbed" should {
     "run a simple IO" in real {
       TestControl.executeEmbed(simple) flatMap { r => IO(r mustEqual (())) }
     }


### PR DESCRIPTION
https://pbs.twimg.com/media/FA3kkFIXIBANkAE?format=jpg&name=900x900