### PR TITLE
Remove trace case and restore tableswitch in immediate interpreters

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -344,10 +344,6 @@ private final class IOFiber[A](
               val ec = currentCtx
               runLoop(next(ec), nextCancelation - 1, nextAutoCede)
 
-            case 23 =>
-              val trace = Trace(tracingEvents)
-              runLoop(next(trace), nextCancelation - 1, nextAutoCede)
-
             case _ =>
               objectState.push(f)
               conts = ByteStack.push(conts, MapK)
@@ -408,10 +404,6 @@ private final class IOFiber[A](
             case 5 =>
               val ec = currentCtx
               runLoop(next(ec), nextCancelation - 1, nextAutoCede)
-
-            case 23 =>
-              val trace = Trace(tracingEvents)
-              runLoop(next(trace), nextCancelation - 1, nextAutoCede)
 
             case _ =>
               objectState.push(f)
@@ -474,10 +466,6 @@ private final class IOFiber[A](
             case 5 =>
               val ec = currentCtx
               runLoop(succeeded(Right(ec), 0), nextCancelation - 1, nextAutoCede)
-
-            case 23 =>
-              val trace = Trace(tracingEvents)
-              runLoop(succeeded(Right(trace), 0), nextCancelation - 1, nextAutoCede)
 
             case _ =>
               conts = ByteStack.push(conts, AttemptK)


### PR DESCRIPTION
Before:
```
602: lookupswitch  { // 7
    0: 668
    1: 698
    2: 727
    3: 896
    4: 946
    5: 996
    23: 1022
    default: 1054
}
```

After:
```
602: tableswitch   { // 0 to 5
    0: 640
    1: 670
    2: 699
    3: 868
    4: 918
    5: 968
   default: 994
}
```

IMO, it's not worth reordering `Trace` to fit in the tableswitch.