### PR TITLE
Ignore sources in the `scalafix` directory

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -2,6 +2,10 @@ version = 3.1.1
 
 runner.dialect = Scala213Source3
 
+project.excludeFilters = [
+  "scalafix/*"
+]
+
 maxColumn = 96
 
 includeCurlyBraceInSelectChains = true


### PR DESCRIPTION
Thank you @fthomas.

This should help with Scala Steward applying formatting to output files in the `scalafix/` directory and ease the merging of scalafmt update PRs.

https://github.com/typelevel/fs2/pull/2711