### PR TITLE
Add `IO.unyielding`

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -32,6 +32,7 @@ private object IOFiberConstants {
   final val UncancelableK: Byte = 7
   final val UnmaskK: Byte = 8
   final val AttemptK: Byte = 9
+  final val UnyieldingK: Byte = 10;
 
   // resume ids
   final val ExecR: Byte = 0

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -32,6 +32,7 @@ final class IOFiberConstants {
   static final byte UncancelableK = 7;
   static final byte UnmaskK = 8;
   static final byte AttemptK = 9;
+  static final byte UnyieldingK = 10;
 
   // resume ids
   static final byte ExecR = 0;

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -687,6 +687,9 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
   def uncancelable: IO[A] =
     IO.uncancelable(_ => this)
 
+  def unyielding: IO[A] =
+    IO.unyielding(this)
+
   /**
    * Ignores the result of this IO.
    */
@@ -1166,6 +1169,9 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
   def uncancelable[A](body: Poll[IO] => IO[A]): IO[A] =
     Uncancelable(body, Tracing.calculateTracingEvent(body))
+
+  def unyielding[A](ioa: IO[A]): IO[A] =
+    Unyielding(ioa)
 
   private[this] val _unit: IO[Unit] = Pure(())
 
@@ -1730,6 +1736,10 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
   private[effect] case object IOTrace extends IO[Trace] {
     def tag = 23
+  }
+
+  private[effect] final case class Unyielding[+A](ioa: IO[A]) extends IO[A] {
+    def tag = 24
   }
 
   // INTERNAL, only created by the runloop itself as the terminal state of several operations


### PR DESCRIPTION
The following PR tries to fix #2610 
I'm not really sure what I'm doing here 😅 if this is utter garbage please feel free to close it.

As I've understood from #2478 and #2530, the `unyielding` method should prevent a section of code from yielding (automatically or manually via `cede`). The examples from the mentioned issues also show that using `start` in an `unyielding` block should prevent fiber scheduling.

Running the following code snippet with the  current changes:
```scala
(IO(println("foo")) *> IO(println("bar")).start *> IO(println("baz"))).unyielding.unsafeRunAndForget()
```
generates the following result:
```
foo
bar
baz
```
If this is indeed the intended behaviour, my question is if the `unyielding` block should also affect `evalOn` or `blocking`?