### PR TITLE
Update to the latest GraalVM image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           - adoptium@8
           - adoptium@11
           - adoptium@17
-          - graalvm-ce-java8@21.2
+          - graalvm-ce-java11@21.3
         ci: [ciJVM, ciJS, ciFirefox, ciChrome]
         exclude:
           - ci: ciJS
@@ -36,7 +36,7 @@ jobs:
           - ci: ciJS
             java: adoptium@17
           - ci: ciJS
-            java: graalvm-ce-java8@21.2
+            java: graalvm-ce-java11@21.3
           - os: windows-latest
             scala: 3.0.2
           - os: windows-latest
@@ -48,7 +48,7 @@ jobs:
           - ci: ciFirefox
             java: adoptium@17
           - ci: ciFirefox
-            java: graalvm-ce-java8@21.2
+            java: graalvm-ce-java11@21.3
           - os: windows-latest
             scala: 3.0.2
           - os: windows-latest
@@ -60,7 +60,7 @@ jobs:
           - ci: ciChrome
             java: adoptium@17
           - ci: ciChrome
-            java: graalvm-ce-java8@21.2
+            java: graalvm-ce-java11@21.3
           - os: windows-latest
             scala: 3.0.2
           - os: windows-latest

--- a/build.sbt
+++ b/build.sbt
@@ -105,9 +105,9 @@ ThisBuild / githubWorkflowTargetBranches := Seq("series/3.*")
 
 val LTSJava = "adoptium@11"
 val LatestJava = "adoptium@17"
-val GraalVM8 = "graalvm-ce-java8@21.2"
+val GraalVM = "graalvm-ce-java11@21.3"
 
-ThisBuild / githubWorkflowJavaVersions := Seq(ScalaJSJava, LTSJava, LatestJava, GraalVM8)
+ThisBuild / githubWorkflowJavaVersions := Seq(ScalaJSJava, LTSJava, LatestJava, GraalVM)
 ThisBuild / githubWorkflowEnv += ("JABBA_INDEX" -> "https://github.com/typelevel/jdk-index/raw/main/index.json")
 ThisBuild / githubWorkflowOSes := Seq(PrimaryOS, Windows)
 


### PR DESCRIPTION
Latest GraalVM 21.3 no longer offers a JDK 8 based image.

Alternatively, we can switch to a JDK 17 image.