### PR TITLE
Blocking mechanism with cached threads

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/BlockingBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/BlockingBenchmark.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020-2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package benchmarks
+
+import cats.effect.unsafe.implicits.global
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * To run the benchmark from within sbt:
+ *
+ * benchmarks/Jmh/run -i 10 -wi 10 -f 2 -t 1 cats.effect.benchmarks.BlockingBenchmark
+ *
+ * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread". Please note that
+ * benchmarks should be usually executed at least in 10 iterations (as a rule of thumb), but
+ * more is better.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class BlockingBenchmark {
+
+  @Param(Array("10000"))
+  var size: Int = _
+
+  /*
+   * Uses `IO.blocking` around a very tiny region. As things stand, each time
+   * `IO.blocking` is executed by the runtime, the whole computation is shifted
+   * to a thread on the blocking EC and immediately shifted back to the compute
+   * EC when the blocking ends.
+   */
+  @Benchmark
+  def fine(): Int = {
+    def loop(n: Int): IO[Int] =
+      IO.blocking(42).flatMap { a =>
+        if (n < size) loop(n + 1)
+        else IO.pure(a)
+      }
+
+    loop(0).unsafeRunSync()
+  }
+
+  /*
+   * Uses `IO.blocking` around a very big region. This should incur only a single
+   * shift to the blocking EC and a single shift back to the compute EC.
+   */
+  @Benchmark
+  def coarse(): Int = {
+    def loop(n: Int): IO[Int] =
+      IO(42).flatMap { a =>
+        if (n < size) loop(n + 1)
+        else IO.pure(a)
+      }
+
+    IO.blocking(loop(0).unsafeRunSync()).unsafeRunSync()
+  }
+
+  /*
+   * Uses `IO.blocking` around a very big region, but the code inside the blocking
+   * region also contains smaller blocking regions.
+   */
+  @Benchmark
+  def nested(): Int = {
+    def loop(n: Int): IO[Int] =
+      IO.blocking(42).flatMap { a =>
+        if (n < size) loop(n + 1)
+        else IO.pure(a)
+      }
+
+    IO.blocking(loop(0).unsafeRunSync()).unsafeRunSync()
+  }
+
+  /*
+   * Cedes after every blocking operation.
+   */
+  @Benchmark
+  def blockThenCede(): Int = {
+    def loop(n: Int): IO[Int] =
+      IO.blocking(42).flatMap { a =>
+        if (n < size) IO.cede.flatMap(_ => loop(n + 1))
+        else IO.cede.flatMap(_ => IO.pure(a))
+      }
+
+    loop(0).unsafeRunSync()
+  }
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -104,6 +104,7 @@ private[effect] final class WorkStealingThreadPool(
   private[unsafe] val done: AtomicBoolean = new AtomicBoolean(false)
 
   private[unsafe] val blockedWorkerThreadCounter: AtomicInteger = new AtomicInteger(0)
+  private[unsafe] val blockedWorkerThreadNamingIndex: AtomicInteger = new AtomicInteger(0)
 
   // Thread pool initialization block.
   {

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -56,7 +56,7 @@ import java.util.concurrent.locks.LockSupport
  */
 private[effect] final class WorkStealingThreadPool(
     threadCount: Int, // number of worker threads
-    threadPrefix: String, // prefix for the name of worker threads
+    private[unsafe] val threadPrefix: String, // prefix for the name of worker threads
     self0: => IORuntime
 ) extends ExecutionContext {
 
@@ -117,15 +117,7 @@ private[effect] final class WorkStealingThreadPool(
       val index = i
       val fiberBag = new WeakBag[IOFiber[_]]()
       val thread =
-        new WorkerThread(
-          index,
-          threadPrefix,
-          queue,
-          parkedSignal,
-          externalQueue,
-          null,
-          fiberBag,
-          this)
+        new WorkerThread(index, queue, parkedSignal, externalQueue, null, fiberBag, this)
       workerThreads(i) = thread
       i += 1
     }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -264,9 +264,11 @@ private final class WorkerThread(
      */
     var state = 4
 
+    val done = pool.done
+
     def parkLoop(): Unit = {
       var cont = true
-      while (cont && !isInterrupted()) {
+      while (cont && !done.get()) {
         // Park the thread until further notice.
         LockSupport.park(pool)
 
@@ -274,8 +276,6 @@ private final class WorkerThread(
         cont = parked.get()
       }
     }
-
-    val done = pool.done
 
     while (!blocking && !done.get()) {
       ((state & ExternalQueueTicksMask): @switch) match {

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -39,8 +39,6 @@ import java.util.concurrent.locks.LockSupport
  */
 private final class WorkerThread(
     idx: Int,
-    // Thread prefix string used for naming new instances of `WorkerThread`.
-    private[this] val threadPrefix: String,
     // Local queue instance with exclusive write access.
     private[this] var queue: LocalQueue,
     // The state of the `WorkerThread` (parked/unparked).
@@ -99,7 +97,7 @@ private final class WorkerThread(
     setDaemon(true)
 
     // Set the name of this thread.
-    setName(s"$threadPrefix-$index")
+    setName(s"${pool.threadPrefix}-$index")
   }
 
   /**
@@ -569,15 +567,7 @@ private final class WorkerThread(
         // for unparking.
         val idx = index
         val clone =
-          new WorkerThread(
-            idx,
-            threadPrefix,
-            queue,
-            parked,
-            external,
-            cedeBypass,
-            fiberBag,
-            pool)
+          new WorkerThread(idx, queue, parked, external, cedeBypass, fiberBag, pool)
         cedeBypass = null
         pool.replaceWorker(idx, clone)
         clone.start()

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -293,12 +293,7 @@ private final class WorkerThread(
     while (!done.get()) {
 
       if (blocking) {
-        _index = -1
-        queue = null
-        parked = null
-        external = null
-        cedeBypass = null
-        fiberBag = null
+        init(WorkerThread.NullData)
 
         pool.cachedThreads.add(this)
         try {
@@ -309,20 +304,10 @@ private final class WorkerThread(
               return
             } else {
               data = dataTransfer.take()
-              _index = data.index
-              queue = data.queue
-              parked = data.parked
-              external = data.external
-              cedeBypass = data.cedeBypass
-              fiberBag = data.fiberBag
+              init(data)
             }
           } else {
-            _index = data.index
-            queue = data.queue
-            parked = data.parked
-            external = data.external
-            cedeBypass = data.cedeBypass
-            fiberBag = data.fiberBag
+            init(data)
           }
         } catch {
           case _: InterruptedException =>
@@ -599,6 +584,15 @@ private final class WorkerThread(
     }
   }
 
+  private[this] def init(data: WorkerThread.Data): Unit = {
+    _index = data.index
+    queue = data.queue
+    parked = data.parked
+    external = data.external
+    cedeBypass = data.cedeBypass
+    fiberBag = data.fiberBag
+  }
+
   /**
    * Returns the number of fibers which are currently asynchronously suspended and tracked by
    * this worker thread.
@@ -623,4 +617,7 @@ private object WorkerThread {
       val cedeBypass: IOFiber[_],
       val fiberBag: WeakBag[IOFiber[_]]
   )
+
+  private[WorkerThread] val NullData: Data =
+    new Data(-1, null, null, null, null, null)
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -96,8 +96,10 @@ private final class WorkerThread(
     // Worker threads are daemon threads.
     setDaemon(true)
 
+    val prefix = pool.threadPrefix
+    val nameIndex = pool.blockedWorkerThreadNamingIndex.incrementAndGet()
     // Set the name of this thread.
-    setName(s"${pool.threadPrefix}-$index")
+    setName(s"$prefix-$nameIndex")
   }
 
   /**

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -941,16 +941,33 @@ private final class IOFiber[A](
           }
 
           if (cur.hint eq IOFiber.TypeBlocking) {
-            resumeTag = BlockingR
-            resumeIO = cur
+            val ec = currentCtx
+            if (ec.isInstanceOf[WorkStealingThreadPool]) {
+              var error: Throwable = null
+              val r =
+                try {
+                  scala.concurrent.blocking(cur.thunk())
+                } catch {
+                  case NonFatal(t) =>
+                    error = t
+                  case t: Throwable =>
+                    onFatalFailure(t)
+                }
 
-            if (isStackTracing) {
-              val handle = monitor()
-              objectState.push(handle)
+              val next = if (error eq null) succeeded(r, 0) else failed(error, 0)
+              runLoop(next, nextCancelation, nextAutoCede)
+            } else {
+              resumeTag = BlockingR
+              resumeIO = cur
+
+              if (isStackTracing) {
+                val handle = monitor()
+                objectState.push(handle)
+              }
+
+              val ec = runtime.blocking
+              scheduleOnForeignEC(ec, this)
             }
-
-            val ec = runtime.blocking
-            scheduleOnForeignEC(ec, this)
           } else {
             runLoop(interruptibleImpl(cur, runtime.blocking), nextCancelation, nextAutoCede)
           }


### PR DESCRIPTION
Up to now, every thread that was spawned in order to respond to `scala.concurrent.blocking` simply replaced the blocked worker thread. The worked thread that got blocked died after running the blocking code.

This PR adds a mechanism for caching threads, similar to `Executors.newCachedThreadPool`, where the threads are kept around for one minute after they become inactive, in case more blocking work arrives. This saves the expensive process of spawning a new thread.

For now, the retention period is fixed and non-configurable, but I am open to making it user configurable in `3.4.0`.

Furthemore, this PR makes a change in the `IOFiber` blocking section, where fibers can determine if they are running on the WSTP and instead of making an expensive shift to the blocking executor and another expensive shift back to the compute pool, the blocking actions are wrapped in `scala.concurrent.blocking` and executed in place, taking advantage of cached worker threads or spawning new ones if necessary.

I also added benchmarks and the improvements are pretty sweet.

`series/3.3.x`:
```scala
Benchmark                        (size)   Mode  Cnt     Score     Error  Units
BlockingBenchmark.blockThenCede   10000  thrpt   20     3.353 ±   0.081  ops/s
BlockingBenchmark.coarse          10000  thrpt   20  3580.270 ± 164.925  ops/s
BlockingBenchmark.fine            10000  thrpt   20     3.321 ±   0.184  ops/s
BlockingBenchmark.nested          10000  thrpt   20     3.345 ±   0.064  ops/s
```

`This PR`:
```scala
Benchmark                        (size)   Mode  Cnt     Score     Error  Units
BlockingBenchmark.blockThenCede   10000  thrpt   20     6.209 ±   0.055  ops/s
BlockingBenchmark.coarse          10000  thrpt   20  3468.893 ± 138.703  ops/s
BlockingBenchmark.fine            10000  thrpt   20   739.282 ±   5.803  ops/s
BlockingBenchmark.nested          10000  thrpt   20   716.012 ±   4.738  ops/s
```