### PR TITLE
Add fromCompletionStage to Async / IO

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -19,8 +19,7 @@ package cats.effect
 import cats.effect.tracing.Tracing
 
 import java.time.Instant
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionStage
+import java.util.concurrent.{CompletableFuture, CompletionStage}
 
 private[effect] abstract class IOCompanionPlatform { this: IO.type =>
 

--- a/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -20,6 +20,7 @@ import cats.effect.tracing.Tracing
 
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
 
 private[effect] abstract class IOCompanionPlatform { this: IO.type =>
 
@@ -63,6 +64,9 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
 
   def fromCompletableFuture[A](fut: IO[CompletableFuture[A]]): IO[A] =
     asyncForIO.fromCompletableFuture(fut)
+
+  def fromCompletionStage[A](completionStage: IO[CompletionStage[A]]): IO[A] =
+    asyncForIO.fromCompletionStage(completionStage)
 
   def realTimeInstant: IO[Instant] = asyncForIO.realTimeInstant
 }

--- a/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
@@ -18,8 +18,12 @@ package cats.effect.kernel
 
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
+import java.util.concurrent.CompletionStage
 
 private[kernel] trait AsyncPlatform[F[_]] { this: Async[F] =>
+
+  def fromCompletionStage[A](completionStage: F[CompletionStage[A]]): F[A] =
+    fromCompletableFuture(flatMap(completionStage) { cs => delay(cs.toCompletableFuture()) })
 
   /**
    * Suspend a `java.util.concurrent.CompletableFuture` into the `F[_]` context.

--- a/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
@@ -16,9 +16,7 @@
 
 package cats.effect.kernel
 
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionException
-import java.util.concurrent.CompletionStage
+import java.util.concurrent.{CompletableFuture, CompletionException, CompletionStage}
 
 private[kernel] trait AsyncPlatform[F[_]] { this: Async[F] =>
 


### PR DESCRIPTION
CompletionStage is a more generic instance of CompletableFuture, and it can be applied to a number of things. An example can be the [RFuture](https://www.javadoc.io/doc/org.redisson/redisson/3.2.0/org/redisson/api/RFuture.html) from the Redisson library. 

This PR implements a `fromCompletionStage` function on Async and IO, which simply converts the CompletionStage to a completable future and runs `fromCompletableFuture`.

I tried implementing this the other way (move the core logic of `fromCompletableFuture` to `fromCompletionStage`, and simply have `fromCompletableFuture` run `fromCompletionStage` with a CompletableFuture value), but `CompletionStage` does not have a `cancel` method, so I was unable to replicate what was there. 

LMK any thoughts here. Happy to adjust as needed