### PR TITLE
Disable JS SuspendedFiberBag in production

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
@@ -18,6 +18,8 @@ package cats.effect
 package unsafe
 
 import scala.scalajs.js
+import scala.scalajs.LinkingInfo
+
 
 private[effect] sealed abstract class SuspendedFiberBag {
 
@@ -66,7 +68,7 @@ private final class NoOpSuspendedFiberBag extends SuspendedFiberBag {
 
 private[effect] object SuspendedFiberBag {
   def apply(): SuspendedFiberBag =
-    if (IterableWeakMap.isAvailable)
+    if (LinkingInfo.developmentMode && IterableWeakMap.isAvailable)
       new ES2021SuspendedFiberBag
     else
       new NoOpSuspendedFiberBag

--- a/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/SuspendedFiberBag.scala
@@ -20,7 +20,6 @@ package unsafe
 import scala.scalajs.js
 import scala.scalajs.LinkingInfo
 
-
 private[effect] sealed abstract class SuspendedFiberBag {
 
   /**


### PR DESCRIPTION
Forgot to do this. If there's any doubt, we've already disabled tracing in production which makes the fiberbag pretty useless anyway :)