### PR TITLE
Enable creating `IOLocal` in `SyncIO`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOLocal.scala
+++ b/core/shared/src/main/scala/cats/effect/IOLocal.scala
@@ -40,7 +40,7 @@ object IOLocal {
 
   def inSyncIO[A](default: A): SyncIO[IOLocal[A]] = in[SyncIO, A](default)
 
-  def in[F[_], A](default: A)(implicit F: Sync[F]): F[IOLocal[A]] =
+  private def in[F[_], A](default: A)(implicit F: Sync[F]): F[IOLocal[A]] =
     F delay {
       new IOLocal[A] { self =>
         override def get: IO[A] =

--- a/core/shared/src/main/scala/cats/effect/IOLocal.scala
+++ b/core/shared/src/main/scala/cats/effect/IOLocal.scala
@@ -36,8 +36,12 @@ sealed trait IOLocal[A] {
 
 object IOLocal {
 
-  def apply[A](default: A): IO[IOLocal[A]] =
-    IO {
+  def apply[A](default: A): IO[IOLocal[A]] = in[IO, A](default)
+
+  def inSyncIO[A](default: A): SyncIO[IOLocal[A]] = in[SyncIO, A](default)
+
+  def in[F[_], A](default: A)(implicit F: Sync[F]): F[IOLocal[A]] =
+    F delay {
       new IOLocal[A] { self =>
         override def get: IO[A] =
           IO.Local(state => (state, state.get(self).map(_.asInstanceOf[A]).getOrElse(default)))


### PR DESCRIPTION
Not gonna lie, I want this so I can use `SyncIO` to do unsafe things 😆

But, having these sort of `in` constructors seems standard in CE3.