### PR TITLE
Add a configurable timeout for the JVM shutdown hook

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
@@ -17,6 +17,7 @@
 package cats.effect
 package unsafe
 
+import scala.concurrent.duration.Duration
 import scala.util.Try
 
 private[unsafe] abstract class IORuntimeConfigCompanionPlatform { this: IORuntimeConfig.type =>
@@ -42,6 +43,16 @@ private[unsafe] abstract class IORuntimeConfigCompanionPlatform { this: IORuntim
       .flatMap(x => Try(x.toInt).toOption)
       .getOrElse(DefaultTraceBufferSize)
 
-    apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize)
+    val shutdownHookTimeout = process
+      .env("CATS_EFFECT_SHUTDOWN_HOOK_TIMEOUT")
+      .flatMap(x => Try(Duration(x)).toOption)
+      .getOrElse(DefaultShutdownHookTimeout)
+
+    apply(
+      cancelationCheckThreshold,
+      autoYieldThreshold,
+      enhancedExceptions,
+      traceBufferSize,
+      shutdownHookTimeout)
   }
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
@@ -17,6 +17,7 @@
 package cats.effect
 package unsafe
 
+import scala.concurrent.duration.Duration
 import scala.util.Try
 
 private[unsafe] abstract class IORuntimeConfigCompanionPlatform { this: IORuntimeConfig.type =>
@@ -38,6 +39,16 @@ private[unsafe] abstract class IORuntimeConfigCompanionPlatform { this: IORuntim
       Try(System.getProperty("cats.effect.tracing.buffer.size").toInt)
         .getOrElse(DefaultTraceBufferSize)
 
-    apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize)
+    val shutdownHookTimeout =
+      Try(System.getProperty("cats.effect.shutdown.hook.timeout"))
+        .map(Duration(_))
+        .getOrElse(DefaultShutdownHookTimeout)
+
+    apply(
+      cancelationCheckThreshold,
+      autoYieldThreshold,
+      enhancedExceptions,
+      traceBufferSize,
+      shutdownHookTimeout)
   }
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -498,26 +498,6 @@ private[effect] final class WorkStealingThreadPool(
       // Clear the interrupt flag.
       Thread.interrupted()
 
-      // Check if a worker thread is shutting down the thread pool, to avoid a
-      // self join, which hangs forever. Any other thread shutting down the pool
-      // will receive an index of `-1`, which means that it will join all worker
-      // threads.
-      val thread = Thread.currentThread()
-      val workerIndex = if (thread.isInstanceOf[WorkerThread]) {
-        val worker = thread.asInstanceOf[WorkerThread]
-        worker.index
-      } else {
-        -1
-      }
-
-      i = 0
-      while (i < threadCount) {
-        if (workerIndex != i) {
-          workerThreads(i).join()
-        }
-        i += 1
-      }
-
       // It is now safe to clean up the state of the thread pool.
       state.lazySet(0)
 

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
@@ -26,10 +26,7 @@ final case class IORuntimeConfig private (
     val traceBufferSize: Int,
     val shutdownHookTimeout: Duration) {
 
-  @deprecated(
-    "Use IORuntimeConfig.apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize, shutdownHookTimeout)",
-    "3.3.0")
-  def this(cancelationCheckThreshold: Int, autoYieldThreshold: Int) =
+  private[unsafe] def this(cancelationCheckThreshold: Int, autoYieldThreshold: Int) =
     this(
       cancelationCheckThreshold,
       autoYieldThreshold,
@@ -98,10 +95,9 @@ object IORuntimeConfig extends IORuntimeConfigCompanionPlatform {
 
   def apply(): IORuntimeConfig = Default
 
-  @deprecated(
-    "Use IORuntimeConfig.apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize, shutdownHookTimeout)",
-    "3.3.0")
-  def apply(cancelationCheckThreshold: Int, autoYieldThreshold: Int): IORuntimeConfig =
+  private[unsafe] def apply(
+      cancelationCheckThreshold: Int,
+      autoYieldThreshold: Int): IORuntimeConfig =
     apply(
       cancelationCheckThreshold,
       autoYieldThreshold,
@@ -109,10 +105,7 @@ object IORuntimeConfig extends IORuntimeConfigCompanionPlatform {
       DefaultTraceBufferSize,
       DefaultShutdownHookTimeout)
 
-  @deprecated(
-    "Use IORuntimeConfig.apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize, shutdownHookTimeout)",
-    "3.3.0")
-  def apply(
+  private[unsafe] def apply(
       cancelationCheckThreshold: Int,
       autoYieldThreshold: Int,
       enhancedExceptions: Boolean,

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
@@ -37,10 +37,7 @@ final case class IORuntimeConfig private (
       IORuntimeConfig.DefaultTraceBufferSize,
       IORuntimeConfig.DefaultShutdownHookTimeout)
 
-  @deprecated(
-    "Use IORuntimeConfig.apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize, shutdownHookTimeout",
-    "3.3.0")
-  def this(
+  private[unsafe] def this(
       cancelationCheckThreshold: Int,
       autoYieldThreshold: Int,
       enhancedExceptions: Boolean,

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
@@ -95,9 +95,7 @@ object IORuntimeConfig extends IORuntimeConfigCompanionPlatform {
 
   def apply(): IORuntimeConfig = Default
 
-  private[unsafe] def apply(
-      cancelationCheckThreshold: Int,
-      autoYieldThreshold: Int): IORuntimeConfig =
+  def apply(cancelationCheckThreshold: Int, autoYieldThreshold: Int): IORuntimeConfig =
     apply(
       cancelationCheckThreshold,
       autoYieldThreshold,
@@ -105,7 +103,7 @@ object IORuntimeConfig extends IORuntimeConfigCompanionPlatform {
       DefaultTraceBufferSize,
       DefaultShutdownHookTimeout)
 
-  private[unsafe] def apply(
+  def apply(
       cancelationCheckThreshold: Int,
       autoYieldThreshold: Int,
       enhancedExceptions: Boolean,

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
@@ -26,6 +26,9 @@ final case class IORuntimeConfig private (
     val traceBufferSize: Int,
     val shutdownHookTimeout: Duration) {
 
+  @deprecated(
+    "Use IORuntimeConfig.apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize, shutdownHookTimeout",
+    "3.3.0")
   def this(cancelationCheckThreshold: Int, autoYieldThreshold: Int) =
     this(
       cancelationCheckThreshold,
@@ -34,11 +37,27 @@ final case class IORuntimeConfig private (
       IORuntimeConfig.DefaultTraceBufferSize,
       IORuntimeConfig.DefaultShutdownHookTimeout)
 
+  @deprecated(
+    "Use IORuntimeConfig.apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize, shutdownHookTimeout",
+    "3.3.0")
+  def this(
+      cancelationCheckThreshold: Int,
+      autoYieldThreshold: Int,
+      enhancedExceptions: Boolean,
+      traceBufferSize: Int) =
+    this(
+      cancelationCheckThreshold,
+      autoYieldThreshold,
+      enhancedExceptions,
+      traceBufferSize,
+      IORuntimeConfig.DefaultShutdownHookTimeout)
+
   def copy(
       cancelationCheckThreshold: Int = this.cancelationCheckThreshold,
       autoYieldThreshold: Int = this.autoYieldThreshold,
       enhancedExceptions: Boolean = this.enhancedExceptions,
-      traceBufferSize: Int = this.traceBufferSize): IORuntimeConfig =
+      traceBufferSize: Int = this.traceBufferSize,
+      shutdownHookTimeout: Duration = this.shutdownHookTimeout): IORuntimeConfig =
     new IORuntimeConfig(
       cancelationCheckThreshold,
       autoYieldThreshold,
@@ -46,7 +65,19 @@ final case class IORuntimeConfig private (
       traceBufferSize,
       shutdownHookTimeout)
 
-  // shim for binary compat
+  // shims for binary compat
+  private[unsafe] def copy(
+      cancelationCheckThreshold: Int,
+      autoYieldThreshold: Int,
+      enhancedExceptions: Boolean,
+      traceBufferSize: Int): IORuntimeConfig =
+    new IORuntimeConfig(
+      cancelationCheckThreshold,
+      autoYieldThreshold,
+      enhancedExceptions,
+      traceBufferSize,
+      shutdownHookTimeout)
+
   private[unsafe] def copy(
       cancelationCheckThreshold: Int,
       autoYieldThreshold: Int): IORuntimeConfig =
@@ -70,12 +101,30 @@ object IORuntimeConfig extends IORuntimeConfigCompanionPlatform {
 
   def apply(): IORuntimeConfig = Default
 
+  @deprecated(
+    "Use IORuntimeConfig.apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize, shutdownHookTimeout",
+    "3.3.0")
   def apply(cancelationCheckThreshold: Int, autoYieldThreshold: Int): IORuntimeConfig =
     apply(
       cancelationCheckThreshold,
       autoYieldThreshold,
       DefaultEnhancedExceptions,
       DefaultTraceBufferSize,
+      DefaultShutdownHookTimeout)
+
+  @deprecated(
+    "Use IORuntimeConfig.apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize, shutdownHookTimeout",
+    "3.3.0")
+  def apply(
+      cancelationCheckThreshold: Int,
+      autoYieldThreshold: Int,
+      enhancedExceptions: Boolean,
+      traceBufferSize: Int): IORuntimeConfig =
+    apply(
+      cancelationCheckThreshold,
+      autoYieldThreshold,
+      enhancedExceptions,
+      traceBufferSize,
       DefaultShutdownHookTimeout)
 
   def apply(

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
@@ -37,18 +37,6 @@ final case class IORuntimeConfig private (
       IORuntimeConfig.DefaultTraceBufferSize,
       IORuntimeConfig.DefaultShutdownHookTimeout)
 
-  private[unsafe] def this(
-      cancelationCheckThreshold: Int,
-      autoYieldThreshold: Int,
-      enhancedExceptions: Boolean,
-      traceBufferSize: Int) =
-    this(
-      cancelationCheckThreshold,
-      autoYieldThreshold,
-      enhancedExceptions,
-      traceBufferSize,
-      IORuntimeConfig.DefaultShutdownHookTimeout)
-
   def copy(
       cancelationCheckThreshold: Int = this.cancelationCheckThreshold,
       autoYieldThreshold: Int = this.autoYieldThreshold,
@@ -63,6 +51,18 @@ final case class IORuntimeConfig private (
       shutdownHookTimeout)
 
   // shims for binary compat
+  private[unsafe] def this(
+      cancelationCheckThreshold: Int,
+      autoYieldThreshold: Int,
+      enhancedExceptions: Boolean,
+      traceBufferSize: Int) =
+    this(
+      cancelationCheckThreshold,
+      autoYieldThreshold,
+      enhancedExceptions,
+      traceBufferSize,
+      IORuntimeConfig.DefaultShutdownHookTimeout)
+
   private[unsafe] def copy(
       cancelationCheckThreshold: Int,
       autoYieldThreshold: Int,

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
@@ -27,7 +27,7 @@ final case class IORuntimeConfig private (
     val shutdownHookTimeout: Duration) {
 
   @deprecated(
-    "Use IORuntimeConfig.apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize, shutdownHookTimeout",
+    "Use IORuntimeConfig.apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize, shutdownHookTimeout)",
     "3.3.0")
   def this(cancelationCheckThreshold: Int, autoYieldThreshold: Int) =
     this(
@@ -99,7 +99,7 @@ object IORuntimeConfig extends IORuntimeConfigCompanionPlatform {
   def apply(): IORuntimeConfig = Default
 
   @deprecated(
-    "Use IORuntimeConfig.apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize, shutdownHookTimeout",
+    "Use IORuntimeConfig.apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize, shutdownHookTimeout)",
     "3.3.0")
   def apply(cancelationCheckThreshold: Int, autoYieldThreshold: Int): IORuntimeConfig =
     apply(
@@ -110,7 +110,7 @@ object IORuntimeConfig extends IORuntimeConfigCompanionPlatform {
       DefaultShutdownHookTimeout)
 
   @deprecated(
-    "Use IORuntimeConfig.apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize, shutdownHookTimeout",
+    "Use IORuntimeConfig.apply(cancelationCheckThreshold, autoYieldThreshold, enhancedExceptions, traceBufferSize, shutdownHookTimeout)",
     "3.3.0")
   def apply(
       cancelationCheckThreshold: Int,

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -20,6 +20,7 @@ import cats.syntax.all._
 
 import org.specs2.mutable.Specification
 
+import scala.concurrent.duration.Duration
 import scala.io.Source
 import scala.sys.process.{BasicIO, Process}
 
@@ -121,6 +122,11 @@ class IOAppSpec extends Specification {
           "Cats Effect global runtime already initialized; custom configurations will be ignored")
         h.stderr() must not(contain("boom"))
       }
+
+      "abort awaiting shutdown hooks" in {
+        val h = java(ShutdownHookImmediateTimeout, List.empty)
+        h.awaitStatus() mustEqual 0
+      }
     }
   }
 
@@ -213,5 +219,14 @@ package examples {
 
     def run(args: List[String]): IO[ExitCode] =
       IO.pure(ExitCode.Success)
+  }
+
+  object ShutdownHookImmediateTimeout extends IOApp.Simple {
+
+    override protected def runtimeConfig =
+      super.runtimeConfig.copy(shutdownHookTimeout = Duration.Zero)
+
+    val run: IO[Unit] =
+      IO(System.exit(0)).uncancelable
   }
 }


### PR DESCRIPTION
Fixes #746 for Cats Effect 3.
Adds an IMO safer alternative to #1992 (by not having to depend on `sun.misc` APIs _and_ providing configuration).

A little bit of background: `Ctrl+C` or `System.exit` on an `IOApp` with an uncancelable main fiber results in an apparent deadlock due to cancelation backpressure. If you want to try it, run the following:

```scala
object Main extends IOApp.Simple {
  val run: IO[Unit] =
    IO(System.exit(0)).uncancelable
}
```

This PR does a few things:
1. It introduces `shutdownHookTimeout` as a configurable option through `-Dcats.effect.shutdown.hook.timeout` and through `IORuntimeConfig`. The diff also includes the usual binary compatibility dance.
2. `IOApp` uses this configuration option to execute a `CountDownLatch.await()` with a timeout in the `io-cancel-hook` thread. IMO, this behavior restores user expectation when they hit `Ctrl+C` or execute `System.exit`, and the application waits forever for an uncancelable fiber to be canceled, and they are free to configure it to match their application needs.
3. I removed the `join`ing of `WorkerThread` instances in the `WorkStealingThreadPool#shutdown` method. We still interrupt the threads. The reason why `join` doesn't "work" in this case is because `System.exit` is an uninterruptible method, so `join`ing a `WorkerThread` that executed `System.exit` looked like the application was hanging, which is bad user experience.
4. The PR as I'm opening has a **BAD** (again, IMO) default for `shutdownHookTimeout`. I set it to `Duration.Inf`, because I wanted to match the previous behavior, but I think we should put it to something like 10 seconds (I swear I have seen other software do this, allow the application to gracefully shutdown within 10 seconds and then forcefully terminate it, but I cannot seem to find a source for this, I'm sorry).
5. I marked a couple of `IORuntimeConfig` _constructors_ (not `apply` methods) as deprecated, because I intend to _remove_ them in a future release, since they were never meant to be public anyway (the default constructor is private).
6. Added a unit test that exercises the new functionality with a `Duration.Zero` timeout.

Interested to hear thoughts on this.