### PR TITLE
Simplify the transfer of WorkerThread data structures when blocking

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -445,8 +445,13 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "cats.effect.unsafe.LocalQueue.stealInto"),
       // introduced by #2673, Cross platform weak bag implementation
+      // changes to `cats.effect.unsafe` package private code
       ProblemFilters.exclude[DirectMissingMethodProblem](
-        "cats.effect.unsafe.WorkerThread.monitor")
+        "cats.effect.unsafe.WorkerThread.monitor"),
+      // introduced by #2769, Simplify the transfer of WorkerThread data structures when blocking
+      // changes to `cats.effect.unsafe` package private code
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.WorkerThread$"),
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.WorkerThread$Data")
     )
   )
   .jvmSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -452,7 +452,19 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       // changes to `cats.effect.unsafe` package private code
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.WorkerThread$"),
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.WorkerThread$Data")
-    )
+    ) ++ {
+      if (isDotty.value) {
+        // Scala 3 specific exclusions
+        Seq(
+          // introduced by #2769, Simplify the transfer of WorkerThread data structures when blocking
+          // changes to `cats.effect.unsafe` package private code
+          ProblemFilters.exclude[DirectMissingMethodProblem](
+            "cats.effect.unsafe.WorkStealingThreadPool.localQueuesForwarder"),
+          ProblemFilters.exclude[DirectMissingMethodProblem](
+            "cats.effect.unsafe.WorkerThread.NullData")
+        )
+      } else Seq()
+    }
   )
   .jvmSettings(
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8")

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -60,7 +60,7 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
             case _: Throwable =>
           }
 
-          val localQueues = threadPool.localQueuesForwarder
+          val localQueues = threadPool.localQueues
           var i = 0
           val len = localQueues.length
 

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -586,9 +586,6 @@ private[effect] final class WorkStealingThreadPool(
     }
   }
 
-  private[unsafe] def localQueuesForwarder: Array[LocalQueue] =
-    localQueues
-
   /*
    * What follows is a collection of methos used in the implementation of the
    * `cats.effect.unsafe.metrics.ComputePoolSamplerMBean` interface.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -76,6 +76,7 @@ private[effect] final class WorkStealingThreadPool(
   private[this] val workerThreads: Array[WorkerThread] = new Array(threadCount)
   private[this] val localQueues: Array[LocalQueue] = new Array(threadCount)
   private[this] val parkedSignals: Array[AtomicBoolean] = new Array(threadCount)
+  private[this] val fiberBags: Array[WeakBag[IOFiber[_]]] = new Array(threadCount)
 
   /**
    * Atomic variable for used for publishing changes to the references in the `workerThreads`
@@ -118,6 +119,7 @@ private[effect] final class WorkStealingThreadPool(
       parkedSignals(i) = parkedSignal
       val index = i
       val fiberBag = new WeakBag[IOFiber[_]]()
+      fiberBags(i) = fiberBag
       val thread =
         new WorkerThread(index, queue, parkedSignal, externalQueue, fiberBag, this)
       workerThreads(i) = thread

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -119,7 +119,7 @@ private[effect] final class WorkStealingThreadPool(
       val index = i
       val fiberBag = new WeakBag[IOFiber[_]]()
       val thread =
-        new WorkerThread(index, queue, parkedSignal, externalQueue, null, fiberBag, this)
+        new WorkerThread(index, queue, parkedSignal, externalQueue, fiberBag, this)
       workerThreads(i) = thread
       i += 1
     }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -74,9 +74,9 @@ private[effect] final class WorkStealingThreadPool(
    * References to worker threads and their local queues.
    */
   private[this] val workerThreads: Array[WorkerThread] = new Array(threadCount)
-  private[this] val localQueues: Array[LocalQueue] = new Array(threadCount)
-  private[this] val parkedSignals: Array[AtomicBoolean] = new Array(threadCount)
-  private[this] val fiberBags: Array[WeakBag[IOFiber[_]]] = new Array(threadCount)
+  private[unsafe] val localQueues: Array[LocalQueue] = new Array(threadCount)
+  private[unsafe] val parkedSignals: Array[AtomicBoolean] = new Array(threadCount)
+  private[unsafe] val fiberBags: Array[WeakBag[IOFiber[_]]] = new Array(threadCount)
 
   /**
    * Atomic variable for used for publishing changes to the references in the `workerThreads`

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -92,7 +92,7 @@ private final class WorkerThread(
    */
   private[this] var _active: IOFiber[_] = _
 
-  private val indexTransfer: ArrayBlockingQueue[Int] = new ArrayBlockingQueue(1)
+  private val indexTransfer: ArrayBlockingQueue[Integer] = new ArrayBlockingQueue(1)
 
   val nameIndex: Int = pool.blockedWorkerThreadNamingIndex.incrementAndGet()
 
@@ -329,7 +329,7 @@ private final class WorkerThread(
         try {
           // Wait up to 60 seconds (should be configurable in the future) for
           // another thread to wake this thread up.
-          var newIdx = indexTransfer.poll(60L, TimeUnit.SECONDS)
+          var newIdx: Integer = indexTransfer.poll(60L, TimeUnit.SECONDS)
           if (newIdx eq null) {
             // The timeout elapsed and no one woke up this thread. Try to remove
             // the thread from the cached threads data structure.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -46,7 +46,7 @@ private final class WorkerThread(
     private[this] var parked: AtomicBoolean,
     // External queue used by the local queue for offloading excess fibers, as well as
     // for drawing fibers when the local queue is exhausted.
-    private[this] var external: ScalQueue[AnyRef],
+    private[this] val external: ScalQueue[AnyRef],
     // A mutable reference to a fiber which is used to bypass the local queue
     // when a `cede` operation would enqueue a fiber to the empty local queue
     // and then proceed to dequeue the same fiber again from the queue. This not
@@ -597,7 +597,7 @@ private final class WorkerThread(
       if (cached ne null) {
         // There is a cached worker thread that can be reused.
         val idx = index
-        val data = new WorkerThread.Data(idx, queue, parked, external, cedeBypass, fiberBag)
+        val data = new WorkerThread.Data(idx, queue, parked, cedeBypass, fiberBag)
         cedeBypass = null
         pool.replaceWorker(idx, cached)
         // Transfer the data structures to the cached thread and wake it up.
@@ -628,7 +628,6 @@ private final class WorkerThread(
     _index = data.index
     queue = data.queue
     parked = data.parked
-    external = data.external
     cedeBypass = data.cedeBypass
     fiberBag = data.fiberBag
   }
@@ -653,11 +652,10 @@ private object WorkerThread {
       val index: Int,
       val queue: LocalQueue,
       val parked: AtomicBoolean,
-      val external: ScalQueue[AnyRef],
       val cedeBypass: IOFiber[_],
       val fiberBag: WeakBag[IOFiber[_]]
   )
 
   private[WorkerThread] val NullData: Data =
-    new Data(-1, null, null, null, null, null)
+    new Data(-1, null, null, null, null)
 }


### PR DESCRIPTION
Simplifies the code by moving the references to the data structures inside the pool itself, where the WorkerThreads can fetch it from as soon as they are assigned an index. I have plans to further simplify the code, I would like to get rid of the `ArrayBlockingQueue[Integer]` (`Integer` needed because `null` is a part of the API and we don't want autoboxing to be coerced to a 0 by Scala), but there are enough changes in this PR.

This will also be a nice cleanup when I introduce the `sleep` improvements.