### PR TITLE
Eliminate branching and unreachable JS code when tracing

### DIFF
--- a/core/js/src/main/scala/cats/effect/tracing/TracingPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/tracing/TracingPlatform.scala
@@ -48,9 +48,9 @@ private[tracing] abstract class TracingPlatform { self: Tracing.type =>
     calculateTracingEvent(cont.getClass())
   }
 
-  private[this] def calculateTracingEvent(key: Any): TracingEvent = {
+  private[this] val calculateTracingEvent: Any => TracingEvent = {
     if (LinkingInfo.developmentMode) {
-      if (isCachedStackTracing) {
+      if (isCachedStackTracing) { key =>
         val current = cache(key)
         if (current eq null) {
           val event = buildEvent()
@@ -58,10 +58,11 @@ private[tracing] abstract class TracingPlatform { self: Tracing.type =>
           event
         } else current
       } else if (isFullStackTracing)
-        buildEvent()
+        _ => buildEvent()
       else
-        null
-    } else null
+        _ => null
+    } else
+      _ => null
   }
 
   private[this] final val stackTraceClassNameFilter: Array[String] = Array(

--- a/core/js/src/main/scala/cats/effect/tracing/TracingPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/tracing/TracingPlatform.scala
@@ -48,7 +48,7 @@ private[tracing] abstract class TracingPlatform { self: Tracing.type =>
     calculateTracingEvent(cont.getClass())
   }
 
-  private[this] val calculateTracingEvent: Any => TracingEvent = {
+  private[this] final val calculateTracingEvent: Any => TracingEvent = {
     if (LinkingInfo.developmentMode) {
       if (isCachedStackTracing) { key =>
         val current = cache(key)


### PR DESCRIPTION
It is intuitive to me that this should help remove both the branching code on every invocation of `calculateTracingEvent`, as well as effectively remove unreachable cases. However, JS sometimes has different ideas.

Another question, does the second commit actually do anything or is `Any => TracingEvent` sufficient as the type?

Finally, @armanbilge, can you please run the tracing benchmarks for this branch? I'm curious to see the results. Thank you in advance.