### PR TITLE
Monitor suspended fibers on all platforms

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -16,20 +16,12 @@
 
 package cats.effect
 
-import scala.annotation.nowarn
 import scala.concurrent.ExecutionContext
 
 import java.util.concurrent.atomic.AtomicBoolean
 
 private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
   this: IOFiber[A] =>
-
-  /**
-   * Registers the suspended fiber in the global suspended fiber bag and sets the suspension key
-   * object reference.
-   */
-  @nowarn("cat=unused-params")
-  protected final def monitor(key: AnyRef): Unit = {}
 
   // in theory this code should never be hit due to the override in IOCompanionPlatform
   def interruptibleImpl(cur: IO.Blocking[Any], blockingEc: ExecutionContext): IO[Any] = {

--- a/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -31,12 +31,6 @@ private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
   @nowarn("cat=unused-params")
   protected final def monitor(key: AnyRef): Unit = {}
 
-  /**
-   * Deregisters the suspended fiber from the global suspended fiber bag and clears the
-   * suspension key object reference.
-   */
-  protected final def unmonitor(): Unit = {}
-
   // in theory this code should never be hit due to the override in IOCompanionPlatform
   def interruptibleImpl(cur: IO.Blocking[Any], blockingEc: ExecutionContext): IO[Any] = {
     val _ = blockingEc

--- a/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
@@ -31,15 +31,6 @@ private[effect] sealed abstract class SuspendedFiberBag {
    *   the suspended fiber to be registered
    */
   def monitor(key: AnyRef, fiber: IOFiber[_]): Unit
-
-  /**
-   * Deregisters a resumed fiber, tracked by the provided key which is an opaque object which
-   * uses reference equality for comparison.
-   *
-   * @param key
-   *   an opaque identifier for the resumed fiber
-   */
-  def unmonitor(key: AnyRef): Unit
 }
 
 /**
@@ -51,8 +42,6 @@ private final class ES2021SuspendedFiberBag extends SuspendedFiberBag {
   override def monitor(key: AnyRef, fiber: IOFiber[_]): Unit = {
     bag.set(key, new js.WeakRef(fiber))
   }
-
-  override def unmonitor(key: AnyRef): Unit = ()
 }
 
 /**
@@ -61,7 +50,6 @@ private final class ES2021SuspendedFiberBag extends SuspendedFiberBag {
  */
 private final class NoOpSuspendedFiberBag extends SuspendedFiberBag {
   override def monitor(key: AnyRef, fiber: IOFiber[_]): Unit = ()
-  override def unmonitor(key: AnyRef): Unit = ()
 }
 
 private[effect] object SuspendedFiberBag {

--- a/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -25,14 +25,6 @@ import juc.atomic.{AtomicBoolean, AtomicReference}
 private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
   this: IOFiber[A] =>
 
-  /**
-   * Registers the suspended fiber in the global suspended fiber bag.
-   */
-  protected final def monitor(key: AnyRef): Unit = {
-    val fiber = this
-    fiber.runtimeForwarder.suspendedFiberBag.monitor(key, fiber)
-  }
-
   protected final def interruptibleImpl(
       cur: IO.Blocking[Any],
       blockingEc: ExecutionContext): IO[Any] = {

--- a/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -33,15 +33,6 @@ private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
     fiber.runtimeForwarder.suspendedFiberBag.monitor(key, fiber)
   }
 
-  /**
-   * Deregisters the suspended fiber from the global suspended fiber bag.
-   *
-   * @note
-   *   This method is a no-op because this functionality is native to `java.util.WeakHashMap`
-   *   and we rely on the GC automatically clearing the resumed fibers from the data structure.
-   */
-  protected final def unmonitor(): Unit = {}
-
   protected final def interruptibleImpl(
       cur: IO.Blocking[Any],
       blockingEc: ExecutionContext): IO[Any] = {

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
@@ -17,8 +17,6 @@
 package cats.effect
 package unsafe
 
-import scala.annotation.nowarn
-
 import java.lang.ref.WeakReference
 import java.util.{Collections, Map, WeakHashMap}
 import java.util.concurrent.ThreadLocalRandom
@@ -41,10 +39,6 @@ import java.util.concurrent.ThreadLocalRandom
  *      mechanism, we need several instances of these synchronized `WeakHashMap`s just to reduce
  *      contention between threads. A particular instance is selected using a thread local
  *      source of randomness using an instance of `java.util.concurrent.ThreadLocalRandom`.
- *
- * @note
- *   The `unmonitor` method is a no-op, but it needs to exist to keep source compatibility with
- *   Scala.js. The removal of a resumed fiber is done automatically by the GC.
  */
 private[effect] final class SuspendedFiberBag {
 
@@ -74,18 +68,6 @@ private[effect] final class SuspendedFiberBag {
     val idx = rnd.nextInt(size)
     bags(idx).put(key, new WeakReference(fiber))
     ()
-  }
-
-  /**
-   * Deregisters a resumed fiber, tracked by the provided key which is an opaque object which
-   * uses reference equality for comparison.
-   *
-   * @param key
-   *   an opaque identifier for the resumed fiber
-   */
-  @nowarn("cat=unused-params")
-  def unmonitor(key: AnyRef): Unit = {
-    // no-op
   }
 }
 

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1022,8 +1022,7 @@ private final class IOFiber[A](
    * Registers the suspended fiber in the global suspended fiber bag.
    */
   private[this] def monitor(key: AnyRef): Unit = {
-    val fiber = this
-    runtime.suspendedFiberBag.monitor(key, fiber)
+    runtime.suspendedFiberBag.monitor(key, this)
   }
 
   /* can return null, meaning that no CallbackStack needs to be later invalidated */

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1018,7 +1018,13 @@ private final class IOFiber[A](
   private[this] def suspend(): Unit =
     suspended.set(true)
 
-  private[effect] def runtimeForwarder: IORuntime = runtime
+  /**
+   * Registers the suspended fiber in the global suspended fiber bag.
+   */
+  private[this] def monitor(key: AnyRef): Unit = {
+    val fiber = this
+    runtime.suspendedFiberBag.monitor(key, fiber)
+  }
 
   /* can return null, meaning that no CallbackStack needs to be later invalidated */
   private def registerListener(listener: OutcomeIO[A] => Unit): CallbackStack[A] = {

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -142,7 +142,6 @@ private final class IOFiber[A](
       if (resume()) {
         /* ...it was! was it masked? */
         if (isUnmasked()) {
-          unmonitor()
           /* ...nope! take over the target fiber's runloop and run the finalizers */
           // println(s"<$name> running cancelation (finalizers.length = ${finalizers.unsafeIndex()})")
 
@@ -595,7 +594,6 @@ private final class IOFiber[A](
                 // `resume()` is a volatile read of `suspended` through which
                 // `wasFinalizing` is published
                 if (finalizing == state.wasFinalizing) {
-                  unmonitor()
                   val ec = currentCtx
                   if (!shouldFinalize()) {
                     /* we weren't canceled or completed, so schedule the runloop for execution */
@@ -740,7 +738,6 @@ private final class IOFiber[A](
                */
               if (resume()) {
                 if (shouldFinalize()) {
-                  unmonitor()
                   val fin = prepareFiberForCancelation(null)
                   runLoop(fin, nextCancelation, nextAutoCede)
                 } else {


### PR DESCRIPTION
All our supported platforms have reached feature parity, thanks to the awesome work of @armanbilge. It's time to monitor the suspended fibers on JS too, as well as get rid of some unnecessary methods. Furthermore, move everything under `IOFiber`, which we prefer because we like `invokespecial` `private[this] def monitor()` instead of `invokevirtual` `protected def monitor()`.