### PR TITLE
Use the tracing constants for speed

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -113,8 +113,9 @@ private final class IOFiber[A](
   /* similar prefetch for EndFiber */
   private[this] val IOEndFiber: IO.EndFiber.type = IO.EndFiber
 
-  private[this] val tracingEvents: RingBuffer =
+  private[this] val tracingEvents: RingBuffer = if (isStackTracing) {
     RingBuffer.empty(runtime.traceBufferLogSize)
+  } else null
 
   override def run(): Unit = {
     // insert a read barrier after every async boundary
@@ -965,7 +966,8 @@ private final class IOFiber[A](
     objectState.invalidate()
     finalizers.invalidate()
     currentCtx = null
-    tracingEvents.invalidate()
+
+    if (isStackTracing) tracingEvents.invalidate()
   }
 
   /**

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -244,7 +244,7 @@ private final class IOFiber[A](
         case 2 =>
           val cur = cur0.asInstanceOf[Delay[Any]]
 
-          pushTracingEvent(cur.event)
+          if (isStackTracing) pushTracingEvent(cur.event)
 
           var error: Throwable = null
           val r =
@@ -283,7 +283,7 @@ private final class IOFiber[A](
         case 6 =>
           val cur = cur0.asInstanceOf[Map[Any, Any]]
 
-          pushTracingEvent(cur.event)
+          if (isStackTracing) pushTracingEvent(cur.event)
 
           val ioe = cur.ioe
           val f = cur.f
@@ -314,7 +314,7 @@ private final class IOFiber[A](
             case 2 =>
               val delay = ioe.asInstanceOf[Delay[Any]]
 
-              pushTracingEvent(delay.event)
+              if (isStackTracing) pushTracingEvent(delay.event)
 
               // this code is inlined in order to avoid two `try` blocks
               var error: Throwable = null
@@ -351,7 +351,7 @@ private final class IOFiber[A](
         case 7 =>
           val cur = cur0.asInstanceOf[FlatMap[Any, Any]]
 
-          pushTracingEvent(cur.event)
+          if (isStackTracing) pushTracingEvent(cur.event)
 
           val ioe = cur.ioe
           val f = cur.f
@@ -377,7 +377,7 @@ private final class IOFiber[A](
             case 2 =>
               val delay = ioe.asInstanceOf[Delay[Any]]
 
-              pushTracingEvent(delay.event)
+              if (isStackTracing) pushTracingEvent(delay.event)
 
               // this code is inlined in order to avoid two `try` blocks
               val result =
@@ -430,7 +430,7 @@ private final class IOFiber[A](
             case 2 =>
               val delay = ioa.asInstanceOf[Delay[Any]]
 
-              pushTracingEvent(delay.event)
+              if (isStackTracing) pushTracingEvent(delay.event)
 
               // this code is inlined in order to avoid two `try` blocks
               var error: Throwable = null
@@ -470,7 +470,7 @@ private final class IOFiber[A](
         case 9 =>
           val cur = cur0.asInstanceOf[HandleErrorWith[Any]]
 
-          pushTracingEvent(cur.event)
+          if (isStackTracing) pushTracingEvent(cur.event)
 
           objectState.push(cur.f)
           conts = ByteStack.push(conts, HandleErrorWithK)
@@ -504,7 +504,7 @@ private final class IOFiber[A](
         case 12 =>
           val cur = cur0.asInstanceOf[Uncancelable[Any]]
 
-          pushTracingEvent(cur.event)
+          if (isStackTracing) pushTracingEvent(cur.event)
 
           masks += 1
           val id = masks
@@ -552,7 +552,7 @@ private final class IOFiber[A](
            */
           val body = cur.body
 
-          pushTracingEvent(cur.event)
+          if (isStackTracing) pushTracingEvent(cur.event)
 
           /*
            *`get` and `cb` (callback) race over the runloop.
@@ -901,7 +901,7 @@ private final class IOFiber[A](
           val cur = cur0.asInstanceOf[Blocking[Any]]
           /* we know we're on the JVM here */
 
-          pushTracingEvent(cur.event)
+          if (isStackTracing) pushTracingEvent(cur.event)
 
           if (cur.hint eq IOFiber.TypeBlocking) {
             resumeTag = BlockingR

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -245,7 +245,9 @@ private final class IOFiber[A](
         case 2 =>
           val cur = cur0.asInstanceOf[Delay[Any]]
 
-          if (isStackTracing) pushTracingEvent(cur.event)
+          if (isStackTracing) {
+            pushTracingEvent(cur.event)
+          }
 
           var error: Throwable = null
           val r =
@@ -284,7 +286,9 @@ private final class IOFiber[A](
         case 6 =>
           val cur = cur0.asInstanceOf[Map[Any, Any]]
 
-          if (isStackTracing) pushTracingEvent(cur.event)
+          if (isStackTracing) {
+            pushTracingEvent(cur.event)
+          }
 
           val ioe = cur.ioe
           val f = cur.f
@@ -315,7 +319,9 @@ private final class IOFiber[A](
             case 2 =>
               val delay = ioe.asInstanceOf[Delay[Any]]
 
-              if (isStackTracing) pushTracingEvent(delay.event)
+              if (isStackTracing) {
+                pushTracingEvent(delay.event)
+              }
 
               // this code is inlined in order to avoid two `try` blocks
               var error: Throwable = null
@@ -352,7 +358,9 @@ private final class IOFiber[A](
         case 7 =>
           val cur = cur0.asInstanceOf[FlatMap[Any, Any]]
 
-          if (isStackTracing) pushTracingEvent(cur.event)
+          if (isStackTracing) {
+            pushTracingEvent(cur.event)
+          }
 
           val ioe = cur.ioe
           val f = cur.f
@@ -378,7 +386,9 @@ private final class IOFiber[A](
             case 2 =>
               val delay = ioe.asInstanceOf[Delay[Any]]
 
-              if (isStackTracing) pushTracingEvent(delay.event)
+              if (isStackTracing) {
+                pushTracingEvent(delay.event)
+              }
 
               // this code is inlined in order to avoid two `try` blocks
               val result =
@@ -431,7 +441,9 @@ private final class IOFiber[A](
             case 2 =>
               val delay = ioa.asInstanceOf[Delay[Any]]
 
-              if (isStackTracing) pushTracingEvent(delay.event)
+              if (isStackTracing) {
+                pushTracingEvent(delay.event)
+              }
 
               // this code is inlined in order to avoid two `try` blocks
               var error: Throwable = null
@@ -471,7 +483,9 @@ private final class IOFiber[A](
         case 9 =>
           val cur = cur0.asInstanceOf[HandleErrorWith[Any]]
 
-          if (isStackTracing) pushTracingEvent(cur.event)
+          if (isStackTracing) {
+            pushTracingEvent(cur.event)
+          }
 
           objectState.push(cur.f)
           conts = ByteStack.push(conts, HandleErrorWithK)
@@ -505,7 +519,9 @@ private final class IOFiber[A](
         case 12 =>
           val cur = cur0.asInstanceOf[Uncancelable[Any]]
 
-          if (isStackTracing) pushTracingEvent(cur.event)
+          if (isStackTracing) {
+            pushTracingEvent(cur.event)
+          }
 
           masks += 1
           val id = masks
@@ -553,7 +569,9 @@ private final class IOFiber[A](
            */
           val body = cur.body
 
-          if (isStackTracing) pushTracingEvent(cur.event)
+          if (isStackTracing) {
+            pushTracingEvent(cur.event)
+          }
 
           /*
            *`get` and `cb` (callback) race over the runloop.
@@ -902,7 +920,9 @@ private final class IOFiber[A](
           val cur = cur0.asInstanceOf[Blocking[Any]]
           /* we know we're on the JVM here */
 
-          if (isStackTracing) pushTracingEvent(cur.event)
+          if (isStackTracing) {
+            pushTracingEvent(cur.event)
+          }
 
           if (cur.hint eq IOFiber.TypeBlocking) {
             resumeTag = BlockingR
@@ -967,7 +987,9 @@ private final class IOFiber[A](
     finalizers.invalidate()
     currentCtx = null
 
-    if (isStackTracing) tracingEvents.invalidate()
+    if (isStackTracing) {
+      tracingEvents.invalidate()
+    }
   }
 
   /**

--- a/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
@@ -54,11 +54,6 @@ private[effect] final class RingBuffer private (logSize: Int) {
 }
 
 private[effect] object RingBuffer {
-  def empty(logSize: Int): RingBuffer = {
-    if (TracingConstants.isStackTracing) {
-      new RingBuffer(logSize)
-    } else NullBuffer
-  }
-
-  private[this] val NullBuffer = new RingBuffer(0)
+  def empty(logSize: Int): RingBuffer =
+    new RingBuffer(logSize)
 }


### PR DESCRIPTION
Every little bit helps.

`series/3.x`:
```
Benchmark                (size)   Mode  Cnt     Score    Error  Units
DeepBindBenchmark.async   10000  thrpt   20  1160.801 ± 18.224  ops/s
```

`This PR`:
```
Benchmark                (size)   Mode  Cnt     Score    Error  Units
DeepBindBenchmark.async   10000  thrpt   20  1216.760 ± 17.077  ops/s
```