### PR TITLE
Undo workarounds for `bitmap$init`

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -102,7 +102,7 @@ private[effect] final class WorkStealingThreadPool(
    */
   private[this] val done: AtomicBoolean = new AtomicBoolean(false)
 
-  private[this] val blockedWorkerThreadCounter: AtomicInteger = new AtomicInteger(0)
+  private[unsafe] val blockedWorkerThreadCounter: AtomicInteger = new AtomicInteger(0)
 
   // Thread pool initialization block.
   {
@@ -565,9 +565,6 @@ private[effect] final class WorkStealingThreadPool(
       Thread.currentThread().interrupt()
     }
   }
-
-  private[unsafe] def blockedWorkerThreadCounterForwarder: AtomicInteger =
-    blockedWorkerThreadCounter
 
   /*
    * What follows is a collection of methos used in the implementation of the

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -517,7 +517,7 @@ private final class WorkerThread(
       // this worker thread has run its course and it is time to die, after the
       // blocking code has been successfully executed.
       blocking = true
-      pool.blockedWorkerThreadCounterForwarder.incrementAndGet()
+      pool.blockedWorkerThreadCounter.incrementAndGet()
 
       // Spawn a new `WorkerThread`, a literal clone of this one. It is safe to
       // transfer ownership of the local queue and the parked signal to the new
@@ -539,7 +539,7 @@ private final class WorkerThread(
       // action.
       val result = thunk
 
-      pool.blockedWorkerThreadCounterForwarder.decrementAndGet()
+      pool.blockedWorkerThreadCounter.decrementAndGet()
 
       result
     }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -81,7 +81,7 @@ private final class WorkerThread(
    * detecting nested blocking regions, in order to avoid unnecessarily spawning extra
    * [[WorkerThread]] s.
    */
-  private[this] var blocking: Boolean = _
+  private[this] var blocking: Boolean = false
 
   /**
    * Holds a reference to the fiber currently being executed by this worker thread. This field


### PR DESCRIPTION
Don't feel strongly about this, but I think the old code was just a little cleaner and better scoped. I think these were the only two places?