### PR TITLE
Optional active fiber

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -109,7 +109,7 @@ private[effect] final class FiberMonitor(
 
       val localAndActive = workersMap.foldLeft(Set.empty[IOFiber[_]]) {
         case (acc, (_, (active, local))) =>
-          (acc ++ local) + active
+          (acc ++ local) ++ active.toSet
       }
       val external = rawExternal -- localAndActive
       val foreign = rawForeign -- localAndActive -- external
@@ -141,7 +141,7 @@ private[effect] final class FiberMonitor(
           val workerString = s"$worker (#${worker.index}): ${local.size} enqueued"
 
           print(doubleNewline)
-          print(fiberString(active, status))
+          active.map(fiberString(_, status)).foreach(print(_))
           printFibers(local, "YIELDING")
 
           workerString


### PR DESCRIPTION
```
Exception in thread "SIGINFO handler" java.lang.NullPointerException
        at cats.effect.unsafe.FiberMonitor.fiberString$1(FiberMonitor.scala:123)
        at cats.effect.unsafe.FiberMonitor.$anonfun$liveFiberSnapshot$4(FiberMonitor.scala:135)
        at scala.collection.StrictOptimizedMapOps.map(StrictOptimizedMapOps.scala:28)
        at scala.collection.StrictOptimizedMapOps.map$(StrictOptimizedMapOps.scala:27)
        at scala.collection.immutable.HashMap.map(HashMap.scala:39)
        at cats.effect.unsafe.FiberMonitor.$anonfun$liveFiberSnapshot$2(FiberMonitor.scala:128)
        at scala.Option.map(Option.scala:242)
        at cats.effect.unsafe.FiberMonitor.liveFiberSnapshot(FiberMonitor.scala:99)
        at cats.effect.IOApp.$anonfun$main$8(IOApp.scala:251)
        at cats.effect.Signal.lambda$invocationHandlerFromConsumer$0(Signal.java:105)
        at jdk.proxy4.$Proxy144.handle(Unknown Source)
        at sun.misc.Signal$InternalMiscHandler.handle(Signal.java:198)
        at jdk.internal.misc.Signal$1.run(Signal.java:219)
        at java.lang.Thread.run(Thread.java:833)
        at com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:596)
        at com.oracle.svm.core.posix.thread.PosixJavaThreads.pthreadStartRoutine(PosixJavaThreads.java:192)
```