### PR TITLE
Register the live fiber snapshot trigger mbean on IORuntime construction

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -60,4 +60,9 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
 
     _global
   }
+
+  private[effect] def registerFiberMonitorMBean(fiberMonitor: FiberMonitor): () => Unit = {
+    val _ = fiberMonitor
+    () => ()
+  }
 }

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -215,15 +215,12 @@ trait IOApp {
 
         val fiberMonitor = FiberMonitor(compute)
 
-        val unregisterFiberMonitorMBean = IORuntime.registerFiberMonitorMBean(fiberMonitor)
-
         IORuntime(
           compute,
           blocking,
           scheduler,
           fiberMonitor,
           { () =>
-            unregisterFiberMonitorMBean()
             compDown()
             blockDown()
             schedDown()

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -150,8 +150,6 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
         val (compute, _) = createDefaultComputeThreadPool(global)
         val (blocking, _) = createDefaultBlockingExecutionContext()
         val (scheduler, _) = createDefaultScheduler()
-        val fiberMonitor = FiberMonitor(compute)
-        registerFiberMonitorMBean(fiberMonitor)
 
         IORuntime(compute, blocking, scheduler, () => (), IORuntimeConfig())
       }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -60,6 +60,9 @@ object IORuntime extends IORuntimeCompanionPlatform {
       blocking: ExecutionContext,
       scheduler: Scheduler,
       shutdown: () => Unit,
-      config: IORuntimeConfig): IORuntime =
-    new IORuntime(compute, blocking, scheduler, FiberMonitor(compute), shutdown, config)
+      config: IORuntimeConfig): IORuntime = {
+    val fiberMonitor = FiberMonitor(compute)
+    registerFiberMonitorMBean(fiberMonitor)
+    new IORuntime(compute, blocking, scheduler, fiberMonitor, shutdown, config)
+  }
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -62,7 +62,11 @@ object IORuntime extends IORuntimeCompanionPlatform {
       shutdown: () => Unit,
       config: IORuntimeConfig): IORuntime = {
     val fiberMonitor = FiberMonitor(compute)
-    registerFiberMonitorMBean(fiberMonitor)
-    new IORuntime(compute, blocking, scheduler, fiberMonitor, shutdown, config)
+    val unregister = registerFiberMonitorMBean(fiberMonitor)
+    val fullShutdown = () => {
+      unregister()
+      shutdown()
+    }
+    new IORuntime(compute, blocking, scheduler, fiberMonitor, fullShutdown, config)
   }
 }


### PR DESCRIPTION
It should be done for every constructed `IORuntime`, not just for the global one.