### PR TITLE
Run blocking code on the compute pool more carefully

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -28,4 +28,5 @@ private[effect] sealed abstract class WorkStealingThreadPool private ()
   def reportFailure(cause: Throwable): Unit
   private[effect] def rescheduleFiber(fiber: IOFiber[_]): Unit
   private[effect] def scheduleFiber(fiber: IOFiber[_]): Unit
+  private[effect] def canExecuteBlockingCode(): Boolean
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -430,6 +430,20 @@ private[effect] final class WorkStealingThreadPool(
   }
 
   /**
+   * Checks if the blocking code can be executed in the current context (only returns true for
+   * worker threads that belong to this execution context).
+   */
+  private[effect] def canExecuteBlockingCode(): Boolean = {
+    val thread = Thread.currentThread()
+    if (thread.isInstanceOf[WorkerThread]) {
+      val worker = thread.asInstanceOf[WorkerThread]
+      worker.isOwnedBy(this)
+    } else {
+      false
+    }
+  }
+
+  /**
    * Schedules a fiber for execution on this thread pool originating from an external thread (a
    * thread which is not owned by this thread pool).
    *

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -437,7 +437,7 @@ private[effect] final class WorkStealingThreadPool(
     val thread = Thread.currentThread()
     if (thread.isInstanceOf[WorkerThread]) {
       val worker = thread.asInstanceOf[WorkerThread]
-      worker.isOwnedBy(this)
+      worker.canExecuteBlockingCodeOn(this)
     } else {
       false
     }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -161,6 +161,21 @@ private final class WorkerThread(
     (pool eq threadPool) && !blocking
 
   /**
+   * Checks whether this [[WorkerThread]] operates within the [[WorkStealingThreadPool]]
+   * provided as an argument to this method. The implementation checks whether the provided
+   * [[WorkStealingThreadPool]] matches the reference of the pool provided when this
+   * [[WorkerThread]] was constructed.
+   *
+   * @param threadPool
+   *   a work stealing thread pool reference
+   * @return
+   *   `true` if this worker thread is owned by the provided work stealing thread pool, `false`
+   *   otherwise
+   */
+  def canExecuteBlockingCodeOn(threadPool: WorkStealingThreadPool): Boolean =
+    pool eq threadPool
+
+  /**
    * Registers a suspended fiber.
    *
    * @param fiber


### PR DESCRIPTION
Only run blocking code if the worker thread matches the compute runtime.