### PR TITLE
Create fiber-aware EC for JS

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
@@ -32,6 +32,7 @@ private[effect] class FiberAwareExecutionContext(ec: ExecutionContext)
       fiberBag += r
       ec execute { () =>
         // We have to remove r _before_ running it, b/c it may be re-enqueued while running
+        // B/c JS is single-threaded, nobody can observe the bag while it is running anyway
         fiberBag -= r
         r.run()
       }

--- a/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
@@ -23,9 +23,8 @@ import scala.concurrent.ExecutionContext
 private[effect] class FiberAwareExecutionContext(ec: ExecutionContext)
     extends ExecutionContext {
 
-  def fibers: Set[IOFiber[_]] = fiberBag.toSet ++ Option(running).toSet
+  def fibers: Set[IOFiber[_]] = fiberBag.toSet
 
-  private[this] var running: IOFiber[_] = null
   private[this] val fiberBag = mutable.Set[IOFiber[_]]()
 
   def execute(runnable: Runnable): Unit = runnable match {
@@ -34,9 +33,7 @@ private[effect] class FiberAwareExecutionContext(ec: ExecutionContext)
       ec execute { () =>
         // We have to remove r _before_ running it, b/c it may be re-enqueued while running
         fiberBag -= r
-        running = r
         r.run()
-        running = null
       }
 
     case r => r.run()

--- a/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
@@ -20,7 +20,7 @@ package unsafe
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 
-private[effect] class FiberAwareExecutionContext(ec: ExecutionContext)
+private[effect] final class FiberAwareExecutionContext(ec: ExecutionContext)
     extends ExecutionContext {
 
   def fibers: Set[IOFiber[_]] = fiberBag.toSet

--- a/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package unsafe
+
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext
+
+private[effect] class FiberAwareExecutionContext(ec: ExecutionContext)
+    extends ExecutionContext {
+
+  def fibers: collection.Set[IOFiber[_]] = fiberBag
+
+  private[this] val fiberBag = mutable.Set[IOFiber[_]]()
+
+  def execute(runnable: Runnable): Unit = runnable match {
+    case r: IOFiber[_] =>
+      fiberBag += r
+      ec execute { () =>
+        r.run()
+        fiberBag -= r
+      }
+
+    case r => r.run()
+  }
+
+  def reportFailure(cause: Throwable): Unit = ec.reportFailure(cause)
+
+}

--- a/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
@@ -20,12 +20,11 @@ package unsafe
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 
-private[effect] final class FiberAwareExecutionContext(ec: ExecutionContext)
-    extends ExecutionContext {
+private final class FiberAwareExecutionContext(ec: ExecutionContext) extends ExecutionContext {
 
-  def fibers: Set[IOFiber[_]] = fiberBag.toSet
+  def liveFibers(): Set[IOFiber[_]] = fiberBag.toSet
 
-  private[this] val fiberBag = mutable.Set[IOFiber[_]]()
+  private[this] val fiberBag = mutable.Set.empty[IOFiber[_]]
 
   def execute(runnable: Runnable): Unit = runnable match {
     case r: IOFiber[_] =>

--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -19,10 +19,14 @@ package cats.effect.unsafe
 import org.scalajs.macrotaskexecutor.MacrotaskExecutor
 
 import scala.concurrent.ExecutionContext
+import scala.scalajs.LinkingInfo
 
 private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type =>
 
-  def defaultComputeExecutionContext: ExecutionContext = MacrotaskExecutor
+  def defaultComputeExecutionContext: ExecutionContext = if (LinkingInfo.developmentMode)
+    new FiberAwareExecutionContext(MacrotaskExecutor)
+  else
+    MacrotaskExecutor
 
   def defaultScheduler: Scheduler = Scheduler.createDefaultScheduler()._1
 

--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -19,14 +19,10 @@ package cats.effect.unsafe
 import org.scalajs.macrotaskexecutor.MacrotaskExecutor
 
 import scala.concurrent.ExecutionContext
-import scala.scalajs.LinkingInfo
 
 private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type =>
 
-  def defaultComputeExecutionContext: ExecutionContext = if (LinkingInfo.developmentMode)
-    new FiberAwareExecutionContext(MacrotaskExecutor)
-  else
-    MacrotaskExecutor
+  def defaultComputeExecutionContext: ExecutionContext = MacrotaskExecutor
 
   def defaultScheduler: Scheduler = Scheduler.createDefaultScheduler()._1
 


### PR DESCRIPTION
This is a slight adaptation of Daniel's code. The difference is, here we add the fiber to the set _as soon as it's queued_ (rather than when the underlying EC decides to run it). Then, just before the underlying EC starts running it, it removes it. In the process of running, it may re-enqueue itself.