### PR TITLE
Enrich the `delay` scaladoc for `IO` and `Sync`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -932,8 +932,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
   /**
    * Suspends a synchronous side effect in `IO`.
    * Use [[IO.apply]] if your side effect is not thread-blocking;
-   * otherwise you should use [[IO.blocking]] or `IO.interruptible`
-   * depending on the need of the created effect cancelation.
+   * otherwise you should use [[IO.blocking]] (uncancelable) or `IO.interruptible` (cancelable).
    *
    * Alias for [[IO.delay]].
    */
@@ -942,8 +941,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
   /**
    * Suspends a synchronous side effect in `IO`.
    * Use [[IO.delay]] if your side effect is not thread-blocking;
-   * otherwise you should use [[IO.blocking]] or `IO.interruptible`
-   * depending on the need of the created effect cancelation.
+   * otherwise you should use [[IO.blocking]] (uncancelable) or `IO.interruptible` (cancelable).
    *
    * Any exceptions thrown by the effect will be caught and sequenced into the `IO`.
    */

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -932,17 +932,17 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
   /**
    * Suspends a synchronous side effect in `IO`.
    * Use [[IO.apply]] if your side effect is not thread-blocking;
-   * otherwise you should use [[IO.blocking]] or [[IO.interruptible]]
+   * otherwise you should use [[IO.blocking]] or `IO.interruptible`
    * depending on the need of the created effect cancelation.
    *
-   * Alias for `IO.delay(body)`.
+   * Alias for [[IO.delay]].
    */
   def apply[A](thunk: => A): IO[A] = delay(thunk)
 
   /**
    * Suspends a synchronous side effect in `IO`.
    * Use [[IO.delay]] if your side effect is not thread-blocking;
-   * otherwise you should use [[IO.blocking]] or [[IO.interruptible]]
+   * otherwise you should use [[IO.blocking]] or `IO.interruptible`
    * depending on the need of the created effect cancelation.
    *
    * Any exceptions thrown by the effect will be caught and sequenced into the `IO`.

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -931,6 +931,9 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
   /**
    * Suspends a synchronous side effect in `IO`.
+   * Use [[IO.apply]] if your side effect is not thread-blocking;
+   * otherwise you should use [[IO.blocking]] or [[IO.interruptible]]
+   * depending on the need of the created effect cancelation.
    *
    * Alias for `IO.delay(body)`.
    */

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -938,6 +938,9 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
   /**
    * Suspends a synchronous side effect in `IO`.
+   * Use [[IO.delay]] if your side effect is not thread-blocking;
+   * otherwise you should use [[IO.blocking]] or [[IO.interruptible]]
+   * depending on the need of the created effect cancelation.
    *
    * Any exceptions thrown by the effect will be caught and sequenced into the `IO`.
    */

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
@@ -43,8 +43,7 @@ trait Sync[F[_]] extends MonadCancel[F, Throwable] with Clock[F] with Unique[F] 
    *
    * Equivalent to [[Applicative.pure]] for pure expressions, the purpose of this function is to
    * suspend side effects in `F`. Use [[Sync.delay]] if your side effect is not thread-blocking;
-   * otherwise you should use [[Sync.blocking]] or [[Sync.interruptible]]
-   * depending on the need of the created effect cancelation.
+   * otherwise you should use [[Sync.blocking]] (uncancelable) or [[Sync.interruptible]] (cancelable).
    *
    * @param thunk
    *   The side effect which is to be suspended in `F[_]`

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
@@ -41,8 +41,10 @@ trait Sync[F[_]] extends MonadCancel[F, Throwable] with Clock[F] with Unique[F] 
   /**
    * The synchronous FFI - lifts any by-name parameter into the `F[_]` context.
    *
-   * Equivalent to `Applicative.pure` for pure expressions, the purpose of this function is to
-   * suspend side effects in `F`.
+   * Equivalent to [[Applicative.pure]] for pure expressions, the purpose of this function is to
+   * suspend side effects in `F`. Use [[Sync.delay]] if your side effect is not thread-blocking;
+   * otherwise you should use [[Sync.blocking]] or [[Sync.interruptible]]
+   * depending on the need of the created effect cancelation.
    *
    * @param thunk
    *   The side effect which is to be suspended in `F[_]`


### PR DESCRIPTION
This is a minor thing but should help in picking a suitable constructor.