### PR TITLE
Workaround for dotty#14240

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,11 @@
 version = 3.2.1
 
 runner.dialect = Scala213Source3
+fileOverride {
+  "glob:**/scala-3/**" {
+    runner.dialect = scala3
+  }
+}
 
 project.excludeFilters = [
   "scalafix/*"

--- a/build.sbt
+++ b/build.sbt
@@ -336,6 +336,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .dependsOn(kernel, std)
   .settings(
     name := "cats-effect",
+    mimaPreviousArtifacts += "org.typelevel" %%% "cats-effect" % "3.3.4",
     mimaBinaryIssueFilters ++= Seq(
       // introduced by #1837, removal of package private class
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.AsyncPropagateCancelation"),

--- a/core/shared/src/main/scala-2/cats/effect/ExitCode.scala
+++ b/core/shared/src/main/scala-2/cats/effect/ExitCode.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+/**
+ * Represents the exit code of an application.
+ *
+ * `code` is constrained to a range from 0 to 255, inclusive.
+ */
+sealed abstract case class ExitCode private (code: Int)
+
+object ExitCode {
+
+  /**
+   * Creates an `ExitCode`.
+   *
+   * @param i
+   *   the value whose 8 least significant bits are used to construct an exit code within the
+   *   valid range.
+   */
+  def apply(i: Int): ExitCode = new ExitCode(i & 0xff) {}
+
+  val Success: ExitCode = ExitCode(0)
+  val Error: ExitCode = ExitCode(1)
+}

--- a/core/shared/src/main/scala-3/cats/effect/ExitCode.scala
+++ b/core/shared/src/main/scala-3/cats/effect/ExitCode.scala
@@ -16,18 +16,13 @@
 
 package cats.effect
 
-import scala.annotation.targetName
-
 /**
  * Represents the exit code of an application.
  *
  * `code` is constrained to a range from 0 to 255, inclusive.
  */
 // The strange encoding of this class is due to https://github.com/lampepfl/dotty/issues/14240
-sealed class ExitCode private[effect] (val code: Int)
-    extends Product
-    with Equals
-    with Serializable {
+sealed class ExitCode private[effect] (val code: Int) extends Product, Equals, Serializable {
 
   def _1: Int = code
 

--- a/core/shared/src/main/scala-3/cats/effect/ExitCode.scala
+++ b/core/shared/src/main/scala-3/cats/effect/ExitCode.scala
@@ -28,6 +28,9 @@ sealed class ExitCode private[effect] (val code: Int)
     extends Product
     with Equals
     with Serializable {
+
+  def _1: Int = code
+
   def canEqual(that: Any): Boolean = that.isInstanceOf[ExitCode]
 
   override def equals(that: Any): Boolean = that match {
@@ -55,11 +58,7 @@ object ExitCode {
    */
   def apply(i: Int): ExitCode = new ExitCode(i & 0xff)
 
-  @targetName("unapply")
-  private[effect] def unapplyBinCompat(ec: ExitCode): Option[Int] = Some(ec.code)
-
-  @targetName("unapplyTotal")
-  def unapply(ec: ExitCode): Some[Int] = Some(ec.code)
+  def unapply(ec: ExitCode): ExitCode = ec
 
   val Success: ExitCode = ExitCode(0)
   val Error: ExitCode = ExitCode(1)

--- a/core/shared/src/main/scala-3/cats/effect/ExitCode.scala
+++ b/core/shared/src/main/scala-3/cats/effect/ExitCode.scala
@@ -16,6 +16,8 @@
 
 package cats.effect
 
+import scala.annotation.targetName
+
 /**
  * Represents the exit code of an application.
  *
@@ -53,7 +55,11 @@ object ExitCode {
    */
   def apply(i: Int): ExitCode = new ExitCode(i & 0xff)
 
-  def unapply(ec: ExitCode): Option[Int] = Some(ec.code)
+  @targetName("unapply")
+  private[effect] def unapplyBinCompat(ec: ExitCode): Option[Int] = Some(ec.code)
+
+  @targetName("unapplyTotal")
+  def unapply(ec: ExitCode): Some[Int] = Some(ec.code)
 
   val Success: ExitCode = ExitCode(0)
   val Error: ExitCode = ExitCode(1)

--- a/tests/shared/src/test/scala/cats/effect/ExitCodeSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ExitCodeSpec.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+class ExitCodeSpec extends BaseSpec {
+
+  "ExitCode.unapply is exhaustive" >> {
+    ExitCode(0) match { // if not, should be a fatal warning in CI
+      case ExitCode(_) => ok
+    }
+  }
+
+}


### PR DESCRIPTION
Reported by @mn98. This turned out to be a Scala 3 bug reported in https://github.com/lampepfl/dotty/issues/14240, but we can code defensively around it in the mean time.