### PR TITLE
Fix of 2.x series tutorial paragraph about error promotion of join call

### DIFF
--- a/docs/guides/tutorial.md
+++ b/docs/guides/tutorial.md
@@ -756,7 +756,7 @@ call to `join` will forward it to the main flow. Problem is, we need to call to
 `join` first, so if for example the `consumerFiber` throws an exception while
 `producerFiber` is still running then the exception will not interrupt the main
 flow until it reaches `consumerFiber.join`. Also, a fiber throwing an error
-does not cancel the execution of the other fibers. Taking care of cancelling
+does not cancel the execution of the other fibers. Taking care of canceling
 the remaining fibers is the responsibility of the programmer.
 
 In contrast `parMapN` not only promotes errors raised by fibers to the caller, it also takes care of canceling the other fibers. This way `parMapN`

--- a/docs/guides/tutorial.md
+++ b/docs/guides/tutorial.md
@@ -759,11 +759,10 @@ flow until it reaches `consumerFiber.join`. Also, a fiber throwing an error
 does not cancel the execution of the other fibers. Taking care of cancelling
 the remaining fibers is the responsibility of the programmer.
 
-In contrast `parMapN` not only promotes errors raised by fibers to the main
-flow, it also take care of cancelling the other fibers. This way `parMapN`
-leads to simpler and more concise code. _Thus, if possible, programmers should
-prefer to use higher level commands such as `parMapN` or `parSequence` to deal
-with fibers_.
+In contrast `parMapN` not only promotes errors raised by fibers to the caller, it also takes care of canceling the other fibers. This way `parMapN`
+leads to simpler and more concise code. _Thus, unless you have some specific and
+unusual requirements you should prefer to use higher level commands such as
+`parMapN` or `parSequence` to work with fibers_.
 
 Ok, we stick to our implementation based on `.parMapN`. Are we done? Does it
 Work? Well, it works... but it is far from ideal. If we run it we will find that

--- a/docs/guides/tutorial.md
+++ b/docs/guides/tutorial.md
@@ -752,7 +752,7 @@ def run(args: List[String]): IO[ExitCode] =
 
 Note the code above does not include error handling. Errors in the underlying
 fiber are promoted by `join`, meaning that if the fiber raises an error the
-call to `join` will forward it to the main flow. Problem is, we need to call to
+call to `join` will raise the error to the caller. Problem is, we need to call
 `join` first, so if for example the `consumerFiber` raises an exception while
 `producerFiber` is still running then the exception will not interrupt the main
 flow until it reaches `consumerFiber.join`. Also, a fiber throwing an error

--- a/docs/guides/tutorial.md
+++ b/docs/guides/tutorial.md
@@ -753,7 +753,7 @@ def run(args: List[String]): IO[ExitCode] =
 Note the code above does not include error handling. Errors in the underlying
 fiber are promoted by `join`, meaning that if the fiber raises an error the
 call to `join` will forward it to the main flow. Problem is, we need to call to
-`join` first, so if for example the `consumerFiber` throws an exception while
+`join` first, so if for example the `consumerFiber` raises an exception while
 `producerFiber` is still running then the exception will not interrupt the main
 flow until it reaches `consumerFiber.join`. Also, a fiber throwing an error
 does not cancel the execution of the other fibers. Taking care of canceling

--- a/docs/guides/tutorial.md
+++ b/docs/guides/tutorial.md
@@ -757,7 +757,7 @@ call to `join` will forward it to the main flow. Problem is, we need to call to
 `producerFiber` is still running then the exception will not interrupt the main
 flow until it reaches `consumerFiber.join`. Also, a fiber throwing an error
 does not cancel the execution of the other fibers. Taking care of cancelling
-the reamining fibers is the responsability of the programmer.
+the remaining fibers is the responsibility of the programmer.
 
 In contrast `parMapN` not only promotes errors raised by fibers to the main
 flow, it also take care of cancelling the other fibers. This way `parMapN`

--- a/docs/guides/tutorial.md
+++ b/docs/guides/tutorial.md
@@ -751,7 +751,7 @@ def run(args: List[String]): IO[ExitCode] =
 ```
 
 Note the code above does not include error handling. Errors in the underlying
-fiber are promoted by `join`, meaning that if the fiber throws an error the
+fiber are promoted by `join`, meaning that if the fiber raises an error the
 call to `join` will forward it to the main flow. Problem is, we need to call to
 `join` first, so if for example the `consumerFiber` throws an exception while
 `producerFiber` is still running then the exception will not interrupt the main

--- a/docs/guides/tutorial.md
+++ b/docs/guides/tutorial.md
@@ -754,8 +754,8 @@ Note the code above does not include error handling. Errors in the underlying
 fiber are promoted by `join`, meaning that if the fiber raises an error the
 call to `join` will raise the error to the caller. Problem is, we need to call
 `join` first, so if for example the `consumerFiber` raises an exception while
-`producerFiber` is still running then the exception will not interrupt the main
-flow until it reaches `consumerFiber.join`. Also, a fiber throwing an error
+`producerFiber` is still running then the exception will not interrupt `producerFiber`
+until it reaches `consumerFiber.join`. Also, a fiber throwing an error
 does not cancel the execution of the other fibers. Taking care of canceling
 the remaining fibers is the responsibility of the programmer.
 


### PR DESCRIPTION
The tutorial contains a paragraph about `.start` and `.join` that is messy if not plainly wrong. _E.g._ see [this msg](https://discord.com/channels/632277896739946517/632278585700384799/900807315190599800) in CE discord channel.

This PR tries to fix this for the 2.x series tutorial, briefly explaining the limitations of the `.start` + `.join` approach to underscore how using `.parMapN` or `.parSequence` is generally a better choice. Resulting text can be read [here](https://lrodero.github.io/cats-effect/docs/2.x/guides/tutorial).