### PR TITLE
Fixed `PureConc` finalizers and further optimized `par`

### DIFF
--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/pure.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/pure.scala
@@ -376,7 +376,7 @@ object pure {
         checkM.ifM(
           canceled.ifM(
             // if unmasked and canceled, finalize
-            ctx.finalizers.sequence_.as(true),
+            allocateForPureConc[E].uncancelable(_ => ctx.finalizers.sequence_.as(true)),
             // if unmasked but not canceled, ignore
             false.pure[PureConc[E, *]]
           ),

--- a/kernel/shared/src/main/scala/cats/effect/kernel/instances/GenSpawnInstances.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/instances/GenSpawnInstances.scala
@@ -197,7 +197,7 @@ trait GenSpawnInstances {
 
       // assumed to be uncancelable
       private[this] def bothUnit(a: F[Unit], b: F[Unit]): F[Unit] =
-        F.start(a) flatMap { fiberA => b *> fiberA.join.void }
+        F.start(a).flatMap(f => b *> f.join.void)
     }
 
   implicit def alignForParallelF[F[_], E](implicit F: GenSpawn[F, E]): Align[ParallelF[F, *]] =

--- a/kernel/shared/src/main/scala/cats/effect/kernel/instances/GenSpawnInstances.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/instances/GenSpawnInstances.scala
@@ -197,9 +197,7 @@ trait GenSpawnInstances {
 
       // assumed to be uncancelable
       private[this] def bothUnit(a: F[Unit], b: F[Unit]): F[Unit] =
-        F.start(a) flatMap { fiberA =>
-          b *> fiberA.join.void
-        }
+        F.start(a) flatMap { fiberA => b *> fiberA.join.void }
     }
 
   implicit def alignForParallelF[F[_], E](implicit F: GenSpawn[F, E]): Align[ParallelF[F, *]] =

--- a/laws/shared/src/test/scala/cats/effect/laws/PureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/PureConcSpec.scala
@@ -52,7 +52,17 @@ class PureConcSpec extends Specification with Discipline with BaseSpec {
       val fa: F[String] = F.pure("a")
       val fb: F[String] = F.pure("b")
       val fc: F[Unit] = F.raiseError[Unit](42)
-      pure.run(ParallelF.value(ParallelF(fa).product(ParallelF(fb)).product(ParallelF(fc)))) mustEqual Outcome.Errored(42)
+      pure.run(
+        ParallelF.value(
+          ParallelF(fa).product(ParallelF(fb)).product(ParallelF(fc)))) mustEqual Outcome
+        .Errored(42)
+    }
+
+    "ignore unmasking in finalizers" in {
+      val fa = F.uncancelable { poll => F.onCancel(poll(F.unit), poll(F.unit)) }
+
+      pure.run(fa.start.flatMap(_.cancel))
+      ok
     }
   }
 

--- a/laws/shared/src/test/scala/cats/effect/laws/PureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/PureConcSpec.scala
@@ -45,6 +45,15 @@ class PureConcSpec extends Specification with Discipline with BaseSpec {
       pure.run((F.never[Unit], F.raiseError[Unit](42)).parTupled) mustEqual Outcome.Errored(42)
       pure.run((F.raiseError[Unit](42), F.never[Unit]).parTupled) mustEqual Outcome.Errored(42)
     }
+
+    "not run forever on chained product" in {
+      import cats.effect.kernel.Par.ParallelF
+
+      val fa: F[String] = F.pure("a")
+      val fb: F[String] = F.pure("b")
+      val fc: F[Unit] = F.raiseError[Unit](42)
+      pure.run(ParallelF.value(ParallelF(fa).product(ParallelF(fb)).product(ParallelF(fc)))) mustEqual Outcome.Errored(42)
+    }
   }
 
   checkAll(


### PR DESCRIPTION
The optimization for `par` is pretty straightforward: we don't need the full generality of `racePair` when we'll never error or be canceled and don't need results. We don't even need a third fiber, in fact.

The `PureConc` fix is a bit more subtle, but basically it boiled down to an interaction between cancelation realization and finalizers. I had assumed that, due to the way they were being dispatched, there was no way that cancelation could be observed within the sequence. Apparently this is false, and it is revealed by @armanbilge's cheeky `poll`. The fix is the same as it is in `IOFiber`: wrap the whole finalizer execution in `uncancelable`.