### PR TITLE
Fix of tutorial paragraph about error promotion of join call

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -647,10 +647,30 @@ object InefficientProducerConsumer extends IOApp {
 }
 ```
 
-Problem is, if there is an error in any of the fibers the `join` call will not
-hint it, nor it will return. In contrast `parMapN` does promote the error it
-finds to the caller. _In general, if possible, programmers should prefer to use
-higher level commands such as `parMapN` or `parSequence` to deal with fibers_.
+However in most situations it is not advisable to handle fibers manually as
+they are not trivial to work with. For example, if there is an error in a fiber
+the `join` call to that fiber will _not_ raise it, it will return normally and
+you must explicitly check the `Outcome` instance returned by the `.join` call
+to see if it errored. Also, the other fibers will keep running unaware of what
+happened.
+
+Cats Effect provides additional `joinWith` or `joinWithNever` methods to make
+sure at least that the error is raised with the usual `MonadError` semantics
+(e.g., short-circuiting).  Now that we are raising the error, we also need to
+cancel the other running fibers. We can easily get ourselves trapped in a
+tangled mess of fibers to keep an eye on.  On top of that the error raised by a
+fiber is not promoted until the call to `joinWith` or `.joinWithNever` is
+reached. So in our example above if `consumerFiber` raises an error then we
+have no way to observe that until the producer fiber has finished. Alarmingly,
+note that in our example the producer _never_ finishes and thus the error would
+_never_ be observed!  And even if the producer fiber did finish, it would have
+been consuming resources for nothing.
+ 
+In contrast `parMapN` does promote any error it finds to the caller _and_ takes
+care of canceling the other running fibers. As a result `parMapN` is simpler to
+use, more concise, and easier to reason about. _Because of that, unless you
+have some specific and unusual requirements you should prefer to use higher
+level commands such as `parMapN` or `parSequence` to work with fibers_.
 
 Ok, we stick to our implementation based on `.parMapN`. Are we done? Does it
 Work? Well, it works... but it is far from ideal. If we run it we will find that


### PR DESCRIPTION
The tutorial contains a paragraph about `.start` and `.join` that is messy if not plainly wrong. _E.g._ see [this msg](https://discord.com/channels/632277896739946517/632278585700384799/900807315190599800) in CE discord channel.

This PR tries to fix this for the 3.2.x series tutorial, briefly explaining the limitations of the `.start` + `.join` (or `joinWith` or `joinWithNever`) approach to underscore how using `.parMapN` or `.parSequence` is generally a better choice. Resulting text can be read [here](https://lrodero.github.io/cats-effect/docs/tutorial).

Text changes were discussed in a previous [PR](https://github.com/typelevel/cats-effect/pull/2458) for `series/3.x`, which was closed to be replaced by this one.