### PR TITLE
Set the callback unsafely without memory barriers and allocations

### DIFF
--- a/core/shared/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/shared/src/main/scala/cats/effect/CallbackStack.scala
@@ -40,6 +40,10 @@ private final class CallbackStack[A](private[this] var callback: OutcomeIO[A] =>
     loop()
   }
 
+  def unsafeSetCallback(cb: OutcomeIO[A] => Unit): Unit = {
+    callback = cb
+  }
+
   /**
    * Invokes *all* non-null callbacks in the queue, starting with the current one.
    */

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -878,8 +878,8 @@ private final class IOFiber[A](
                     rt
                   )
 
-                  fiberA.registerListener(oc => cb(Right(Left((oc, fiberB)))))
-                  fiberB.registerListener(oc => cb(Right(Right((fiberA, oc)))))
+                  fiberA.setCallback(oc => cb(Right(Left((oc, fiberB)))))
+                  fiberB.setCallback(oc => cb(Right(Right((fiberA, oc)))))
 
                   scheduleFiber(ec, fiberA)
                   scheduleFiber(ec, fiberB)
@@ -1097,8 +1097,16 @@ private final class IOFiber[A](
     runtime.fiberMonitor.monitorSuspended(this)
   }
 
+  /**
+   * Can only be correctly called on a fiber which has not started execution and was initially
+   * created with a `null` callback, i.e. in `RacePair`.
+   */
+  private def setCallback(cb: OutcomeIO[A] => Unit): Unit = {
+    callbacks.unsafeSetCallback(cb)
+  }
+
   /* can return null, meaning that no CallbackStack needs to be later invalidated */
-  private def registerListener(listener: OutcomeIO[A] => Unit): CallbackStack[A] = {
+  private[this] def registerListener(listener: OutcomeIO[A] => Unit): CallbackStack[A] = {
     if (outcome == null) {
       val back = callbacks.push(listener)
 


### PR DESCRIPTION
`series/3.3.x`:
```scala
Benchmark                      (cpuTokens)  (size)   Mode  Cnt    Score   Error  Units
ParallelBenchmark.parTraverse        10000    1000  thrpt   20  313.308 ± 8.235  ops/s
```

`This PR`:
```scala
Benchmark                      (cpuTokens)  (size)   Mode  Cnt    Score   Error  Units
ParallelBenchmark.parTraverse        10000    1000  thrpt   20  320.792 ± 1.811  ops/s
```