### PR TITLE
Fix weak bag for the blocking mechanism

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -411,7 +411,11 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "cats.effect.IO#Uncancelable#UnmaskRunLoop.copy"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
-        "cats.effect.IO#Uncancelable#UnmaskRunLoop.this")
+        "cats.effect.IO#Uncancelable#UnmaskRunLoop.this"),
+      // introduced by #2510, Fix weak bag for the blocking mechanism
+      // changes to `cats.effect.unsafe` package private code
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "cats.effect.unsafe.WorkerThread.this")
     )
   )
   .jvmSettings(

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -32,6 +32,8 @@ package unsafe
 
 import scala.concurrent.ExecutionContext
 
+import java.lang.ref.WeakReference
+import java.util.WeakHashMap
 import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import java.util.concurrent.locks.LockSupport
@@ -106,8 +108,17 @@ private[effect] final class WorkStealingThreadPool(
       val parkedSignal = new AtomicBoolean(false)
       parkedSignals(i) = parkedSignal
       val index = i
+      val fiberBag = new WeakHashMap[AnyRef, WeakReference[IOFiber[_]]]()
       val thread =
-        new WorkerThread(index, threadPrefix, queue, parkedSignal, externalQueue, null, this)
+        new WorkerThread(
+          index,
+          threadPrefix,
+          queue,
+          parkedSignal,
+          externalQueue,
+          null,
+          fiberBag,
+          this)
       workerThreads(i) = thread
       i += 1
     }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -56,6 +56,8 @@ private final class WorkerThread(
     // worker threads that new work has become available, even though that's not
     // true in tis case.
     private[this] var cedeBypass: IOFiber[_],
+    // A worker-thread-local weak bag for tracking suspended fibers.
+    private[this] val fiberBag: WeakHashMap[AnyRef, WeakReference[IOFiber[_]]],
     // Reference to the `WorkStealingThreadPool` in which this thread operates.
     private[this] val pool: WorkStealingThreadPool)
     extends Thread
@@ -77,11 +79,6 @@ private final class WorkerThread(
    * [[WorkerThread]] s.
    */
   private[this] var blocking: Boolean = false
-
-  /**
-   * A worker-thread-local weak bag for tracking suspended fibers.
-   */
-  private[this] val fiberBag: WeakHashMap[AnyRef, WeakReference[IOFiber[_]]] = new WeakHashMap()
 
   // Constructor code.
   {
@@ -469,7 +466,7 @@ private final class WorkerThread(
       // for unparking.
       val idx = index
       val clone =
-        new WorkerThread(idx, threadPrefix, queue, parked, external, cedeBypass, pool)
+        new WorkerThread(idx, threadPrefix, queue, parked, external, cedeBypass, fiberBag, pool)
       cedeBypass = null
       pool.replaceWorker(idx, clone)
       clone.start()

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -78,7 +78,7 @@ private final class WorkerThread(
    * detecting nested blocking regions, in order to avoid unnecessarily spawning extra
    * [[WorkerThread]] s.
    */
-  private[this] var blocking: Boolean = false
+  private[this] var blocking: Boolean = _
 
   // Constructor code.
   {


### PR DESCRIPTION
Copied commit messages for visibility:

Make the worker thread local fiber bag a constructor argument
    - This works across the blocking mechanism when new worker threads are
    spawned to replace existing blocked threads.

Remove the last bitmap$init creator
    - Uninitialized `var`s do not cause synchronization in the constructor