### PR TITLE
Cherry pick documentation changes

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,9 +8,11 @@ Everyone is expected to follow the [Scala Code of Conduct] when discussing the p
 
 Any questions, concerns, or moderation requests please contact a member of the project.
 
-- Ross A. Baker [gitter](https://gitter.im/rossabaker) | [twitter](https://twitter.com/rossabaker) | [email](mailto:ross@rossabaker.com)
-- Christopher Davenport [gitter](https://gitter.im/christopherdavenport) | [twitter](https://twitter.com/davenpcm) | [email](mailto:chris@christopherdavenport.tech)
-- Alexandru Nedelcu: [gitter](https://gitter.im/alexandru) | [twitter](https://twitter.com/alexelcu) | [email](mailto:y20+coc@alexn.org)
-- Daniel Spiewak: [gitter](https://gitter.im/djspiewak) | [twitter](https://twitter.com/djspiewak) | [email](mailto:djspiewak@gmail.com)
+- Ross A. Baker | [twitter](https://twitter.com/rossabaker) | [email](mailto:ross@rossabaker.com)
+- Christopher Davenport | [twitter](https://twitter.com/davenpcm) | [email](mailto:chris@christopherdavenport.tech)
+- Alexandru Nedelcu | [twitter](https://twitter.com/alexelcu) | [email](mailto:y20+coc@alexn.org)
+- Daniel Spiewak | [twitter](https://twitter.com/djspiewak) | [email](mailto:djspiewak@gmail.com)
+
+And of course, always feel free to reach out to anyone with the **mods** role in [Discord](https://discord.gg/QNnHKHq5Ts).
 
 [Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If you follow these rules, and you use libraries and frameworks which also follo
 
 [The benchmark](https://github.com/typelevel/cats-effect/blob/220d0106ca0ff6106746a41504b6ab07d8fc9199/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala) measures the performance of a typical "disruptor pattern" application written using a fixed thread pool (from `java.util.concurrent.Executors`) compared to the same workflow implemented using Cats Effect (specifically version 3.0). The scores are not a typo: Cats Effect is *almost 55x faster* than the typical disruptor-style, hand-tuned implementation. Similarly dramatic results are consistently observed when comparing Cats Effect with other popular asynchronous and functional frameworks.
 
-As always, benchmarks are one thing, and your application is its own special snowflake with its own performance profile. Always measure and test *your application* before assuming that someone else's performance results apply in your use-case. When in doubt, [come talk with us](https://gitter.im/typelevel/cats-effect) and we'll give you an honest opinion!
+As always, benchmarks are one thing, and your application is its own special snowflake with its own performance profile. Always measure and test *your application* before assuming that someone else's performance results apply in your use-case. When in doubt, [come talk with us](https://discord.gg/QNnHKHq5Ts) and we'll give you an honest opinion!
 
 ## Abstraction
 
@@ -128,7 +128,7 @@ And, just as with arithmetic, even when you don't directly leverage the nature o
 
 ## Contributing
 
-There's always lots to do! This is an incredibly exciting project used by countless teams and companies around the world. Ask in the [Gitter channel](https://gitter.im/typelevel/cats-effect-dev) if you are unsure where to begin, or check out our [issue tracker](https://github.com/typelevel/cats-effect/issues) and try your hand at something that looks interesting! Please note that all of the Cats Effect maintainers are, unfortunately, extremely busy most of the time, so don't get discouraged if you don't get a response right away! We love you and we want you to join us, we just may have our hair on fire inside a melting production server at the exact moment you asked.
+There's always lots to do! This is an incredibly exciting project used by countless teams and companies around the world. Ask in the [Discord development channel](https://discord.gg/QNnHKHq5Ts) (make sure to select the **dev** role in the **role-selection** channel) if you are unsure where to begin, or check out our [issue tracker](https://github.com/typelevel/cats-effect/issues) and try your hand at something that looks interesting! Please note that all of the Cats Effect maintainers are, unfortunately, extremely busy most of the time, so don't get discouraged if you don't get a response right away! We love you and we want you to join us, we just may have our hair on fire inside a melting production server at the exact moment you asked.
 
 Cats Effect is built with [sbt](https://github.com/sbt/sbt), and you should be able to jump right in by running `sbt test`. I will note, however, that `sbt +test` takes about two hours on my laptop, so you probably *shouldn't* start there...
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 
 ## Getting Started
 
-- Wired: **3.2.5**
+- Wired: **3.2.8**
 - Tired: **2.5.3**
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-effect" % "3.2.5"
+libraryDependencies += "org.typelevel" %% "cats-effect" % "3.2.8"
 ```
 
 The above represents the core, stable dependency which brings in the entirety of Cats Effect. This is *most likely* what you want. All current Cats Effect releases are published for Scala 2.12, 2.13, 3.0.0-RC2 and RC3, and ScalaJS 1.5.x.
@@ -30,22 +30,22 @@ Depending on your use-case, you may want to consider one of the several other mo
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats-effect-kernel" % "3.2.5",
-  "org.typelevel" %% "cats-effect-laws"   % "3.2.5" % Test)
+  "org.typelevel" %% "cats-effect-kernel" % "3.2.8",
+  "org.typelevel" %% "cats-effect-laws"   % "3.2.8" % Test)
 ```
 
 If you're a middleware framework (like fs2), you probably want to depend on **std**, which gives you access to `Queue`, `Semaphore`, and much more without introducing a hard-dependency on `IO` outside of your tests:
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats-effect-std" % "3.2.5",
-  "org.typelevel" %% "cats-effect"     % "3.2.5" % Test)
+  "org.typelevel" %% "cats-effect-std" % "3.2.8",
+  "org.typelevel" %% "cats-effect"     % "3.2.8" % Test)
 ```
 
 You may also find some utility in the **testkit** and **kernel-testkit** projects, which contain `TestContext`, generators for `IO`, and a few other things:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-effect-testkit" % "3.2.5" % Test
+libraryDependencies += "org.typelevel" %% "cats-effect-testkit" % "3.2.8" % Test
 ```
 
 Cats Effect provides backward binary compatibility within the 2.x and 3.x version lines, and both forward and backward compatibility within any major/minor line. This is analogous to the versioning scheme used by Cats itself, as well as other major projects such as ScalaJS. Thus, any project depending upon Cats Effect 2.2.1 can be used with libraries compiled against Cats Effect 2.0.0 or 2.2.3, but *not* with libraries compiled against 2.3.0 or higher.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 
 ## Getting Started
 
-- Wired: **3.2.8**
-- Tired: **2.5.3**
+- Wired: **3.2.9**
+- Tired: **2.5.4**
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-effect" % "3.2.8"
+libraryDependencies += "org.typelevel" %% "cats-effect" % "3.2.9"
 ```
 
 The above represents the core, stable dependency which brings in the entirety of Cats Effect. This is *most likely* what you want. All current Cats Effect releases are published for Scala 2.12, 2.13, 3.0.0-RC2 and RC3, and ScalaJS 1.5.x.
@@ -30,22 +30,22 @@ Depending on your use-case, you may want to consider one of the several other mo
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats-effect-kernel" % "3.2.8",
-  "org.typelevel" %% "cats-effect-laws"   % "3.2.8" % Test)
+  "org.typelevel" %% "cats-effect-kernel" % "3.2.9",
+  "org.typelevel" %% "cats-effect-laws"   % "3.2.9" % Test)
 ```
 
 If you're a middleware framework (like fs2), you probably want to depend on **std**, which gives you access to `Queue`, `Semaphore`, and much more without introducing a hard-dependency on `IO` outside of your tests:
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats-effect-std" % "3.2.8",
-  "org.typelevel" %% "cats-effect"     % "3.2.8" % Test)
+  "org.typelevel" %% "cats-effect-std" % "3.2.9",
+  "org.typelevel" %% "cats-effect"     % "3.2.9" % Test)
 ```
 
 You may also find some utility in the **testkit** and **kernel-testkit** projects, which contain `TestContext`, generators for `IO`, and a few other things:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-effect-testkit" % "3.2.8" % Test
+libraryDependencies += "org.typelevel" %% "cats-effect-testkit" % "3.2.9" % Test
 ```
 
 Cats Effect provides backward binary compatibility within the 2.x and 3.x version lines, and both forward and backward compatibility within any major/minor line. This is analogous to the versioning scheme used by Cats itself, as well as other major projects such as ScalaJS. Thus, any project depending upon Cats Effect 2.2.1 can be used with libraries compiled against Cats Effect 2.0.0 or 2.2.3, but *not* with libraries compiled against 2.3.0 or higher.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ title: Getting Started
 Add the following to your **build.sbt**:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-effect" % "3.2.8"
+libraryDependencies += "org.typelevel" %% "cats-effect" % "3.2.9"
 ```
 
 Naturally, if you're using ScalaJS, you should replace the double `%%` with a triple `%%%`. If you're on Scala 2, it is *highly* recommended that you enable the [better-monadic-for](https://github.com/oleg-py/better-monadic-for) plugin, which fixes a number of surprising elements of the `for`-comprehension syntax in the Scala language:
@@ -62,7 +62,7 @@ We will learn more about constructs like `start` and `*>` in later pages, but fo
 Of course, the easiest way to play with Cats Effect is to try it out in a Scala REPL. We recommend using [Ammonite](https://ammonite.io/#Ammonite-REPL) for this kind of thing. To get started, run the following lines (if not using Ammonite, skip the first line and make sure that Cats Effect and its dependencies are correctly configured on the classpath):
 
 ```scala
-import $ivy.`org.typelevel::cats-effect:3.2.8`
+import $ivy.`org.typelevel::cats-effect:3.2.9`
 
 import cats.effect.unsafe.implicits._ 
 import cats.effect.IO 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,7 @@ import scala.concurrent.duration._
 
 // obviously this isn't actually the problem definition, but it's kinda fun
 object StupidFizzBuzz extends IOApp.Simple {
-  val run = 
+  val run =
     for {
       ctr <- IO.ref(0)
 
@@ -64,21 +64,25 @@ Of course, the easiest way to play with Cats Effect is to try it out in a Scala 
 ```scala
 import $ivy.`org.typelevel::cats-effect:3.2.9`
 
-import cats.effect.unsafe.implicits._ 
-import cats.effect.IO 
+import cats.effect.unsafe.implicits._
+import cats.effect.IO
 
-val program = IO.println("Hello, World!") 
-program.unsafeRunSync() 
+val program = IO.println("Hello, World!")
+program.unsafeRunSync()
 ```
 
 Congratulations, you've just run your first `IO` within the REPL! The `unsafeRunSync()` function is not meant to be used within a normal application. As the name suggests, its implementation is unsafe in several ways, but it is very useful for REPL-based experimentation and sometimes useful for testing.
 
 ## Testing
 
+### Munit
+
+[![munit-cats-effect Scala version support](https://index.scala-lang.org/typelevel/munit-cats-effect/munit-cats-effect-3/latest-by-scala-version.svg)](https://index.scala-lang.org/typelevel/munit-cats-effect/munit-cats-effect)
+
 The easiest way to write unit tests which use Cats Effect is with [MUnit](https://scalameta.org/munit/) and [MUnit Cats Effect](https://github.com/typelevel/munit-cats-effect). To get started, add the following to your **build.sbt**:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "munit-cats-effect-3" % "1.0.3" % Test
+libraryDependencies += "org.typelevel" %% "munit-cats-effect-3" % "x.y.z" % Test
 ```
 
 With this dependency, you can now write unit tests which directly return `IO` programs without being forced to run them using one of the `unsafe` functions. This is particularly useful if you're either using ScalaJS (where the fact that the `unsafe` functions block the event dispatcher would result in deadlock), or if you simply want your tests to run more efficiently (since MUnit can run them in parallel):
@@ -96,9 +100,40 @@ class ExampleSuite extends CatsEffectSuite {
 }
 ```
 
+### Weaver-test
+
+[![weaver-cats Scala version support](https://index.scala-lang.org/disneystreaming/weaver-test/weaver-cats/latest-by-scala-version.svg)](https://index.scala-lang.org/disneystreaming/weaver-test/weaver-cats)
+
+[Weaver](https://github.com/disneystreaming/weaver-test) is a test-framework build directly on top of cats-effect. It is designed specifically to handle thousands of tests exercising I/O layers (http, database calls) concurrently. Weaver makes heavy use of the concurrency constructs and abstractions provided by cats-effect to safely share resources (clients) across tests and suite, and runs all tests in parallel by default.
+
+To get started, add the following to your **build.sbt**:
+
+```scala
+libraryDependencies += "com.disneystreaming" %% "weaver-cats" % "x.y.z" % Test
+testFrameworks += new TestFramework("weaver.framework.CatsEffect")
+```
+
+Similarly to MUnit, this setup allows you to write your tests directly against `IO`.
+
+```scala
+import cats.effect.IO
+import weaver._
+
+class ExampleSuite extends SimpleIOSuite {
+  test("make sure IO computes the right result") {
+    IO.pure(1).map(_ + 2) map { result =>
+      expect.eql(result, 3)
+    }
+  }
+}
+```
+
+
 ### Other Testing Frameworks
 
-If MUnit isn't your speed, the [Cats Effect Testing](https://github.com/typelevel/cats-effect-testing) library provides seamless integration with most major test frameworks. Specifically:
+[![core Scala version support](https://index.scala-lang.org/typelevel/cats-effect-testing/core/latest-by-scala-version.svg)](https://index.scala-lang.org/typelevel/cats-effect-testing/core)
+
+If neither MUnit nor Weaver are your speed, the [Cats Effect Testing](https://github.com/typelevel/cats-effect-testing) library provides seamless integration with most major test frameworks. Specifically:
 
 - ScalaTest
 - Specs2
@@ -108,7 +143,7 @@ If MUnit isn't your speed, the [Cats Effect Testing](https://github.com/typeleve
 Simply add a dependency on the module which is appropriate to your test framework of choice. For example, Specs2:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-effect-testing-specs2" % "1.1.1" % Test
+libraryDependencies += "org.typelevel" %% "cats-effect-testing-specs2" % "x.y.z" % Test
 ```
 
 Once this is done, you can write specifications in the familiar Specs2 style, except where each example may now return in `IO`:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ title: Getting Started
 Add the following to your **build.sbt**:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-effect" % "3.2.5"
+libraryDependencies += "org.typelevel" %% "cats-effect" % "3.2.8"
 ```
 
 Naturally, if you're using ScalaJS, you should replace the double `%%` with a triple `%%%`. If you're on Scala 2, it is *highly* recommended that you enable the [better-monadic-for](https://github.com/oleg-py/better-monadic-for) plugin, which fixes a number of surprising elements of the `for`-comprehension syntax in the Scala language:
@@ -62,7 +62,7 @@ We will learn more about constructs like `start` and `*>` in later pages, but fo
 Of course, the easiest way to play with Cats Effect is to try it out in a Scala REPL. We recommend using [Ammonite](https://ammonite.io/#Ammonite-REPL) for this kind of thing. To get started, run the following lines (if not using Ammonite, skip the first line and make sure that Cats Effect and its dependencies are correctly configured on the classpath):
 
 ```scala
-import $ivy.`org.typelevel::cats-effect:3.2.5`
+import $ivy.`org.typelevel::cats-effect:3.2.8`
 
 import cats.effect.unsafe.implicits._ 
 import cats.effect.IO 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,7 +82,7 @@ Congratulations, you've just run your first `IO` within the REPL! The `unsafeRun
 The easiest way to write unit tests which use Cats Effect is with [MUnit](https://scalameta.org/munit/) and [MUnit Cats Effect](https://github.com/typelevel/munit-cats-effect). To get started, add the following to your **build.sbt**:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "munit-cats-effect-3" % "x.y.z" % Test
+libraryDependencies += "org.typelevel" %% "munit-cats-effect-3" % "1.0.6" % Test
 ```
 
 With this dependency, you can now write unit tests which directly return `IO` programs without being forced to run them using one of the `unsafe` functions. This is particularly useful if you're either using ScalaJS (where the fact that the `unsafe` functions block the event dispatcher would result in deadlock), or if you simply want your tests to run more efficiently (since MUnit can run them in parallel):
@@ -109,7 +109,7 @@ class ExampleSuite extends CatsEffectSuite {
 To get started, add the following to your **build.sbt**:
 
 ```scala
-libraryDependencies += "com.disneystreaming" %% "weaver-cats" % "x.y.z" % Test
+libraryDependencies += "com.disneystreaming" %% "weaver-cats" % "0.7.6" % Test
 testFrameworks += new TestFramework("weaver.framework.CatsEffect")
 ```
 
@@ -143,7 +143,7 @@ If neither MUnit nor Weaver are your speed, the [Cats Effect Testing](https://gi
 Simply add a dependency on the module which is appropriate to your test framework of choice. For example, Specs2:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-effect-testing-specs2" % "x.y.z" % Test
+libraryDependencies += "org.typelevel" %% "cats-effect-testing-specs2" % "1.2.0" % Test
 ```
 
 Once this is done, you can write specifications in the familiar Specs2 style, except where each example may now return in `IO`:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -104,7 +104,7 @@ class ExampleSuite extends CatsEffectSuite {
 
 [![weaver-cats Scala version support](https://index.scala-lang.org/disneystreaming/weaver-test/weaver-cats/latest-by-scala-version.svg)](https://index.scala-lang.org/disneystreaming/weaver-test/weaver-cats)
 
-[Weaver](https://github.com/disneystreaming/weaver-test) is a test-framework build directly on top of cats-effect. It is designed specifically to handle thousands of tests exercising I/O layers (http, database calls) concurrently. Weaver makes heavy use of the concurrency constructs and abstractions provided by cats-effect to safely share resources (clients) across tests and suite, and runs all tests in parallel by default.
+[Weaver](https://github.com/disneystreaming/weaver-test) is a test-framework built directly on top of Cats Effect. It is designed specifically to handle thousands of tests exercising I/O layers (http, database calls) concurrently. Weaver makes heavy use of the concurrency constructs and abstractions provided by Cats Effect to safely share resources (clients) across tests and suite, and runs all tests in parallel by default.
 
 To get started, add the following to your **build.sbt**:
 
@@ -119,7 +119,7 @@ Similarly to MUnit, this setup allows you to write your tests directly against `
 import cats.effect.IO
 import weaver._
 
-class ExampleSuite extends SimpleIOSuite {
+object ExampleSuite extends SimpleIOSuite {
   test("make sure IO computes the right result") {
     IO.pure(1).map(_ + 2) map { result =>
       expect.eql(result, 3)

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -23,7 +23,7 @@ to 3.0.0.
 
 ### 🤔 Need Help?
 
-If any point of the migration turns out to be difficult and you feel like you need help, feel free to [explain your problem on Gitter](https://gitter.im/typelevel/cats-effect) and we will do our best to assist you.
+If any point of the migration turns out to be difficult and you feel like you need help, feel free to [explain your problem in Discord](https://discord.gg/QNnHKHq5Ts) and we will do our best to assist you.
 If you spot a mistake in the guide or the library itself, you can [report an issue on GitHub](https://github.com/typelevel/cats-effect/issues/new)
 or [fix it with a pull request](https://github.com/typelevel/cats-effect/compare).
 

--- a/docs/scaling-and-tuning/system-properties.md
+++ b/docs/scaling-and-tuning/system-properties.md
@@ -1,0 +1,30 @@
+---
+id: system-properties
+title: System Properties
+---
+# System properties
+
+There are some properties configurable from system properties.
+
+## JVM
+You can set these properties via JVM arguments.
+```
+-Dcats.effect.propName=propValue
+```
+
+|Property|Value(default)|Description|CE version |
+|---|---|---|---|
+|cats.effect.logNonDaemonThreadsOnExit| Boolean(true)| Whether or not we should check for non-daemon threads on jvm exit. |3|
+|cats.effect.logNonDaemonThreads.sleepIntervalMillis|Long(10000L)|Time to sleep between checking for non-daemon threads present|3|
+|cats.effect.cancelation.check.threshold|Int(512)|configure how often cancellation is checked. By default, Every 512 iteration of the run loop.|3|
+|cats.effect.auto.yield.threshold.multiplier|Int(2)|This property determinses auto-yield threshold in combination with cancellation check threshold. Auto-yield threshold is product of them. About auto-yielding, see [thread-model](../thread-model.md).|3|
+|cats.effect.tracing.exceptions.enhanced|Boolean(true)|Augment the stack traces of caught exceptions to include frames from the asynchronous stack traces. For further information, visit [tracing](../tracing.md) page|2, 3|
+|cats.effect.tracing.buffer.size|Int(16)|Initial tracing buffer size is 2 by the power of this value. Thus, 2^16 by default.|2, 3|
+
+## JS
+You can set these properties via environment variables.
+
+|Property|Value(default)|Description|CE version|
+|---|---|---|---|
+|CATS_EFFECT_TRACING_MODE|"cached"\|"full"("cached")|Configure tracing mode.|3|
+|REACT_APP_CATS_EFFECT_TRACING_MODE|"cached"\|"full"("cached")|Alias for CATS_EFFECT_TRACING_MODE in react app|3|

--- a/docs/scaling-and-tuning/system-properties.md
+++ b/docs/scaling-and-tuning/system-properties.md
@@ -12,19 +12,12 @@ You can set these properties via JVM arguments.
 -Dcats.effect.propName=propValue
 ```
 
-|Property|Value(default)|Description|CE version |
-|---|---|---|---|
-|cats.effect.logNonDaemonThreadsOnExit| Boolean(true)| Whether or not we should check for non-daemon threads on jvm exit. |3|
-|cats.effect.logNonDaemonThreads.sleepIntervalMillis|Long(10000L)|Time to sleep between checking for non-daemon threads present|3|
-|cats.effect.cancelation.check.threshold|Int(512)|configure how often cancellation is checked. By default, Every 512 iteration of the run loop.|3|
-|cats.effect.auto.yield.threshold.multiplier|Int(2)|This property determinses auto-yield threshold in combination with cancellation check threshold. Auto-yield threshold is product of them. About auto-yielding, see [thread-model](../thread-model.md).|3|
-|cats.effect.tracing.exceptions.enhanced|Boolean(true)|Augment the stack traces of caught exceptions to include frames from the asynchronous stack traces. For further information, visit [tracing](../tracing.md) page|2, 3|
-|cats.effect.tracing.buffer.size|Int(16)|Initial tracing buffer size is 2 by the power of this value. Thus, 2^16 by default.|2, 3|
+|Property|Value(default)|Description|
+|---|---|---|
+|cats.effect.logNonDaemonThreadsOnExit| Boolean(true)| Whether or not we should check for non-daemon threads on jvm exit. |
+|cats.effect.logNonDaemonThreads.sleepIntervalMillis|Long(10000L)|Time to sleep between checking for non-daemon threads present|
+|cats.effect.cancelation.check.threshold|Int(512)|configure how often cancellation is checked. By default, Every 512 iteration of the run loop.|
+|cats.effect.auto.yield.threshold.multiplier|Int(2)|This property determinses auto-yield threshold in combination with cancellation check threshold. Auto-yield threshold is product of them. About auto-yielding, see [thread-model](../thread-model.md).|
+|cats.effect.tracing.exceptions.enhanced|Boolean(true)|Augment the stack traces of caught exceptions to include frames from the asynchronous stack traces. For further information, visit [tracing](../tracing.md) page|
+|cats.effect.tracing.buffer.size|Int(16)|Initial tracing buffer size is 2 by the power of this value. Thus, 2^16 by default.|
 
-## JS
-You can set these properties via environment variables.
-
-|Property|Value(default)|Description|CE version|
-|---|---|---|---|
-|CATS_EFFECT_TRACING_MODE|"cached"\|"full"("cached")|Configure tracing mode.|3|
-|REACT_APP_CATS_EFFECT_TRACING_MODE|"cached"\|"full"("cached")|Alias for CATS_EFFECT_TRACING_MODE in react app|3|

--- a/docs/schedulers.md
+++ b/docs/schedulers.md
@@ -59,14 +59,14 @@ While JavaScript runtimes are single-threaded, and thus do not have the *m:n* pr
 
 Ultimately, though, `IO` is able to achieve this with exceptionally high performance, and without interfering with other mechanisms which leverage the event loop (such as animations in the browser or I/O on the server). The techniques which are used by `IO` to achieve this run across all platforms which support ScalaJS. However, optimal performance is available only in the following environments:
 
-- NodeJS 0.9.1+
-- [Any browser providing `window.postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#browser_compatibility), including:
+- [NodeJS 0.9.1+](https://nodejs.org/api/timers.html#timers_setimmediate_callback_args)
+- [Any browser implementing `window.postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#browser_compatibility), including:
   - Chrome 1+
   - Safari 4+
   - Internet Explorer 9+ (including Edge)
   - Firefox 3+
   - Opera 9.5+
-- Web Workers [in all major browsers](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel#browser_compatibility)
+- [Web Workers implementing `MessageChannel`](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel#browser_compatibility)
 
 ### Yielding
 

--- a/docs/schedulers.md
+++ b/docs/schedulers.md
@@ -59,12 +59,14 @@ While JavaScript runtimes are single-threaded, and thus do not have the *m:n* pr
 
 Ultimately, though, `IO` is able to achieve this with exceptionally high performance, and without interfering with other mechanisms which leverage the event loop (such as animations in the browser or I/O on the server). The techniques which are used by `IO` to achieve this run across all platforms which support ScalaJS. However, optimal performance is available only in the following environments:
 
-- NodeJS (all versions)
-- Internet Explorer 9+ (including Edge)
-- Firefox 3+
-- Opera 9.5+
-- *All WebKit browsers*
-- Web Workers
+- NodeJS 0.9.1+
+- [Any browser providing `window.postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#browser_compatibility), including:
+  - Chrome 1+
+  - Safari 4+
+  - Internet Explorer 9+ (including Edge)
+  - Firefox 3+
+  - Opera 9.5+
+- Web Workers [in all major browsers](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel#browser_compatibility)
 
 ### Yielding
 
@@ -140,7 +142,6 @@ The only elements of the polyfill which are *not* implemented by Cats Effect are
 
 - `process.nextTick` is used by the JavaScript polyfill when running on NodeJS versions below 0.9. However, ScalaJS itself does not support NodeJS 0.9 or below, so there's really no point in supporting this case.
 - Similarly, older versions of IE (6 through 8, specifically) allow a particular exploitation of the `onreadystatechange` event fired when a `<script>` element is inserted into the DOM. However, ScalaJS does not support these environments *either*, and so there is no benefit to implementing this case.
-- Web workers have entirely alien semantics for task queuing and no access to the DOM, but they do have `MessageChannel` which accomplishes exactly what we need. However, they're very hard to test in CI (apparently), and so Cats Effect does not yet implement this leg of the polyfill. There are plans to fix this.
 
 On environments where the polyfill is unsupported, `setTimeout` is still used as a final fallback.
 

--- a/docs/schedulers.md
+++ b/docs/schedulers.md
@@ -60,7 +60,7 @@ While JavaScript runtimes are single-threaded, and thus do not have the *m:n* pr
 Ultimately, though, `IO` is able to achieve this with exceptionally high performance, and without interfering with other mechanisms which leverage the event loop (such as animations in the browser or I/O on the server). The techniques which are used by `IO` to achieve this run across all platforms which support ScalaJS. However, optimal performance is available only in the following environments:
 
 - [NodeJS 0.9.1+](https://nodejs.org/api/timers.html#timers_setimmediate_callback_args)
-- [Any browser implementing `window.postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#browser_compatibility), including:
+- [Browsers implementing `window.postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#browser_compatibility), including:
   - Chrome 1+
   - Safari 4+
   - Internet Explorer 9+ (including Edge)

--- a/docs/schedulers.md
+++ b/docs/schedulers.md
@@ -64,10 +64,7 @@ Ultimately, though, `IO` is able to achieve this with exceptionally high perform
 - Firefox 3+
 - Opera 9.5+
 - *All WebKit browsers*
-
-Notably, at the present time, web workers are *not* supported at maximum performance. Cats Effect `IO` does run under web workers, but with degraded performance on operations involving fibers. There's a known fix for this bug, and the only blocker is really just setting up CI infrastructure which can run the `IO` test suite within a web worker.
-
-**Also note:** At present, a bug in Dotty prevents the use of the high performance scheduler in ScalaJS applications compiled with Scala 0.27.0-RC1. This is expected to be fixed in Scala 3.0.0-M1.
+- Web Workers
 
 ### Yielding
 

--- a/docs/std/dispatcher.md
+++ b/docs/std/dispatcher.md
@@ -8,7 +8,7 @@ title: Dispatcher
 ## Motivation
 
 Users of cats effect 2 may be familiar with the `Effect` and `ConcurrentEffect`
-typeclasses. These have been removed as they contrained implementations of the
+typeclasses. These have been removed as they constrained implementations of the
 typeclasses too much by forcing them to be embeddable in `IO` via `def
 toIO[A](fa: F[A]): IO[A]`. However, these typeclasses also had a valid use-case
 for unsafe running of effects to interface with impure APIs (`Future`, `NIO`,

--- a/docs/std/supervisor.md
+++ b/docs/std/supervisor.md
@@ -9,7 +9,7 @@ There are multiple ways to spawn a fiber to run an action:
 
 `Spawn[F]#start`: start and forget, no lifecycle management for the spawned fiber 
 
-`Concurrent[F]#background`: ties the lifecycle of the spawned fiber to that of the fiber that invoked `background`
+`Spawn[F]#background`: ties the lifecycle of the spawned fiber to that of the fiber that invoked `background`
 
 But what if we want to spawn a fiber that should outlive the scope that created
 it, but we still want to control its lifecycle?

--- a/docs/thread-model.md
+++ b/docs/thread-model.md
@@ -138,7 +138,7 @@ So we've seen that best performance is achieved when we dedicate use of the comp
 to evaluating `IO` fiber runloops and ensure that we shift _all_ blocking operations
 to a separate blocking threadpool. We've also seen that many things do not need to
 block a thread at all - cats effect provides semantic blocking abstractions for waiting
-for arbtirary conditions to be satisifed. Now it's time to see the details of how we achieve
+for arbitrary conditions to be satisifed. Now it's time to see the details of how we achieve
 this in cats effect 2 and 3.
 
 ## Cats Effect 2

--- a/docs/thread-model.md
+++ b/docs/thread-model.md
@@ -138,7 +138,7 @@ So we've seen that best performance is achieved when we dedicate use of the comp
 to evaluating `IO` fiber runloops and ensure that we shift _all_ blocking operations
 to a separate blocking threadpool. We've also seen that many things do not need to
 block a thread at all - cats effect provides semantic blocking abstractions for waiting
-for arbitrary conditions to be satisifed. Now it's time to see the details of how we achieve
+for arbitrary conditions to be satisfied. Now it's time to see the details of how we achieve
 this in cats effect 2 and 3.
 
 ## Cats Effect 2

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -42,11 +42,11 @@ running the code snippets in this tutorial, it is recommended to use the same
 ```scala
 name := "cats-effect-tutorial"
 
-version := "3.2.8"
+version := "3.2.9"
 
 scalaVersion := "2.13.6"
 
-libraryDependencies += "org.typelevel" %% "cats-effect" % "3.2.8" withSources() withJavadoc()
+libraryDependencies += "org.typelevel" %% "cats-effect" % "3.2.9" withSources() withJavadoc()
 
 scalacOptions ++= Seq(
   "-feature",

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -42,11 +42,11 @@ running the code snippets in this tutorial, it is recommended to use the same
 ```scala
 name := "cats-effect-tutorial"
 
-version := "3.2.5"
+version := "3.2.8"
 
-scalaVersion := "2.13.5"
+scalaVersion := "2.13.6"
 
-libraryDependencies += "org.typelevel" %% "cats-effect" % "3.2.5" withSources() withJavadoc()
+libraryDependencies += "org.typelevel" %% "cats-effect" % "3.2.8" withSources() withJavadoc()
 
 scalacOptions ++= Seq(
   "-feature",

--- a/docs/typeclasses/async.md
+++ b/docs/typeclasses/async.md
@@ -35,7 +35,7 @@ def fromFuture[A](fut: F[Future[A]]): F[A] =
   }
 ```
 
-`async_` is somewhat contrained however. We can't perform any `F` effects
+`async_` is somewhat constrained however. We can't perform any `F` effects
 in the process of registering the callback and we also can't register
 a finalizer to cancel the asynchronous task in the event that the fiber
 running `async_` is canceled.

--- a/site-docs/sidebars.json
+++ b/site-docs/sidebars.json
@@ -36,6 +36,9 @@
       "std/semaphore",
       "std/supervisor",
       "std/async-await"
+    ],
+    "Scaling and Tuning":[
+      "scaling-and-tuning/system-properties"
     ]
   }
 }


### PR DESCRIPTION
I only cherry picked documentation relevant to `series/3.2.x`, which is the branch from which documentation will be published while `3.2.x` is current version.