### PR TITLE
Detect sbt thread cleaner and terminate workers

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -287,7 +287,7 @@ private final class WorkerThread(
 
         // the only way we can be interrupted here is if it happened *externally* (probably sbt)
         if (isInterrupted())
-          done.set(true)
+          pool.shutdown()
         else
           // Spurious wakeup check.
           cont = parked.get()

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -285,8 +285,12 @@ private final class WorkerThread(
         // Park the thread until further notice.
         LockSupport.park(pool)
 
-        // Spurious wakeup check.
-        cont = parked.get()
+        // the only way we can be interrupted here is if it happened *externally* (probably sbt)
+        if (isInterrupted())
+          done.set(true)
+        else
+          // Spurious wakeup check.
+          cont = parked.get()
       }
     }
 

--- a/tests/js/src/main/scala/catseffect/examplesplatform.scala
+++ b/tests/js/src/main/scala/catseffect/examplesplatform.scala
@@ -34,6 +34,7 @@ package examples {
 
     register(HelloWorld)
     register(Arguments)
+    register(NonFatalError)
     register(FatalError)
     register(Canceled)
     register(GlobalRacingInit)

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -200,6 +200,12 @@ class IOAppSpec extends Specification {
           }
         }
 
+        "exit on non-fatal error" in {
+          val h = platform(NonFatalError, List.empty)
+          h.awaitStatus() mustEqual 1
+          h.stderr() must contain("Boom!")
+        }
+
         "exit on fatal error" in {
           val h = platform(FatalError, List.empty)
           h.awaitStatus() mustEqual 1

--- a/tests/shared/src/main/scala/catseffect/examples.scala
+++ b/tests/shared/src/main/scala/catseffect/examples.scala
@@ -33,6 +33,11 @@ package examples {
       args.traverse_(s => IO(println(s))).as(ExitCode.Success)
   }
 
+  object NonFatalError extends IOApp {
+    def run(args: List[String]): IO[ExitCode] =
+      IO(throw new RuntimeException("Boom!")).as(ExitCode.Success)
+  }
+
   object FatalError extends IOApp {
     def run(args: List[String]): IO[ExitCode] =
       IO(throw new OutOfMemoryError("Boom!")).as(ExitCode.Success)


### PR DESCRIPTION
Also added a non-fatal test which *doesn't* reproduce the issue. I wasn't able to come up with a good way of rigorously testing this.

Fixes #2704 