### PR TITLE
Remove the `InterruptibleMany` prefetch

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -25,8 +25,6 @@ import juc.atomic.{AtomicBoolean, AtomicReference}
 private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
   this: IOFiber[A] =>
 
-  private[this] val TypeInterruptibleMany = Sync.Type.InterruptibleMany
-
   /**
    * Registers the suspended fiber in the global suspended fiber bag.
    */
@@ -60,7 +58,7 @@ private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
      * 6. Action completed, finalizer unregistered
      */
 
-    val many = cur.hint eq TypeInterruptibleMany
+    val many = cur.hint eq Sync.Type.InterruptibleMany
 
     // we grab this here rather than in the instance to avoid bloating IOFiber's object header
     val RightUnit = IOFiber.RightUnit


### PR DESCRIPTION
Fixes #2451.

`interruptible` has too much overhead for this optimization to be meaningful. This change saves 4 bytes per fiber.