### PR TITLE
Starting point for working fiber dumps

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
@@ -46,4 +46,6 @@ private[effect] final class SuspendedFiberBag {
    */
   @nowarn("cat=unused-params")
   def unmonitor(key: AnyRef): Unit = {}
+
+  def contents(): Set[IOFiber[_]] = Set()
 }

--- a/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -28,4 +28,5 @@ private[effect] sealed abstract class WorkStealingThreadPool private ()
   def reportFailure(cause: Throwable): Unit
   private[effect] def rescheduleFiber(fiber: IOFiber[_]): Unit
   private[effect] def scheduleFiber(fiber: IOFiber[_]): Unit
+  private[unsafe] def fiberDump(): String
 }

--- a/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -28,5 +28,5 @@ private[effect] sealed abstract class WorkStealingThreadPool private ()
   def reportFailure(cause: Throwable): Unit
   private[effect] def rescheduleFiber(fiber: IOFiber[_]): Unit
   private[effect] def scheduleFiber(fiber: IOFiber[_]): Unit
-  private[unsafe] def contents(): (Set[IOFiber[_]], Set[IOFiber[_]])
+  private[unsafe] def contents(): (Set[IOFiber[_]], Map[IOFiber[_], Thread])
 }

--- a/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -28,5 +28,5 @@ private[effect] sealed abstract class WorkStealingThreadPool private ()
   def reportFailure(cause: Throwable): Unit
   private[effect] def rescheduleFiber(fiber: IOFiber[_]): Unit
   private[effect] def scheduleFiber(fiber: IOFiber[_]): Unit
-  private[unsafe] def fiberDump(): String
+  private[unsafe] def contents(): (Set[IOFiber[_]], Set[IOFiber[_]])
 }

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -236,17 +236,15 @@ trait IOApp {
     // TODO is it worth it to factor this out reflectively?
     val DumpSignalName = sys.props.get("os.name").map(_.toLowerCase) flatMap { os =>
       if (os == "linux")
-        Some("USR1")  // INFO is unavailable on Linux, and USR1 is unavailable elsewhere
+        Some("USR1") // INFO is unavailable on Linux, and USR1 is unavailable elsewhere
       else if (os.contains("windows"))
-        None    // nothing is available on windows
+        None // nothing is available on windows
       else
-        Some("INFO")    // ctrl-t on macos and bsd
+        Some("INFO") // ctrl-t on macos and bsd
     }
 
     DumpSignalName.map(new Signal(_)) foreach { sig =>
-      Signal.handle(sig, { _ =>
-        System.err.println(runtime.fiberDump())
-      })
+      Signal.handle(sig, _ => runtime.fiberDump().foreach(System.err.println(_)))
     }
 
     val rt = Runtime.getRuntime()

--- a/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
@@ -991,5 +991,8 @@ private final class LocalQueue {
    */
   def getTailTag(): Int = tailPublisher.get()
 
-  def contents(): Set[IOFiber[_]] = buffer.toSet
+  def contents(): Set[IOFiber[_]] = {
+    val _ = size()      // read fence to get a more updated snapshot on this thread
+    buffer.toSet
+  }
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
@@ -992,7 +992,7 @@ private final class LocalQueue {
   def getTailTag(): Int = tailPublisher.get()
 
   def contents(): Set[IOFiber[_]] = {
-    val _ = size()      // read fence to get a more updated snapshot on this thread
+    val _ = size() // read fence to get a more updated snapshot on this thread
     buffer.toSet
   }
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
@@ -990,4 +990,6 @@ private final class LocalQueue {
    *   the "tail" tag of the tail of the local queue
    */
   def getTailTag(): Int = tailPublisher.get()
+
+  def contents(): Set[IOFiber[_]] = buffer.toSet
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/ScalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/ScalQueue.scala
@@ -212,4 +212,6 @@ private final class ScalQueue[A <: AnyRef](threadCount: Int) {
       i += 1
     }
   }
+
+  def contents(): Set[AnyRef] = queues.flatMap(_.toArray).toSet
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
@@ -21,7 +21,7 @@ import scala.annotation.nowarn
 import scala.collection.mutable.ArrayBuffer
 
 import java.lang.ref.WeakReference
-import java.util.{ConcurrentModificationException, Collections, Map, WeakHashMap}
+import java.util.{Collections, ConcurrentModificationException, Map, WeakHashMap}
 import java.util.concurrent.ThreadLocalRandom
 
 /**

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -521,12 +521,4 @@ private[effect] final class WorkStealingThreadPool(
 
     live ++ suspended
   }
-
-  private[unsafe] def fiberDump(): String = {
-    val strings = contents().toList map { fiber =>
-      fiber.toString + "\n" + tracing.Tracing.prettyPrint(fiber.trace())
-    }
-
-    strings.mkString("\n\n")
-  }
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -508,7 +508,7 @@ private[effect] final class WorkStealingThreadPool(
   }
 
   // TODO the living and the dead
-  private[unsafe] def contents(): (Set[IOFiber[_]], Set[IOFiber[_]]) = {
+  private[unsafe] def contents(): (Set[IOFiber[_]], Map[IOFiber[_], Thread]) = {
     // check the external first since workers inadvertently publish on it, so we get more up to date results
     val ext = externalQueue.contents() flatMap {
       case arr: Array[_] => arr.asInstanceOf[Array[IOFiber[_]]].toSet
@@ -517,7 +517,7 @@ private[effect] final class WorkStealingThreadPool(
 
     val int = localQueues.map(_.contents()).toSet.flatten
     val yielding = ext ++ int - null
-    val active = workerThreads.map(_.active).toSet - null
+    val active = workerThreads.map(t => t.active -> t).toMap - null
 
     (yielding, active)
   }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -508,7 +508,7 @@ private[effect] final class WorkStealingThreadPool(
   }
 
   // TODO the living and the dead
-  private[unsafe] def contents(): Set[IOFiber[_]] = {
+  private[unsafe] def contents(): (Set[IOFiber[_]], Set[IOFiber[_]]) = {
     // check the external first since workers inadvertently publish on it, so we get more up to date results
     val ext = externalQueue.contents() flatMap {
       case arr: Array[_] => arr.asInstanceOf[Array[IOFiber[_]]].toSet
@@ -516,9 +516,9 @@ private[effect] final class WorkStealingThreadPool(
     }
 
     val int = localQueues.map(_.contents()).toSet.flatten
-    val live = ext ++ int - null
-    val suspended = Set() // TODO
+    val yielding = ext ++ int - null
+    val active = workerThreads.map(_.active).toSet - null
 
-    live ++ suspended
+    (yielding, active)
   }
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -523,8 +523,8 @@ private[effect] final class WorkStealingThreadPool(
   }
 
   private[unsafe] def fiberDump(): String = {
-    val strings = contents() map { fiber =>
-      fiber.toString + tracing.Tracing.prettyPrint(fiber.trace())
+    val strings = contents().toList map { fiber =>
+      fiber.toString + "\n" + tracing.Tracing.prettyPrint(fiber.trace())
     }
 
     strings.mkString("\n\n")

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1406,6 +1406,8 @@ private final class IOFiber[A](
     val state = if (suspended.get()) "SUSPENDED" else "RUNNING"
     s"cats.effect.IOFiber@${System.identityHashCode(this).toHexString} $state"
   }
+
+  private[effect] def trace(): RingBuffer = tracingEvents
 }
 
 private object IOFiber {

--- a/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
@@ -33,7 +33,7 @@ private[effect] final class RingBuffer private (logSize: Int) {
   /**
    * Returns a list in reverse order of insertion.
    */
-  def toList: List[TracingEvent] = {
+  def toList(): List[TracingEvent] = {
     var result = List.empty[TracingEvent]
     val msk = mask
     val idx = index

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -22,6 +22,11 @@ private[effect] object Tracing extends TracingPlatform {
 
   import TracingConstants._
 
+  private[this] val TurnRight = "╰"
+  // private[this] val InverseTurnRight = "╭"
+  private[this] val Junction = "├"
+  // private[this] val Line = "│"
+
   private[tracing] def buildEvent(): TracingEvent = {
     new TracingEvent.StackTrace()
   }
@@ -105,8 +110,20 @@ private[effect] object Tracing extends TracingPlatform {
 
   def getFrames(events: RingBuffer): List[StackTraceElement] =
     events
-      .toList
+      .toList()
       .collect { case ev: TracingEvent.StackTrace => getOpAndCallSite(ev.getStackTrace) }
       .filter(_ ne null)
 
+  def prettyPrint(events: RingBuffer): String = {
+    val frames = getFrames(events)
+
+    frames
+      .zipWithIndex
+      .map {
+        case (frame, index) =>
+          val junc = if (index == frames.length - 1) TurnRight else Junction
+          s" $junc $frame"
+      }
+      .mkString("\n")
+  }
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -42,6 +42,8 @@ final class IORuntime private (
   private[effect] val fiberErrorCbs: StripedHashtable = new StripedHashtable()
 
   private[effect] val suspendedFiberBag: SuspendedFiberBag = new SuspendedFiberBag()
+  
+  private[effect] def fiberDump(): String = "insert hardcore fiber dumping..."
 
   override def toString: String = s"IORuntime($compute, $scheduler, $config)"
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -42,9 +42,16 @@ final class IORuntime private (
   private[effect] val fiberErrorCbs: StripedHashtable = new StripedHashtable()
 
   private[effect] val suspendedFiberBag: SuspendedFiberBag = new SuspendedFiberBag()
-  
+
   private[effect] def fiberDump(): Option[String] =
-    Some(compute) collect { case compute: WorkStealingThreadPool => compute.fiberDump() }
+    Some(compute) collect {
+      case compute: WorkStealingThreadPool =>
+        val strings = (compute.contents() ++ suspendedFiberBag.contents()).toList map { fiber =>
+          fiber.toString + "\n" + tracing.Tracing.prettyPrint(fiber.trace())
+        }
+
+        strings.mkString("\n \n")
+    }
 
   override def toString: String = s"IORuntime($compute, $scheduler, $config)"
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -50,12 +50,13 @@ final class IORuntime private (
         val suspended = suspendedFiberBag.contents()
 
         val strings = (yielding ++ active ++ suspended).toList map { fiber =>
-          val status = if (yielding(fiber))
-            "YIELDING"
-          else if (active(fiber))
-            "RUNNING"
-          else
-            "WAITING"
+          val status =
+            if (yielding(fiber))
+              "YIELDING"
+            else if (active(fiber))
+              "RUNNING"
+            else
+              "WAITING"
 
           val id = System.identityHashCode(fiber)
 

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -49,14 +49,18 @@ final class IORuntime private (
         val (yielding, active) = compute.contents()
         val suspended = suspendedFiberBag.contents()
 
-        val strings = (yielding ++ active ++ suspended).toList map { fiber =>
+        val strings = (yielding ++ active.keys ++ suspended).toList map { fiber =>
           val status =
-            if (yielding(fiber))
+            if (yielding.contains(fiber)) {
               "YIELDING"
-            else if (active(fiber))
-              "RUNNING"
-            else
+            } else if (active.contains(fiber)) {
+              if (active(fiber).getState() == Thread.State.RUNNABLE)
+                "RUNNING"
+              else
+                "BLOCKED"
+            } else {
               "WAITING"
+            }
 
           val id = System.identityHashCode(fiber)
 

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -43,7 +43,8 @@ final class IORuntime private (
 
   private[effect] val suspendedFiberBag: SuspendedFiberBag = new SuspendedFiberBag()
   
-  private[effect] def fiberDump(): String = "insert hardcore fiber dumping..."
+  private[effect] def fiberDump(): Option[String] =
+    Some(compute) collect { case compute: WorkStealingThreadPool => compute.fiberDump() }
 
   override def toString: String = s"IORuntime($compute, $scheduler, $config)"
 }


### PR DESCRIPTION
Where by "working" I mean "actually not quite working yet". Also we should come up with a way to test this. Needs to build on #2408 and related work to get the suspended fibers. Major caveat on this at the end…

This works by registering a signal handler for `SIGINFO` on macOS and BSD, and for `SIGUSR1` on Linux. Confusingly, `SIGINFO` doesn't exist on Linux, and `SIGUSR1` serves a VM-level function on macOS and BSD. Nothing works on Windows, unsurprisingly. This is exactly what the `dd` utility does, btw, so it's not an unfamiliar paradigm. Pleasantly enough, macOS TTYs bind <kbd>Ctrl</kbd>-<kbd>T</kbd> to `SIGINFO`, which means we get a single hotkey for dumping fiber traces. Cool, right?

Anyway, this is obviously very lossy because I'm peeking inside concurrent data structures. Unfortunately, it's *especially* lossy in some very important ways. In particular, we will never see the *currently executing* fiber on a worker thread in the current encoding. Honestly, I'm not 100% sure if it's even possible to circumvent this limitation without adding a lot of overhead. Maybe this is less of a concern though given that, 99% of the time, the most useful traces are going to be the suspended fibers? Worth some discussion, anyway.

When all is said and done, I'd also like to expose this via an MBean, so that users aren't forced to exclusively access this information via POSIX signaling. That also gives an alternative for those poor souls on Windows.

At any rate, this seems pretty cool. It makes no attempt to do anything on ScalaJS.

Fixes #1029 