### PR TITLE
Global GC fiber bag implementation

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
   this: IOFiber[A] =>
 
-  protected final var suspensionKey: AnyRef = null
+  private[this] final var suspensionKey: AnyRef = null
 
   protected final def monitor(key: AnyRef): Unit = {
     val fiber = this

--- a/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -16,6 +16,7 @@
 
 package cats.effect
 
+import scala.annotation.nowarn
 import scala.concurrent.ExecutionContext
 
 import java.util.concurrent.atomic.AtomicBoolean
@@ -24,32 +25,17 @@ private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
   this: IOFiber[A] =>
 
   /**
-   * Explicit suspension key object reference due to lack of `WeakHashMap` support in Scala.js.
-   * This reference is set when a fiber is suspended (and the key is used to register the fiber
-   * in the global suspended fiber bag), and cleared when the fiber is resumed.
-   */
-  private[this] final var suspensionKey: AnyRef = null
-
-  /**
    * Registers the suspended fiber in the global suspended fiber bag and sets the suspension key
    * object reference.
    */
-  protected final def monitor(key: AnyRef): Unit = {
-    val fiber = this
-    fiber.runtimeForwarder.suspendedFiberBag.monitor(key, fiber)
-    suspensionKey = key
-  }
+  @nowarn("cat=unused-params")
+  protected final def monitor(key: AnyRef): Unit = {}
 
   /**
    * Deregisters the suspended fiber from the global suspended fiber bag and clears the
    * suspension key object reference.
    */
-  protected final def unmonitor(): Unit = {
-    val fiber = this
-    val key = suspensionKey
-    fiber.runtimeForwarder.suspendedFiberBag.unmonitor(key)
-    suspensionKey = null
-  }
+  protected final def unmonitor(): Unit = {}
 
   // in theory this code should never be hit due to the override in IOCompanionPlatform
   def interruptibleImpl(cur: IO.Blocking[Any], blockingEc: ExecutionContext): IO[Any] = {

--- a/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -23,6 +23,21 @@ import java.util.concurrent.atomic.AtomicBoolean
 private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
   this: IOFiber[A] =>
 
+  protected final var suspensionKey: AnyRef = null
+
+  protected final def monitor(key: AnyRef): Unit = {
+    val fiber = this
+    fiber.runtimeForwarder.suspendedFiberBag.monitor(key, fiber)
+    suspensionKey = key
+  }
+
+  protected final def unmonitor(): Unit = {
+    val fiber = this
+    val key = suspensionKey
+    fiber.runtimeForwarder.suspendedFiberBag.unmonitor(key)
+    suspensionKey = null
+  }
+
   // in theory this code should never be hit due to the override in IOCompanionPlatform
   def interruptibleImpl(cur: IO.Blocking[Any], blockingEc: ExecutionContext): IO[Any] = {
     val _ = blockingEc

--- a/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -23,14 +23,27 @@ import java.util.concurrent.atomic.AtomicBoolean
 private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
   this: IOFiber[A] =>
 
+  /**
+   * Explicit suspension key object reference due to lack of `WeakHashMap` support in Scala.js.
+   * This reference is set when a fiber is suspended (and the key is used to register the fiber
+   * in the global suspended fiber bag), and cleared when the fiber is resumed.
+   */
   private[this] final var suspensionKey: AnyRef = null
 
+  /**
+   * Registers the suspended fiber in the global suspended fiber bag and sets the suspension key
+   * object reference.
+   */
   protected final def monitor(key: AnyRef): Unit = {
     val fiber = this
     fiber.runtimeForwarder.suspendedFiberBag.monitor(key, fiber)
     suspensionKey = key
   }
 
+  /**
+   * Deregisters the suspended fiber from the global suspended fiber bag and clears the
+   * suspension key object reference.
+   */
   protected final def unmonitor(): Unit = {
     val fiber = this
     val key = suspensionKey

--- a/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
@@ -27,7 +27,7 @@ import scala.collection.mutable
  * a `java.util.WeakHashMap` so that the removal of resumed fibers is handled automatically, but
  * weak references are still not available in Scala.js.
  */
-private final class SuspendedFiberBag {
+private[effect] final class SuspendedFiberBag {
   private[this] val bag: mutable.Map[AnyRef, IOFiber[_]] =
     mutable.Map.empty
 

--- a/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package unsafe
+
+import scala.collection.mutable
+
+/**
+ * A simple implementation of an unordered bag used for tracking asynchronously suspended fiber
+ * instances on Scala.js. This bag is backed by a mutable hash map and delegates all
+ * functionality to it. Because Scala.js runs in a single-threaded environment, there's no need
+ * for any synchronization. Ideally, we would have liked the Scala.js implementation to also use
+ * a `java.util.WeakHashMap` so that the removal of resumed fibers is handled automatically, but
+ * weak references are still not available in Scala.js.
+ */
+private final class SuspendedFiberBag {
+  private[this] val bag: mutable.Map[AnyRef, IOFiber[_]] =
+    mutable.Map.empty
+
+  /**
+   * Registers a suspended fiber, tracked by the provided key which is an opaque object which
+   * uses reference equality for comparison.
+   *
+   * @param key
+   *   an opaque identifier for the suspended fiber
+   * @param fiber
+   *   the suspended fiber to be registered
+   */
+  def monitor(key: AnyRef, fiber: IOFiber[_]): Unit = {
+    bag(key) = fiber
+  }
+
+  /**
+   * Deregisters a resumed fiber, tracked by the provided key which is an opaque object which
+   * uses reference equality for comparison.
+   *
+   * @param key
+   *   an opaque identifier for the resumed fiber
+   */
+  def unmonitor(key: AnyRef): Unit = {
+    bag -= key
+  }
+}

--- a/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
@@ -17,19 +17,13 @@
 package cats.effect
 package unsafe
 
-import scala.collection.mutable
+import scala.annotation.nowarn
 
 /**
- * A simple implementation of an unordered bag used for tracking asynchronously suspended fiber
- * instances on Scala.js. This bag is backed by a mutable hash map and delegates all
- * functionality to it. Because Scala.js runs in a single-threaded environment, there's no need
- * for any synchronization. Ideally, we would have liked the Scala.js implementation to also use
- * a `java.util.WeakHashMap` so that the removal of resumed fibers is handled automatically, but
- * weak references are still not available in Scala.js.
+ * A no-op implementation of an unordered bag used for tracking asynchronously suspended fiber
+ * instances on Scala.js. We will iterate on this in the future.
  */
 private[effect] final class SuspendedFiberBag {
-  private[this] val bag: mutable.Map[AnyRef, IOFiber[_]] =
-    mutable.Map.empty
 
   /**
    * Registers a suspended fiber, tracked by the provided key which is an opaque object which
@@ -40,9 +34,8 @@ private[effect] final class SuspendedFiberBag {
    * @param fiber
    *   the suspended fiber to be registered
    */
-  def monitor(key: AnyRef, fiber: IOFiber[_]): Unit = {
-    bag(key) = fiber
-  }
+  @nowarn("cat=unused-params")
+  def monitor(key: AnyRef, fiber: IOFiber[_]): Unit = {}
 
   /**
    * Deregisters a resumed fiber, tracked by the provided key which is an opaque object which
@@ -51,7 +44,6 @@ private[effect] final class SuspendedFiberBag {
    * @param key
    *   an opaque identifier for the resumed fiber
    */
-  def unmonitor(key: AnyRef): Unit = {
-    bag -= key
-  }
+  @nowarn("cat=unused-params")
+  def unmonitor(key: AnyRef): Unit = {}
 }

--- a/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -27,11 +27,21 @@ private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
 
   private[this] val TypeInterruptibleMany = Sync.Type.InterruptibleMany
 
+  /**
+   * Registers the suspended fiber in the global suspended fiber bag.
+   */
   protected final def monitor(key: AnyRef): Unit = {
     val fiber = this
     fiber.runtimeForwarder.suspendedFiberBag.monitor(key, fiber)
   }
 
+  /**
+   * Deregisters the suspended fiber from the global suspended fiber bag.
+   *
+   * @note
+   *   This method is a no-op because this functionality is native to `java.util.WeakHashMap`
+   *   and we rely on the GC automatically clearing the resumed fibers from the data structure.
+   */
   protected final def unmonitor(): Unit = {}
 
   protected final def interruptibleImpl(

--- a/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -27,6 +27,13 @@ private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
 
   private[this] val TypeInterruptibleMany = Sync.Type.InterruptibleMany
 
+  protected final def monitor(key: AnyRef): Unit = {
+    val fiber = this
+    fiber.runtimeForwarder.suspendedFiberBag.monitor(key, fiber)
+  }
+
+  protected final def unmonitor(): Unit = {}
+
   protected final def interruptibleImpl(
       cur: IO.Blocking[Any],
       blockingEc: ExecutionContext): IO[Any] = {

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
@@ -46,7 +46,7 @@ import java.util.concurrent.ThreadLocalRandom
  *   The `unmonitor` method is a no-op, but it needs to exist to keep source compatibility with
  *   Scala.js. The removal of a resumed fiber is done automatically by the GC.
  */
-private final class SuspendedFiberBag {
+private[effect] final class SuspendedFiberBag {
 
   private[this] val size: Int = Runtime.getRuntime().availableProcessors() << 2
   private[this] val bags: Array[Map[AnyRef, WeakReference[IOFiber[_]]]] =

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package unsafe
+
+import scala.annotation.nowarn
+
+import java.lang.ref.WeakReference
+import java.util.{Collections, Map, WeakHashMap}
+import java.util.concurrent.ThreadLocalRandom
+
+/**
+ * A slightly more involved implementation of an unordered bag used for tracking asynchronously
+ * suspended fiber instances on the JVM. This bag is backed by an array of synchronized
+ * `java.util.WeakHashMap` instances. This decision is based on several factors:
+ *   1. A `java.util.WeakHashMap` is used because we want the resumed fibers to be automatically
+ *      removed from the hash map data structure by the GC, whenever their keys expire (which is
+ *      right around their resumption).
+ *   1. `java.util.WeakHashMap` is **not** thread safe by nature. In the official javadoc for
+ *      this class it is recommended that an instance be wrapped in
+ *      `java.util.Collections.synchronizedMap` before writing to the hash map from different
+ *      threads. This is absolutely crucial in our use case, because fibers can be carried by
+ *      any thread (including threads external to the compute thread pool, e.g. when using
+ *      `IO#evalOn`).
+ *   1. Because `java.util.Collections.synchronizedMap` is a simple wrapper around any map which
+ *      just synchronizes the access to the map through the built in JVM `synchronized`
+ *      mechanism, we need several instances of these synchronized `WeakHashMap`s just to reduce
+ *      contention between threads. A particular instance is selected using a thread local
+ *      source of randomness using an instance of `java.util.concurrent.ThreadLocalRandom`.
+ *
+ * @note
+ *   The `unmonitor` method is a no-op, but it needs to exist to keep source compatibility with
+ *   Scala.js. The removal of a resumed fiber is done automatically by the GC.
+ */
+private final class SuspendedFiberBag {
+
+  private[this] val size: Int = Runtime.getRuntime().availableProcessors() << 2
+  private[this] val bags: Array[Map[AnyRef, WeakReference[IOFiber[_]]]] =
+    new Array(size)
+
+  {
+    var i = 0
+    while (i < size) {
+      bags(i) = Collections.synchronizedMap(new WeakHashMap())
+      i += 1
+    }
+  }
+
+  /**
+   * Registers a suspended fiber, tracked by the provided key which is an opaque object which
+   * uses reference equality for comparison.
+   *
+   * @param key
+   *   an opaque identifier for the suspended fiber
+   * @param fiber
+   *   the suspended fiber to be registered
+   */
+  def monitor(key: AnyRef, fiber: IOFiber[_]): Unit = {
+    val rnd = ThreadLocalRandom.current()
+    val idx = rnd.nextInt(size)
+    bags(idx).put(key, new WeakReference(fiber))
+    ()
+  }
+
+  /**
+   * Deregisters a resumed fiber, tracked by the provided key which is an opaque object which
+   * uses reference equality for comparison.
+   *
+   * @param key
+   *   an opaque identifier for the resumed fiber
+   */
+  @nowarn("cat=unused-params")
+  def unmonitor(key: AnyRef): Unit = {
+    // no-op
+  }
+}

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1014,6 +1014,8 @@ private final class IOFiber[A](
   private[this] def suspend(): Unit =
     suspended.set(true)
 
+  private[effect] def runtimeForwarder: IORuntime = runtime
+
   /* returns the *new* context, not the old */
   private[this] def popContext(): ExecutionContext = {
     ctxs.pop()

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -41,6 +41,8 @@ final class IORuntime private (
 ) {
   private[effect] val fiberErrorCbs: StripedHashtable = new StripedHashtable()
 
+  private[effect] val suspendedFiberBag: SuspendedFiberBag = new SuspendedFiberBag()
+
   override def toString: String = s"IORuntime($compute, $scheduler, $config)"
 }
 


### PR DESCRIPTION
The global fallback for #2368. This PR does not yet contain the worker-thread-local suspended bags, that will arrive in a follow up PR.

One detail to discuss here is the fact that we're tying this bag to an `IORuntime` instance, which doesn't necessarily make it global the way the tracing cache is for example. I really do not know how we should treat `IORuntime`, but I am going to say that there might be possibilities for further optimizing cache lookups for tracing if we somehow decide that there can only ever be one `IORuntime` per JVM. Probably should be a separate discussion, but still something to think about.