### PR TITLE
Fixes #2606

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -116,8 +116,8 @@ private[effect] final class FiberMonitor(
             (acc ++ local) ++ active.toSet
         }
         val external = rawExternal -- localAndActive
-        val foreign = rawForeign -- localAndActive -- external
         val suspended = rawSuspended -- localAndActive -- external
+        val foreign = rawForeign -- localAndActive -- external -- suspended
 
         val workersStatuses = workersMap map {
           case (worker, (active, local)) =>


### PR DESCRIPTION
In the case of IOApp, the main fiber is registered as an external fiber
but then also monitored when it is scheduled on the workpool.

Whilst somewhat hacky, removing any fibers known to be suspended from the set of
foreign fibers seems reasonable at least. The issue was also exhibited when using
`evalOn` with an `IO` action that suspends and the same fix applies.