### PR TITLE
Inline the head and the tail of the local queue while avoiding false sharing

### DIFF
--- a/core/jvm/src/main/java/cats/effect/unsafe/LocalQueue.java
+++ b/core/jvm/src/main/java/cats/effect/unsafe/LocalQueue.java
@@ -19,30 +19,36 @@ package cats.effect.unsafe;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 @SuppressWarnings("unused")
-class HeadPadding {
-  private final int hp00 = 0;
-  private final long hp01 = 0;
-  private final long hp02 = 0;
-  private final long hp03 = 0;
-  private final long hp04 = 0;
-  private final long hp05 = 0;
-  private final long hp06 = 0;
-  private final long hp07 = 0;
-  private final long hp08 = 0;
-  private final long hp09 = 0;
-  private final long hp10 = 0;
-  private final long hp11 = 0;
-  private final long hp12 = 0;
-  private final long hp13 = 0;
-  private final long hp14 = 0;
-  private final long hp15 = 0;
-  private final long hp16 = 0;
+class ClassPadding {
+  private final int p00 = 0;
+}
+
+@SuppressWarnings("unused")
+class HeadPadding extends ClassPadding {
+  private final long p01 = 0;
+  private final long p02 = 0;
+  private final long p03 = 0;
+  private final long p04 = 0;
+  private final long p05 = 0;
+  private final long p06 = 0;
+  private final long p07 = 0;
+  private final long p08 = 0;
+  private final long p09 = 0;
+  private final long p10 = 0;
+  private final long p11 = 0;
+  private final long p12 = 0;
+  private final long p13 = 0;
+  private final long p14 = 0;
+  private final long p15 = 0;
+  private final long p16 = 0;
 }
 
 @SuppressWarnings("unused")
 class Head extends HeadPadding {
   protected static final AtomicIntegerFieldUpdater<Head> updater =
       AtomicIntegerFieldUpdater.newUpdater(Head.class, "head");
+
+  private final int p00 = 0;
 
   /**
    * The head of the queue.
@@ -73,23 +79,22 @@ class Head extends HeadPadding {
 
 @SuppressWarnings("unused")
 class TailPadding extends Head {
-  private final int tp00 = 0;
-  private final long tp01 = 0;
-  private final long tp02 = 0;
-  private final long tp03 = 0;
-  private final long tp04 = 0;
-  private final long tp05 = 0;
-  private final long tp06 = 0;
-  private final long tp07 = 0;
-  private final long tp08 = 0;
-  private final long tp09 = 0;
-  private final long tp10 = 0;
-  private final long tp11 = 0;
-  private final long tp12 = 0;
-  private final long tp13 = 0;
-  private final long tp14 = 0;
-  private final long tp15 = 0;
-  private final long tp16 = 0;
+  private final long p01 = 0;
+  private final long p02 = 0;
+  private final long p03 = 0;
+  private final long p04 = 0;
+  private final long p05 = 0;
+  private final long p06 = 0;
+  private final long p07 = 0;
+  private final long p08 = 0;
+  private final long p09 = 0;
+  private final long p10 = 0;
+  private final long p11 = 0;
+  private final long p12 = 0;
+  private final long p13 = 0;
+  private final long p14 = 0;
+  private final long p15 = 0;
+  private final long p16 = 0;
 }
 
 @SuppressWarnings("unused")
@@ -114,21 +119,20 @@ class Tail extends TailPadding {
 
 @SuppressWarnings("unused")
 class LocalQueuePadding extends Tail {
-  private final int qp00 = 0;
-  private final long qp01 = 0;
-  private final long qp02 = 0;
-  private final long qp03 = 0;
-  private final long qp04 = 0;
-  private final long qp05 = 0;
-  private final long qp06 = 0;
-  private final long qp07 = 0;
-  private final long qp08 = 0;
-  private final long qp09 = 0;
-  private final long qp10 = 0;
-  private final long qp11 = 0;
-  private final long qp12 = 0;
-  private final long qp13 = 0;
-  private final long qp14 = 0;
-  private final long qp15 = 0;
-  private final long qp16 = 0;
+  private final long p01 = 0;
+  private final long p02 = 0;
+  private final long p03 = 0;
+  private final long p04 = 0;
+  private final long p05 = 0;
+  private final long p06 = 0;
+  private final long p07 = 0;
+  private final long p08 = 0;
+  private final long p09 = 0;
+  private final long p10 = 0;
+  private final long p11 = 0;
+  private final long p12 = 0;
+  private final long p13 = 0;
+  private final long p14 = 0;
+  private final long p15 = 0;
+  private final long p16 = 0;
 }

--- a/core/jvm/src/main/java/cats/effect/unsafe/LocalQueue.java
+++ b/core/jvm/src/main/java/cats/effect/unsafe/LocalQueue.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.unsafe;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+@SuppressWarnings("unused")
+class HeadPadding {
+  private final long hp01 = 0;
+  private final long hp02 = 0;
+  private final long hp03 = 0;
+  private final long hp04 = 0;
+  private final long hp05 = 0;
+  private final long hp06 = 0;
+  private final long hp07 = 0;
+  private final long hp08 = 0;
+  private final long hp09 = 0;
+  private final long hp10 = 0;
+  private final long hp11 = 0;
+  private final long hp12 = 0;
+  private final long hp13 = 0;
+  private final long hp14 = 0;
+  private final long hp15 = 0;
+  private final long hp16 = 0;
+}
+
+@SuppressWarnings("unused")
+class Head extends HeadPadding {
+  protected static final AtomicIntegerFieldUpdater<Head> updater =
+      AtomicIntegerFieldUpdater.newUpdater(Head.class, "head");
+
+  /**
+   * The head of the queue.
+   *
+   * <p>Concurrently updated by many [[WorkerThread]] s.
+   *
+   * <p>Conceptually, it is a concatenation of two unsigned 16 bit values. Since the capacity of the
+   * local queue is less than (2^16 - 1), the extra unused values are used to distinguish between
+   * the case where the queue is empty (`head` == `tail`) and (`head` - `tail` ==
+   * [[LocalQueueConstants.LocalQueueCapacity]]), which is an important distinction for other
+   * [[WorkerThread]] s trying to steal work from the queue.
+   *
+   * <p>The least significant 16 bits of the integer value represent the ''real'' value of the head,
+   * pointing to the next [[cats.effect.IOFiber]] instance to be dequeued from the queue.
+   *
+   * <p>The most significant 16 bits of the integer value represent the ''steal'' tag of the head.
+   * This value is altered by another [[WorkerThread]] which has managed to win the race and become
+   * the exclusive ''stealer'' of the queue. During the period in which the ''steal'' tag differs
+   * from the ''real'' value, no other [[WorkerThread]] can steal from the queue, and the owner
+   * [[WorkerThread]] also takes special care to not mangle the ''steal'' tag set by the
+   * ''stealer''. The stealing [[WorkerThread]] is free to transfer half of the available
+   * [[cats.effect.IOFiber]] object references from this queue into its own [[LocalQueue]] during
+   * this period, making sure to undo the changes to the ''steal'' tag of the head on completion,
+   * action which ultimately signals that stealing is finished.
+   */
+  private volatile int head = 0;
+}
+
+@SuppressWarnings("unused")
+class TailPadding extends Head {
+  private final long tp01 = 0;
+  private final long tp02 = 0;
+  private final long tp03 = 0;
+  private final long tp04 = 0;
+  private final long tp05 = 0;
+  private final long tp06 = 0;
+  private final long tp07 = 0;
+  private final long tp08 = 0;
+  private final long tp09 = 0;
+  private final long tp10 = 0;
+  private final long tp11 = 0;
+  private final long tp12 = 0;
+  private final long tp13 = 0;
+  private final long tp14 = 0;
+  private final long tp15 = 0;
+  private final long tp16 = 0;
+}
+
+@SuppressWarnings("unused")
+class Tail extends TailPadding {
+  protected static final AtomicIntegerFieldUpdater<Tail> updater =
+      AtomicIntegerFieldUpdater.newUpdater(Tail.class, "tailPublisher");
+
+  /**
+   * The tail of the queue.
+   *
+   * <p>Only ever updated by the owner [[WorkerThread]], but also read by other threads to determine
+   * the current size of the queue, for work stealing purposes. Denotes the next available free slot
+   * in the `buffer` array.
+   *
+   * <p>Conceptually, it is an unsigned 16 bit value (the most significant 16 bits of the integer
+   * value are ignored in most operations).
+   */
+  protected int tail = 0;
+
+  private volatile int tailPublisher = 0;
+}
+
+@SuppressWarnings("unused")
+class LocalQueuePadding extends Tail {
+  private final long qp01 = 0;
+  private final long qp02 = 0;
+  private final long qp03 = 0;
+  private final long qp04 = 0;
+  private final long qp05 = 0;
+  private final long qp06 = 0;
+  private final long qp07 = 0;
+  private final long qp08 = 0;
+  private final long qp09 = 0;
+  private final long qp10 = 0;
+  private final long qp11 = 0;
+  private final long qp12 = 0;
+  private final long qp13 = 0;
+  private final long qp14 = 0;
+  private final long qp15 = 0;
+  private final long qp16 = 0;
+}

--- a/core/jvm/src/main/java/cats/effect/unsafe/LocalQueue.java
+++ b/core/jvm/src/main/java/cats/effect/unsafe/LocalQueue.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 @SuppressWarnings("unused")
 class HeadPadding {
+  private final int hp00 = 0;
   private final long hp01 = 0;
   private final long hp02 = 0;
   private final long hp03 = 0;
@@ -72,6 +73,7 @@ class Head extends HeadPadding {
 
 @SuppressWarnings("unused")
 class TailPadding extends Head {
+  private final int tp00 = 0;
   private final long tp01 = 0;
   private final long tp02 = 0;
   private final long tp03 = 0;
@@ -112,6 +114,7 @@ class Tail extends TailPadding {
 
 @SuppressWarnings("unused")
 class LocalQueuePadding extends Tail {
+  private final int qp00 = 0;
   private final long qp01 = 0;
   private final long qp02 = 0;
   private final long qp03 = 0;

--- a/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
@@ -31,7 +31,6 @@ package unsafe
 import cats.effect.tracing.TracingConstants
 
 import java.util.concurrent.ThreadLocalRandom
-import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Fixed length, FIFO, single producer, multiple consumer, lock-free, circular buffer queue
@@ -120,7 +119,7 @@ import java.util.concurrent.atomic.AtomicInteger
  * `Unsafe`. And `Unsafe` is only really needed on JVM 8. JVM 9+ introduce much richer and
  * better APIs and tools for building high-performance concurrent systems (e.g. `VarHandle`).
  */
-private final class LocalQueue {
+private final class LocalQueue extends LocalQueuePadding {
 
   import LocalQueueConstants._
   import TracingConstants._
@@ -130,49 +129,6 @@ private final class LocalQueue {
    * buffer queue.
    */
   private[this] val buffer: Array[IOFiber[_]] = new Array(LocalQueueCapacity)
-
-  /**
-   * The head of the queue.
-   *
-   * Concurrently updated by many [[WorkerThread]] s.
-   *
-   * Conceptually, it is a concatenation of two unsigned 16 bit values. Since the capacity of
-   * the local queue is less than (2^16 - 1), the extra unused values are used to distinguish
-   * between the case where the queue is empty (`head` == `tail`) and (`head` - `tail` ==
-   * [[LocalQueueConstants.LocalQueueCapacity]]), which is an important distinction for other
-   * [[WorkerThread]] s trying to steal work from the queue.
-   *
-   * The least significant 16 bits of the integer value represent the ''real'' value of the
-   * head, pointing to the next [[cats.effect.IOFiber]] instance to be dequeued from the queue.
-   *
-   * The most significant 16 bits of the integer value represent the ''steal'' tag of the head.
-   * This value is altered by another [[WorkerThread]] which has managed to win the race and
-   * become the exclusive ''stealer'' of the queue. During the period in which the ''steal'' tag
-   * differs from the ''real'' value, no other [[WorkerThread]] can steal from the queue, and
-   * the owner [[WorkerThread]] also takes special care to not mangle the ''steal'' tag set by
-   * the ''stealer''. The stealing [[WorkerThread]] is free to transfer half of the available
-   * [[cats.effect.IOFiber]] object references from this queue into its own [[LocalQueue]]
-   * during this period, making sure to undo the changes to the ''steal'' tag of the head on
-   * completion, action which ultimately signals that stealing is finished.
-   */
-  private[this] val head: AtomicInteger = new AtomicInteger(0)
-
-  /**
-   * The tail of the queue.
-   *
-   * Only ever updated by the owner [[WorkerThread]], but also read by other threads to
-   * determine the current size of the queue, for work stealing purposes. Denotes the next
-   * available free slot in the `buffer` array.
-   *
-   * Conceptually, it is an unsigned 16 bit value (the most significant 16 bits of the integer
-   * value are ignored in most operations).
-   */
-  private[this] var tail: Int = 0
-
-  /**
-   * The publisher for the tail of the queue. Accessed by other [[WorkerThread]] s.
-   */
-  private[this] val tailPublisher: AtomicInteger = new AtomicInteger(0)
 
   /*
    * What follows is a collection of counters exposed through the
@@ -250,7 +206,7 @@ private final class LocalQueue {
     // observed.
     while (true) {
       // A load of the head of the queue using `acquire` semantics.
-      val hd = head.get()
+      val hd = Head.updater.get(this)
 
       // Preparation for outcome 1, calculating the "steal" tag of the head.
       val steal = msb(hd)
@@ -267,7 +223,7 @@ private final class LocalQueue {
         }
 
         val newTl = unsignedShortAddition(tl, 1)
-        tailPublisher.lazySet(newTl)
+        Tail.updater.lazySet(this, newTl)
         tail = newTl
         return
       }
@@ -280,7 +236,7 @@ private final class LocalQueue {
         // external queue and break out of the loop.
         if (isStackTracing) {
           totalSpilloverCount += 1
-          tailPublisher.lazySet(tl)
+          Tail.updater.lazySet(this, tl)
         }
 
         external.offer(fiber, random)
@@ -296,7 +252,7 @@ private final class LocalQueue {
       // external queue one by one.
       val realPlusHalf = unsignedShortAddition(real, HalfLocalQueueCapacity)
       val newHd = pack(realPlusHalf, realPlusHalf)
-      if (head.compareAndSet(hd, newHd)) {
+      if (Head.updater.compareAndSet(this, hd, newHd)) {
         // Outcome 3, half of the queue has been claimed by the owner
         // `WorkerThread`, to be transferred to the batched queue.
         // Due to the new tuning, half of the local queue does not equal a
@@ -390,7 +346,7 @@ private final class LocalQueue {
 
     while (true) {
       // A load of the head of the queue using `acquire` semantics.
-      val hd = head.get()
+      val hd = Head.updater.get(this)
       val steal = msb(hd)
 
       // Check the current occupancy of the queue. In the one pathological case
@@ -416,7 +372,7 @@ private final class LocalQueue {
 
         // Publish the new tail.
         val newTl = unsignedShortAddition(tl, SpilloverBatchSize - 1)
-        tailPublisher.lazySet(newTl)
+        Tail.updater.lazySet(this, newTl)
         tail = newTl
         // Return a fiber to be directly executed, withouth enqueueing it first
         // on the local queue. This does sacrifice some fairness, because the
@@ -466,7 +422,7 @@ private final class LocalQueue {
     // the head by 1 position, securing the fiber to return in the process.
     while (true) {
       // A load of the head of the queue using `acquire` semantics.
-      val hd = head.get()
+      val hd = Head.updater.get(this)
 
       // Dequeueing only cares about the "real" value of the head.
       val real = lsb(hd)
@@ -491,7 +447,7 @@ private final class LocalQueue {
         worker.active = fiber
       }
 
-      if (head.compareAndSet(hd, newHd)) {
+      if (Head.updater.compareAndSet(this, hd, newHd)) {
         // The head has been successfully moved forward and the fiber secured.
         // Proceed to null out the reference to the fiber and return it.
         buffer(idx) = null
@@ -540,7 +496,7 @@ private final class LocalQueue {
     val dstTl = dst.plainLoadTail()
 
     // A load of the head of the destination queue using `acquire` semantics.
-    val dstHd = dst.headForwarder.get()
+    val dstHd = Head.updater.get(dst)
 
     // Before a steal is attempted, make sure that the destination queue is not
     // being stolen from. It can be argued that an attempt to steal fewer fibers
@@ -557,7 +513,7 @@ private final class LocalQueue {
     // stealing from this queue.
     while (true) {
       // A load of the head of the local queue using `acquire` semantics.
-      var hd = head.get()
+      var hd = Head.updater.get(this)
 
       val steal = msb(hd)
       val real = lsb(hd)
@@ -572,7 +528,7 @@ private final class LocalQueue {
       // A load of the tail of the local queue using `acquire` semantics.  Here,
       // the `WorkerThread` that executes this code is **not** the owner of this
       // local queue, hence the need for an `acquire` load.
-      val tl = tailPublisher.get()
+      val tl = Tail.updater.get(this)
 
       // Calculate the current size of the queue (the number of enqueued fibers).
       var n = unsignedShortSubtraction(tl, real)
@@ -593,7 +549,7 @@ private final class LocalQueue {
       // signal to other threads that stealing is underway.
       var newHd = pack(steal, newReal)
 
-      if (head.compareAndSet(hd, newHd)) {
+      if (Head.updater.compareAndSet(this, hd, newHd)) {
         // The head has been successfully moved forward and the stealing process
         // announced. Proceed to transfer all of the fibers between the old
         // "steal" tag and the new "real" value, nulling out the references for
@@ -637,7 +593,7 @@ private final class LocalQueue {
         while (true) {
           newHd = pack(newReal, newReal)
 
-          if (head.compareAndSet(hd, newHd)) {
+          if (Head.updater.compareAndSet(this, hd, newHd)) {
             // The "steal" tag now matches the "real" head value. Proceed to
             // return a fiber that can immediately be executed by the stealing
             // `WorkerThread`.
@@ -647,7 +603,7 @@ private final class LocalQueue {
               // synchronization operations.
 
               if (isStackTracing) {
-                dst.tailPublisherForwarder.lazySet(dstTl)
+                Tail.updater.lazySet(dst, dstTl)
                 dst.plainStoreTail(dstTl)
               }
 
@@ -662,13 +618,13 @@ private final class LocalQueue {
 
             // Publish the new tail of the destination queue. That way the
             // destination queue also becomes eligible for stealing.
-            dst.tailPublisherForwarder.lazySet(newDstTl)
+            Tail.updater.lazySet(dst, newDstTl)
             dst.plainStoreTail(newDstTl)
             return headFiber
           } else {
             // Failed to opportunistically restore the value of the `head`. Load
             // it again and retry.
-            hd = head.get()
+            hd = Head.updater.get(this)
             newReal = lsb(hd)
           }
         }
@@ -712,7 +668,7 @@ private final class LocalQueue {
 
     while (true) {
       // A load of the head of the queue using `acquire` semantics.
-      val hd = head.get()
+      val hd = Head.updater.get(this)
 
       val real = lsb(hd)
 
@@ -730,7 +686,7 @@ private final class LocalQueue {
       val steal = msb(hd)
       val newHd = if (steal == real) pack(newReal, newReal) else pack(steal, newReal)
 
-      if (head.compareAndSet(hd, newHd)) {
+      if (Head.updater.compareAndSet(this, hd, newHd)) {
         // The head has been successfully moved forward and a batch of fibers
         // secured. Proceed to null out the references to the fibers and
         // transfer them to the batch.
@@ -749,7 +705,7 @@ private final class LocalQueue {
         // batched queue.
         if (isStackTracing) {
           totalSpilloverCount += SpilloverBatchSize
-          tailPublisher.lazySet(tl)
+          Tail.updater.lazySet(this, tl)
         }
 
         external.offer(batch, random)
@@ -765,8 +721,8 @@ private final class LocalQueue {
    *   `true` if the queue is empty, `false` otherwise
    */
   def isEmpty(): Boolean = {
-    val hd = head.get()
-    val tl = tailPublisher.get()
+    val hd = Head.updater.get(this)
+    val tl = Tail.updater.get(this)
     lsb(hd) == tl
   }
 
@@ -788,8 +744,8 @@ private final class LocalQueue {
    *   the number of fibers currently enqueued on this local queue
    */
   def size(): Int = {
-    val hd = head.get()
-    val tl = tailPublisher.get()
+    val hd = Head.updater.get(this)
+    val tl = Tail.updater.get(this)
     unsignedShortSubtraction(tl, lsb(hd))
   }
 
@@ -819,22 +775,6 @@ private final class LocalQueue {
    *   a reference to [[LocalQueue#buf]]
    */
   def bufferForwarder: Array[IOFiber[_]] = buffer
-
-  /**
-   * A forwarder method to the `head` of the queue.
-   *
-   * @return
-   *   a reference to the `head` of the queue
-   */
-  private def headForwarder: AtomicInteger = head
-
-  /**
-   * A forwarder method to the `tailPublisher`.
-   *
-   * @return
-   *   a reference to the `tailPublisher`
-   */
-  private def tailPublisherForwarder: AtomicInteger = tailPublisher
 
   /**
    * Computes the index into the circular buffer for a given integer value.
@@ -938,7 +878,7 @@ private final class LocalQueue {
    *   the index representing the head of the queue
    */
   def getHeadIndex(): Int = {
-    val hd = head.get()
+    val hd = Head.updater.get(this)
     index(lsb(hd))
   }
 
@@ -950,7 +890,7 @@ private final class LocalQueue {
    *   the index representing the tail of the queue
    */
   def getTailIndex(): Int = {
-    val tl = tailPublisher.get()
+    val tl = Tail.updater.get(this)
     index(tl)
   }
 
@@ -961,7 +901,7 @@ private final class LocalQueue {
    *   the total number of fibers enqueued during the lifetime of this local queue
    */
   def getTotalFiberCount(): Long = {
-    val _ = tailPublisher.get()
+    val _ = Tail.updater.get(this)
     totalFiberCount
   }
 
@@ -973,7 +913,7 @@ private final class LocalQueue {
    *   the total number of fibers spilt over to the external queue
    */
   def getTotalSpilloverCount(): Long = {
-    val _ = tailPublisher.get()
+    val _ = Tail.updater.get(this)
     totalSpilloverCount
   }
 
@@ -985,7 +925,7 @@ private final class LocalQueue {
    *   the total number of successful steal attempts by other worker threads
    */
   def getSuccessfulStealAttemptCount(): Long = {
-    val _ = head.get()
+    val _ = Head.updater.get(this)
     successfulStealAttemptCount
   }
 
@@ -997,7 +937,7 @@ private final class LocalQueue {
    *   the total number of stolen fibers by other worker threads
    */
   def getStolenFiberCount(): Long = {
-    val _ = head.get()
+    val _ = Head.updater.get(this)
     stolenFiberCount
   }
 
@@ -1014,7 +954,7 @@ private final class LocalQueue {
    *   the "real" value of the head of the local queue
    */
   def getRealHeadTag(): Int = {
-    val hd = head.get()
+    val hd = Head.updater.get(this)
     lsb(hd)
   }
 
@@ -1031,7 +971,7 @@ private final class LocalQueue {
    *   the "steal" tag of the head of the local queue
    */
   def getStealHeadTag(): Int = {
-    val hd = head.get()
+    val hd = Head.updater.get(this)
     msb(hd)
   }
 
@@ -1048,5 +988,7 @@ private final class LocalQueue {
    * @return
    *   the "tail" tag of the tail of the local queue
    */
-  def getTailTag(): Int = tailPublisher.get()
+  def getTailTag(): Int = {
+    Tail.updater.get(this)
+  }
 }


### PR DESCRIPTION
False sharing is not a joke Jim, millions of fibers suffer every day. https://www.youtube.com/watch?v=WaaANll8h18

I ran the benchmarks twice each, and let the computer cool down between runs.

`series/3.x`:
```
Benchmark                          (size)   Mode  Cnt   Score   Error    Units
WorkStealingBenchmark.scheduling  1000000  thrpt   20  11.439 ± 0.317  ops/min

Benchmark                          (size)   Mode  Cnt   Score   Error    Units
WorkStealingBenchmark.scheduling  1000000  thrpt   20  11.475 ± 0.338  ops/min
```

`This PR`:
```
Benchmark                          (size)   Mode  Cnt   Score   Error    Units
WorkStealingBenchmark.scheduling  1000000  thrpt   20  12.969 ± 0.350  ops/min

Benchmark                          (size)   Mode  Cnt   Score   Error    Units
WorkStealingBenchmark.scheduling  1000000  thrpt   20  13.354 ± 0.277  ops/min
```

I still need to do some cleanups.