### PR TITLE
Introduce `IORuntimeBuilder`

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
@@ -35,8 +35,8 @@ private[unsafe] abstract class IORuntimeBuilderPlatform { self: IORuntimeBuilder
     val runtimeConfig = customConfig.getOrElse(IORuntimeConfig())
 
     runtime = IORuntime.apply(
-      computeWrapper(compute),
-      blockingWrapper(blocking),
+      computeTransform(compute),
+      blockingTransform(blocking),
       scheduler,
       shutdown,
       runtimeConfig

--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
@@ -30,7 +30,7 @@ private[unsafe] abstract class IORuntimeBuilderPlatform { self: IORuntimeBuilder
       computeShutdown()
       blockingShutdown()
       schedulerShutdown()
-      extraShutdownHooks.foreach(_())
+      extraShutdownHooks.reverse.foreach(_())
     }
     val runtimeConfig = customConfig.getOrElse(IORuntimeConfig())
 

--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.unsafe
+import scala.concurrent.ExecutionContext
+
+private[unsafe] abstract class IORuntimeBuilderPlatform {
+
+  def build(
+      computeWrapper: ExecutionContext => ExecutionContext = identity,
+      blockingWrapper: ExecutionContext => ExecutionContext = identity,
+      customConfig: Option[IORuntimeConfig] = None,
+      customScheduler: Option[Scheduler] = None,
+      customShutdown: Option[() => Unit] = None
+  ) = {
+    var runtime: IORuntime = null
+    val compute = IORuntime.defaultComputeExecutionContext
+    val blocking = compute
+    val scheduler = customScheduler.getOrElse(IORuntime.defaultScheduler)
+    val shutdown = customShutdown.getOrElse(() => ())
+    val runtimeConfig = customConfig.getOrElse(IORuntimeConfig())
+
+    runtime = IORuntime.apply(
+      computeWrapper(compute),
+      blockingWrapper(blocking),
+      scheduler,
+      shutdown,
+      runtimeConfig
+    )
+    runtime
+  }
+
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
@@ -35,8 +35,8 @@ private[unsafe] abstract class IORuntimeBuilderPlatform { self: IORuntimeBuilder
     val runtimeConfig = customConfig.getOrElse(IORuntimeConfig())
 
     runtime = IORuntime.apply(
-      computeWrapper(compute),
-      blockingWrapper(blocking),
+      computeTransform(compute),
+      blockingTransform(blocking),
       scheduler,
       shutdown,
       runtimeConfig

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.unsafe
+import scala.concurrent.ExecutionContext
+
+private[unsafe] abstract class IORuntimeBuilderPlatform {
+
+  def build(
+      computeWrapper: ExecutionContext => ExecutionContext = identity,
+      blockingWrapper: ExecutionContext => ExecutionContext = identity,
+      customConfig: Option[IORuntimeConfig] = None,
+      customScheduler: Option[Scheduler] = None,
+      customShutdown: Option[() => Unit] = None
+  ) = {
+    var runtime: IORuntime = null
+    val compute = IORuntime.createDefaultComputeThreadPool(runtime)._1
+    val blocking = IORuntime.createDefaultBlockingExecutionContext()._1
+    val scheduler = customScheduler.getOrElse(IORuntime.createDefaultScheduler()._1)
+    val shutdown = customShutdown.getOrElse(() => ())
+    val runtimeConfig = customConfig.getOrElse(IORuntimeConfig())
+
+    runtime = IORuntime.apply(
+      computeWrapper(compute),
+      blockingWrapper(blocking),
+      scheduler,
+      shutdown,
+      runtimeConfig
+    )
+    runtime
+  }
+
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
@@ -30,7 +30,7 @@ private[unsafe] abstract class IORuntimeBuilderPlatform { self: IORuntimeBuilder
       computeShutdown()
       blockingShutdown()
       schedulerShutdown()
-      extraShutdownHooks.foreach(_())
+      extraShutdownHooks.reverse.foreach(_())
     }
     val runtimeConfig = customConfig.getOrElse(IORuntimeConfig())
 

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -52,7 +52,6 @@ final class IORuntime private[unsafe] (
   private[effect] val traceBufferLogSize: Int = config.traceBufferLogSize
 
   override def toString: String = s"IORuntime($compute, $scheduler, $config)"
-
 }
 
 object IORuntime extends IORuntimeCompanionPlatform {
@@ -63,5 +62,4 @@ object IORuntime extends IORuntimeCompanionPlatform {
       shutdown: () => Unit,
       config: IORuntimeConfig): IORuntime =
     new IORuntime(compute, blocking, scheduler, FiberMonitor(compute), shutdown, config)
-
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -52,6 +52,15 @@ final class IORuntime private[unsafe] (
   private[effect] val traceBufferLogSize: Int = config.traceBufferLogSize
 
   override def toString: String = s"IORuntime($compute, $scheduler, $config)"
+
+  def wrappingCompute(wrapCompute: ExecutionContext => ExecutionContext): IORuntime = 
+    IORuntime(
+      wrapCompute(compute),
+      blocking,
+      scheduler,
+      shutdown,
+      config
+    )
 }
 
 object IORuntime extends IORuntimeCompanionPlatform {

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -63,6 +63,6 @@ object IORuntime extends IORuntimeCompanionPlatform {
       config: IORuntimeConfig): IORuntime =
     new IORuntime(compute, blocking, scheduler, FiberMonitor(compute), shutdown, config)
 
-  def builder = 
+  def builder: IORuntimeBuilder =
     IORuntimeBuilder()
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -62,4 +62,7 @@ object IORuntime extends IORuntimeCompanionPlatform {
       shutdown: () => Unit,
       config: IORuntimeConfig): IORuntime =
     new IORuntime(compute, blocking, scheduler, FiberMonitor(compute), shutdown, config)
+
+  def builder = 
+    IORuntimeBuilder()
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -63,6 +63,6 @@ object IORuntime extends IORuntimeCompanionPlatform {
       config: IORuntimeConfig): IORuntime =
     new IORuntime(compute, blocking, scheduler, FiberMonitor(compute), shutdown, config)
 
-  def builder: IORuntimeBuilder =
+  def builder(): IORuntimeBuilder =
     IORuntimeBuilder()
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -53,14 +53,6 @@ final class IORuntime private[unsafe] (
 
   override def toString: String = s"IORuntime($compute, $scheduler, $config)"
 
-  def wrappingCompute(wrapCompute: ExecutionContext => ExecutionContext): IORuntime = 
-    IORuntime(
-      wrapCompute(compute),
-      blocking,
-      scheduler,
-      shutdown,
-      config
-    )
 }
 
 object IORuntime extends IORuntimeCompanionPlatform {
@@ -71,4 +63,6 @@ object IORuntime extends IORuntimeCompanionPlatform {
       shutdown: () => Unit,
       config: IORuntimeConfig): IORuntime =
     new IORuntime(compute, blocking, scheduler, FiberMonitor(compute), shutdown, config)
+
+  def builder: IORuntimeBuilder = IORuntimeBuilder()
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -64,5 +64,4 @@ object IORuntime extends IORuntimeCompanionPlatform {
       config: IORuntimeConfig): IORuntime =
     new IORuntime(compute, blocking, scheduler, FiberMonitor(compute), shutdown, config)
 
-  def builder: IORuntimeBuilder = IORuntimeBuilder()
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
@@ -38,7 +38,7 @@ final class IORuntimeBuilder protected (
    * Set a custom compute pool
    *
    * @param compute
-   *   [[ExecutionContext]] for compute
+   *   `ExecutionContext` for compute
    * @param shutdown
    *   shutdown hook upon [[IORuntime]] shutdown
    */

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
@@ -38,7 +38,7 @@ final class IORuntimeBuilder protected (
    * Override the defaul computing execution context
    *
    * @param compute
-   *   execution context for compute
+   *   [[ExecutionContext]] for compute
    * @param shutdown
    *   method called upon compute context shutdown
    */

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
@@ -44,7 +44,7 @@ final class IORuntimeBuilder protected (
    */
   def setCompute(compute: ExecutionContext, shutdown: () => Unit) = {
     if (customCompute.isDefined) {
-      throw new RuntimeException("Compute can only be set once")
+      throw new IllegalStateException("Compute can be set only once")
     }
     customCompute = Some((compute, shutdown))
     this

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
@@ -62,7 +62,7 @@ final class IORuntimeBuilder protected (
   }
 
   /**
-   * Override the defaul blocking execution context
+   * Override the default blocking execution context
    *
    * @param compute
    *   execution context for blocking

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
@@ -20,26 +20,36 @@ package unsafe
 import scala.concurrent.ExecutionContext
 
 final class IORuntimeBuilder protected (
-    var computeWrapper: ExecutionContext => ExecutionContext = identity,
-    var blockingWrapper: ExecutionContext => ExecutionContext = identity,
-    var customConfig: Option[IORuntimeConfig] = None,
-    var customScheduler: Option[Scheduler] = None,
-    var customShutdown: Option[() => Unit] = None
+    protected var computeWrapper: ExecutionContext => ExecutionContext = identity,
+    protected var blockingWrapper: ExecutionContext => ExecutionContext = identity,
+    protected var customConfig: Option[IORuntimeConfig] = None,
+    protected var customScheduler: Option[Scheduler] = None,
+    protected var customShutdown: Option[() => Unit] = None
 ) extends IORuntimeBuilderPlatform {
-  def withComputeWrapper(wrapper: ExecutionContext => ExecutionContext) =
+  def withComputeWrapper(wrapper: ExecutionContext => ExecutionContext) = {
     computeWrapper = wrapper.andThen(computeWrapper)
+    this
+  }
 
-  def withBlockingWrapper(wrapper: ExecutionContext => ExecutionContext) =
+  def withBlockingWrapper(wrapper: ExecutionContext => ExecutionContext) = {
     blockingWrapper = wrapper.andThen(blockingWrapper)
+    this
+  }
 
-  def withConfig(config: IORuntimeConfig) =
+  def withConfig(config: IORuntimeConfig) = {
     customConfig = Some(config)
+    this
+  }
 
-  def withScheduler(scheduler: Scheduler) =
+  def withScheduler(scheduler: Scheduler) = {
     customScheduler = Some(scheduler)
+    this
+  }
 
-  def withShutdown(shutdown: () => Unit) =
+  def withShutdown(shutdown: () => Unit) = {
     customShutdown = Some(shutdown)
+    this
+  }
 
   def build: IORuntime =
     build(computeWrapper, blockingWrapper, customConfig, customScheduler, customShutdown)

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package unsafe
+
+import scala.concurrent.ExecutionContext
+
+case class IORuntimeBuilder(
+  computeWrapper: ExecutionContext => ExecutionContext = identity,
+  blockingWrapper: ExecutionContext => ExecutionContext = identity,
+  customConfig: Option[IORuntimeConfig] = None,
+  customScheduler: Option[Scheduler] = None,
+  customShutdown: Option[() => Unit] = None,
+) {
+  def withComputeWrapper(wrapper: ExecutionContext => ExecutionContext) =
+    this.copy(computeWrapper = wrapper.andThen(computeWrapper))
+
+  def withBlockingWrapper(wrapper: ExecutionContext => ExecutionContext) =
+    this.copy(blockingWrapper = wrapper.andThen(blockingWrapper))
+
+  def withConfig(config: IORuntimeConfig) = 
+    this.copy(customConfig = Some(config))
+
+  def withScheduler(scheduler: Scheduler) = 
+    this.copy(customScheduler = Some(scheduler))
+
+  def withShutdown(shutdown: () => Unit) = 
+    this.copy(customShutdown = Some(shutdown))
+
+  def build = {
+    var runtime: IORuntime = null
+    val compute = IORuntime.createDefaultComputeThreadPool(runtime)._1
+    val blocking = IORuntime.createDefaultBlockingExecutionContext()._1
+    val scheduler = customScheduler.getOrElse(IORuntime.createDefaultScheduler()._1)
+    val shutdown = customShutdown.getOrElse(() => ())
+    val runtimeConfig = customConfig.getOrElse(IORuntimeConfig())
+
+    runtime = IORuntime.apply(
+      computeWrapper(compute),
+      blockingWrapper(blocking),
+      scheduler,
+      shutdown,
+      runtimeConfig
+    )
+    runtime
+  }
+}
+
+

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
@@ -35,7 +35,7 @@ final class IORuntimeBuilder protected (
 ) extends IORuntimeBuilderPlatform {
 
   /**
-   * Override the defaul computing execution context
+   * Set a custom compute pool
    *
    * @param compute
    *   [[ExecutionContext]] for compute

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
@@ -95,7 +95,7 @@ final class IORuntimeBuilder protected (
    * @param config
    * @return
    */
-  def withConfig(config: IORuntimeConfig) = {
+  def setConfig(config: IORuntimeConfig) = {
     customConfig = Some(config)
     this
   }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
@@ -41,7 +41,7 @@ final class IORuntimeBuilder protected (
    * @param shutdown
    *   method called upon compute context shutdown
    */
-  def overrideCompute(compute: ExecutionContext, shutdown: () => Unit = () => ()) = {
+  def setCompute(compute: ExecutionContext, shutdown: () => Unit) = {
     customCompute = Some((compute, shutdown))
     this
   }
@@ -65,7 +65,7 @@ final class IORuntimeBuilder protected (
    * @param shutdown
    *   method called upon blocking context shutdown
    */
-  def overrideBlocking(blocking: ExecutionContext, shutdown: () => Unit = () => ()) = {
+  def setBlocking(blocking: ExecutionContext, shutdown: () => Unit) = {
     customBlocking = Some((blocking, shutdown))
     this
   }
@@ -101,7 +101,7 @@ final class IORuntimeBuilder protected (
    * @param shutdown
    *   method called upon compute context shutdown
    */
-  def withScheduler(scheduler: Scheduler, shutdown: () => Unit = () => ()) = {
+  def setScheduler(scheduler: Scheduler, shutdown: () => Unit) = {
     customScheduler = Some((scheduler, shutdown))
     this
   }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
@@ -40,7 +40,7 @@ final class IORuntimeBuilder protected (
    * @param compute
    *   [[ExecutionContext]] for compute
    * @param shutdown
-   *   method called upon compute context shutdown
+   *   shutdown hook upon [[IORuntime]] shutdown
    */
   def setCompute(compute: ExecutionContext, shutdown: () => Unit) = {
     if (customCompute.isDefined) {

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeBuilder.scala
@@ -25,9 +25,9 @@ import scala.concurrent.ExecutionContext
  */
 final class IORuntimeBuilder protected (
     protected var customCompute: Option[(ExecutionContext, () => Unit)] = None,
-    protected var computeWrapper: ExecutionContext => ExecutionContext = identity,
+    protected var computeTransform: ExecutionContext => ExecutionContext = identity,
     protected var customBlocking: Option[(ExecutionContext, () => Unit)] = None,
-    protected var blockingWrapper: ExecutionContext => ExecutionContext = identity,
+    protected var blockingTransform: ExecutionContext => ExecutionContext = identity,
     protected var customConfig: Option[IORuntimeConfig] = None,
     protected var customScheduler: Option[(Scheduler, () => Unit)] = None,
     protected var extraShutdownHooks: List[() => Unit] = Nil,
@@ -54,10 +54,10 @@ final class IORuntimeBuilder protected (
    * Modifies the execution underlying execution context. Useful in case you want to use the
    * default compute but add extra logic to `execute`, e.g. for adding instrumentation.
    *
-   * @param wrapper
+   * @param transform
    */
-  def withComputeWrapper(wrapper: ExecutionContext => ExecutionContext) = {
-    computeWrapper = wrapper.andThen(computeWrapper)
+  def transformCompute(transform: ExecutionContext => ExecutionContext) = {
+    computeTransform = transform.andThen(computeTransform)
     this
   }
 
@@ -82,10 +82,10 @@ final class IORuntimeBuilder protected (
    * use the default blocking context but add extra logic to `execute`, e.g. for adding
    * instrumentation.
    *
-   * @param wrapper
+   * @param transform
    */
-  def withBlockingWrapper(wrapper: ExecutionContext => ExecutionContext) = {
-    blockingWrapper = wrapper.andThen(blockingWrapper)
+  def transformBlocking(transform: ExecutionContext => ExecutionContext) = {
+    blockingTransform = transform.andThen(blockingTransform)
     this
   }
 


### PR DESCRIPTION
I'm working on migrating applications from CE2 to CE3. In CE2 I used `IOApp` and prior to running any `IO`, I'd override the default execution context with the one wrapped with Kanela.

With CE3 we have this `IORuntime` that hides the underlying execution context. If I wanted to reproduce that approach with CE3, I'd basically have to create the whole `IORuntime` on my own. Instead of doing that, doing `runtime.copy(context = wrap(runtime.context))` would be enough.

This PR introduces a method that exposes the necessary API for my use case. What do you think about it? Is it the right approach or is there anything else I should try?