### PR TITLE
Higher-precision `realTime` for `Clock`

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Clock.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Clock.scala
@@ -23,6 +23,7 @@ import scala.concurrent.duration.FiniteDuration
 
 import cats.kernel.{Monoid, Semigroup}
 import cats.{Defer, Monad}
+import java.util.concurrent.TimeUnit
 
 /**
  * A typeclass which encodes various notions of time. Analogous to some of the time functions
@@ -45,6 +46,14 @@ trait Clock[F[_]] extends ClockPlatform[F] {
    * Analogous to `java.lang.System.currentTimeMillis`.
    */
   def realTime: F[FiniteDuration]
+
+  /**
+   * A representation of the current system time in terms of the provided [[TimeUnit]].
+   * Implementors should make a best-effort to provide precision matching the [[TimeUnit]], but
+   * this is not guaranteed.
+   */
+  def realTime(unit: TimeUnit): F[FiniteDuration] =
+    applicative.map(realTime)(rt => FiniteDuration(unit.convert(rt.length, rt.unit), unit))
 
   /**
    * Returns an effect that completes with the result of the source together with the duration


### PR DESCRIPTION
An alternative approach to https://github.com/typelevel/cats-effect/pull/2416.

This adds a `realTime` overload to `Clock` that enables the user to request the result in a particular `TimeUnit`. Then, the implementer makes a best-effort to return a result matching the precision of that `TimeUnit`. This enables a default implementation in terms of the current `realTime` with only millisecond accuracy.

If we're happy with this strategy, I'll go ahead and finish this PR by adding implementations for JVM and JS.