### PR TITLE
Removed `interruptible` dependency on an explicit `ExecutionContext`

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -16,16 +16,11 @@
 
 package cats.effect
 
-import scala.concurrent.ExecutionContext
-
 import java.util.concurrent.atomic.AtomicBoolean
 
 private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
   this: IOFiber[A] =>
 
   // in theory this code should never be hit due to the override in IOCompanionPlatform
-  def interruptibleImpl(cur: IO.Blocking[Any], blockingEc: ExecutionContext): IO[Any] = {
-    val _ = blockingEc
-    IO(cur.thunk())
-  }
+  def interruptibleImpl(cur: IO.Blocking[Any]): IO[Any] = IO(cur.thunk())
 }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -950,7 +950,7 @@ private final class IOFiber[A](
             val ec = runtime.blocking
             scheduleOnForeignEC(ec, this)
           } else {
-            runLoop(interruptibleImpl(cur, runtime.blocking), nextCancelation, nextAutoCede)
+            runLoop(interruptibleImpl(cur), nextCancelation, nextAutoCede)
           }
 
         case 22 =>


### PR DESCRIPTION
This does result in *slightly* more overhead, but it's a lot more composable and provides compatibility with #2687 (and all future revisions in this area).