### PR TITLE
Add configuration forwarders to `IORuntime` and remove prefetched values in `IOFiber`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -114,7 +114,7 @@ private final class IOFiber[A](
   private[this] val IOEndFiber: IO.EndFiber.type = IO.EndFiber
 
   private[this] val tracingEvents: RingBuffer =
-    RingBuffer.empty(runtime.config.traceBufferLogSize)
+    RingBuffer.empty(runtime.traceBufferLogSize)
 
   override def run(): Unit = {
     // insert a read barrier after every async boundary
@@ -421,7 +421,7 @@ private final class IOFiber[A](
               val t = error.t
               // We need to augment the exception here because it doesn't get
               // forwarded to the `failed` path.
-              Tracing.augmentThrowable(runtime.config.enhancedExceptions, t, tracingEvents)
+              Tracing.augmentThrowable(runtime.enhancedExceptions, t, tracingEvents)
               runLoop(succeeded(Left(t), 0), nextCancelation - 1, nextAutoCede)
 
             case 2 =>
@@ -437,10 +437,7 @@ private final class IOFiber[A](
                   case NonFatal(t) =>
                     // We need to augment the exception here because it doesn't
                     // get forwarded to the `failed` path.
-                    Tracing.augmentThrowable(
-                      runtime.config.enhancedExceptions,
-                      t,
-                      tracingEvents)
+                    Tracing.augmentThrowable(runtime.enhancedExceptions, t, tracingEvents)
                     error = t
                   case t: Throwable =>
                     onFatalFailure(t)
@@ -1108,7 +1105,7 @@ private final class IOFiber[A](
     }
 
   private[this] def failed(error: Throwable, depth: Int): IO[Any] = {
-    Tracing.augmentThrowable(runtime.config.enhancedExceptions, error, tracingEvents)
+    Tracing.augmentThrowable(runtime.enhancedExceptions, error, tracingEvents)
 
     // println(s"<$name> failed() with $error")
     /*val buffer = conts.unsafeBuffer()

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -43,7 +43,7 @@ final class IORuntime private (
 
   private[effect] val suspendedFiberBag: SuspendedFiberBag = new SuspendedFiberBag()
 
-  /**
+  /*
    * Forwarder methods for `IOFiber`.
    */
   private[effect] val cancelationCheckThreshold: Int = config.cancelationCheckThreshold

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -43,6 +43,14 @@ final class IORuntime private (
 
   private[effect] val suspendedFiberBag: SuspendedFiberBag = new SuspendedFiberBag()
 
+  /**
+   * Forwarder methods for `IOFiber`.
+   */
+  private[effect] val cancelationCheckThreshold: Int = config.cancelationCheckThreshold
+  private[effect] val autoYieldThreshold: Int = config.autoYieldThreshold
+  private[effect] val enhancedExceptions: Boolean = config.enhancedExceptions
+  private[effect] val traceBufferLogSize: Int = config.traceBufferLogSize
+
   override def toString: String = s"IORuntime($compute, $scheduler, $config)"
 }
 


### PR DESCRIPTION
Since I refactored the run loop to count down from `cancelationCheckThreshold` and `autoYieldThreshold` towards 0 during an execution of a fiber, the prefetched values were only relegated to be used in `R` methods, which are executed in `run()` and before the run loop starts. These `R` methods run after async boundaries which are already expensive in terms of memory access. This PR is a compromise between heavily reduced fiber footprint (8 bytes per fiber) and slightly better access to the configuration values through 1 fewer pointer dereference.