### PR TITLE
Update year to 2022 (series/3.3.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,46 +11,46 @@
 
 ## Getting Started
 
-- Wired: **3.3.0**
+- Wired: **3.3.3**
 - Tired: **2.5.4**
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-effect" % "3.3.0"
+libraryDependencies += "org.typelevel" %% "cats-effect" % "3.3.3"
 ```
 
-The above represents the core, stable dependency which brings in the entirety of Cats Effect. This is *most likely* what you want. All current Cats Effect releases are published for Scala 2.12, 2.13, 3.0.0-RC2 and RC3, and ScalaJS 1.5.x.
+The above represents the core, stable dependency which brings in the entirety of Cats Effect. This is *most likely* what you want. All current Cats Effect releases are published for Scala 2.12, 2.13, 3.0, and Scala.js 1.7.
 
-Or, if you prefer a less bare-bones starting point, you can try the Giter8 template:
+Or, if you prefer a less bare-bones starting point, you can try [the Giter8 template](https://github.com/typelevel/ce3.g8):
 
 ```bash
 $ sbt -Dsbt.version=1.5.5 new typelevel/ce3.g8
 ```
 
-Depending on your use-case, you may want to consider one of the several other modules which are made available within the Cats Effect release. If you're a datatype implementer (like Monix), you probably only want to depend on **kernel** (the typeclasses) in your compile scope and **laws** in your test scope:
+Depending on your use-case, you may want to consider one of the several other modules which are made available within the Cats Effect release. If you're a datatype implementer (like [Monix](https://monix.io)), you probably only want to depend on **kernel** (the typeclasses) in your compile scope and **laws** in your test scope:
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats-effect-kernel" % "3.3.0",
-  "org.typelevel" %% "cats-effect-laws"   % "3.3.0" % Test)
+  "org.typelevel" %% "cats-effect-kernel" % "3.3.3",
+  "org.typelevel" %% "cats-effect-laws"   % "3.3.3" % Test)
 ```
 
-If you're a middleware framework (like fs2), you probably want to depend on **std**, which gives you access to `Queue`, `Semaphore`, and much more without introducing a hard-dependency on `IO` outside of your tests:
+If you're a middleware framework (like [Fs2](https://fs2.io/)), you probably want to depend on **std**, which gives you access to `Queue`, `Semaphore`, and much more without introducing a hard-dependency on `IO` outside of your tests:
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats-effect-std" % "3.3.0",
-  "org.typelevel" %% "cats-effect"     % "3.3.0" % Test)
+  "org.typelevel" %% "cats-effect-std" % "3.3.3",
+  "org.typelevel" %% "cats-effect"     % "3.3.3" % Test)
 ```
 
 You may also find some utility in the **testkit** and **kernel-testkit** projects, which contain `TestContext`, generators for `IO`, and a few other things:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-effect-testkit" % "3.3.0" % Test
+libraryDependencies += "org.typelevel" %% "cats-effect-testkit" % "3.3.3" % Test
 ```
 
-Cats Effect provides backward binary compatibility within the 2.x and 3.x version lines, and both forward and backward compatibility within any major/minor line. This is analogous to the versioning scheme used by Cats itself, as well as other major projects such as ScalaJS. Thus, any project depending upon Cats Effect 2.2.1 can be used with libraries compiled against Cats Effect 2.0.0 or 2.2.3, but *not* with libraries compiled against 2.3.0 or higher.
+Cats Effect provides backward binary compatibility within the 2.x and 3.x version lines, and both forward and backward compatibility within any major/minor line. This is analogous to the versioning scheme used by Cats itself, as well as other major projects such as Scala.js. Thus, any project depending upon Cats Effect 2.2.1 can be used with libraries compiled against Cats Effect 2.0.0 or 2.2.3, but *not* with libraries compiled against 2.3.0 or higher.
 
-### Moving from cats-effect 1.x / 2.x?
+### Updating from Cats Effect 1.x / 2.x
 
 Check out the [migration guide](https://typelevel.org/cats-effect/docs/migration-guide)!
 
@@ -165,7 +165,7 @@ If everything goes well, your browser will open at the end of this.
 ## License
 
 ```
-Copyright 2017-2021 Typelevel
+Copyright 2017-2022 Typelevel
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/AsyncBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/AsyncBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/AttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/AttemptBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/BlockingBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/BlockingBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/BothBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/BothBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/DeepBindBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/DeepBindBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/DispatcherBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/DispatcherBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/HandleErrorBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/HandleErrorBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/MapCallsBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/MapCallsBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/MapStreamBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/MapStreamBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/ParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/ParallelBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/RaceBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/RaceBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/RedeemBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/RedeemBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/RedeemWithBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/RedeemWithBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/RefBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/RefBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/ShallowBindBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/ShallowBindBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/SleepDrift.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/SleepDrift.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"
 
 ThisBuild / startYear := Some(2020)
-ThisBuild / endYear := Some(2021)
+ThisBuild / endYear := Some(2022)
 
 ThisBuild / developers := List(
   Developer(

--- a/core/js/src/main/scala/cats/effect/IOApp.scala
+++ b/core/js/src/main/scala/cats/effect/IOApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/IOPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/SyncIOCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/SyncIOCompanionPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/SyncIOConstants.scala
+++ b/core/js/src/main/scala/cats/effect/SyncIOConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/process.scala
+++ b/core/js/src/main/scala/cats/effect/process.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/tracing/TracingConstants.scala
+++ b/core/js/src/main/scala/cats/effect/tracing/TracingConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/tracing/TracingPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/tracing/TracingPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/unsafe/ref/Reference.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/ref/Reference.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/unsafe/ref/ReferenceQueue.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/ref/ReferenceQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/js/src/main/scala/cats/effect/unsafe/ref/WeakReference.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/ref/WeakReference.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/java/cats/effect/Signal.java
+++ b/core/jvm/src/main/java/cats/effect/Signal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/java/cats/effect/SyncIOConstants.java
+++ b/core/jvm/src/main/java/cats/effect/SyncIOConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/java/cats/effect/tracing/TracingConstants.java
+++ b/core/jvm/src/main/java/cats/effect/tracing/TracingConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/java/cats/effect/unsafe/LocalQueue.java
+++ b/core/jvm/src/main/java/cats/effect/unsafe/LocalQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/java/cats/effect/unsafe/LocalQueueConstants.java
+++ b/core/jvm/src/main/java/cats/effect/unsafe/LocalQueueConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/java/cats/effect/unsafe/WorkStealingThreadPoolConstants.java
+++ b/core/jvm/src/main/java/cats/effect/unsafe/WorkStealingThreadPoolConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/IOPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/NonDaemonThreadLogger.scala
+++ b/core/jvm/src/main/scala/cats/effect/NonDaemonThreadLogger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/SyncIOCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/SyncIOCompanionPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/tracing/TracingPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/tracing/TracingPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/LocalQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/ScalQueue.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/ScalQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SynchronizedWeakBag.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SynchronizedWeakBag.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSampler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/ComputePoolSamplerMBean.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/LiveFiberSnapshotTrigger.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/LiveFiberSnapshotTrigger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/LiveFiberSnapshotTriggerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/LiveFiberSnapshotTriggerMBean.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/LocalQueueSampler.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/LocalQueueSampler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/LocalQueueSamplerMBean.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/LocalQueueSamplerMBean.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/ref/package.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/ref/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/shared/src/main/scala/cats/effect/ArrayStack.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/ByteStack.scala
+++ b/core/shared/src/main/scala/cats/effect/ByteStack.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/shared/src/main/scala/cats/effect/CallbackStack.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/ContState.scala
+++ b/core/shared/src/main/scala/cats/effect/ContState.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/ExitCode.scala
+++ b/core/shared/src/main/scala/cats/effect/ExitCode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/IOLocal.scala
+++ b/core/shared/src/main/scala/cats/effect/IOLocal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/LiftIO.scala
+++ b/core/shared/src/main/scala/cats/effect/LiftIO.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/ResourceApp.scala
+++ b/core/shared/src/main/scala/cats/effect/ResourceApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/SyncIO.scala
+++ b/core/shared/src/main/scala/cats/effect/SyncIO.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/Thunk.scala
+++ b/core/shared/src/main/scala/cats/effect/Thunk.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/Trace.scala
+++ b/core/shared/src/main/scala/cats/effect/Trace.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/implicits.scala
+++ b/core/shared/src/main/scala/cats/effect/implicits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/instances/AllInstances.scala
+++ b/core/shared/src/main/scala/cats/effect/instances/AllInstances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/instances/package.scala
+++ b/core/shared/src/main/scala/cats/effect/instances/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/syntax/AllSyntax.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/AllSyntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/syntax/package.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/tracing/TracingEvent.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/TracingEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/unsafe/FiberMonitorShared.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/FiberMonitorShared.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/unsafe/Scheduler.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/Scheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/unsafe/StripedHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/StripedHashtable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/unsafe/WeakBag.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/WeakBag.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/cats/effect/unsafe/implicits.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/implicits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example/js/src/main/scala/cats/effect/example/Example.scala
+++ b/example/js/src/main/scala/cats/effect/example/Example.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example/jvm/src/main/scala/cats/effect/example/Example.scala
+++ b/example/jvm/src/main/scala/cats/effect/example/Example.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/FreeSyncGenerators.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/FreeSyncGenerators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/Generators.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/Generators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/PureConcGenerators.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/PureConcGenerators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/TestContext.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/TestContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/TestInstances.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/TestInstances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/TimeT.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/TimeT.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/freeEval.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/freeEval.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/package.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/pure.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/pure.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/js/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
+++ b/kernel/js/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/js/src/main/scala/cats/effect/kernel/ClockPlatform.scala
+++ b/kernel/js/src/main/scala/cats/effect/kernel/ClockPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/js/src/main/scala/cats/effect/kernel/ResourcePlatform.scala
+++ b/kernel/js/src/main/scala/cats/effect/kernel/ResourcePlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/jvm/src/main/scala/cats/effect/kernel/ClockPlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/ClockPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/jvm/src/main/scala/cats/effect/kernel/ResourcePlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/ResourcePlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/CancelScope.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/CancelScope.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Clock.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Clock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Cont.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Cont.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Deferred.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Deferred.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Fiber.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Fiber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenTemporal.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenTemporal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MiniSemaphore.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MiniSemaphore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/ParallelF.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/ParallelF.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Poll.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Poll.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Unique.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Unique.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/implicits.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/implicits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/instances/AllInstances.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/instances/AllInstances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/instances/GenSpawnInstances.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/instances/GenSpawnInstances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/instances/package.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/instances/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AllSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AllSyntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AsyncSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AsyncSyntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/ClockSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/ClockSyntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenConcurrentSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenConcurrentSyntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenSpawnSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenSpawnSyntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenTemporalSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenTemporalSyntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/MonadCancelSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/MonadCancelSyntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/ResourceSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/ResourceSyntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/package.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/shared/src/test/scala/cats/effect/kernel/SyntaxSpec.scala
+++ b/kernel/shared/src/test/scala/cats/effect/kernel/SyntaxSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/ClockLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ClockLaws.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/ClockTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/ClockTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/GenSpawnLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenSpawnLaws.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/GenSpawnTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenSpawnTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/GenTemporalLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenTemporalLaws.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/GenTemporalTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenTemporalTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/IsEq.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/IsEq.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/MonadCancelLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/MonadCancelLaws.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/MonadCancelTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/MonadCancelTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncLaws.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/Tolerance.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/Tolerance.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/UniqueLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/UniqueLaws.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/UniqueTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/UniqueTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/main/scala/cats/effect/laws/package.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/BaseSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/BaseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/kernel/OutcomeSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/kernel/OutcomeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/ClockSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/ClockSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/EitherTFreeSyncSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/EitherTFreeSyncSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/EitherTPureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/EitherTPureConcSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/FreeSyncSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/FreeSyncSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/GenTemporalSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/GenTemporalSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/IorTFreeSyncSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/IorTFreeSyncSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/IorTPureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/IorTPureConcSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/KleisliFreeSyncSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/KleisliFreeSyncSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/KleisliPureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/KleisliPureConcSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/OptionTFreeSyncSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/OptionTFreeSyncSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/OptionTPureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/OptionTPureConcSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/PureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/PureConcSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/ReaderWriterStateTFreeSyncSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/ReaderWriterStateTFreeSyncSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/ReaderWriterStateTPureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/ReaderWriterStateTPureConcSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/ResourcePureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/ResourcePureConcSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/StateTFreeSyncSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/StateTFreeSyncSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/StateTPureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/StateTPureConcSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/WriterTFreeSyncSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/WriterTFreeSyncSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/laws/WriterTPureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/WriterTPureConcSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/laws/shared/src/test/scala/cats/effect/testkit/TimeTSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/testkit/TimeTSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/CI.scala
+++ b/project/CI.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/JSEnv.scala
+++ b/project/JSEnv.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/js/src/main/scala/cats/effect/std/DispatcherPlatform.scala
+++ b/std/js/src/main/scala/cats/effect/std/DispatcherPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/jvm/src/main/scala/cats/effect/std/DispatcherPlatform.scala
+++ b/std/jvm/src/main/scala/cats/effect/std/DispatcherPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/Backpressure.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Backpressure.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/Console.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Console.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/CountDownLatch.scala
+++ b/std/shared/src/main/scala/cats/effect/std/CountDownLatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
+++ b/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/Dequeue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dequeue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/PQueue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/PQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/Queue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Queue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/Random.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Random.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
+++ b/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/internal/BankersQueue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/internal/BankersQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/internal/BinomialHeap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/internal/BinomialHeap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/syntax/AllSyntax.scala
+++ b/std/shared/src/main/scala/cats/effect/std/syntax/AllSyntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/syntax/BackpressureSyntax.scala
+++ b/std/shared/src/main/scala/cats/effect/std/syntax/BackpressureSyntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/syntax/SupervisorSyntax.scala
+++ b/std/shared/src/main/scala/cats/effect/std/syntax/SupervisorSyntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/main/scala/cats/effect/std/syntax/package.scala
+++ b/std/shared/src/main/scala/cats/effect/std/syntax/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/std/shared/src/test/scala/cats/effect/std/SyntaxSpec.scala
+++ b/std/shared/src/test/scala/cats/effect/std/SyntaxSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testkit/shared/src/main/scala/cats/effect/testkit/TestControl.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/TestControl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testkit/shared/src/main/scala/cats/effect/testkit/TestException.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/TestException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testkit/shared/src/main/scala/cats/effect/testkit/package.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/js/src/main/scala/catseffect/examplesplatform.scala
+++ b/tests/js/src/main/scala/catseffect/examplesplatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/js/src/test/scala/cats/effect/ContSpecBasePlatform.scala
+++ b/tests/js/src/test/scala/cats/effect/ContSpecBasePlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/js/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/js/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/js/src/test/scala/cats/effect/RunnersPlatform.scala
+++ b/tests/js/src/test/scala/cats/effect/RunnersPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/js/src/test/scala/cats/effect/SyncIOPlatformSpecification.scala
+++ b/tests/js/src/test/scala/cats/effect/SyncIOPlatformSpecification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/js/src/test/scala/cats/effect/unsafe/SchedulerSpec.scala
+++ b/tests/js/src/test/scala/cats/effect/unsafe/SchedulerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/js/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
+++ b/tests/js/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/jvm/src/main/scala/catseffect/examplesplatform.scala
+++ b/tests/jvm/src/main/scala/catseffect/examplesplatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/jvm/src/test/scala/cats/effect/ContSpecBasePlatform.scala
+++ b/tests/jvm/src/test/scala/cats/effect/ContSpecBasePlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/jvm/src/test/scala/cats/effect/ParasiticECSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/ParasiticECSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/jvm/src/test/scala/cats/effect/ResourceJVMSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/ResourceJVMSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/jvm/src/test/scala/cats/effect/RunnersPlatform.scala
+++ b/tests/jvm/src/test/scala/cats/effect/RunnersPlatform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/jvm/src/test/scala/cats/effect/SyncIOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/SyncIOPlatformSpecification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/jvm/src/test/scala/cats/effect/kernel/AsyncPlatformSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/kernel/AsyncPlatformSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/jvm/src/test/scala/cats/effect/std/ConsoleJVMSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/std/ConsoleJVMSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/jvm/src/test/scala/cats/effect/std/DeferredJVMSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/std/DeferredJVMSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/jvm/src/test/scala/cats/effect/std/DispatcherJVMSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/std/DispatcherJVMSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/jvm/src/test/scala/cats/effect/unsafe/BlockingStressSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/BlockingStressSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/jvm/src/test/scala/cats/effect/unsafe/DrainBatchSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/DrainBatchSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/jvm/src/test/scala/cats/effect/unsafe/HelperThreadParkSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/HelperThreadParkSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/jvm/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/main/scala/catseffect/examples.scala
+++ b/tests/shared/src/main/scala/catseffect/examples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/BaseSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/BaseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/ContSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ContSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/EitherTIOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/EitherTIOSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/IOFiberSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOFiberSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/IOLocalSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOLocalSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/IOParSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOParSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/IOPropSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOPropSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/IorTIOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IorTIOSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/KleisliIOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/KleisliIOSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/MemoizeSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/MemoizeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/OptionTIOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/OptionTIOSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/Runners.scala
+++ b/tests/shared/src/test/scala/cats/effect/Runners.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/StateTIOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/StateTIOSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/SyncIOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/SyncIOSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/ThunkSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ThunkSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/WriterTIOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/WriterTIOSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/kernel/DeferredSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/DeferredSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/kernel/LensRefSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/LensRefSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/kernel/MiniSemaphoreSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/MiniSemaphoreSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/kernel/ParallelFSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/ParallelFSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/kernel/RefSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/RefSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/kernel/SemaphoreSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/SemaphoreSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/std/BackpressureSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/BackpressureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/std/ConsoleSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/ConsoleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/std/CountDownLatchSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/CountDownLatchSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/std/CyclicBarrierSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/CyclicBarrierSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/std/DequeueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DequeueSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/std/PQueueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/PQueueSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/std/internal/BankersQueueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/internal/BankersQueueSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/std/internal/BinomialHeapSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/internal/BinomialHeapSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/testkit/TestControlSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/testkit/TestControlSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/tracing/TraceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/tracing/TraceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/cats/effect/tracing/TracingSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/tracing/TracingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Typelevel
+ * Copyright 2020-2022 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
First half of this process. Once this is merged, we'll re-merge to `series/3.x` and re-run the transformation. This avoids creating incidental merge conflicts.