### PR TITLE
Rename `SuspendedFiberBag` to `FiberMonitor`

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -33,7 +33,7 @@ private[effect] sealed abstract class FiberMonitor {
    * @param fiber
    *   the suspended fiber to be registered
    */
-  def monitor(key: AnyRef, fiber: IOFiber[_]): Unit
+  def monitorSuspended(key: AnyRef, fiber: IOFiber[_]): Unit
 }
 
 /**
@@ -47,7 +47,7 @@ private final class ES2021FiberMonitor(
 ) extends FiberMonitor {
   private[this] val bag = new IterableWeakMap[AnyRef, js.WeakRef[IOFiber[_]]]
 
-  override def monitor(key: AnyRef, fiber: IOFiber[_]): Unit = {
+  override def monitorSuspended(key: AnyRef, fiber: IOFiber[_]): Unit = {
     bag.set(key, new js.WeakRef(fiber))
   }
 }
@@ -57,7 +57,7 @@ private final class ES2021FiberMonitor(
  * instances on Scala.js. This is used as a fallback.
  */
 private final class NoOpFiberMonitor extends FiberMonitor {
-  override def monitor(key: AnyRef, fiber: IOFiber[_]): Unit = ()
+  override def monitorSuspended(key: AnyRef, fiber: IOFiber[_]): Unit = ()
 }
 
 private[effect] object FiberMonitor {

--- a/core/js/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -68,7 +68,7 @@ private[effect] object FiberMonitor {
         val faec = compute.asInstanceOf[FiberAwareExecutionContext]
         new ES2021FiberMonitor(faec)
       } else {
-        new NoOpFiberMonitor()
+        new ES2021FiberMonitor(null)
       }
     } else {
       new NoOpFiberMonitor()

--- a/core/js/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -18,6 +18,7 @@ package cats.effect
 package unsafe
 
 import scala.annotation.nowarn
+import scala.concurrent.ExecutionContext
 import scala.scalajs.js
 import scala.scalajs.LinkingInfo
 
@@ -56,12 +57,10 @@ private final class NoOpFiberMonitor extends FiberMonitor {
 
 private[effect] object FiberMonitor {
 
-  // Only exists for source compatibility with JVM code.
+  // TODO: Use the execution context reference to obtain live fibers from the Scala.js
+  // executor. Coming in a later PR.
   @nowarn("cat=unused-params")
-  def apply(compute: WorkStealingThreadPool): FiberMonitor =
-    apply()
-
-  def apply(): FiberMonitor =
+  def apply(compute: ExecutionContext): FiberMonitor =
     if (LinkingInfo.developmentMode && IterableWeakMap.isAvailable)
       new ES2021FiberMonitor()
     else

--- a/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -69,7 +69,7 @@ private[effect] final class FiberMonitor(
    * @param fiber
    *   the suspended fiber to be registered
    */
-  def monitor(key: AnyRef, fiber: IOFiber[_]): Unit = {
+  def monitorSuspended(key: AnyRef, fiber: IOFiber[_]): Unit = {
     val thread = Thread.currentThread()
     if (thread.isInstanceOf[WorkerThread]) {
       val worker = thread.asInstanceOf[WorkerThread]

--- a/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -40,7 +40,7 @@ import java.util.concurrent.ThreadLocalRandom
  *      contention between threads. A particular instance is selected using a thread local
  *      source of randomness using an instance of `java.util.concurrent.ThreadLocalRandom`.
  */
-private[effect] final class SuspendedFiberBag(
+private[effect] final class FiberMonitor(
     // A reference to the compute pool of the `IORuntime` in which this suspended fiber bag
     // operates. `null` if the compute pool of the `IORuntime` is not a `WorkStealingThreadPool`.
     private[this] val compute: WorkStealingThreadPool
@@ -90,8 +90,8 @@ private[effect] final class SuspendedFiberBag(
   }
 }
 
-private[effect] object SuspendedFiberBag {
-  def apply(): SuspendedFiberBag = new SuspendedFiberBag(null)
+private[effect] object FiberMonitor {
+  def apply(): FiberMonitor = new FiberMonitor(null)
 
-  def apply(compute: WorkStealingThreadPool): SuspendedFiberBag = new SuspendedFiberBag(compute)
+  def apply(compute: WorkStealingThreadPool): FiberMonitor = new FiberMonitor(compute)
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -17,10 +17,11 @@
 package cats.effect
 package unsafe
 
+import scala.concurrent.ExecutionContext
+
 import java.lang.ref.WeakReference
 import java.util.{Collections, Map, WeakHashMap}
 import java.util.concurrent.ThreadLocalRandom
-import scala.concurrent.ExecutionContext
 
 /**
  * A slightly more involved implementation of an unordered bag used for tracking asynchronously

--- a/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -20,6 +20,7 @@ package unsafe
 import java.lang.ref.WeakReference
 import java.util.{Collections, Map, WeakHashMap}
 import java.util.concurrent.ThreadLocalRandom
+import scala.concurrent.ExecutionContext
 
 /**
  * A slightly more involved implementation of an unordered bag used for tracking asynchronously
@@ -91,7 +92,12 @@ private[effect] final class FiberMonitor(
 }
 
 private[effect] object FiberMonitor {
-  def apply(): FiberMonitor = new FiberMonitor(null)
-
-  def apply(compute: WorkStealingThreadPool): FiberMonitor = new FiberMonitor(compute)
+  def apply(compute: ExecutionContext): FiberMonitor = {
+    if (compute.isInstanceOf[WorkStealingThreadPool]) {
+      val wstp = compute.asInstanceOf[WorkStealingThreadPool]
+      new FiberMonitor(wstp)
+    } else {
+      new FiberMonitor(null)
+    }
+  }
 }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1022,7 +1022,7 @@ private final class IOFiber[A](
    * Registers the suspended fiber in the global suspended fiber bag.
    */
   private[this] def monitor(key: AnyRef): Unit = {
-    runtime.suspendedFiberBag.monitorSuspended(key, this)
+    runtime.fiberMonitor.monitorSuspended(key, this)
   }
 
   /* can return null, meaning that no CallbackStack needs to be later invalidated */

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1022,7 +1022,7 @@ private final class IOFiber[A](
    * Registers the suspended fiber in the global suspended fiber bag.
    */
   private[this] def monitor(key: AnyRef): Unit = {
-    runtime.suspendedFiberBag.monitor(key, this)
+    runtime.suspendedFiberBag.monitorSuspended(key, this)
   }
 
   /* can return null, meaning that no CallbackStack needs to be later invalidated */

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -41,12 +41,12 @@ final class IORuntime private (
 ) {
   private[effect] val fiberErrorCbs: StripedHashtable = new StripedHashtable()
 
-  private[effect] val suspendedFiberBag: SuspendedFiberBag =
+  private[effect] val suspendedFiberBag: FiberMonitor =
     if (compute.isInstanceOf[WorkStealingThreadPool]) {
       val wstp = compute.asInstanceOf[WorkStealingThreadPool]
-      SuspendedFiberBag(wstp)
+      FiberMonitor(wstp)
     } else {
-      SuspendedFiberBag()
+      FiberMonitor()
     }
 
   /*

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -41,8 +41,7 @@ final class IORuntime private (
 ) {
   private[effect] val fiberErrorCbs: StripedHashtable = new StripedHashtable()
 
-  private[effect] val suspendedFiberBag: FiberMonitor =
-    FiberMonitor(compute)
+  private[effect] val fiberMonitor: FiberMonitor = FiberMonitor(compute)
 
   /*
    * Forwarder methods for `IOFiber`.

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -42,12 +42,7 @@ final class IORuntime private (
   private[effect] val fiberErrorCbs: StripedHashtable = new StripedHashtable()
 
   private[effect] val suspendedFiberBag: FiberMonitor =
-    if (compute.isInstanceOf[WorkStealingThreadPool]) {
-      val wstp = compute.asInstanceOf[WorkStealingThreadPool]
-      FiberMonitor(wstp)
-    } else {
-      FiberMonitor()
-    }
+    FiberMonitor(compute)
 
   /*
    * Forwarder methods for `IOFiber`.


### PR DESCRIPTION
This class will not only return the suspended fibers, but also all live fibers on the compute pool, so it makes sense to do the renaming now.

Both the JVM code and the JS code will have a reference to the compute pool, discriminate on its type and the platform specific code will be completely internalized to this class.

I will follow up with an augmented type of `ExecutionContext` on JS which will keep a set of live fibers.