### PR TITLE
Port the `Sync.blocking` scaladoc to `IO.blocking`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1549,7 +1549,9 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
      * Like [[IO.delay]] but intended for thread blocking operations. `blocking` will shift the
      * execution of the blocking operation to a separate threadpool to avoid blocking on the main
      * execution context. See the thread-model documentation for more information on why this is
-     * necessary.
+     * necessary. Note that created effect will be uncancelable. If you're wondering about
+     * an interruption of evaluation, for instance via [[IO.timeout]], then you should use
+     * [[IO.interruptible]] or [[IO.interruptibleMany]].
      *
      * {{{
      * IO.blocking(scala.io.Source.fromFile("path").mkString)

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1545,6 +1545,20 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
     override def delay[A](thunk: => A): IO[A] = IO(thunk)
 
+    /**
+     * Like [[IO.delay]] but intended for thread blocking operations. `blocking` will shift the
+     * execution of the blocking operation to a separate threadpool to avoid blocking on the main
+     * execution context. See the thread-model documentation for more information on why this is
+     * necessary.
+     *
+     * {{{
+     * IO.blocking(scala.io.Source.fromFile("path").mkString)
+     * }}}
+     *
+     * @param thunk
+     *   The side effect which is to be suspended in `IO` and evaluated on a blocking execution
+     *   context
+     */
     override def blocking[A](thunk: => A): IO[A] = IO.blocking(thunk)
 
     /**

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1549,9 +1549,8 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
      * Like [[IO.delay]] but intended for thread blocking operations. `blocking` will shift the
      * execution of the blocking operation to a separate threadpool to avoid blocking on the main
      * execution context. See the thread-model documentation for more information on why this is
-     * necessary. Note that created effect will be uncancelable. If you're wondering about
-     * an interruption of evaluation, for instance via [[IO.timeout]], then you should use
-     * [[IO.interruptible]] or [[IO.interruptibleMany]].
+     * necessary. Note that the created effect will be uncancelable; if you need cancelation,
+     * then you should use [[IO.interruptible]] or [[IO.interruptibleMany]].
      *
      * {{{
      * IO.blocking(scala.io.Source.fromFile("path").mkString)

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
@@ -63,7 +63,8 @@ trait Sync[F[_]] extends MonadCancel[F, Throwable] with Clock[F] with Unique[F] 
    * Like [[Sync.delay]] but intended for thread blocking operations. `blocking` will shift the
    * execution of the blocking operation to a separate threadpool to avoid blocking on the main
    * execution context. See the thread-model documentation for more information on why this is
-   * necesary.
+   * necessary. Note that the created effect will be uncancelable; if you need cancelation
+   * then you should use [[Sync.interruptible]] or [[Sync.interruptibleMany]].
    *
    * {{{
    * Sync[F].blocking(scala.io.Source.fromFile("path").mkString)


### PR DESCRIPTION
Also, this adds a note about the cancelation of effects created via `blocking`.