### PR TITLE
Invalid comment in IO.Par

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -919,8 +919,9 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
    * Newtype encoding for an `IO` datatype that has a `cats.Applicative` capable of doing
    * parallel processing in `ap` and `map2`, needed for implementing `cats.Parallel`.
    *
-   * Helpers are provided for converting back and forth in `Par.apply` for wrapping any `IO`
-   * value and `Par.unwrap` for unwrapping.
+   * For converting back and forth you can use either the `Parallel[IO]` instance or 
+   * the methods `cats.effect.kernel.Par.ParallelF.apply` for wrapping any `IO` value and
+   * `cats.effect.kernel.Par.ParallelF.value` for unwrapping it.
    *
    * The encoding is based on the "newtypes" project by Alexander Konovalov, chosen because it's
    * devoid of boxing issues and a good choice until opaque types will land in Scala.


### PR DESCRIPTION
The doc stated that Par.apply and Par.unwrap exist as methods to convert between IO and IO.Par but this is no longer the case.

The change removes this paragraph and replaces it with one suggesting to ways to do the conversion:

the Parallel[IO] instance
methods apply / value from the object cats.effect.kernel.Par.ParallelF