### PR TITLE
Fix of 3.x series tutorial paragraph about error promotion of join call

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -649,8 +649,10 @@ object InefficientProducerConsumer extends IOApp {
 
 However in most situations it is not advisable to handle fibers manually as
 they are not trivial to work with. For example, if there is an error in a fiber
-the `join` call to that fiber will _not_ hint it, it will just 'swallow' the
-error. Also, the other fibers will keep running unaware of what happened.
+the `join` call to that fiber will _not_ raise it, it will return normally and
+you must explicitly check the `Outcome` instance returned by the `.join` call to
+see if it errored. Also, the other fibers will keep running unaware of what
+happened.
 Cats Effect provides additional `joinWith` or `joinWithNever` methods to make
 sure at least that the error is raised with the usual `MonadError` semantics (e.g., short-circuiting).
 Unfortunately this is a complex task, as when we handle the error from a fiber

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -667,9 +667,9 @@ consuming resources for nothing.
  
 In contrast `parMapN` does promote the error it finds to the caller _and_ takes
 care of cancelling the remaining alive fibers. As a result `parMapN` is simpler
-to use, more concise, and easier to reason about. _Because of that, if possible,
-programmers should prefer to use higher level commands such as `parMapN` or
-`parSequence` to deal with fibers_.
+to use, more concise, and easier to reason about. _Because of that, unless you have some specific and
+unusual requirements you should prefer to use higher level commands such as
+`parMapN` or `parSequence` to work with fibers_.
 
 Ok, we stick to our implementation based on `.parMapN`. Are we done? Does it
 Work? Well, it works... but it is far from ideal. If we run it we will find that

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -651,7 +651,7 @@ However in most situations it is not advisable to handle fibers manually as
 they are not trivial to work with. For example, if there is an error in a fiber
 the `join` call to that fiber will _not_ hint it, it will just 'swallow' the
 error. Also, the other fibers will keep running unaware of what happened.
-Cats-effect 3 provides additional `joinWith` or `joinWithNever` methods to make
+Cats Effect provides additional `joinWith` or `joinWithNever` methods to make
 sure at least that the error is promoted and give us a chance to deal with it.
 Unfortunately this is a complex task, as when we handle the error from a fiber
 we must also consider if we should at least cancel the other running fibers. We

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -657,7 +657,7 @@ Cats Effect provides additional `joinWith` or `joinWithNever` methods to make
 sure at least that the error is raised with the usual `MonadError` semantics (e.g., short-circuiting).
 Unfortunately this is a complex task, as when we handle the error from a fiber
 we must also consider if we should at least cancel the other running fibers. We
-can easily get ourselves trapped in a tangled mess of fibers to keep an eye of.
+can easily get ourselves trapped in a tangled mess of fibers to keep an eye on.
 On top of that the error raised by a fiber is not promoted until the call to
 `joinWith` or `.joinWithNever` is reached. So in our example above if
 `consumerFiber` raises an error then that error will not 'reach' the main flow

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -665,7 +665,7 @@ consuming resources for nothing.
  
 In contrast `parMapN` does promote the error it finds to the caller _and_ takes
 care of cancelling the remaining alive fibers. As a result `parMapN` is simpler
-to use, more concise, and ease to reason with. _Because of that, if possible,
+to use, more concise, and easier to reason about. _Because of that, if possible,
 programmers should prefer to use higher level commands such as `parMapN` or
 `parSequence` to deal with fibers_.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -652,7 +652,7 @@ they are not trivial to work with. For example, if there is an error in a fiber
 the `join` call to that fiber will _not_ hint it, it will just 'swallow' the
 error. Also, the other fibers will keep running unaware of what happened.
 Cats Effect provides additional `joinWith` or `joinWithNever` methods to make
-sure at least that the error is promoted and give us a chance to deal with it.
+sure at least that the error is raised with the usual `MonadError` semantics (e.g., short-circuiting).
 Unfortunately this is a complex task, as when we handle the error from a fiber
 we must also consider if we should at least cancel the other running fibers. We
 can easily get ourselves trapped in a tangled mess of fibers to keep an eye of.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -647,10 +647,27 @@ object InefficientProducerConsumer extends IOApp {
 }
 ```
 
-Problem is, if there is an error in any of the fibers the `join` call will not
-hint it, nor it will return. In contrast `parMapN` does promote the error it
-finds to the caller. _In general, if possible, programmers should prefer to use
-higher level commands such as `parMapN` or `parSequence` to deal with fibers_.
+However in most situations it is not advisable to handle fibers manually as
+they are not trivial to work with. For example, if there is an error in a fiber
+the `join` call to that fiber will _not_ hint it, it will just 'swallow' the
+error. Also, the other fibers will keep running unaware of what happened.
+Cats-effect 3 provides additional `joinWith` or `joinWithNever` methods to make
+sure at least that the error is promoted and give us a chance to deal with it.
+Unfortunately this is a complex task, as when we handle the error from a fiber
+we must also consider if we should at least cancel the other running fibers. We
+can easily get ourselves trapped in a tangled mess of fibers to keep an eye of.
+On top of that the error raised by a fiber is not promoted until the call to
+`joinWith` or `.joinWithNever` is reached. So in our example above if
+`consumerFiber` raises an error then that error will not 'reach' the main flow
+until the producer fiber has finished. Note that in our example that should
+never happen!  And even if the producer fiber did finish, it would have been
+consuming resources for nothing.
+ 
+In contrast `parMapN` does promote the error it finds to the caller _and_ takes
+care of cancelling the remaining alive fibers. As a result `parMapN` is simpler
+to use, more concise, and ease to reason with. _Because of that, if possible,
+programmers should prefer to use higher level commands such as `parMapN` or
+`parSequence` to deal with fibers_.
 
 Ok, we stick to our implementation based on `.parMapN`. Are we done? Does it
 Work? Well, it works... but it is far from ideal. If we run it we will find that


### PR DESCRIPTION
The tutorial contains a paragraph about `.start` and `.join` that is messy if not plainly wrong. _E.g._ see [this msg](https://discord.com/channels/632277896739946517/632278585700384799/900807315190599800) in CE discord channel.

This PR tries to fix this for the 3.x series tutorial, briefly explaining the limitations of the `.start` + `.join` (or `joinWith` or `joinWithNever`) approach to underscore how using `.parMapN` or `.parSequence` is generally a better choice. Resulting text can be read [here](https://lrodero.github.io/cats-effect/docs/tutorial).