### PR TITLE
Support microsecond precision in `realTime` and `realTimeInstant` on the JVM

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
@@ -38,6 +38,7 @@ private[unsafe] abstract class SchedulerCompanionPlatform { this: Scheduler.type
 
         def nowMillis() = System.currentTimeMillis()
         def monotonicNanos() = System.nanoTime()
+        override def nowMicros(): Long = nowMillis() * 1000
       },
       () => ())
 

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
@@ -18,9 +18,9 @@ package cats.effect.unsafe
 
 import scala.concurrent.duration.FiniteDuration
 
-import java.util.concurrent.{Executors, ScheduledExecutorService}
 import java.time.Instant
 import java.time.temporal.ChronoField
+import java.util.concurrent.{Executors, ScheduledExecutorService}
 
 private[unsafe] abstract class SchedulerCompanionPlatform { this: Scheduler.type =>
   def createDefaultScheduler(): (Scheduler, () => Unit) = {

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
@@ -18,10 +18,9 @@ package cats.effect.unsafe
 
 import scala.concurrent.duration.FiniteDuration
 
+import java.util.concurrent.{Executors, ScheduledExecutorService}
 import java.time.Instant
 import java.time.temporal.ChronoField
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
 
 private[unsafe] abstract class SchedulerCompanionPlatform { this: Scheduler.type =>
   def createDefaultScheduler(): (Scheduler, () => Unit) = {

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
@@ -18,7 +18,10 @@ package cats.effect.unsafe
 
 import scala.concurrent.duration.FiniteDuration
 
-import java.util.concurrent.{Executors, ScheduledExecutorService}
+import java.time.Instant
+import java.time.temporal.ChronoField
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
 
 private[unsafe] abstract class SchedulerCompanionPlatform { this: Scheduler.type =>
   def createDefaultScheduler(): (Scheduler, () => Unit) = {
@@ -44,6 +47,11 @@ private[unsafe] abstract class SchedulerCompanionPlatform { this: Scheduler.type
       }
 
       def nowMillis() = System.currentTimeMillis()
+
+      override def nowMicros(): Long = {
+        val now = Instant.now()
+        now.getEpochSecond * 1000000 + now.getLong(ChronoField.MICRO_OF_SECOND)
+      }
 
       def monotonicNanos() = System.nanoTime()
     }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -276,7 +276,7 @@ private final class IOFiber[A](
         /* RealTime */
         case 3 =>
           runLoop(
-            succeeded(runtime.scheduler.nowMillis().millis, 0),
+            succeeded(runtime.scheduler.nowMicros().micros, 0),
             nextCancelation,
             nextAutoCede)
 
@@ -346,7 +346,7 @@ private final class IOFiber[A](
               runLoop(nextIO, nextCancelation - 1, nextAutoCede)
 
             case 3 =>
-              val realTime = runtime.scheduler.nowMillis().millis
+              val realTime = runtime.scheduler.nowMicros().micros
               runLoop(next(realTime), nextCancelation - 1, nextAutoCede)
 
             case 4 =>
@@ -411,7 +411,7 @@ private final class IOFiber[A](
               runLoop(result, nextCancelation - 1, nextAutoCede)
 
             case 3 =>
-              val realTime = runtime.scheduler.nowMillis().millis
+              val realTime = runtime.scheduler.nowMicros().micros
               runLoop(next(realTime), nextCancelation - 1, nextAutoCede)
 
             case 4 =>
@@ -472,7 +472,7 @@ private final class IOFiber[A](
               runLoop(next, nextCancelation - 1, nextAutoCede)
 
             case 3 =>
-              val realTime = runtime.scheduler.nowMillis().millis
+              val realTime = runtime.scheduler.nowMicros().micros
               runLoop(succeeded(Right(realTime), 0), nextCancelation - 1, nextAutoCede)
 
             case 4 =>

--- a/core/shared/src/main/scala/cats/effect/unsafe/Scheduler.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/Scheduler.scala
@@ -28,6 +28,9 @@ trait Scheduler {
 
   def nowMillis(): Long
 
+  def nowMicros(): Long =
+    nowMillis() * 1000
+
   def monotonicNanos(): Long
 }
 

--- a/kernel/jvm/src/main/scala/cats/effect/kernel/ClockPlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/ClockPlatform.scala
@@ -20,6 +20,6 @@ import java.time.Instant
 
 private[effect] trait ClockPlatform[F[_]] extends Serializable { self: Clock[F] =>
   def realTimeInstant: F[Instant] = {
-    self.applicative.map(self.realTime)(d => Instant.ofEpochMilli(d.toMillis))
+    self.applicative.map(self.realTime)(d => Instant.EPOCH.plusNanos(d.toNanos))
   }
 }

--- a/testkit/shared/src/main/scala/cats/effect/testkit/TestControl.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/TestControl.scala
@@ -321,6 +321,9 @@ object TestControl {
           def nowMillis() =
             ctx.now().toMillis
 
+          override def nowMicros(): Long =
+            ctx.now().toMicros
+
           def monotonicNanos() =
             ctx.now().toNanos
         },

--- a/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
@@ -250,6 +250,7 @@ trait TestInstances extends ParallelFGenerators with OutcomeGenerators with Sync
       }
 
       def nowMillis() = ctx.now().toMillis
+      override def nowMicros(): Long = ctx.now().toMicros
       def monotonicNanos() = ctx.now().toNanos
     }
   }


### PR DESCRIPTION
* Use `java.time.Instant` to provide microsecond precision for `nowMicros`
* Use `nowMicros` instead of `nowMillis` to determine the real time

This is a follow up to #1461