### PR TITLE
Initialize tracing buffer if needed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -411,7 +411,9 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       // introduced by #2361, Bye bye helper thread
       // changes to `cats.effect.unsafe` package private code
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.HelperThread"),
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.LocalQueue$")
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.LocalQueue$"),
+      // introduced by #2434, Initialize tracing buffer if needed
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.ArrayStack.copy")
     )
   )
   .jvmSettings(

--- a/core/shared/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/shared/src/main/scala/cats/effect/ArrayStack.scala
@@ -16,7 +16,7 @@
 
 package cats.effect
 
-private[effect] final class ArrayStack[A <: AnyRef](
+private final class ArrayStack[A <: AnyRef](
     private[this] var buffer: Array[AnyRef],
     private[this] var index: Int) {
 
@@ -65,18 +65,6 @@ private[effect] final class ArrayStack[A <: AnyRef](
   def invalidate(): Unit = {
     index = 0
     buffer = null
-  }
-
-  def copy(): ArrayStack[A] = {
-    val buffer2 = if (index == 0) {
-      new Array[AnyRef](buffer.length)
-    } else {
-      val buffer2 = new Array[AnyRef](buffer.length)
-      System.arraycopy(buffer, 0, buffer2, 0, buffer.length)
-      buffer2
-    }
-
-    new ArrayStack[A](buffer2, index)
   }
 
   private[this] def checkAndGrow(): Unit =

--- a/core/shared/src/main/scala/cats/effect/ByteStack.scala
+++ b/core/shared/src/main/scala/cats/effect/ByteStack.scala
@@ -16,7 +16,7 @@
 
 package cats.effect
 
-private[effect] object ByteStack {
+private object ByteStack {
 
   final def toDebugString(stack: Array[Int], translate: Byte => String = _.toString): String = {
     val count = size(stack)

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -118,7 +118,7 @@ private final class IOFiber[A](
   private[this] val cancelationCheckThreshold: Int = runtime.config.cancelationCheckThreshold
   private[this] val autoYieldThreshold: Int = runtime.config.autoYieldThreshold
 
-  private[this] var tracingEvents: RingBuffer =
+  private[this] val tracingEvents: RingBuffer =
     RingBuffer.empty(runtime.config.traceBufferLogSize)
 
   override def run(): Unit = {
@@ -970,7 +970,7 @@ private final class IOFiber[A](
     finalizers.invalidate()
     ctxs.invalidate()
     currentCtx = null
-    tracingEvents = null
+    tracingEvents.invalidate()
   }
 
   private[this] def asyncCancel(cb: Either[Throwable, Unit] => Unit): Unit = {

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -85,7 +85,7 @@ private final class IOFiber[A](
    * Ideally these would be on the stack, but they can't because we sometimes need to
    * relocate our runloop to another fiber.
    */
-  private[this] var conts = ByteStack.create(16) // use ByteStack to interact
+  private[this] var conts: ByteStack = _
   private[this] val objectState: ArrayStack[AnyRef] = new ArrayStack()
 
   /* fast-path to head */
@@ -1159,7 +1159,7 @@ private final class IOFiber[A](
     if (canceled) {
       done(IOFiber.OutcomeCanceled.asInstanceOf[OutcomeIO[A]])
     } else {
-      conts = ByteStack.create(8)
+      conts = ByteStack.create(16)
       conts = ByteStack.push(conts, RunTerminusK)
 
       objectState.init(16)

--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -80,4 +80,6 @@ package object effect {
   val Ref = cekernel.Ref
 
   private[effect] type IOLocalState = scala.collection.immutable.Map[IOLocal[_], Any]
+
+  private[effect] type ByteStack = Array[Int]
 }

--- a/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
@@ -21,7 +21,7 @@ private[effect] final class RingBuffer private (logSize: Int) {
   private[this] val length = 1 << logSize
   private[this] val mask = length - 1
 
-  private[this] val buffer: Array[TracingEvent] = new Array(length)
+  private[this] var buffer: Array[TracingEvent] = new Array(length)
   private[this] var index: Int = 0
 
   def push(te: TracingEvent): Unit = {
@@ -45,6 +45,11 @@ private[effect] final class RingBuffer private (logSize: Int) {
       i += 1
     }
     result
+  }
+
+  def invalidate(): Unit = {
+    index = 0
+    buffer = null
   }
 }
 

--- a/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
@@ -54,5 +54,9 @@ private[effect] final class RingBuffer private (logSize: Int) {
 }
 
 private[effect] object RingBuffer {
-  def empty(logSize: Int): RingBuffer = new RingBuffer(logSize)
+  def empty(logSize: Int): RingBuffer = {
+    if (TracingConstants.isStackTracing) {
+      new RingBuffer(logSize)
+    } else null
+  }
 }


### PR DESCRIPTION
Changes in no particular order:
- The `conts` stack was being initialized twice.
- I changed `ArrayStack` so that fewer objects are allocated when an `IOFiber` instance is created (should speed up `start` for immediately canceled fibers now that the "wrapper" `ArrayStack` object is no longer allocated on creation).
- The `tracingEvents` ring buffer is now created only if needed (not at all allocated if tracing is disabled, which wasn't the case before).