### PR TITLE
Create fiber-aware EC for JVM

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
@@ -17,7 +17,6 @@
 package cats.effect
 package unsafe
 
-import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 
 import java.lang.ref.WeakReference
@@ -33,10 +32,6 @@ private final class FiberAwareExecutionContext(ec: ExecutionContext, monitor: Fi
       bag
     }
   }
-
-  def liveFibers(): Set[IOFiber[_]] = fiberBag.toSet
-
-  private[this] val fiberBag = mutable.Set.empty[IOFiber[_]]
 
   def execute(runnable: Runnable): Unit = runnable match {
     case f: IOFiber[_] =>

--- a/core/jvm/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package unsafe
+
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext
+
+import java.lang.ref.WeakReference
+import java.util.{Map, WeakHashMap}
+
+private final class FiberAwareExecutionContext(ec: ExecutionContext, monitor: FiberMonitor)
+    extends ExecutionContext {
+
+  private[this] val localBag = new ThreadLocal[Map[AnyRef, WeakReference[IOFiber[_]]]] {
+    override def initialValue(): Map[AnyRef, WeakReference[IOFiber[_]]] = {
+      val bag = new WeakHashMap[AnyRef, WeakReference[IOFiber[_]]]
+      monitor.registerExtraBag(bag)
+      bag
+    }
+  }
+
+  def liveFibers(): Set[IOFiber[_]] = fiberBag.toSet
+
+  private[this] val fiberBag = mutable.Set.empty[IOFiber[_]]
+
+  def execute(runnable: Runnable): Unit = runnable match {
+    case f: IOFiber[_] =>
+      val r: Runnable = () => f.run()
+      localBag.get().put(r, new WeakReference(f))
+      ec.execute(r)
+
+    case r => r.run()
+  }
+
+  def reportFailure(cause: Throwable): Unit = ec.reportFailure(cause)
+
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -51,7 +51,7 @@ private[effect] final class FiberMonitor(
   private[this] val size: Int = Runtime.getRuntime().availableProcessors() << 2
   private[this] val bags: Array[Map[AnyRef, WeakReference[IOFiber[_]]]] =
     new Array(size)
-  private[this] val extraBags: Set[Map[AnyRef, WeakReference[IOFiber[_]]]] = 
+  private[this] val extraBags: Set[Map[AnyRef, WeakReference[IOFiber[_]]]] =
     // A synchronized weak set
     Collections.newSetFromMap(Collections.synchronizedMap(new WeakHashMap()))
 

--- a/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -53,7 +53,7 @@ private[effect] final class FiberMonitor(
     new Array(size)
   private[this] val extraBags: Set[Map[AnyRef, WeakReference[IOFiber[_]]]] =
     // A synchronized weak set
-    Collections.newSetFromMap(Collections.synchronizedMap(new WeakHashMap()))
+    Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap()))
 
   {
     var i = 0


### PR DESCRIPTION
This combines the ideas in #2506 and #2507 to create an (effectively) contention-free fiber-aware EC for the JVM. It uses a thread local to keep a weak fiber bag on each submitting thread. There is only a one-time contention when this bag is initialized, so as to register it with the `FiberMonitor`.