### PR TITLE
Return a reference to an actual tracing buffer instead of null to avoid NPE on fiber cleanup

### DIFF
--- a/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
@@ -57,6 +57,8 @@ private[effect] object RingBuffer {
   def empty(logSize: Int): RingBuffer = {
     if (TracingConstants.isStackTracing) {
       new RingBuffer(logSize)
-    } else null
+    } else NullBuffer
   }
+
+  private[this] val NullBuffer = new RingBuffer(0)
 }


### PR DESCRIPTION
Follow up to #2434.

Fixes the following:

```
[error] Exception in thread "io-compute-3" java.lang.NullPointerException: Cannot invoke "cats.effect.tracing.RingBuffer.invalidate()" because "this.tracingEvents" is null
[error]         at cats.effect.IOFiber.done(IOFiber.scala:973)
[error]         at cats.effect.IOFiber.runTerminusSuccessK(IOFiber.scala:1299)
[error]         at cats.effect.IOFiber.succeeded(IOFiber.scala:1062)
[error]         at cats.effect.IOFiber.runLoop(IOFiber.scala:239)
[error]         at cats.effect.IOFiber.cedeR(IOFiber.scala:1227)
[error]         at cats.effect.IOFiber.run(IOFiber.scala:135)
[error]         at cats.effect.unsafe.WorkerThread.run(WorkerThread.scala:388)
```

when running with `-Dcats.effect.tracing.mode=none`.