### PR TITLE
Remove duplicate resumption states

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -17,44 +17,44 @@
 package cats.effect
 
 // defined in Java for the JVM, Scala for ScalaJS (where object field access is faster)
-private[effect] object IOFiberConstants {
+private object IOFiberConstants {
 
-  val MaxStackDepth: Int = 512
+  final val MaxStackDepth: Int = 512
 
   /*
    * allow for 255 masks before conflicting; 255 chosen because it is a familiar bound,
    * and because it's evenly divides UnsignedInt.MaxValue.
    * This scheme gives us 16,843,009 (~2^24) potential derived fibers before masks can conflict
    */
-  val ChildMaskOffset: Int = 255
+  final val ChildMaskOffset: Int = 255
 
   // continuation ids (should all be inlined)
-  val MapK: Byte = 0
-  val FlatMapK: Byte = 1
-  val CancelationLoopK: Byte = 2
-  val RunTerminusK: Byte = 3
-  val EvalOnK: Byte = 4
-  val HandleErrorWithK: Byte = 5
-  val OnCancelK: Byte = 6
-  val UncancelableK: Byte = 7
-  val UnmaskK: Byte = 8
-  val AttemptK: Byte = 9
+  final val MapK: Byte = 0
+  final val FlatMapK: Byte = 1
+  final val CancelationLoopK: Byte = 2
+  final val RunTerminusK: Byte = 3
+  final val EvalOnK: Byte = 4
+  final val HandleErrorWithK: Byte = 5
+  final val OnCancelK: Byte = 6
+  final val UncancelableK: Byte = 7
+  final val UnmaskK: Byte = 8
+  final val AttemptK: Byte = 9
 
   // resume ids
-  val ExecR: Byte = 0
-  val AsyncContinueSuccessfulR: Byte = 1
-  val AsyncContinueFailedR: Byte = 2
-  val BlockingR: Byte = 3
-  val AfterBlockingSuccessfulR: Byte = 4
-  val AfterBlockingFailedR: Byte = 5
-  val EvalOnR: Byte = 6
-  val CedeR: Byte = 7
-  val AutoCedeR: Byte = 8
-  val DoneR: Byte = 9
+  final val ExecR: Byte = 0
+  final val AsyncContinueSuccessfulR: Byte = 1
+  final val AsyncContinueFailedR: Byte = 2
+  final val BlockingR: Byte = 3
+  final val AfterBlockingSuccessfulR: Byte = 4
+  final val AfterBlockingFailedR: Byte = 5
+  final val EvalOnR: Byte = 6
+  final val CedeR: Byte = 7
+  final val AutoCedeR: Byte = 8
+  final val DoneR: Byte = 9
 
   // ContState tags
-  val ContStateInitial: Int = 0
-  val ContStateWaiting: Int = 1
-  val ContStateWinner: Int = 2
-  val ContStateResult: Int = 3
+  final val ContStateInitial: Int = 0
+  final val ContStateWaiting: Int = 1
+  final val ContStateWinner: Int = 2
+  final val ContStateResult: Int = 3
 }

--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -45,12 +45,10 @@ private object IOFiberConstants {
   final val AsyncContinueSuccessfulR: Byte = 1
   final val AsyncContinueFailedR: Byte = 2
   final val BlockingR: Byte = 3
-  final val AfterBlockingSuccessfulR: Byte = 4
-  final val AfterBlockingFailedR: Byte = 5
-  final val EvalOnR: Byte = 6
-  final val CedeR: Byte = 7
-  final val AutoCedeR: Byte = 8
-  final val DoneR: Byte = 9
+  final val EvalOnR: Byte = 4
+  final val CedeR: Byte = 5
+  final val AutoCedeR: Byte = 6
+  final val DoneR: Byte = 7
 
   // ContState tags
   final val ContStateInitial: Int = 0

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -19,7 +19,7 @@ package cats.effect;
 // defined in Java since Scala doesn't let us define static fields
 final class IOFiberConstants {
 
-  public static final int MaxStackDepth = 512;
+  static final int MaxStackDepth = 512;
 
   /*
    * allow for 255 masks before conflicting; 255 chosen because it is a familiar
@@ -27,35 +27,35 @@ final class IOFiberConstants {
    * gives us 16,843,009 (~2^24) potential derived fibers before masks can
    * conflict
    */
-  public static final int ChildMaskOffset = 255;
+  static final int ChildMaskOffset = 255;
 
   // continuation ids (should all be inlined)
-  public static final byte MapK = 0;
-  public static final byte FlatMapK = 1;
-  public static final byte CancelationLoopK = 2;
-  public static final byte RunTerminusK = 3;
-  public static final byte EvalOnK = 4;
-  public static final byte HandleErrorWithK = 5;
-  public static final byte OnCancelK = 6;
-  public static final byte UncancelableK = 7;
-  public static final byte UnmaskK = 8;
-  public static final byte AttemptK = 9;
+  static final byte MapK = 0;
+  static final byte FlatMapK = 1;
+  static final byte CancelationLoopK = 2;
+  static final byte RunTerminusK = 3;
+  static final byte EvalOnK = 4;
+  static final byte HandleErrorWithK = 5;
+  static final byte OnCancelK = 6;
+  static final byte UncancelableK = 7;
+  static final byte UnmaskK = 8;
+  static final byte AttemptK = 9;
 
   // resume ids
-  public static final byte ExecR = 0;
-  public static final byte AsyncContinueSuccessfulR = 1;
-  public static final byte AsyncContinueFailedR = 2;
-  public static final byte BlockingR = 3;
-  public static final byte AfterBlockingSuccessfulR = 4;
-  public static final byte AfterBlockingFailedR = 5;
-  public static final byte EvalOnR = 6;
-  public static final byte CedeR = 7;
-  public static final byte AutoCedeR = 8;
-  public static final byte DoneR = 9;
+  static final byte ExecR = 0;
+  static final byte AsyncContinueSuccessfulR = 1;
+  static final byte AsyncContinueFailedR = 2;
+  static final byte BlockingR = 3;
+  static final byte AfterBlockingSuccessfulR = 4;
+  static final byte AfterBlockingFailedR = 5;
+  static final byte EvalOnR = 6;
+  static final byte CedeR = 7;
+  static final byte AutoCedeR = 8;
+  static final byte DoneR = 9;
 
   // ContState tags
-  public static final int ContStateInitial = 0;
-  public static final int ContStateWaiting = 1;
-  public static final int ContStateWinner = 2;
-  public static final int ContStateResult = 3;
+  static final int ContStateInitial = 0;
+  static final int ContStateWaiting = 1;
+  static final int ContStateWinner = 2;
+  static final int ContStateResult = 3;
 }

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -46,12 +46,10 @@ final class IOFiberConstants {
   static final byte AsyncContinueSuccessfulR = 1;
   static final byte AsyncContinueFailedR = 2;
   static final byte BlockingR = 3;
-  static final byte AfterBlockingSuccessfulR = 4;
-  static final byte AfterBlockingFailedR = 5;
-  static final byte EvalOnR = 6;
-  static final byte CedeR = 7;
-  static final byte AutoCedeR = 8;
-  static final byte DoneR = 9;
+  static final byte EvalOnR = 4;
+  static final byte CedeR = 5;
+  static final byte AutoCedeR = 6;
+  static final byte DoneR = 7;
 
   // ContState tags
   static final int ContStateInitial = 0;

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -129,12 +129,10 @@ private final class IOFiber[A](
       case 1 => asyncContinueSuccessfulR()
       case 2 => asyncContinueFailedR()
       case 3 => blockingR()
-      case 4 => afterBlockingSuccessfulR()
-      case 5 => afterBlockingFailedR()
-      case 6 => evalOnR()
-      case 7 => cedeR()
-      case 8 => autoCedeR()
-      case 9 => ()
+      case 4 => evalOnR()
+      case 5 => cedeR()
+      case 6 => autoCedeR()
+      case 7 => ()
     }
   }
 
@@ -1188,24 +1186,14 @@ private final class IOFiber[A](
       }
 
     if (error == null) {
-      resumeTag = AfterBlockingSuccessfulR
+      resumeTag = AsyncContinueSuccessfulR
       objectState.push(r.asInstanceOf[AnyRef])
     } else {
-      resumeTag = AfterBlockingFailedR
+      resumeTag = AsyncContinueFailedR
       objectState.push(error)
     }
     val ec = currentCtx
     scheduleFiber(ec, this)
-  }
-
-  private[this] def afterBlockingSuccessfulR(): Unit = {
-    val result = objectState.pop()
-    runLoop(succeeded(result, 0), cancelationCheckThreshold, autoYieldThreshold)
-  }
-
-  private[this] def afterBlockingFailedR(): Unit = {
-    val error = objectState.pop().asInstanceOf[Throwable]
-    runLoop(failed(error, 0), cancelationCheckThreshold, autoYieldThreshold)
   }
 
   private[this] def evalOnR(): Unit = {
@@ -1300,7 +1288,7 @@ private final class IOFiber[A](
     val ec = popContext()
 
     if (!shouldFinalize()) {
-      resumeTag = AfterBlockingSuccessfulR
+      resumeTag = AsyncContinueSuccessfulR
       objectState.push(result.asInstanceOf[AnyRef])
       scheduleFiber(ec, this)
     } else {
@@ -1314,7 +1302,7 @@ private final class IOFiber[A](
     val ec = popContext()
 
     if (!shouldFinalize()) {
-      resumeTag = AfterBlockingFailedR
+      resumeTag = AsyncContinueFailedR
       objectState.push(t)
       scheduleFiber(ec, this)
     } else {


### PR DESCRIPTION
I don't know if these were always duplicate or became duplicates through optimizations, but they are unnecessary.