### PR TITLE
Tighten up specs2 dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -479,10 +479,11 @@ lazy val tests: CrossProject = crossProject(JSPlatform, JVMPlatform)
     name := "cats-effect-tests",
     libraryDependencies ++= Seq(
       "org.scalacheck" %%% "scalacheck" % ScalaCheckVersion,
-      ("org.specs2" %%% "specs2-core" % Specs2Version % Test)
+      ("org.specs2" %%% "specs2-scalacheck" % Specs2Version % Test)
         .cross(CrossVersion.for3Use2_13)
-        .exclude("org.scala-js", "scala-js-macrotask-executor_sjs1_2.13"),
-      "org.specs2" %%% "specs2-scalacheck" % Specs2Version % Test cross CrossVersion.for3Use2_13,
+        .exclude("org.scala-js", "scala-js-macrotask-executor_sjs1_2.13")
+        .exclude("org.scalacheck", "scalacheck_2.13")
+        .exclude("org.scalacheck", "scalacheck_sjs1_2.13"),
       "org.typelevel" %%% "discipline-specs2" % DisciplineVersion % Test,
       "org.typelevel" %%% "cats-kernel-laws" % CatsVersion % Test
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -479,9 +479,10 @@ lazy val tests: CrossProject = crossProject(JSPlatform, JVMPlatform)
     name := "cats-effect-tests",
     libraryDependencies ++= Seq(
       "org.scalacheck" %%% "scalacheck" % ScalaCheckVersion,
-      ("org.specs2" %%% "specs2-scalacheck" % Specs2Version % Test)
+      ("org.specs2" %%% "specs2-core" % Specs2Version % Test)
         .cross(CrossVersion.for3Use2_13)
         .exclude("org.scala-js", "scala-js-macrotask-executor_sjs1_2.13"),
+      "org.specs2" %%% "specs2-scalacheck" % Specs2Version % Test cross CrossVersion.for3Use2_13,
       "org.typelevel" %%% "discipline-specs2" % DisciplineVersion % Test,
       "org.typelevel" %%% "cats-kernel-laws" % CatsVersion % Test
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -284,21 +284,12 @@ lazy val kernel = crossProject(JSPlatform, JVMPlatform)
   .settings(
     name := "cats-effect-kernel",
     libraryDependencies += "org.typelevel" %%% "cats-core" % CatsVersion)
-  .jvmSettings(libraryDependencies += {
-    if (isDotty.value)
-      ("org.specs2" %%% "specs2-core" % Specs2Version % Test).cross(CrossVersion.for3Use2_13)
-    else
-      "org.specs2" %%% "specs2-core" % Specs2Version % Test
-  })
+  .settings(
+    libraryDependencies += ("org.specs2" %%% "specs2-core" % Specs2Version % Test)
+      .cross(CrossVersion.for3Use2_13)
+      .exclude("org.scala-js", "scala-js-macrotask-executor_sjs1_2.13")
+  )
   .jsSettings(
-    libraryDependencies += {
-      if (isDotty.value)
-        ("org.specs2" %%% "specs2-core" % Specs2Version % Test)
-          .cross(CrossVersion.for3Use2_13)
-          .exclude("org.scala-js", "scala-js-macrotask-executor_sjs1_2.13")
-      else
-        "org.specs2" %%% "specs2-core" % Specs2Version % Test
-    },
     libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % MacrotaskExecutorVersion % Test
   )
 
@@ -469,21 +460,13 @@ lazy val testkit = crossProject(JSPlatform, JVMPlatform)
   .dependsOn(core, kernelTestkit)
   .settings(
     name := "cats-effect-testkit",
-    libraryDependencies += "org.scalacheck" %%% "scalacheck" % ScalaCheckVersion)
-  .jvmSettings(libraryDependencies += {
-    if (isDotty.value)
-      ("org.specs2" %%% "specs2-core" % Specs2Version % Test).cross(CrossVersion.for3Use2_13)
-    else
-      "org.specs2" %%% "specs2-core" % Specs2Version % Test
-  })
-  .jsSettings(libraryDependencies += {
-    if (isDotty.value)
+    libraryDependencies ++= Seq(
+      "org.scalacheck" %%% "scalacheck" % ScalaCheckVersion,
       ("org.specs2" %%% "specs2-core" % Specs2Version % Test)
         .cross(CrossVersion.for3Use2_13)
         .exclude("org.scala-js", "scala-js-macrotask-executor_sjs1_2.13")
-    else
-      "org.specs2" %%% "specs2-core" % Specs2Version % Test
-  })
+    )
+  )
 
 /**
  * Unit tests for the core project, utilizing the support provided by testkit.
@@ -495,8 +478,13 @@ lazy val tests: CrossProject = crossProject(JSPlatform, JVMPlatform)
   .settings(
     name := "cats-effect-tests",
     libraryDependencies ++= Seq(
+      "org.scalacheck" %%% "scalacheck" % ScalaCheckVersion,
+      ("org.specs2" %%% "specs2-scalacheck" % Specs2Version % Test)
+        .cross(CrossVersion.for3Use2_13)
+        .exclude("org.scala-js", "scala-js-macrotask-executor_sjs1_2.13"),
       "org.typelevel" %%% "discipline-specs2" % DisciplineVersion % Test,
-      "org.typelevel" %%% "cats-kernel-laws" % CatsVersion % Test),
+      "org.typelevel" %%% "cats-kernel-laws" % CatsVersion % Test
+    ),
     buildInfoPackage := "catseffect"
   )
   .jsSettings(
@@ -538,27 +526,16 @@ lazy val std = crossProject(JSPlatform, JVMPlatform)
   .dependsOn(kernel)
   .settings(
     name := "cats-effect-std",
-    libraryDependencies += "org.scalacheck" %%% "scalacheck" % ScalaCheckVersion % Test)
-  .jvmSettings(libraryDependencies += {
-    if (isDotty.value)
+    libraryDependencies ++= Seq(
+      "org.scalacheck" %%% "scalacheck" % ScalaCheckVersion % Test,
       ("org.specs2" %%% "specs2-scalacheck" % Specs2Version % Test)
         .cross(CrossVersion.for3Use2_13)
+        .exclude("org.scala-js", "scala-js-macrotask-executor_sjs1_2.13")
         .exclude("org.scalacheck", "scalacheck_2.13")
         .exclude("org.scalacheck", "scalacheck_sjs1_2.13")
-    else
-      "org.specs2" %%% "specs2-scalacheck" % Specs2Version % Test
-  })
+    )
+  )
   .jsSettings(
-    libraryDependencies += {
-      if (isDotty.value)
-        ("org.specs2" %%% "specs2-scalacheck" % Specs2Version % Test)
-          .cross(CrossVersion.for3Use2_13)
-          .exclude("org.scala-js", "scala-js-macrotask-executor_sjs1_2.13")
-          .exclude("org.scalacheck", "scalacheck_2.13")
-          .exclude("org.scalacheck", "scalacheck_sjs1_2.13")
-      else
-        "org.specs2" %%% "specs2-scalacheck" % Specs2Version % Test
-    },
     libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % MacrotaskExecutorVersion % Test
   )
 


### PR DESCRIPTION
Removes unnecessary ceremony around Scala 2/3 and explicitly brings in specs2-scalacheck so we don't rely on discipline-specs2 for transitive updates.