### PR TITLE
Make `IORuntime#blocking` public

### DIFF
--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -34,7 +34,7 @@ avoid unintentionally degrading your application performance.
 """)
 final class IORuntime private[unsafe] (
     val compute: ExecutionContext,
-    private[effect] val blocking: ExecutionContext,
+    val blocking: ExecutionContext,
     val scheduler: Scheduler,
     private[effect] val fiberMonitor: FiberMonitor,
     val shutdown: () => Unit,


### PR DESCRIPTION
I understand there is/was some contention around this, so apologies for poking the bear and feel free to close.

My assumptions are:
1. You can achieve the same thing by manually creating a default `IORuntime` using `IORuntime.createDefaultBlockingExecutionContext` and keeping a reference to it.
2. There are APIs which will ask for a blocking compute pool e.g. to run a `Future`.

Assuming the above are true, hiding it just makes things unnecessarily difficult when there is a reasonable use-case for it to be public.

If the concern is about leaking this to JS:
1. The _requirement_ for a blocking EC is already in the JS `IORuntime` constructor.
2. Various blocking-related methods are already leaked to JS one way or another.
3. Of course, this can be worked around, if it is truly a concern. In which case, I'd argue we should fix it everywhere, but that's a separate discussion.

An aside, but it also occurred to me that while there is `Async#executionContext`, AFAICT there is no way to get access to the blocking EC from inside of `F`. Which for situations like the above, where you are interacting with a `Future`-based API that wants a blocking `ExecutionContext` is unfortunate.

