### PR TITLE
Allocate callback wrapper once on push

### DIFF
--- a/core/shared/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/shared/src/main/scala/cats/effect/CallbackStack.scala
@@ -23,16 +23,21 @@ import java.util.concurrent.atomic.AtomicReference
 private final class CallbackStack[A](private[this] var callback: OutcomeIO[A] => Unit)
     extends AtomicReference[CallbackStack[A]] {
 
-  @tailrec
   def push(next: OutcomeIO[A] => Unit): CallbackStack[A] = {
-    val cur = get()
     val attempt = new CallbackStack(next)
-    attempt.set(cur)
 
-    if (!compareAndSet(cur, attempt))
-      push(next)
-    else
-      attempt
+    @tailrec
+    def loop(): CallbackStack[A] = {
+      val cur = get()
+      attempt.lazySet(cur)
+
+      if (!compareAndSet(cur, attempt))
+        loop()
+      else
+        attempt
+    }
+
+    loop()
   }
 
   /**

--- a/core/shared/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/shared/src/main/scala/cats/effect/CallbackStack.scala
@@ -20,7 +20,7 @@ import scala.annotation.tailrec
 
 import java.util.concurrent.atomic.AtomicReference
 
-private[effect] final class CallbackStack[A](private[this] var callback: OutcomeIO[A] => Unit)
+private final class CallbackStack[A](private[this] var callback: OutcomeIO[A] => Unit)
     extends AtomicReference[CallbackStack[A]] {
 
   @tailrec


### PR DESCRIPTION
`@tailrec` seems to be unable to optimize this, and maybe that's fair.

`CallbackStack#push` on `series/3.x` compiles to the following bytecode:
```
public cats.effect.CallbackStack<A> push(scala.Function1<cats.effect.kernel.Outcome<cats.effect.IO, java.lang.Throwable, A>, scala.runtime.BoxedUnit>);
  Code:
      0: aload_0
      1: invokevirtual #20                 // Method get:()Ljava/lang/Object;
      4: checkcast     #2                  // class cats/effect/CallbackStack
      7: astore_3
      8: new           #2                  // class cats/effect/CallbackStack
    11: dup
    12: aload_1
    13: invokespecial #24                 // Method "<init>":(Lscala/Function1;)V
    16: astore        4
    18: aload         4
    20: aload_3
    21: invokevirtual #28                 // Method set:(Ljava/lang/Object;)V
    24: aload_0
    25: aload_3
    26: aload         4
    28: invokevirtual #32                 // Method compareAndSet:(Ljava/lang/Object;Ljava/lang/Object;)Z
    31: ifne          39
    34: aload_1
    35: astore_1
    36: goto          0
    39: aload         4
    41: areturn
```

The gist of `@tailrec` is bytecode `36: goto 0`, which just jumps back to the beginning of the method. That works as intended. However, `8: new // CallbackStack` and `11: dup` are bytecodes for allocating objects, and they are unconditional, so every time `push` fails to `compareAndSet` the `attempt` reference, it starts all over again and allocates a fresh instance every time.

This PR compiles to the following bytecode:
```
public cats.effect.CallbackStack<A> push(scala.Function1<cats.effect.kernel.Outcome<cats.effect.IO, java.lang.Throwable, A>, scala.runtime.BoxedUnit>);
Code:
    0: new           #2                  // class cats/effect/CallbackStack
    3: dup
    4: aload_1
    5: invokespecial #20                 // Method "<init>":(Lscala/Function1;)V
    8: astore_2
    9: aload_0
    10: aload_2
    11: invokespecial #24                 // Method loop$1:(Lcats/effect/CallbackStack;)Lcats/effect/CallbackStack;
    14: areturn

private final cats.effect.CallbackStack loop$1(cats.effect.CallbackStack);
  Code:
      0: aload_0
      1: invokevirtual #48                 // Method get:()Ljava/lang/Object;
      4: checkcast     #2                  // class cats/effect/CallbackStack
      7: astore_3
      8: aload_1
      9: aload_3
    10: invokevirtual #59                 // Method lazySet:(Ljava/lang/Object;)V
    13: aload_0
    14: aload_3
    15: aload_1
    16: invokevirtual #63                 // Method compareAndSet:(Ljava/lang/Object;Ljava/lang/Object;)Z
    19: ifne          25
    22: goto          0
    25: aload_1
    26: areturn

```

The `attempt` instance is allocated before the loop, and passed to it as an argument.