### PR TITLE
Invoke `process.exit` within a `Try` in IOApp.js

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOApp.scala
+++ b/core/js/src/main/scala/cats/effect/IOApp.scala
@@ -219,8 +219,10 @@ trait IOApp {
     val argList = process.argv.getOrElse(args.toList)
 
     // Store the default process.exit function, if it exists
-    val hardExit =
-      Try(js.Dynamic.global.process.exit.asInstanceOf[js.Function1[Int, Unit]]: Int => Unit)
+    val hardExit: Int => Unit =
+      Try(js.Dynamic.global.process.exit.asInstanceOf[js.Function1[Int, Unit]])
+        // we got *something*, but we don't know what it is really. so wrap in a Try
+        .map(f => (i: Int) => { Try(f(i)); () })
         .getOrElse((_: Int) => ())
 
     var cancelCode = 1 // So this can be updated by external cancellation

--- a/tests/js/src/main/scala/catseffect/examplesplatform.scala
+++ b/tests/js/src/main/scala/catseffect/examplesplatform.scala
@@ -43,11 +43,15 @@ package examples {
     register(FatalErrorUnsafeRun)
     register(Finalizers)
     register(LeakedFiber)
+    register(UndefinedProcessExit)
 
     @nowarn("cat=unused")
     def main(paperweight: Array[String]): Unit = {
       val args = js.Dynamic.global.process.argv.asInstanceOf[js.Array[String]]
       val app = args(2)
+      if (app == UndefinedProcessExit.getClass.getName.init)
+        // emulates the situation in browsers
+        js.Dynamic.global.process.exit = js.undefined
       args.shift()
       apps(app).main(Array.empty)
     }
@@ -81,4 +85,7 @@ package examples {
         .as(ExitCode.Success)
   }
 
+  object UndefinedProcessExit extends IOApp {
+    def run(args: List[String]): IO[ExitCode] = IO.pure(ExitCode.Success)
+  }
 }

--- a/tests/jvm/src/main/scala/catseffect/examplesplatform.scala
+++ b/tests/jvm/src/main/scala/catseffect/examplesplatform.scala
@@ -59,4 +59,8 @@ package examples {
         .as(ExitCode.Success)
   }
 
+  // just a stub to satisfy compiler, never run on JVM
+  object UndefinedProcessExit extends IOApp {
+    def run(args: List[String]): IO[ExitCode] = IO.never
+  }
 }

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -267,9 +267,12 @@ class IOAppSpec extends Specification {
         } else {
           "live fiber snapshot" in {
             val h = platform(LiveFiberSnapshot, List.empty)
-            // Allow the process some time to start
-            // and register the signal handlers.
-            Thread.sleep(4000L)
+
+            // wait for the application to fully start before trying to send the signal
+            while (!h.stdout().contains("ready")) {
+              Thread.sleep(100L)
+            }
+
             val pid = h.pid()
             pid must beSome
             pid.foreach(platform.sendSignal)

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -269,7 +269,7 @@ class IOAppSpec extends Specification {
             val h = platform(LiveFiberSnapshot, List.empty)
             // Allow the process some time to start
             // and register the signal handlers.
-            Thread.sleep(2000L)
+            Thread.sleep(4000L)
             val pid = h.pid()
             pid must beSome
             pid.foreach(platform.sendSignal)

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -250,6 +250,13 @@ class IOAppSpec extends Specification {
           }
         }
 
+        if (BuildInfo.testJSIOApp) {
+          "gracefully ignore undefined process.exit" in {
+            val h = platform(UndefinedProcessExit, List.empty)
+            h.awaitStatus() mustEqual 0
+          }
+        }
+
         if (!BuildInfo.testJSIOApp && sys
             .props
             .get("java.version")

--- a/tests/shared/src/main/scala/catseffect/examples.scala
+++ b/tests/shared/src/main/scala/catseffect/examples.scala
@@ -83,6 +83,7 @@ package examples {
       } yield ()
 
       _ <- sleeper.start
+      _ <- IO.println("ready")
       _ <- fibers.traverse(_.join)
     } yield ()
   }


### PR DESCRIPTION
Fixes #2730.

We have a `Try` in case reading the global variable `process.exit` fails, but just because it succeeded, doesn't mean we got a legit `exit` function. In #2730, `process` existed but `process.exit` was `undefined`, and in theory there could be just about anything in there :) in which case attempting some sort of typecheck seems fruitless. So this PR just wraps it all up in one more `Try`.

Since browsers can configure CE via a `process.env` global, this sort of situation can happen quite easily.

I didn't add a test, but I would like to. I need to think about how to set this one up.