### PR TITLE
Only use `FiberAwareExecutionContext` if tracing is enabled

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -16,6 +16,7 @@
 
 package cats.effect.unsafe
 
+import cats.effect.tracing.TracingConstants
 import org.scalajs.macrotaskexecutor.MacrotaskExecutor
 
 import scala.concurrent.ExecutionContext
@@ -24,7 +25,7 @@ import scala.scalajs.LinkingInfo
 private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type =>
 
   def defaultComputeExecutionContext: ExecutionContext =
-    if (LinkingInfo.developmentMode && IterableWeakMap.isAvailable)
+    if (LinkingInfo.developmentMode && TracingConstants.isStackTracing && IterableWeakMap.isAvailable)
       new FiberAwareExecutionContext(MacrotaskExecutor)
     else
       MacrotaskExecutor


### PR DESCRIPTION
Addresses the JS performance regression reported by @rpiaggio in https://github.com/typelevel/cats-effect/issues/2634#issuecomment-991202431. Credit to @vasilmkd for identifying the problem.