### PR TITLE
Adds CommutativeApplicative instance for Resource.Par

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1103,6 +1103,10 @@ object Resource extends ResourceFOInstances0 with ResourceHOInstances0 with Reso
 
   implicit def parallelForResource[F[_]: Concurrent]: Parallel.Aux[Resource[F, *], Par[F, *]] =
     spawn.parallelForGenSpawn[Resource[F, *], Throwable]
+
+  implicit def commutativeApplicativeForResource[F[_]: Concurrent]
+      : CommutativeApplicative[Par[F, *]] =
+    spawn.commutativeApplicativeForParallelF[Resource[F, *], Throwable]
 }
 
 private[effect] trait ResourceHOInstances0 extends ResourceHOInstances1 {

--- a/tests/shared/src/test/scala/cats/effect/kernel/ParallelFSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/ParallelFSpec.scala
@@ -29,7 +29,7 @@ import org.typelevel.discipline.specs2.mutable.Discipline
 
 class ParallelFSpec extends BaseSpec with Discipline {
 
-  implicit def alleyEq[A: Eq]: Eq[PureConc[Unit, A]] = { (x, y) =>
+  def alleyEq[E, A: Eq]: Eq[PureConc[E, A]] = { (x, y) =>
     import Outcome._
     (run(x), run(y)) match {
       case (Succeeded(Some(a)), Succeeded(Some(b))) => a eqv b
@@ -37,6 +37,9 @@ class ParallelFSpec extends BaseSpec with Discipline {
       case _ => true
     }
   }
+
+  implicit def alleyEqUnit[A: Eq] = alleyEq[Unit, A]
+  implicit def alleyEqThrowable[A: Eq] = alleyEq[Throwable, A]
 
   checkAll(
     "ParallelF[PureConc]",
@@ -50,5 +53,20 @@ class ParallelFSpec extends BaseSpec with Discipline {
   checkAll(
     "ParallelF[PureConc]",
     AlignTests[ParallelF[PureConc[Unit, *], *]].align[Int, Int, Int, Int])
+
+  checkAll(
+    "ParallelF[Resource[PureConc]]",
+    ParallelTests[
+      Resource[PureConc[Throwable, *], *],
+      ParallelF[Resource[PureConc[Throwable, *], *], *]].parallel[Int, Int])
+
+  checkAll(
+    "ParallelF[Resource[PureConc]]",
+    CommutativeApplicativeTests[ParallelF[Resource[PureConc[Throwable, *], *], *]]
+      .commutativeApplicative[Int, Int, Int])
+
+  checkAll(
+    "ParallelF[Resource[PureConc]]",
+    AlignTests[ParallelF[Resource[PureConc[Throwable, *], *], *]].align[Int, Int, Int, Int])
 
 }

--- a/tests/shared/src/test/scala/cats/effect/kernel/ParallelFSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/ParallelFSpec.scala
@@ -38,8 +38,8 @@ class ParallelFSpec extends BaseSpec with Discipline {
     }
   }
 
-  implicit def alleyEqUnit[A: Eq] = alleyEq[Unit, A]
-  implicit def alleyEqThrowable[A: Eq] = alleyEq[Throwable, A]
+  implicit def alleyEqUnit[A: Eq]: Eq[PureConc[Unit, A]] = alleyEq[Unit, A]
+  implicit def alleyEqThrowable[A: Eq]: Eq[PureConc[Throwable, A]] = alleyEq[Throwable, A]
 
   checkAll(
     "ParallelF[PureConc]",


### PR DESCRIPTION
It's my (admittedly limited!) understanding that Parallel implies CommutativeApplicative - so this adds a CommutativeApplicative instance to Resource's implicit scope (like there was for Parallel). Happy to be enlightened if this was deliberately missing for some reason...

I came across this converting code from CE2 to CE3 - the following stops compiling without this:

```
import cats.Parallel
import cats.effect.Concurrent
import cats.effect.Resource
import cats.syntax.parallel._

object Example {
  def foo[F[_]: Concurrent: Parallel, K, V1, V2](map: Map[K, V1]): Resource[F, Map[K, V2]] = {
    val op: V1 => Resource[F, V2] = ???

    map.parUnorderedTraverse(op)
  }

}
```
