### PR TITLE
Handle live fiber snapshot signals on the JVM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         scala: [3.0.2, 2.12.15, 2.13.7]
         java:
           - adoptium@8
@@ -39,9 +39,15 @@ jobs:
             java: graalvm-ce-java11@21.3
           - os: windows-latest
             scala: 3.0.2
+          - os: macos-latest
+            scala: 3.0.2
           - os: windows-latest
             scala: 2.12.15
+          - os: macos-latest
+            scala: 2.12.15
           - os: windows-latest
+            ci: ciJS
+          - os: macos-latest
             ci: ciJS
           - ci: ciFirefox
             java: adoptium@11
@@ -51,9 +57,15 @@ jobs:
             java: graalvm-ce-java11@21.3
           - os: windows-latest
             scala: 3.0.2
+          - os: macos-latest
+            scala: 3.0.2
           - os: windows-latest
             scala: 2.12.15
+          - os: macos-latest
+            scala: 2.12.15
           - os: windows-latest
+            ci: ciFirefox
+          - os: macos-latest
             ci: ciFirefox
           - ci: ciChrome
             java: adoptium@11
@@ -63,9 +75,15 @@ jobs:
             java: graalvm-ce-java11@21.3
           - os: windows-latest
             scala: 3.0.2
+          - os: macos-latest
+            scala: 3.0.2
           - os: windows-latest
             scala: 2.12.15
+          - os: macos-latest
+            scala: 2.12.15
           - os: windows-latest
+            ci: ciChrome
+          - os: macos-latest
             ci: ciChrome
     runs-on: ${{ matrix.os }}
     steps:

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -236,11 +236,13 @@ trait IOApp {
       .props
       .get("os.name")
       .map(_.toLowerCase)
-      .filterNot(_.contains("windows"))
+      .filterNot(_.contains("windows")) // Windows does not support signals
       .flatMap {
         case "linux" =>
+          // There are no free signals on JDK 8 on Linux.
           sys.props.get("java.version").filterNot(_.startsWith("1.8")).map(_ => List("USR1"))
         case _ =>
+          // MacOS and BSD can handle both USR1 and INFO (nice CTRL+T experience)
           Some(List("USR1", "INFO"))
       }
       .getOrElse(Nil)

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -243,26 +243,17 @@ trait IOApp {
         .filterNot(
           _.contains("windows")
         ) // Windows does not support signals user overridable signals
-        .flatMap { os =>
-          val isJDK8 = sys.props.get("java.version").filter(_.startsWith("1.8")).isDefined
+        .flatMap(_ => List("USR1", "INFO"))
 
-          os match {
-            case "linux" if isJDK8 =>
-              Nil // There are no unused signals on JDK 8 on Linux.
-            case "linux" =>
-              List("USR1")
-            case _ if isJDK8 =>
-              List("INFO")
-            case _ =>
-              // MacOS and BSD can handle both USR1 (except JDK 8) and INFO (nice CTRL+T experience)
-              List("USR1", "INFO")
-          }
+      liveFiberSnapshotSignal foreach { name =>
+        try {
+          Signal.handle(
+            new Signal(name),
+            _ => runtime.fiberMonitor.liveFiberSnapshot().foreach(System.err.println(_)))
+        } catch {
+          case _: IllegalArgumentException =>
+            () // if we can't register a signal, just ignore and move on
         }
-
-      liveFiberSnapshotSignal.map(new Signal(_)).foreach { signal =>
-        Signal.handle(
-          signal,
-          _ => runtime.fiberMonitor.liveFiberSnapshot().foreach(System.err.println(_)))
       }
     }
 

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -16,6 +16,8 @@
 
 package cats.effect
 
+import cats.effect.tracing.TracingConstants._
+
 import scala.concurrent.{blocking, CancellationException}
 
 import java.util.concurrent.CountDownLatch
@@ -232,34 +234,36 @@ trait IOApp {
       _runtime = IORuntime.global
     }
 
-    val liveFiberSnapshotSignal = sys
-      .props
-      .get("os.name")
-      .toList
-      .map(_.toLowerCase)
-      .filterNot(
-        _.contains("windows")
-      ) // Windows does not support signals user overridable signals
-      .flatMap { os =>
-        val isJDK8 = sys.props.get("java.version").filter(_.startsWith("1.8")).isDefined
+    if (isStackTracing) {
+      val liveFiberSnapshotSignal = sys
+        .props
+        .get("os.name")
+        .toList
+        .map(_.toLowerCase)
+        .filterNot(
+          _.contains("windows")
+        ) // Windows does not support signals user overridable signals
+        .flatMap { os =>
+          val isJDK8 = sys.props.get("java.version").filter(_.startsWith("1.8")).isDefined
 
-        os match {
-          case "linux" if isJDK8 =>
-            Nil // There are no unused signals on JDK 8 on Linux.
-          case "linux" =>
-            List("USR1")
-          case _ if isJDK8 =>
-            List("INFO")
-          case _ =>
-            // MacOS and BSD can handle both USR1 (except JDK 8) and INFO (nice CTRL+T experience)
-            List("USR1", "INFO")
+          os match {
+            case "linux" if isJDK8 =>
+              Nil // There are no unused signals on JDK 8 on Linux.
+            case "linux" =>
+              List("USR1")
+            case _ if isJDK8 =>
+              List("INFO")
+            case _ =>
+              // MacOS and BSD can handle both USR1 (except JDK 8) and INFO (nice CTRL+T experience)
+              List("USR1", "INFO")
+          }
         }
-      }
 
-    liveFiberSnapshotSignal.map(new Signal(_)).foreach { signal =>
-      Signal.handle(
-        signal,
-        _ => runtime.fiberMonitor.liveFiberSnapshot().foreach(System.err.println(_)))
+      liveFiberSnapshotSignal.map(new Signal(_)).foreach { signal =>
+        Signal.handle(
+          signal,
+          _ => runtime.fiberMonitor.liveFiberSnapshot().foreach(System.err.println(_)))
+      }
     }
 
     val rt = Runtime.getRuntime()

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -136,7 +136,11 @@ class IOAppSpec extends Specification {
 
       "live fiber snapshot" in {
         val h = java(LiveFiberSnapshot, List.empty)
+        // Allow the process some time to start
+        // and register the signal handlers.
+        Thread.sleep(2000L)
         val pid = h.pid()
+        pid.isDefined must beTrue
         pid.foreach(sendSignal)
         h.awaitStatus()
         val stderr = h.stderr()
@@ -158,7 +162,7 @@ class IOAppSpec extends Specification {
   }
 
   private def sendSignal(pid: Int): Unit = {
-    Process("pkill", List("-SIGUSR1", pid.toString)).run()
+    Runtime.getRuntime().exec(s"kill -USR1 $pid")
     ()
   }
 
@@ -274,7 +278,7 @@ package examples {
         IO.unit.flatMap(_ => loop)
 
     val run = for {
-      fibers <- loop.timeoutTo(3.seconds, IO.unit).start.replicateA(32)
+      fibers <- loop.timeoutTo(5.seconds, IO.unit).start.replicateA(32)
 
       sleeper = for {
         _ <- IO.unit

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -28,7 +28,16 @@ import java.io.File
 
 class IOAppSpec extends Specification {
 
-  val JavaHome = System.getProperty("java.home")
+  val JavaHome = {
+    val path = sys.env.get("JAVA_HOME").getOrElse(System.getProperty("java.home"))
+    if (path.endsWith("/jre")) {
+      // handle JDK 8 installations
+      path.replace("/jre", "")
+    } else {
+      path
+    }
+  }
+
   val ClassPath = System.getProperty("sbt.classpath")
 
   "IOApp (jvm)" should {

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -55,6 +55,11 @@ class IOAppSpec extends Specification {
       "exit on fatal error" in skipped("cannot observe graceful process termination on Windows")
       "exit on fatal error with other unsafe runs" in skipped(
         "cannot observe graceful process termination on Windows")
+      "exit on canceled" in skipped("cannot observe graceful process termination on Windows")
+      "warn on global runtime collision" in skipped(
+        "cannot observe graceful process termination on Windows")
+      "abort awaiting shutdown hooks" in skipped(
+        "cannot observe graceful process termination on Windows")
     } else {
       "run finalizers on TERM" in {
         if (System.getProperty("os.name").toLowerCase.contains("windows")) {


### PR DESCRIPTION
This PR registers the signals for handling live fiber snapshots on the JVM. It also sets up an integration test.

The bulk of the changes are in test code. All affected runtimes are tested.