### PR TITLE
Add support for long sleeps in JS scheduler

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -19,23 +19,12 @@ package cats.effect.unsafe
 import org.scalajs.macrotaskexecutor.MacrotaskExecutor
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.FiniteDuration
-import scala.scalajs.js.timers
 
 private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type =>
 
   def defaultComputeExecutionContext: ExecutionContext = MacrotaskExecutor
 
-  def defaultScheduler: Scheduler =
-    new Scheduler {
-      def sleep(delay: FiniteDuration, task: Runnable): Runnable = {
-        val handle = timers.setTimeout(delay)(task.run())
-        () => timers.clearTimeout(handle)
-      }
-
-      def nowMillis() = System.currentTimeMillis()
-      def monotonicNanos() = System.nanoTime()
-    }
+  def defaultScheduler: Scheduler = Scheduler.createDefaultScheduler()._1
 
   private[this] var _global: IORuntime = null
 

--- a/core/js/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
@@ -20,10 +20,11 @@ import scala.concurrent.duration._
 import scala.scalajs.js.timers
 
 private[unsafe] abstract class SchedulerCompanionPlatform { this: Scheduler.type =>
+  private[this] val maxTimeout = Int.MaxValue.millis
+
   def createDefaultScheduler(): (Scheduler, () => Unit) =
     (
       new Scheduler {
-        private[this] val maxTimeout = Int.MaxValue.millis
 
         def sleep(delay: FiniteDuration, task: Runnable): Runnable =
           if (delay <= maxTimeout) {

--- a/tests/js/src/test/scala/cats/effect/unsafe/SchedulerSpec.scala
+++ b/tests/js/src/test/scala/cats/effect/unsafe/SchedulerSpec.scala
@@ -23,7 +23,11 @@ class SchedulerSpec extends BaseSpec {
 
   "Default scheduler" should {
     "correctly handle very long sleeps" in real {
-      IO.sleep(Long.MaxValue.nanos).race(IO.sleep(1.second)) mustEqual Right(())
+      // When the provided timeout in milliseconds overflows a signed 32-bit int, the implementation defaults to 1 millisecond
+      IO.sleep(Long.MaxValue.nanos).race(IO.sleep(100.millis)) mustEqual Right(())
+    }
+    "is using the correct max timeout" in real {
+      IO.sleep(Int.MaxValue.millis).race(IO.sleep(100.millis)) mustEqual Right(())
     }
   }
 

--- a/tests/js/src/test/scala/cats/effect/unsafe/SchedulerSpec.scala
+++ b/tests/js/src/test/scala/cats/effect/unsafe/SchedulerSpec.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package unsafe
+
+import scala.concurrent.duration._
+
+class SchedulerSpec extends BaseSpec {
+
+  "Default scheduler" should {
+    "correctly handle very long sleeps" in real {
+      IO.sleep(Long.MaxValue.nanos).race(IO.sleep(1.second)) mustEqual Right(())
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes #2388. Also removes a duplicate (?) implementation of the default scheduler.