### PR TITLE
Remove `-P:scalajs:mapSourceURI` for JS tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -479,6 +479,7 @@ lazy val tests = crossProject(JSPlatform, JVMPlatform)
     Test / fork := true,
     Test / javaOptions += s"-Dsbt.classpath=${(Test / fullClasspath).value.map(_.data.getAbsolutePath).mkString(File.pathSeparator)}")
   .jsSettings(
+    // The default configured mapSourceURI is used for trace filtering
     scalacOptions ~= { _.filterNot(_.startsWith("-P:scalajs:mapSourceURI")) }
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -478,6 +478,9 @@ lazy val tests = crossProject(JSPlatform, JVMPlatform)
   .jvmSettings(
     Test / fork := true,
     Test / javaOptions += s"-Dsbt.classpath=${(Test / fullClasspath).value.map(_.data.getAbsolutePath).mkString(File.pathSeparator)}")
+  .jsSettings(
+    scalacOptions ~= { _.filterNot(_.startsWith("-P:scalajs:mapSourceURI")) }
+  )
 
 /**
  * Implementations lof standard functionality (e.g. Semaphore, Console, Queue) purely in terms


### PR DESCRIPTION
This is what tripped me up in https://github.com/typelevel/cats-effect/pull/2557#issuecomment-971989012.

On JVM, traces are filtered by package name, so we test outside the usual package.

On JS, traces are _also_ filtered by filename (e.g. starting with `https://raw.githubusercontent.com/typelevel/cats-effect/`). Removing this setting is equivalent to getting out of the package.