### PR TITLE
Support (suspended) fiber dumps on foreign runtimes

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -279,7 +279,8 @@ trait IOApp {
           latch.countDown()
         })(runtime)
 
-    runtime.fiberMonitor.monitorSuspended(fiber, fiber)
+    if (isStackTracing)
+      runtime.fiberMonitor.monitorSuspended(fiber, fiber)
 
     def handleShutdown(): Unit = {
       if (latch.getCount() > 0) {

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -279,6 +279,8 @@ trait IOApp {
           latch.countDown()
         })(runtime)
 
+    runtime.fiberMonitor.monitorSuspended(fiber, fiber)
+
     def handleShutdown(): Unit = {
       if (latch.getCount() > 0) {
         val cancelLatch = new CountDownLatch(1)


### PR DESCRIPTION
This enables fiber dumps even if the runtime isn't the WSTP. Since we are not tracking live/active fibers on this foreign runtime, we can only capture fibers that are "foreign" to the runtime i.e., suspended and `evalOn`.