### PR TITLE
Fix trace filtering

### DIFF
--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -61,7 +61,7 @@ private[effect] object Tracing extends TracingPlatform {
     var i = 0
     val len = stackTraceClassNameFilter.length
     while (i < len) {
-      if (className.contains(stackTraceClassNameFilter(i)))
+      if (className.startsWith(stackTraceClassNameFilter(i)))
         return true
       i += 1
     }


### PR DESCRIPTION
This PR fixes #2608 

```
cats.effect.IOFiber@72c7fa97 WAITING
 ├ main$ @ io.github.timwspence.cats.stm.Test$.main(Test.scala:21)
 ├ flatMap @ io.github.timwspence.cats.stm.Test$.$anonfun$run$2(Test.scala:26)
 ├ flatMap @ io.github.timwspence.cats.stm.Test$.$anonfun$run$1(Test.scala:25)
 ├ deferred @ io.github.timwspence.cats.stm.Test$.run(Test.scala:24)
 ├ flatMap @ io.github.timwspence.cats.stm.Test$.run(Test.scala:24)
 ╰ run$ @ io.github.timwspence.cats.stm.Test$.run(Test.scala:21)
 
cats.effect.IOFiber@2ff5773a WAITING
 ├ get @ io.github.timwspence.cats.stm.Test$.$anonfun$run$1(Test.scala:25)
 ╰ get @ io.github.timwspence.cats.stm.Test$.$anonfun$run$1(Test.scala:25)
 
Thread[io-compute-9,5,run-main-group-8] (#9): 0 enqueued
Thread[io-compute-0,5,run-main-group-8] (#0): 0 enqueued
Thread[io-compute-6,5,run-main-group-8] (#6): 0 enqueued
Thread[io-compute-11,5,run-main-group-8] (#11): 0 enqueued
Thread[io-compute-2,5,run-main-group-8] (#2): 0 enqueued
Thread[io-compute-8,5,run-main-group-8] (#8): 0 enqueued
Thread[io-compute-3,5,run-main-group-8] (#3): 0 enqueued
Thread[io-compute-4,5,run-main-group-8] (#4): 0 enqueued
Thread[io-compute-5,5,run-main-group-8] (#5): 0 enqueued
Thread[io-compute-7,5,run-main-group-8] (#7): 0 enqueued
Thread[io-compute-10,5,run-main-group-8] (#10): 0 enqueued
Thread[io-compute-1,5,run-main-group-8] (#1): 0 enqueued
```