### PR TITLE
Inline continuations which call `succeded/failed`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
@@ -57,6 +57,8 @@ private[effect] object RingBuffer {
   def empty(logSize: Int): RingBuffer = {
     if (TracingConstants.isStackTracing) {
       new RingBuffer(logSize)
-    } else null
+    } else NullBuffer
   }
+
+  private[this] val NullBuffer = new RingBuffer(0)
 }


### PR DESCRIPTION
Rebased on top of #2439.

Inline the continuations to achieve `tailrec`, otherwise we're growing the thread stack. Turns out this also improves performance.

`series/3.x`:
```
[info] Benchmark                     Mode  Cnt     Score    Error  Units
[info] MapCallsBenchmark.batch120   thrpt   20   282.070 ±  9.781  ops/s
[info] MapCallsBenchmark.batch30    thrpt   20    78.785 ±  1.715  ops/s
[info] MapCallsBenchmark.one        thrpt   20     2.633 ±  0.044  ops/s
[info] MapStreamBenchmark.batch120  thrpt   20  1667.019 ± 57.499  ops/s
[info] MapStreamBenchmark.batch30   thrpt   20   669.397 ±  6.455  ops/s
[info] MapStreamBenchmark.one       thrpt   20  1065.935 ± 17.375  ops/s

[info] Benchmark                (size)   Mode  Cnt     Score    Error  Units
[info] DeepBindBenchmark.async   10000  thrpt   20  1043.697 ± 18.559  ops/s
```

`This PR`:
```
[info] Benchmark                     Mode  Cnt     Score    Error  Units
[info] MapStreamBenchmark.batch120  thrpt   20  1948.278 ± 95.244  ops/s
[info] MapStreamBenchmark.batch30   thrpt   20   794.796 ± 14.619  ops/s
[info] MapStreamBenchmark.one       thrpt   20  1090.688 ± 30.660  ops/s

[info] Benchmark                (size)   Mode  Cnt     Score    Error  Units
[info] DeepBindBenchmark.async   10000  thrpt   20  1152.504 ± 24.355  ops/s
```