### PR TITLE
Handle interruption gracefully and halt the runtime on fatal errors

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -20,6 +20,7 @@ import cats.effect.tracing.TracingConstants._
 import cats.effect.unsafe.FiberMonitor
 
 import scala.concurrent.{blocking, CancellationException}
+import scala.util.control.NonFatal
 
 import java.util.concurrent.CountDownLatch
 
@@ -334,8 +335,12 @@ trait IOApp {
         case _: CancellationException =>
           // Do not report cancelation exceptions but still exit with an error code.
           System.exit(1)
+        case NonFatal(t) =>
+          t.printStackTrace()
+          System.exit(1)
         case t: Throwable =>
-          throw t
+          t.printStackTrace()
+          rt.halt(1)
       }
     } catch {
       // this handles sbt when fork := false

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -280,7 +280,9 @@ private final class WorkerThread(
       }
     }
 
-    while (!blocking && !isInterrupted()) {
+    val done = pool.done
+
+    while (!blocking && !done.get()) {
       ((state & ExternalQueueTicksMask): @switch) match {
         case 0 =>
           // Obtain a fiber or batch of fibers from the external queue.

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1419,7 +1419,6 @@ private final class IOFiber[A](
 
   private[this] def onFatalFailure(t: Throwable): Null = {
     Thread.interrupted()
-    currentCtx.reportFailure(t)
     runtime.shutdown()
 
     // Make sure the shutdown did not interrupt this thread.

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -230,6 +230,13 @@ class IOAppSpec extends Specification {
           h.awaitStatus() mustEqual 0
         }
 
+        "shutdown on worker thread interruption" in {
+          val h = platform(WorkerThreadInterrupt, List.empty)
+          h.awaitStatus() mustEqual 1
+          h.stderr() must contain("java.lang.InterruptedException")
+          ok
+        }
+
         if (!BuildInfo.testJSIOApp && sys
             .props
             .get("java.version")

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -230,11 +230,13 @@ class IOAppSpec extends Specification {
           h.awaitStatus() mustEqual 0
         }
 
-        "shutdown on worker thread interruption" in {
-          val h = platform(WorkerThreadInterrupt, List.empty)
-          h.awaitStatus() mustEqual 1
-          h.stderr() must contain("java.lang.InterruptedException")
-          ok
+        if (!BuildInfo.testJSIOApp) {
+          "shutdown on worker thread interruption" in {
+            val h = platform(WorkerThreadInterrupt, List.empty)
+            h.awaitStatus() mustEqual 1
+            h.stderr() must contain("java.lang.InterruptedException")
+            ok
+          }
         }
 
         if (!BuildInfo.testJSIOApp && sys

--- a/tests/shared/src/main/scala/catseffect/examples.scala
+++ b/tests/shared/src/main/scala/catseffect/examples.scala
@@ -81,4 +81,9 @@ package examples {
       _ <- fibers.traverse(_.join)
     } yield ()
   }
+
+  object WorkerThreadInterrupt extends IOApp.Simple {
+    val run =
+      IO(Thread.currentThread().interrupt()) *> IO(Thread.sleep(1000L))
+  }
 }


### PR DESCRIPTION
This is a change that fortuitously addresses two problems of the current runtime.

1. Executing `IO(Thread.currentThread().interrupt())` would only kill the unlucky `WorkerThread` that executed it (due to the weird shutdown mechanism of the WSTP, my fault). Now, we pretend it didn't happen and if an `InterruptedException` does occur, it is a fatal error and the whole runtime will shut down.
2. This change makes the Java runtime halt in case of fatal exceptions.

Fixes #2586 for CE3.