### PR TITLE
Fixes cancelling CompletableFuture on fiber cancellation

### DIFF
--- a/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
@@ -31,7 +31,7 @@ private[kernel] trait AsyncPlatform[F[_]] { this: Async[F] =>
     flatMap(fut) { cf =>
       async[A] { cb =>
         delay {
-          val stage = cf.handle[Unit] {
+          cf.handle[Unit] {
             case (a, null) => cb(Right(a))
             case (_, t) =>
               cb(Left(t match {
@@ -40,7 +40,7 @@ private[kernel] trait AsyncPlatform[F[_]] { this: Async[F] =>
               }))
           }
 
-          Some(void(delay(stage.cancel(false))))
+          Some(void(delay(cf.cancel(false))))
         }
       }
     }

--- a/tests/jvm/src/test/scala/cats/effect/kernel/AsyncPlatformSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/kernel/AsyncPlatformSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.kernel
+
+import cats.effect.BaseSpec
+import cats.effect.IO
+
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import scala.concurrent.duration._
+
+class AsyncPlatformSpec extends BaseSpec {
+
+  val smallDelay: IO[Unit] = IO.sleep(100.millis)
+
+  "AsyncPlatform CompletableFuture conversion" should {
+    "cancel CompletableFuture on fiber cancellation" in real {
+      lazy val cf = CompletableFuture.supplyAsync { () =>
+        Thread.sleep(200) // some computation
+      }
+
+      for {
+        fiber <- IO.fromCompletableFuture(IO(cf)).start
+        _ <- smallDelay // time for the callback to be set-up
+        _ <- fiber.cancel
+      } yield cf.join() must throwA[CancellationException]
+    }
+  }
+}


### PR DESCRIPTION
See [discussion](https://discord.com/channels/632277896739946517/632278585700384799/921118237540896770) in Discord.
Thanks @armanbilge and @Daenyth  for the feedback. Relevant references:
https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletionStage.html#handle(java.util.function.BiFunction)
https://stackoverflow.com/a/44397321