### PR TITLE
Async cancelation should first re-enqueue the fiber

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -44,11 +44,13 @@ private object IOFiberConstants {
   final val ExecR: Byte = 0
   final val AsyncContinueSuccessfulR: Byte = 1
   final val AsyncContinueFailedR: Byte = 2
-  final val BlockingR: Byte = 3
-  final val EvalOnR: Byte = 4
-  final val CedeR: Byte = 5
-  final val AutoCedeR: Byte = 6
-  final val DoneR: Byte = 7
+  final val AsyncContinueCanceledR: Byte = 3
+  final val AsyncContinueCanceledWithFinalizerR = 4
+  final val BlockingR: Byte = 5
+  final val EvalOnR: Byte = 6
+  final val CedeR: Byte = 7
+  final val AutoCedeR: Byte = 8
+  final val DoneR: Byte = 9
 
   // ContState tags
   final val ContStateInitial: Int = 0

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -45,11 +45,13 @@ final class IOFiberConstants {
   static final byte ExecR = 0;
   static final byte AsyncContinueSuccessfulR = 1;
   static final byte AsyncContinueFailedR = 2;
-  static final byte BlockingR = 3;
-  static final byte EvalOnR = 4;
-  static final byte CedeR = 5;
-  static final byte AutoCedeR = 6;
-  static final byte DoneR = 7;
+  static final byte AsyncContinueCanceledR = 3;
+  static final byte AsyncContinueCanceledWithFinalizerR = 4;
+  static final byte BlockingR = 5;
+  static final byte EvalOnR = 6;
+  static final byte CedeR = 7;
+  static final byte AutoCedeR = 8;
+  static final byte DoneR = 9;
 
   // ContState tags
   static final int ContStateInitial = 0;


### PR DESCRIPTION
This matches the resumption mechanism in the fact that it simply enqueues the canceled fiber for cancelation, instead of executing the canceled fiber's run loop in place, which can already be running as part of another fiber's run loop (e.g. completing an async callback on a worker thread as part of an `IO.delay`).

It also seems to be slightly faster. I chose the `AsyncBenchmark.race` benchmark because it exercises cancelation.

`series/3.x`:
```
Benchmark            (size)   Mode  Cnt      Score      Error  Units
AsyncBenchmark.race     100  thrpt   20  14542.116 ± 1145.839  ops/s
```

`This PR`:
```
Benchmark            (size)   Mode  Cnt      Score     Error  Units
AsyncBenchmark.race     100  thrpt   20  18157.855 ± 430.937  ops/s
```