### PR TITLE
Handle interruption around blocking waits

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -294,16 +294,12 @@ trait IOApp {
         val cancelLatch = new CountDownLatch(1)
         fiber.cancel.unsafeRunAsync(_ => cancelLatch.countDown())(runtime)
 
-        try {
-          val timeout = runtimeConfig.shutdownHookTimeout
-          if (timeout.isFinite) {
-            blocking(cancelLatch.await(timeout.length, timeout.unit))
-            ()
-          } else {
-            blocking(cancelLatch.await())
-          }
-        } catch {
-          case _: InterruptedException =>
+        val timeout = runtimeConfig.shutdownHookTimeout
+        if (timeout.isFinite) {
+          blocking(cancelLatch.await(timeout.length, timeout.unit))
+          ()
+        } else {
+          blocking(cancelLatch.await())
         }
       }
 

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -270,18 +270,18 @@ trait IOApp {
     val fiber =
       ioa.unsafeRunFiber(
         {
-          queue.offer(new CancellationException("IOApp main fiber was canceled"))
           counter.decrementAndGet()
+          queue.offer(new CancellationException("IOApp main fiber was canceled"))
           ()
         },
         { t =>
-          queue.offer(t)
           counter.decrementAndGet()
+          queue.offer(t)
           ()
         },
         { a =>
-          queue.offer(a)
           counter.decrementAndGet()
+          queue.offer(a)
           ()
         }
       )(runtime)

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -361,9 +361,6 @@ trait IOApp {
         case t: Throwable =>
           t.printStackTrace()
           rt.halt(1)
-        case null =>
-          println(
-            s"result is null but is interrupted? ${Thread.currentThread().isInterrupted()}")
       }
     } catch {
       // this handles sbt when fork := false

--- a/core/jvm/src/main/scala/cats/effect/IOPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOPlatform.scala
@@ -20,7 +20,7 @@ import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.blocking
 import scala.concurrent.duration._
 
-import java.util.concurrent.{CompletableFuture, CountDownLatch, TimeUnit}
+import java.util.concurrent.{ArrayBlockingQueue, CompletableFuture, TimeUnit}
 
 abstract private[effect] class IOPlatform[+A] { self: IO[A] =>
 
@@ -69,19 +69,19 @@ abstract private[effect] class IOPlatform[+A] { self: IO[A] =>
    */
   final def unsafeRunTimed(limit: FiniteDuration)(
       implicit runtime: unsafe.IORuntime): Option[A] = {
-    @volatile
-    var results: Either[Throwable, A] = null
-    val latch = new CountDownLatch(1)
+    val queue = new ArrayBlockingQueue[Either[Throwable, A]](1)
 
     unsafeRunAsync { r =>
-      results = r
-      latch.countDown()
+      queue.offer(r)
+      ()
     }
 
-    if (blocking(latch.await(limit.toNanos, TimeUnit.NANOSECONDS))) {
-      results.fold(throw _, a => Some(a))
-    } else {
-      None
+    try {
+      val result = blocking(queue.poll(limit.toNanos, TimeUnit.NANOSECONDS))
+      if (result eq null) None else result.fold(throw _, Some(_))
+    } catch {
+      case _: InterruptedException =>
+        None
     }
   }
 


### PR DESCRIPTION
Resolves #2720.

Removes code that captures mutable variables and volatile at that, for which the Scala runtime has specific classes (`VolatileMutableReference` or something similar, TIL).