### PR TITLE
Remove `-Xcheckinit` compiler flag

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -30,12 +30,6 @@ object Common extends AutoPlugin {
           Nil
         else
           Seq(compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"))
-      },
-      scalacOptions ++= {
-        if (isDotty.value)
-          Nil
-        else
-          Seq("-Xcheckinit")
       }
     )
 }


### PR DESCRIPTION
I'm pretty sure this is responsible for those auto-generated volatile fields that have been taunting @vasilmkd 😆 