### PR TITLE
Implement `SuspendedFiberBag` for JS

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/IterableWeakMap.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IterableWeakMap.scala
@@ -57,6 +57,12 @@ private[unsafe] class IterableWeakMap[K, V] {
 }
 
 private[unsafe] object IterableWeakMap {
+  private[this] final val Undefined = "undefined"
+  def isAvailable: Boolean =
+    js.typeOf(js.Dynamic.global.WeakMap) != "undefined" &&
+      js.typeOf(js.Dynamic.global.WeakRef) != "undefined" &&
+      js.typeOf(js.Dynamic.global.FinalizationRegistry) != "undefined"
+
   private final case class Entry[K, V](value: V, ref: js.WeakRef[K])
 
   private final case class Finalizer[K](set: mutable.Set[js.WeakRef[K]], ref: js.WeakRef[K]) {

--- a/core/js/src/main/scala/cats/effect/unsafe/IterableWeakMap.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IterableWeakMap.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.unsafe
+
+import scala.collection.mutable
+import scala.scalajs.js
+
+import IterableWeakMap._
+
+// https://github.com/tc39/proposal-weakrefs#iterable-weakmaps
+private[unsafe] class IterableWeakMap[K, V] {
+  private[this] val weakMap = new WeakMap[K, Entry[K, V]]
+  private[this] val refSet = mutable.Set[js.WeakRef[K]]()
+  private[this] val finalizationGroup =
+    new js.FinalizationRegistry[K, Finalizer[K], js.WeakRef[K]](_.cleanup())
+
+  def set(key: K, value: V): Unit = {
+    val ref = new js.WeakRef(key)
+
+    weakMap.set(key, Entry(value, ref))
+    refSet.add(ref)
+    finalizationGroup.register(key, Finalizer(refSet, ref), ref)
+  }
+
+  def get(key: K): Option[V] = weakMap.get(key).toOption.map(_.value)
+
+  def delete(key: K): Boolean =
+    weakMap.get(key).fold(false) { entry =>
+      weakMap.delete(key)
+      refSet.remove(entry.ref)
+      finalizationGroup.unregister(entry.ref)
+      true
+    }
+
+  def entries(): Iterator[(K, V)] =
+    refSet.iterator.flatMap { ref =>
+      (for {
+        key <- ref.deref()
+        entry <- weakMap.get(key)
+      } yield (key, entry.value)).toOption
+    }
+
+}
+
+private[unsafe] object IterableWeakMap {
+  private final case class Entry[K, V](value: V, ref: js.WeakRef[K])
+
+  private final case class Finalizer[K](set: mutable.Set[js.WeakRef[K]], ref: js.WeakRef[K]) {
+    def cleanup(): Unit = {
+      set.remove(ref)
+      ()
+    }
+  }
+}

--- a/core/js/src/main/scala/cats/effect/unsafe/IterableWeakMap.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IterableWeakMap.scala
@@ -59,9 +59,9 @@ private[unsafe] class IterableWeakMap[K, V] {
 private[unsafe] object IterableWeakMap {
   private[this] final val Undefined = "undefined"
   def isAvailable: Boolean =
-    js.typeOf(js.Dynamic.global.WeakMap) != "undefined" &&
-      js.typeOf(js.Dynamic.global.WeakRef) != "undefined" &&
-      js.typeOf(js.Dynamic.global.FinalizationRegistry) != "undefined"
+    js.typeOf(js.Dynamic.global.WeakMap) != Undefined &&
+      js.typeOf(js.Dynamic.global.WeakRef) != Undefined &&
+      js.typeOf(js.Dynamic.global.FinalizationRegistry) != Undefined
 
   private final case class Entry[K, V](value: V, ref: js.WeakRef[K])
 

--- a/core/js/src/main/scala/cats/effect/unsafe/IterableWeakMap.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IterableWeakMap.scala
@@ -21,18 +21,42 @@ import scala.scalajs.js
 
 import IterableWeakMap._
 
-// https://github.com/tc39/proposal-weakrefs#iterable-weakmaps
+/**
+ * Although JS provides a native `WeakMap` implementation with weakly-referenced keys, it lacks
+ * the capability to iterate over the keys in the map which we required for fiber dumps.
+ *
+ * Here, we implement an `IterableWeakMap` that also keeps track of its keys for subsequent
+ * iteration, without creating strong references to the keys or otherwise leaking memory. It
+ * requires two features only standardized in ES2021, `WeakRef` and `FinalizationRegistry`,
+ * although already implemented by many runtimes, as well as `WeakMap` from ES6 (aka ES2015).
+ *
+ * This implementation is adapted from an example provided in the
+ * [[https://github.com/tc39/proposal-weakrefs ECMA `WeakRef` proposal]]. Because we do not need
+ * a fully-featured map (e.g., no remove method) we were able to make additional optimizations.
+ */
 private[unsafe] class IterableWeakMap[K, V] {
+
+  // The underlying weak map
   private[this] val weakMap = new WeakMap[K, V]
+
+  // A set of weak refs to all the keys in the map, for iteration
   private[this] val refSet = mutable.Set[js.WeakRef[K]]()
+
+  // A mechanism to register finalizers for when the keys are GCed
+  // Comparable to https://docs.oracle.com/javase/9/docs/api/java/lang/ref/Cleaner.html
   private[this] val finalizationGroup =
     new js.FinalizationRegistry[K, Finalizer[K], js.WeakRef[K]](_.cleanup())
 
   def set(key: K, value: V): Unit = {
     val ref = new js.WeakRef(key)
 
+    // Store the key-value pair
     weakMap.set(key, value)
+
+    // Add a weak ref to the key to our set
     refSet.add(ref)
+
+    // Register a finalizer to remove the ref from the set when the key is GCed
     finalizationGroup.register(key, Finalizer(refSet, ref), ref)
   }
 
@@ -50,11 +74,18 @@ private[unsafe] class IterableWeakMap[K, V] {
 
 private[unsafe] object IterableWeakMap {
   private[this] final val Undefined = "undefined"
+
+  /**
+   * Feature-tests for all the required, well, features :)
+   */
   def isAvailable: Boolean =
     js.typeOf(js.Dynamic.global.WeakMap) != Undefined &&
       js.typeOf(js.Dynamic.global.WeakRef) != Undefined &&
       js.typeOf(js.Dynamic.global.FinalizationRegistry) != Undefined
 
+  /**
+   * A finalizer to run when a key is GCed. Removes a weak ref to the key from a set.
+   */
   private final case class Finalizer[K](set: mutable.Set[js.WeakRef[K]], ref: js.WeakRef[K]) {
     def cleanup(): Unit = {
       set.remove(ref)

--- a/core/js/src/main/scala/cats/effect/unsafe/IterableWeakMap.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IterableWeakMap.scala
@@ -57,7 +57,7 @@ private[unsafe] class IterableWeakMap[K, V] {
     refSet.add(ref)
 
     // Register a finalizer to remove the ref from the set when the key is GCed
-    finalizationGroup.register(key, Finalizer(refSet, ref), ref)
+    finalizationGroup.register(key, Finalizer(refSet, ref))
   }
 
   def get(key: K): Option[V] = weakMap.get(key).toOption

--- a/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
@@ -19,10 +19,6 @@ package unsafe
 
 import scala.scalajs.js
 
-/**
- * A no-op implementation of an unordered bag used for tracking asynchronously suspended fiber
- * instances on Scala.js. We will iterate on this in the future.
- */
 private[effect] sealed abstract class SuspendedFiberBag {
 
   /**
@@ -46,7 +42,9 @@ private[effect] sealed abstract class SuspendedFiberBag {
   def unmonitor(key: AnyRef): Unit
 }
 
-// Relies on features *standardized* in ES2021, although already offered in many environments
+/**
+ * Relies on features *standardized* in ES2021, although already offered in many environments
+ */
 private final class ES2021SuspendedFiberBag extends SuspendedFiberBag {
   private[this] val bag = new IterableWeakMap[AnyRef, js.WeakRef[IOFiber[_]]]
 
@@ -57,6 +55,10 @@ private final class ES2021SuspendedFiberBag extends SuspendedFiberBag {
   override def unmonitor(key: AnyRef): Unit = ()
 }
 
+/**
+ * A no-op implementation of an unordered bag used for tracking asynchronously suspended fiber
+ * instances on Scala.js. This is used as a fallback.
+ */
 private final class NoOpSuspendedFiberBag extends SuspendedFiberBag {
   override def monitor(key: AnyRef, fiber: IOFiber[_]): Unit = ()
   override def unmonitor(key: AnyRef): Unit = ()

--- a/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
@@ -17,13 +17,11 @@
 package cats.effect
 package unsafe
 
-import scala.annotation.nowarn
-
 /**
  * A no-op implementation of an unordered bag used for tracking asynchronously suspended fiber
  * instances on Scala.js. We will iterate on this in the future.
  */
-private[effect] final class SuspendedFiberBag {
+private[effect] sealed abstract class SuspendedFiberBag {
 
   /**
    * Registers a suspended fiber, tracked by the provided key which is an opaque object which
@@ -34,8 +32,7 @@ private[effect] final class SuspendedFiberBag {
    * @param fiber
    *   the suspended fiber to be registered
    */
-  @nowarn("cat=unused-params")
-  def monitor(key: AnyRef, fiber: IOFiber[_]): Unit = {}
+  def monitor(key: AnyRef, fiber: IOFiber[_]): Unit
 
   /**
    * Deregisters a resumed fiber, tracked by the provided key which is an opaque object which
@@ -44,6 +41,22 @@ private[effect] final class SuspendedFiberBag {
    * @param key
    *   an opaque identifier for the resumed fiber
    */
-  @nowarn("cat=unused-params")
-  def unmonitor(key: AnyRef): Unit = {}
+  def unmonitor(key: AnyRef): Unit
+}
+
+private final class ES2021SuspendedFiberBag extends SuspendedFiberBag {
+
+  override def monitor(key: AnyRef, fiber: IOFiber[_]): Unit = ()
+
+  override def unmonitor(key: AnyRef): Unit = ()
+
+}
+
+private final class NoOpSuspendedFiberBag extends SuspendedFiberBag {
+  override def monitor(key: AnyRef, fiber: IOFiber[_]): Unit = ()
+  override def unmonitor(key: AnyRef): Unit = ()
+}
+
+object SuspendedFiberBag {
+  def apply(): SuspendedFiberBag = ???
 }

--- a/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
@@ -63,8 +63,6 @@ private final class NoOpSuspendedFiberBag extends SuspendedFiberBag {
 }
 
 private[effect] object SuspendedFiberBag {
-  private[this] final val Undefined = "undefined"
-
   def apply(): SuspendedFiberBag =
     if (IterableWeakMap.isAvailable)
       new ES2021SuspendedFiberBag

--- a/core/js/src/main/scala/cats/effect/unsafe/WeakMap.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/WeakMap.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.unsafe
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSGlobal
+import scala.annotation.nowarn
+
+@js.native
+@JSGlobal
+@nowarn("cat=unused")
+private[unsafe] class WeakMap[K, V] extends js.Object {
+  def delete(key: K): Boolean = js.native
+  def get(key: K): js.UndefOr[V] = js.native
+  def has(key: K): Boolean = js.native
+  def set(key: K, value: V): this.type = js.native
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
@@ -88,3 +88,7 @@ private[effect] final class SuspendedFiberBag {
     // no-op
   }
 }
+
+object SuspendedFiberBag {
+  def apply(): SuspendedFiberBag = new SuspendedFiberBag
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
@@ -89,6 +89,6 @@ private[effect] final class SuspendedFiberBag {
   }
 }
 
-object SuspendedFiberBag {
+private[effect] object SuspendedFiberBag {
   def apply(): SuspendedFiberBag = new SuspendedFiberBag
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -41,7 +41,7 @@ final class IORuntime private (
 ) {
   private[effect] val fiberErrorCbs: StripedHashtable = new StripedHashtable()
 
-  private[effect] val suspendedFiberBag: SuspendedFiberBag = new SuspendedFiberBag()
+  private[effect] val suspendedFiberBag: SuspendedFiberBag = SuspendedFiberBag()
 
   override def toString: String = s"IORuntime($compute, $scheduler, $config)"
 }


### PR DESCRIPTION
This was a fairly straightforward port of the JVM version. It feature tests for [`WeakMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap), [`WeakRef`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef), and [`FinalizationRegistry`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry) and gracefully falls back to the no-op implementation.