### PR TITLE
Masking without an `initMask` field

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -413,7 +413,16 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.HelperThread"),
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.LocalQueue$"),
       // introduced by #2434, Initialize tracing buffer if needed
-      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.ArrayStack.copy")
+      // changes to `cats.effect` package private code
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.ArrayStack.copy"),
+      // introduced by #2453, Masking without an `initMask` field
+      // changes to `cats.effect` package private code
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "cats.effect.IO#Uncancelable#UnmaskRunLoop.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "cats.effect.IO#Uncancelable#UnmaskRunLoop.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "cats.effect.IO#Uncancelable#UnmaskRunLoop.this")
     )
   )
   .jvmSettings(

--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -21,13 +21,6 @@ private object IOFiberConstants {
 
   final val MaxStackDepth: Int = 512
 
-  /*
-   * allow for 255 masks before conflicting; 255 chosen because it is a familiar bound,
-   * and because it's evenly divides UnsignedInt.MaxValue.
-   * This scheme gives us 16,843,009 (~2^24) potential derived fibers before masks can conflict
-   */
-  final val ChildMaskOffset: Int = 255
-
   // continuation ids (should all be inlined)
   final val MapK: Byte = 0
   final val FlatMapK: Byte = 1

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -21,14 +21,6 @@ final class IOFiberConstants {
 
   static final int MaxStackDepth = 512;
 
-  /*
-   * allow for 255 masks before conflicting; 255 chosen because it is a familiar
-   * bound, and because it's evenly divides UnsignedInt.MaxValue. This scheme
-   * gives us 16,843,009 (~2^24) potential derived fibers before masks can
-   * conflict
-   */
-  static final int ChildMaskOffset = 255;
-
   // continuation ids (should all be inlined)
   static final byte MapK = 0;
   static final byte FlatMapK = 1;

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -448,7 +448,7 @@ private[effect] final class WorkStealingThreadPool(
       // Executing a general purpose computation on the thread pool.
       // Wrap the runnable in an `IO` and execute it as a fiber.
       val io = IO.delay(runnable.run())
-      val fiber = new IOFiber[Unit](0, Map.empty, outcomeToUnit, io, this, self)
+      val fiber = new IOFiber[Unit](Map.empty, outcomeToUnit, io, this, self)
       scheduleFiber(fiber)
     }
   }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -776,7 +776,6 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
       success: A => Unit)(implicit runtime: unsafe.IORuntime): IOFiber[A @uncheckedVariance] = {
 
     val fiber = new IOFiber[A](
-      0,
       Map(),
       oc =>
         oc.fold(
@@ -1595,7 +1594,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
   }
   private[effect] object Uncancelable {
     // INTERNAL, it's only created by the runloop itself during the execution of `Uncancelable`
-    final case class UnmaskRunLoop[+A](ioa: IO[A], id: Int) extends IO[A] {
+    final case class UnmaskRunLoop[+A](ioa: IO[A], id: Int, self: IOFiber[_]) extends IO[A] {
       def tag = 13
     }
   }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -66,7 +66,6 @@ import java.util.concurrent.atomic.AtomicBoolean
  * merely a fast-path and are not necessary for correctness.
  */
 private final class IOFiber[A](
-    private[this] val initMask: Int,
     initLocalState: IOLocalState,
     cb: OutcomeIO[A] => Unit,
     startIO: IO[A],
@@ -93,7 +92,7 @@ private final class IOFiber[A](
   private[this] val ctxs: ArrayStack[ExecutionContext] = new ArrayStack()
 
   private[this] var canceled: Boolean = false
-  private[this] var masks: Int = initMask
+  private[this] var masks: Int = 0
   private[this] var finalizing: Boolean = false
 
   private[this] val finalizers: ArrayStack[IO[Unit]] = new ArrayStack()
@@ -514,7 +513,7 @@ private final class IOFiber[A](
           masks += 1
           val id = masks
           val poll = new Poll[IO] {
-            def apply[B](ioa: IO[B]) = IO.Uncancelable.UnmaskRunLoop(ioa, id)
+            def apply[B](ioa: IO[B]) = IO.Uncancelable.UnmaskRunLoop(ioa, id, IOFiber.this)
           }
 
           /*
@@ -526,12 +525,13 @@ private final class IOFiber[A](
 
         case 13 =>
           val cur = cur0.asInstanceOf[Uncancelable.UnmaskRunLoop[Any]]
+          val self = this
 
           /*
            * we keep track of nested uncancelable sections.
            * The outer block wins.
            */
-          if (masks == cur.id) {
+          if (masks == cur.id && (self eq cur.self)) {
             masks -= 1
             /*
              * The UnmaskK marker gets used by `succeeded` and `failed`
@@ -805,10 +805,8 @@ private final class IOFiber[A](
         case 17 =>
           val cur = cur0.asInstanceOf[Start[Any]]
 
-          val childMask = initMask + ChildMaskOffset
           val ec = currentCtx
           val fiber = new IOFiber[Any](
-            childMask,
             localState,
             null,
             cur.ioa,
@@ -829,12 +827,10 @@ private final class IOFiber[A](
             IO.async[Either[(OutcomeIO[Any], FiberIO[Any]), (FiberIO[Any], OutcomeIO[Any])]] {
               cb =>
                 IO {
-                  val childMask = initMask + ChildMaskOffset
                   val ec = currentCtx
                   val rt = runtime
 
                   val fiberA = new IOFiber[Any](
-                    childMask,
                     localState,
                     null,
                     cur.ioa,
@@ -843,7 +839,6 @@ private final class IOFiber[A](
                   )
 
                   val fiberB = new IOFiber[Any](
-                    childMask,
                     localState,
                     null,
                     cur.iob,
@@ -949,7 +944,7 @@ private final class IOFiber[A](
      * need to reset masks to 0 to terminate async callbacks
      * in `cont` busy spinning in `loop` on the `!shouldFinalize` check.
      */
-    masks = initMask
+    masks = 0
 
     resumeTag = DoneR
     resumeIO = null
@@ -1013,7 +1008,7 @@ private final class IOFiber[A](
     canceled && isUnmasked()
 
   private[this] def isUnmasked(): Boolean =
-    masks == initMask
+    masks == 0
 
   /*
    * You should probably just read this as `suspended.compareAndSet(true, false)`.


### PR DESCRIPTION
There are 2 pieces of information needed for `unmask` to work properly. A "base" mask version (which was computed as `masks += 1; val id = masks` (the `+1` actually guards against bugs in `poll1(poll2(io))` situations)) _and_ the `ChildMaskOffset` mechanism which doesn't let child fibers be unmasked by `polls` of the parent. This is visible in the following unit test:

```scala
"only unmask within current fiber" in ticked { implicit ticker =>
  var passed = false
  val test = IO uncancelable { poll =>
    IO.uncancelable(_ => poll(IO.canceled >> IO { passed = true }))
      .start
      .flatMap(_.join)
      .void
  }

  test must completeAs(())
  passed must beTrue
}
```

This PR is an alternative to the old encoding of masks. Each fiber always starts with a mask value of 0, and is unmasked only if `masks == 0`. The `+1` for `poll1(poll2(io))` is retained. What's changed is the `UnmaskRunLoop` `IO` case, which now not only receives the `id` mask, but also a reference to the fiber which created the `Poll` object (this replaces the child mask offset). This reference is inspected and thus, unmasking is only applied when both `id` and the fiber reference match.

Is this safe to do from a GC standpoint? I'm pretty sure it is.
`Poll` is an anonymous inner class and thus implicitly captures a reference to the fiber that creates it. This is evidenced by the bytecode on `series/3.x`:
```
2374: aload         11
2376: checkcast     #71                 // class cats/effect/IO$Uncancelable
2379: astore        85
2381: aload_0
2382: aload         85
2384: invokevirtual #497                // Method cats/effect/IO$Uncancelable.event:()Lcats/effect/tracing/TracingEvent;
2387: invokespecial #319                // Method pushTracingEvent:(Lcats/effect/tracing/TracingEvent;)V
2390: aload_0
2391: aload_0
2392: getfield      #499                // Field masks:I
2395: iconst_1
2396: iadd
2397: putfield      #499                // Field masks:I
2400: aload_0
2401: getfield      #499                // Field masks:I
2404: istore        86
2406: new           #80                 // class cats/effect/IOFiber$$anon$1
2409: dup
2410: aconst_null
2411: iload         86
2413: invokespecial #502                // Method cats/effect/IOFiber$$anon$1."<init>":(Lcats/effect/IOFiber;I)V
```
Namely, in `2413: invokespecial #502                // Method cats/effect/IOFiber$$anon$1."<init>":(Lcats/effect/IOFiber;I)V` the constructor of `Poll` receives a reference to the fiber.

I want to draw attention to this code snippet:
```scala
val poll = new Poll[IO] {
  def apply[B](ioa: IO[B]) = IO.Uncancelable.UnmaskRunLoop(ioa, id, IOFiber.this)
}
```

`IOFiber.this` helps us get the implicitly captured instance of the outer `IOFiber` when the `Poll` was created. The constructor of `Poll` remains the same: `2413: invokespecial #501                // Method cats/effect/IOFiber$$anon$1."<init>":(Lcats/effect/IOFiber;I)V`. What's changed is the `apply` method of `Poll`.

```
public final class cats.effect.IOFiber$$anon$1 implements cats.effect.kernel.Poll<cats.effect.IO> {
  private final cats.effect.IOFiber $outer;

  private final int id$1;

  public <B> cats.effect.IO$Uncancelable$UnmaskRunLoop<B> apply(cats.effect.IO<B>);
    Code:
       0: new           #20                 // class cats/effect/IO$Uncancelable$UnmaskRunLoop
       3: dup
       4: aload_1
       5: aload_0
       6: getfield      #71                 // Field id$1:I
       9: aload_0
      10: getfield      #73                 // Field $outer:Lcats/effect/IOFiber;
      13: invokespecial #77                 // Method cats/effect/IO$Uncancelable$UnmaskRunLoop."<init>":(Lcats/effect/IO;ILcats/effect/IOFiber;)V
      16: areturn

  public java.lang.Object apply(java.lang.Object);
    Code:
       0: aload_0
       1: aload_1
       2: checkcast     #17                 // class cats/effect/IO
       5: invokevirtual #82                 // Method apply:(Lcats/effect/IO;)Lcats/effect/IO$Uncancelable$UnmaskRunLoop;
       8: areturn

  public cats.effect.IOFiber$$anon$1(cats.effect.IOFiber, int);
    Code:
       0: aload_1
       1: ifnonnull     6
       4: aconst_null
       5: athrow
       6: aload_0
       7: aload_1
       8: putfield      #73                 // Field $outer:Lcats/effect/IOFiber;
      11: aload_0
      12: iload_2
      13: putfield      #71                 // Field id$1:I
      16: aload_0
      17: invokespecial #87                 // Method java/lang/Object."<init>":()V
      20: aload_0
      21: invokestatic  #91                 // InterfaceMethod cats/arrow/FunctionK.$init$:(Lcats/arrow/FunctionK;)V
      24: return
}
```

You can see from `10: getfield      #73                 // Field $outer:Lcats/effect/IOFiber;`, `8: putfield      #73                 // Field $outer:Lcats/effect/IOFiber;` and `private final cats.effect.IOFiber $outer;` that the outer `IOFiber` instance is selected, the one which created the `Poll` instance.

Again, coming back to the GC question. `Poll` already had an implicit reference to `IOFiber`. If `poll` was unused, it would go out of scope and therefore the reference wouldn't be alive anymore. If `poll` is applied, it creates an `UnmaskRunLoop` instance which now does have a strong reference to the fiber. IMO, this is fine, because this `IO` case is completely internal and only exists within the runloop, where the fiber is already live. I cannot see a situation where an `UnmaskRunLoop` is created but not unpacked by the run loop. I might be wrong on this one and would love to know more. Overall, I don't think this change creates any memory leaks.

What did we get from all this? The `initMask` field is deleted, we regain 4 bytes per fiber and a lot of knowledge about how inner classes work and how `Class.this` can be (ab)used. 😋 