### PR TITLE
Intoduce parReplicateAN

### DIFF
--- a/core/shared/src/main/scala/cats/effect/Async.scala
+++ b/core/shared/src/main/scala/cats/effect/Async.scala
@@ -361,6 +361,16 @@ object Async {
     } yield mta
 
   /**
+   * Like `Parallel.parReplicateA`, but limits the degree of parallelism.
+   */
+  def parReplicateAN[M[_], A](n: Long)(replicas: Int, ma: M[A])(implicit M: Async[M], P: Parallel[M]): M[List[A]] =
+    for {
+      semaphore <- Semaphore.uncancelable(n)(M)
+      // TODO replace with semaphore.withPermit(ma).parReplicateA(replicas)(P)
+      mla <- parSequenceN(n)(List.fill(replicas)(semaphore.withPermit(ma)))
+    } yield mla
+
+  /**
    * [[Async]] instance built for `cats.data.EitherT` values initialized
    * with any `F` data type that also implements `Async`.
    */

--- a/core/shared/src/main/scala/cats/effect/Concurrent.scala
+++ b/core/shared/src/main/scala/cats/effect/Concurrent.scala
@@ -641,6 +641,16 @@ object Concurrent {
     } yield mta
 
   /**
+   * Like `Parallel.parReplicateA`, but limits the degree of parallelism.
+   */
+  def parReplicateAN[M[_], A](n: Long)(replicas: Int, ma: M[A])(implicit M: Concurrent[M], P: Parallel[M]): M[List[A]] =
+    for {
+      semaphore <- Semaphore(n)(M)
+      // TODO replace with semaphore.withPermit(ma).parReplicateA(replicas)(P)
+      mla <- parSequenceN(n)(List.fill(replicas)(semaphore.withPermit(ma)))
+    } yield mla
+
+  /**
    * [[Concurrent]] instance built for `cats.data.EitherT` values initialized
    * with any `F` data type that also implements `Concurrent`.
    */

--- a/core/shared/src/main/scala/cats/effect/syntax/AsyncSyntax.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/AsyncSyntax.scala
@@ -37,4 +37,10 @@ final class AsyncObjOps[F[_]](private val F: Async[F]) extends AnyVal {
    */
   def parSequenceN[T[_], A](n: Long)(tma: T[F[A]])(implicit T: Traverse[T], P: Parallel[F]): F[T[A]] =
     Async.parSequenceN(n)(tma)(T, F, P)
+
+  /**
+   * Like `Parallel.parReplicateA`, but limits the degree of parallelism.
+   */
+  def parReplicateAN[A](n: Long)(replicas: Int, fa: F[A])(implicit P: Parallel[F]): F[List[A]] =
+    Async.parReplicateAN(n)(replicas, fa)(F, P)
 }

--- a/core/shared/src/main/scala/cats/effect/syntax/ConcurrentSyntax.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/ConcurrentSyntax.scala
@@ -50,4 +50,10 @@ final class ConcurrentObjOps[F[_]](private val F: Concurrent[F]) extends AnyVal 
    */
   def parSequenceN[T[_], A](n: Long)(tma: T[F[A]])(implicit T: Traverse[T], P: Parallel[F]): F[T[A]] =
     Concurrent.parSequenceN(n)(tma)(T, F, P)
+
+  /**
+   * Like `Parallel.parReplicateA`, but limits the degree of parallelism.
+   */
+  def parReplicateAN[A](n: Long)(replicas: Int, fa: F[A])(implicit P: Parallel[F]): F[List[A]] =
+    Concurrent.parReplicateAN(n)(replicas, fa)(F, P)
 }

--- a/core/shared/src/main/scala/cats/effect/syntax/ParallelNSyntax.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/ParallelNSyntax.scala
@@ -33,6 +33,11 @@ trait ParallelNSyntax {
   implicit final def catsSyntaxParallelSequenceNConcurrent[T[_]: Traverse, M[_]: Monad, A](
     tma: T[M[A]]
   ): ParallelSequenceNConcurrentOps[T, M, A] = new ParallelSequenceNConcurrentOps[T, M, A](tma)
+
+  @nowarn("msg=never used")
+  implicit final def catsSyntaxParallelReplicateANConcurrent[M[_]: Monad, A](
+    ma: M[A]
+  ): ParallelReplicableNConcurrentOps[M, A] = new ParallelReplicableNConcurrentOps[M, A](ma)
 }
 
 final class ParallelSequenceNConcurrentOps[T[_], M[_], A](private val tma: T[M[A]]) extends AnyVal {
@@ -43,4 +48,9 @@ final class ParallelSequenceNConcurrentOps[T[_], M[_], A](private val tma: T[M[A
 final class ParallelTraversableNConcurrentOps[T[_], A](private val ta: T[A]) extends AnyVal {
   def parTraverseN[M[_], B](n: Long)(f: A => M[B])(implicit M: Concurrent[M], T: Traverse[T], P: Parallel[M]): M[T[B]] =
     M.parTraverseN(n)(ta)(f)
+}
+
+final class ParallelReplicableNConcurrentOps[M[_], A](private val ma: M[A]) extends AnyVal {
+  def parReplicateAN(n: Long)(replicas: Int)(implicit M: Concurrent[M], P: Parallel[M]): M[List[A]] =
+    M.parReplicateAN(n)(replicas, ma)(P)
 }

--- a/core/shared/src/test/scala/cats/effect/AsyncTests.scala
+++ b/core/shared/src/test/scala/cats/effect/AsyncTests.scala
@@ -48,4 +48,11 @@ class AsyncTests extends CatsEffectSuite {
     val modifies = implicitly[Async[IO]].parSequenceN(3)(list)
     (IO.shift *> modifies.start *> awaitEqual(r.get, finalValue)).as(assert(true))
   }
+
+  test("F.parReplicateAN(n)(collection)") {
+    val finalValue = 100
+    val r = Ref.unsafe[IO, Int](0)
+    val modifies = implicitly[Async[IO]].parReplicateAN(3)(finalValue, IO.shift *> r.update(_ + 1))
+    (IO.shift *> modifies.start *> awaitEqual(r.get, finalValue)).as(assert(true))
+  }
 }

--- a/core/shared/src/test/scala/cats/effect/ConcurrentTests.scala
+++ b/core/shared/src/test/scala/cats/effect/ConcurrentTests.scala
@@ -64,4 +64,20 @@ class ConcurrentTests extends CatsEffectSuite {
     val modifies = list.parSequenceN(3)
     (IO.shift *> modifies.start *> awaitEqual(r.get, finalValue)).as(assert(true))
   }
+
+  test("F.parReplicateAN(n)(replicas, fa)") {
+    val finalValue = 100
+    val r = Ref.unsafe[IO, Int](0)
+    val fa = IO.shift *> r.update(_ + 1)
+    val modifies = implicitly[Concurrent[IO]].parReplicateAN(3)(finalValue, fa)
+    (IO.shift *> modifies.start *> awaitEqual(r.get, finalValue)).as(assert(true))
+  }
+
+  test("fa.parSequenceN(n)(replicas)") {
+    val finalValue = 100
+    val r = Ref.unsafe[IO, Int](0)
+    val fa = IO.shift *> r.update(_ + 1)
+    val modifies = catsSyntaxParallelReplicateANConcurrent(fa).parReplicateAN(3)(finalValue)
+    (IO.shift *> modifies.start *> awaitEqual(r.get, finalValue)).as(assert(true))
+  }
 }

--- a/core/shared/src/test/scala/cats/effect/SyntaxTests.scala
+++ b/core/shared/src/test/scala/cats/effect/SyntaxTests.scala
@@ -57,9 +57,12 @@ object SyntaxTests extends AllCatsEffectSyntax {
     val ta = mock[T[A]]
     val f = mock[A => F[B]]
     val tma = mock[T[F[A]]]
+    val ma = mock[F[A]]
+    val replicas = mock[Int]
 
     typed[F[T[B]]](F.parTraverseN(n)(ta)(f))
     typed[F[T[A]]](F.parSequenceN(n)(tma))
+    typed[F[List[A]]](F.parReplicateAN(n)(replicas, ma))
   }
 
   def concurrentSyntax[T[_]: Traverse, F[_], A, B](implicit F: Concurrent[F], P: Parallel[F], timer: Timer[F]) = {
@@ -77,9 +80,12 @@ object SyntaxTests extends AllCatsEffectSyntax {
     val ta = mock[T[A]]
     val f = mock[A => F[B]]
     val tma = mock[T[F[A]]]
+    val ma = mock[F[A]]
+    val replicas = mock[Int]
 
     typed[F[T[B]]](F.parTraverseN(n)(ta)(f))
     typed[F[T[A]]](F.parSequenceN(n)(tma))
+    typed[F[List[A]]](F.parReplicateAN(n)(replicas, ma))
   }
 
   def effectSyntax[F[_]: Effect, A] = {


### PR DESCRIPTION
This is a CE counterpart of https://github.com/typelevel/cats/pull/4007 .

In the spots where I would normally use the `parReplicateA` introduced in https://github.com/typelevel/cats/pull/4007, I used an alternative implementation and left TODO's.