### PR TITLE
Attempt to detect host environments (like unforked sbt)

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -200,6 +200,9 @@ trait IOApp {
   def run(args: List[String]): IO[ExitCode]
 
   final def main(args: Array[String]): Unit = {
+    // checked in openjdk 8-17; this attempts to detect when we're running under artificial environments, like sbt
+    val isForked = Thread.currentThread().getName() == "main"
+
     if (runtime == null) {
       import unsafe.IORuntime
 
@@ -329,15 +332,26 @@ trait IOApp {
               new NonDaemonThreadLogger().start()
             else
               ()
-          } else {
+          } else if (isForked) {
             System.exit(result.code)
           }
-        case _: CancellationException =>
-          // Do not report cancelation exceptions but still exit with an error code.
-          System.exit(1)
+
+        case e: CancellationException =>
+          if (isForked)
+            // Do not report cancelation exceptions but still exit with an error code.
+            System.exit(1)
+          else
+            // if we're unforked, the only way to report cancelation is to throw
+            throw e
+
         case NonFatal(t) =>
-          t.printStackTrace()
-          System.exit(1)
+          if (isForked) {
+            t.printStackTrace()
+            System.exit(1)
+          } else {
+            throw t
+          }
+
         case t: Throwable =>
           t.printStackTrace()
           rt.halt(1)

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -201,7 +201,7 @@ trait IOApp {
 
   final def main(args: Array[String]): Unit = {
     // checked in openjdk 8-17; this attempts to detect when we're running under artificial environments, like sbt
-    val isForked = Thread.currentThread().getName() == "main"
+    val isForked = Thread.currentThread().getId() == 1
 
     if (runtime == null) {
       import unsafe.IORuntime


### PR DESCRIPTION
Rather than printing and calling `System.exit`, we just `throw` whenever we're *not* forked. The detection here actually seems robust enough to lean on, particularly since the degradation path is fine. This also has the pleasing side effect of integrating better with sbt's `last` command.

Fixes #2706