### PR TITLE
Swap `System.exit` with `Runtime#halt`

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/internals/PoolUtils.scala
+++ b/core/jvm/src/main/scala/cats/effect/internals/PoolUtils.scala
@@ -57,7 +57,7 @@ private[internals] object PoolUtils {
             case t: Throwable =>
               // under most circumstances, this will work even with fatal errors
               t.printStackTrace()
-              System.exit(1)
+              Runtime.getRuntime().halt(1)
           }
       })
 


### PR DESCRIPTION
This PR aims to fix #2586.

Even though these explanations
- https://github.com/http4s/http4s/issues/5582#issuecomment-978118101
- https://discordapp.com/channels/632277896739946517/632278585700384799/913131970702237696

mention that when encountering SOE it is safe to recover from it, they also state that it's not necessarily ideal to create a special case for handling it.