### PR TITLE
Relax `Resource#mapK` constraints

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -363,8 +363,8 @@ sealed abstract class Resource[F[_], +A] {
    *
    * If the outer `F` fails or is interrupted, `allocated` guarantees that the finalizers will
    * be called. However, if the outer `F` succeeds, it's up to the user to ensure the returned
-   * `ExitCode => F[Unit]` is called once `A` needs to be released. If the returned `F[Unit]` is not called,
-   * the finalizers will not be run.
+   * `ExitCode => F[Unit]` is called once `A` needs to be released. If the returned `F[Unit]` is
+   * not called, the finalizers will not be run.
    *
    * For this reason, this is an advanced and potentially unsafe api which can cause a resource
    * leak if not used correctly, please prefer [[use]] as the standard way of running a
@@ -1085,7 +1085,8 @@ object Resource extends ResourceFOInstances0 with ResourceHOInstances0 with Reso
 
         poll(alloc) map {
           case ((a, rfin), fin) =>
-            val composedFinalizers = (ec: ExitCase) => fin(ec) !> rfin(ec).allocatedFull.flatMap(_._2(ec))
+            val composedFinalizers =
+              (ec: ExitCase) => fin(ec) !> rfin(ec).allocatedFull.flatMap(_._2(ec))
             (a, composedFinalizers)
         }
       }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -324,7 +324,7 @@ sealed abstract class Resource[F[_], +A] {
   )(implicit F: MonadCancel[F, Throwable], G: MonadCancel[G, Throwable]): Resource[G, A] =
     mapKImpl(f)
 
-  // Needed to de-ambiguate the above two
+  // Needed to disambiguate the above two
   private def mapKImpl[G[_]: Functor](
       f: F ~> G
   )(implicit F: MonadCancel[F, Throwable]): Resource[G, A] = {

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -487,9 +487,9 @@ sealed abstract class Resource[F[_], +A] {
       fin: Outcome[Resource[F, *], Throwable, A @uncheckedVariance] => Resource[F, Unit])(
       implicit F: MonadCancel[F, Throwable]): Resource[F, A] =
     Resource.applyFull { poll =>
-      poll(this.allocatedFull) guaranteeCase {
+      poll(this.allocatedFull).guaranteeCase {
         case Outcome.Succeeded(ft) =>
-          fin(Outcome.Succeeded(Resource.eval(ft.map(_._1)))).use_ handleErrorWith { e =>
+          fin(Outcome.Succeeded(Resource.eval(ft.map(_._1)))).use_.handleErrorWith { e =>
             ft.flatMap(_._2(ExitCase.Errored(e))).handleError(_ => ()) >> F.raiseError(e)
           }
 
@@ -588,7 +588,7 @@ sealed abstract class Resource[F[_], +A] {
   }
 
   def evalOn(ec: ExecutionContext)(implicit F: Async[F]): Resource[F, A] =
-    Resource applyFull { poll => poll(this.allocatedFull).evalOn(ec) }
+    Resource.applyFull { poll => poll(this.allocatedFull).evalOn(ec) }
 
   def attempt[E](implicit F: ApplicativeError[F, E]): Resource[F, Either[E, A]] =
     this match {

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -981,15 +981,11 @@ object Resource extends ResourceFOInstances0 with ResourceHOInstances0 with Reso
       val inner = new Poll[Resource[F, *]] {
         def apply[B](rfb: Resource[F, B]): Resource[F, B] =
           Resource applyFull { innerPoll =>
-            innerPoll(poll(rfb.allocated)) map { p =>
-              Functor[(B, *)].map(p)(fin => (_: Resource.ExitCase) => fin)
-            }
+            innerPoll(poll(rfb.allocatedFull))
           }
       }
 
-      body(inner).allocated map { p =>
-        Functor[(A, *)].map(p)(fin => (_: Resource.ExitCase) => fin)
-      }
+      body(inner).allocatedFull
     }
 
   def unique[F[_]](implicit F: Unique[F]): Resource[F, Unique.Token] =

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -356,6 +356,73 @@ sealed abstract class Resource[F[_], +A] {
   def onFinalizeCase(f: ExitCase => F[Unit])(implicit F: Applicative[F]): Resource[F, A] =
     Resource.makeCase(F.unit)((_, ec) => f(ec)).flatMap(_ => this)
 
+  def allocatedFull[B >: A](implicit F: MonadCancel[F, Throwable]): F[(B, ExitCase => F[Unit])] = {
+    sealed trait Stack[AA]
+    case object Nil extends Stack[B]
+    final case class Frame[AA, BB](head: AA => Resource[F, BB], tail: Stack[BB])
+        extends Stack[AA]
+
+    // Indirection for calling `loop` needed because `loop` must be @tailrec
+    def continue[C](
+        current: Resource[F, C],
+        stack: Stack[C],
+        release: ExitCase => F[Unit]): F[(B, ExitCase => F[Unit])] =
+      loop(current, stack, release)
+
+    // Interpreter that knows how to evaluate a Resource data structure;
+    // Maintains its own stack for dealing with Bind chains
+    @tailrec def loop[C](
+        current: Resource[F, C],
+        stack: Stack[C],
+        release: ExitCase => F[Unit]): F[(B, ExitCase => F[Unit])] =
+      current match {
+        case Allocate(resource) =>
+          F uncancelable { poll =>
+            resource(poll) flatMap {
+              case (b, rel) =>
+                val rel2 = (ec: ExitCase) => rel(ec).guarantee(release(ec))
+
+                stack match {
+                  case Nil =>
+                    /*
+                     * We *don't* poll here because this case represents the "there are no flatMaps"
+                     * scenario. If we poll in this scenario, then the following code will have a
+                     * masking gap (where F = Resource):
+                     *
+                     * F.uncancelable(_(F.uncancelable(_ => foo)))
+                     *
+                     * In this case, the inner uncancelable has no trailing flatMap, so it will hit
+                     * this case exactly. If we poll, we will create the masking gap and surface
+                     * cancelation improperly.
+                     */
+                    F.pure((b, rel2))
+
+                  case Frame(head, tail) =>
+                    poll(continue(head(b), tail, rel2))
+                      .onCancel(rel(ExitCase.Canceled))
+                      .onError { case e => rel(ExitCase.Errored(e)).handleError(_ => ()) }
+                }
+            }
+          }
+
+        case Bind(source, fs) =>
+          loop(source, Frame(fs, stack), release)
+
+        case Pure(v) =>
+          stack match {
+            case Nil =>
+              (v: B, release).pure[F]
+            case Frame(head, tail) =>
+              loop(head(v), tail, release)
+          }
+
+        case Eval(fa) =>
+          fa.flatMap(a => continue(Resource.pure(a), stack, release))
+      }
+
+    loop(this, Nil, _ => F.unit)
+  }
+
   /**
    * Given a `Resource`, possibly built by composing multiple `Resource`s monadically, returns
    * the acquired resource, as well as an action that runs all the finalizers for releasing it.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1089,6 +1089,7 @@ object Resource extends ResourceFOInstances0 with ResourceHOInstances0 with Reso
           case ((a, rfin), fin) =>
             val composedFinalizers =
               (ec: ExitCase) =>
+                //Break stack-unsafe mutual recursion with allocatedFull
                 (F.unit >> fin(ec))
                   .guarantee(F.unit >> rfin(ec).allocatedFull.flatMap(_._2(ec)))
             (a, composedFinalizers)

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -316,6 +316,17 @@ sealed abstract class Resource[F[_], +A] {
    */
   def mapK[G[_]: Functor](
       f: F ~> G
+  )(implicit F: MonadCancel[F, Throwable]): Resource[G, A] = mapKImpl(f)
+
+  @deprecated("retaining for bincompat", "3.3.1")
+  private[effect] def mapK[G[_]](
+      f: F ~> G
+  )(implicit F: MonadCancel[F, Throwable], G: MonadCancel[G, Throwable]): Resource[G, A] =
+    mapKImpl(f)
+
+  // Needed to de-ambiguate the above two
+  private def mapKImpl[G[_]: Functor](
+      f: F ~> G
   )(implicit F: MonadCancel[F, Throwable]): Resource[G, A] = {
     Resource
       .makeCaseFull[G, (A, ExitCase => F[Unit])](poll => poll(f(allocatedFull))) {

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -358,8 +358,8 @@ sealed abstract class Resource[F[_], +A] {
 
   /**
    * Given a `Resource`, possibly built by composing multiple `Resource`s monadically, returns
-   * the acquired resource, as well as a cleanup function that takes an [[ExitCase exit case]]
-   * and runs all the finalizers for releasing it.
+   * the acquired resource, as well as a cleanup function that takes an
+   * [[Resource.ExitCase exit case]] and runs all the finalizers for releasing it.
    *
    * If the outer `F` fails or is interrupted, `allocated` guarantees that the finalizers will
    * be called. However, if the outer `F` succeeds, it's up to the user to ensure the returned

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -966,12 +966,13 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
     }
 
     "use is stack-safe over binds" in ticked { implicit ticker =>
-      val res = Resource.make(IO.unit)(_ => IO.unit).uncancelable
+      val res = Resource.make(IO.unit)(_ => IO.unit)
       val r = (1 to 10000)
         .foldLeft(res) {
           case (r, _) =>
             r.flatMap(_ => res)
         }
+        .uncancelable
         .use_
       r eqv IO.unit
     }

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -950,21 +950,21 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
   }
 
   "uncancelable" >> {
-      "does not suppress errors within use" in real {
-        case object TestException extends RuntimeException
+    "does not suppress errors within use" in real {
+      case object TestException extends RuntimeException
 
-        for {
-          slot <- IO.deferred[Resource.ExitCase]
-          rsrc = Resource.makeCase(IO.unit)((_, ec) => slot.complete(ec).void)
-          _ <- rsrc.uncancelable.use(_ => IO.raiseError(TestException)).handleError(_ => ())
-          results <- slot.get
+      for {
+        slot <- IO.deferred[Resource.ExitCase]
+        rsrc = Resource.makeCase(IO.unit)((_, ec) => slot.complete(ec).void)
+        _ <- rsrc.uncancelable.use(_ => IO.raiseError(TestException)).handleError(_ => ())
+        results <- slot.get
 
-          _ <- IO {
-            results mustEqual Resource.ExitCase.Errored(TestException)
-          }
-        } yield ok
-      }
+        _ <- IO {
+          results mustEqual Resource.ExitCase.Errored(TestException)
+        }
+      } yield ok
     }
+  }
 
   "Resource[Resource[IO, *], *]" should {
     "flatten with finalizers inside-out" in ticked { implicit ticker =>

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -979,6 +979,21 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
 
   }
 
+  "allocatedFull" >> {
+    "is stack-safe" in ticked { implicit ticker =>
+      val res = Resource.make(IO.unit)(_ => IO.unit)
+      val r = (1 to 50000)
+        .foldLeft(res) {
+          case (r, _) =>
+            r.flatMap(_ => res)
+        }
+        .allocatedFull
+        .map(_._1)
+      r eqv IO.unit
+
+    }
+  }
+
   "Resource[Resource[IO, *], *]" should {
     "flatten with finalizers inside-out" in ticked { implicit ticker =>
       var results = ""

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -964,6 +964,18 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
         }
       } yield ok
     }
+
+    "use is stack-safe over binds" in ticked { implicit ticker =>
+      val res = Resource.make(IO.unit)(_ => IO.unit).uncancelable
+      val r = (1 to 10000)
+        .foldLeft(res) {
+          case (r, _) =>
+            r.flatMap(_ => res)
+        }
+        .use_
+      r eqv IO.unit
+    }
+
   }
 
   "Resource[Resource[IO, *], *]" should {


### PR DESCRIPTION
Branch based on https://github.com/typelevel/cats-effect/pull/2617.

Earlier on [Discord](https://discord.com/channels/632277896739946517/632278585700384799/919255475772604446) a user lamented the need for a `MonadCancel` constraint on _both_ the `F` and the `G` of `Resource#mapK`. This prompted a lengthy discussion about the necessity for the constraint on `G`.

Here, I've re-implemented `mapK` in terms of the new `allocatedFull` and accordingly the constraint on `G` is reduced to `Functor`.

However, the constraint on `F` did have to be strengthened from `MonadCancel[F, _]` to `MonadCancel[F, Throwable]` because `allocatedFull` expects the latter constraint. This manifests as a source-breaking change that will ripple through e.g. semaphore.

I also made an attempt to completely remove `Functor` constraint on `G` in https://github.com/armanbilge/cats-effect/commit/89f4f41507084e9ef0ef201076a69b7d5e0f72c5. This requires creating a `MapK` node. This is difficult for two reasons:
1. `Resource` is a sealed public ADT used in e.g. fs2, so adding new nodes breaks compatibility.
2. `Resource#attempt[E]` is difficult (impossible?) to implement for a generic `E`, because of the hard-coding for `Throwable` mentioned above.