### PR TITLE
Faster runnables on the WSTP

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala
@@ -132,7 +132,7 @@ class WorkStealingBenchmark {
       }
     }
 
-    (0 to theSize).foreach(_ => run(0))
+    (0 until theSize).foreach(_ => run(0))
 
     countDown.await()
   }
@@ -144,6 +144,11 @@ class WorkStealingBenchmark {
   @Benchmark
   def runnableScheduling(): Unit = {
     runnableSchedulingBenchmark(cats.effect.unsafe.implicits.global.compute)
+  }
+
+  @Benchmark
+  def runnableSchedulingScalaGlobal(): Unit = {
+    runnableSchedulingBenchmark(ExecutionContext.global)
   }
 
   lazy val manyThreadsRuntime: IORuntime = {

--- a/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -42,7 +42,8 @@ private object IOFiberConstants {
   final val BlockingR: Byte = 5
   final val CedeR: Byte = 6
   final val AutoCedeR: Byte = 7
-  final val DoneR: Byte = 8
+  final val ExecuteRunnableR: Byte = 8
+  final val DoneR: Byte = 9
 
   // ContState tags
   final val ContStateInitial: Int = 0

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -42,7 +42,8 @@ final class IOFiberConstants {
   static final byte BlockingR = 5;
   static final byte CedeR = 6;
   static final byte AutoCedeR = 7;
-  static final byte DoneR = 8;
+  static final byte ExecuteRunnableR = 8;
+  static final byte DoneR = 9;
 
   // ContState tags
   static final int ContStateInitial = 0;

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -518,20 +518,9 @@ private[effect] final class WorkStealingThreadPool(
       scheduleFiber(fiber)
     } else {
       // Executing a general purpose computation on the thread pool.
-      // Wrap the runnable in an `IO` and execute it as a fiber.
-      val io = IO.delay(runnable.run())
-      val fiber = new IOFiber[Unit](Map.empty, outcomeToUnit, io, this, self)
+      val fiber = new IOFiber[Unit](runnable, this, self)
       scheduleFiber(fiber)
     }
-  }
-
-  /**
-   * Preallocated fiber callback function for transforming [[java.lang.Runnable]] values into
-   * [[cats.effect.IOFiber]] instances.
-   */
-  private[this] val outcomeToUnit: OutcomeIO[Unit] => Unit = {
-    case Outcome.Errored(t) => reportFailure(t)
-    case _ => ()
   }
 
   /**

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -105,7 +105,7 @@ private final class IOFiber[A](
 
   /* mutable state for resuming the fiber in different states */
   private[this] var resumeTag: Byte = ExecR
-  private[this] var resumeIO: IO[Any] = startIO
+  private[this] var resumeIO: Any = startIO
 
   /* prefetch for Right(()) */
   private[this] val RightUnit: Either[Throwable, Unit] = IOFiber.RightUnit
@@ -1306,7 +1306,7 @@ private final class IOFiber[A](
       objectState.init(16)
       finalizers.init(16)
 
-      val io = resumeIO
+      val io = resumeIO.asInstanceOf[IO[Any]]
       resumeIO = null
       runLoop(io, runtime.cancelationCheckThreshold, runtime.autoYieldThreshold)
     }
@@ -1367,7 +1367,7 @@ private final class IOFiber[A](
   }
 
   private[this] def autoCedeR(): Unit = {
-    val io = resumeIO
+    val io = resumeIO.asInstanceOf[IO[Any]]
     resumeIO = null
     runLoop(io, runtime.cancelationCheckThreshold, runtime.autoYieldThreshold)
   }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -98,6 +98,17 @@ private final class IOFiber[A] private (
     runtime
   )
 
+  def this(runnable: Runnable, startEC: ExecutionContext, runtime: IORuntime) = this(
+    null,
+    null,
+    startEC,
+    null,
+    null,
+    IOFiberConstants.ExecuteRunnableR,
+    runnable,
+    null,
+    runtime)
+
   import IO._
   import IOFiberConstants._
   import TracingConstants._

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -65,17 +65,38 @@ import java.util.concurrent.atomic.AtomicBoolean
  * by the Executor read/write barriers, but their writes are
  * merely a fast-path and are not necessary for correctness.
  */
-private final class IOFiber[A](
-    initLocalState: IOLocalState,
-    cb: OutcomeIO[A] => Unit,
-    startIO: IO[A],
-    startEC: ExecutionContext,
+private final class IOFiber[A] private (
+    private[this] var localState: IOLocalState,
+    private[this] val objectState: ArrayStack[AnyRef],
+    private[this] var currentCtx: ExecutionContext,
+    private[this] val finalizers: ArrayStack[IO[Unit]],
+    private[this] val callbacks: CallbackStack[A],
+    private[this] var resumeTag: Byte,
+    private[this] var resumeIO: AnyRef,
+    private[this] val tracingEvents: RingBuffer,
     private[this] val runtime: IORuntime
 ) extends IOFiberPlatform[A]
     with FiberIO[A]
     with Runnable {
   /* true when semantically blocking (ensures that we only unblock *once*) */
   suspended: AtomicBoolean =>
+
+  def this(
+      localState: IOLocalState,
+      cb: OutcomeIO[A] => Unit,
+      startIO: IO[A],
+      startEC: ExecutionContext,
+      runtime: IORuntime) = this(
+    localState,
+    new ArrayStack(),
+    startEC,
+    new ArrayStack(),
+    new CallbackStack(cb),
+    IOFiberConstants.ExecR,
+    startIO,
+    if (TracingConstants.isStackTracing) RingBuffer.empty(runtime.traceBufferLogSize) else null,
+    runtime
+  )
 
   import IO._
   import IOFiberConstants._
@@ -86,36 +107,19 @@ private final class IOFiber[A](
    * relocate our runloop to another fiber.
    */
   private[this] var conts: ByteStack = _
-  private[this] val objectState: ArrayStack[AnyRef] = new ArrayStack()
-
-  private[this] var currentCtx: ExecutionContext = startEC
 
   private[this] var canceled: Boolean = false
   private[this] var masks: Int = 0
   private[this] var finalizing: Boolean = false
 
-  private[this] val finalizers: ArrayStack[IO[Unit]] = new ArrayStack()
-
-  private[this] val callbacks: CallbackStack[A] = new CallbackStack(cb)
-
-  private[this] var localState: IOLocalState = initLocalState
-
   @volatile
   private[this] var outcome: OutcomeIO[A] = _
-
-  /* mutable state for resuming the fiber in different states */
-  private[this] var resumeTag: Byte = ExecR
-  private[this] var resumeIO: Any = startIO
 
   /* prefetch for Right(()) */
   private[this] val RightUnit: Either[Throwable, Unit] = IOFiber.RightUnit
 
   /* similar prefetch for EndFiber */
   private[this] val IOEndFiber: IO.EndFiber.type = IO.EndFiber
-
-  private[this] val tracingEvents: RingBuffer = if (isStackTracing) {
-    RingBuffer.empty(runtime.traceBufferLogSize)
-  } else null
 
   override def run(): Unit = {
     // insert a read barrier after every async boundary


### PR DESCRIPTION
What it says on the tin.

`series/3.3.x`:
```scala
Benchmark                                  (size)   Mode  Cnt    Score   Error    Units
WorkStealingBenchmark.runnableScheduling  1000000  thrpt   20  222.826 ± 2.604  ops/min
```

`This PR`:
```scala
Benchmark                                  (size)   Mode  Cnt    Score   Error    Units
WorkStealingBenchmark.runnableScheduling  1000000  thrpt   20  537.854 ± 2.387  ops/min
```

What is the big idea?

Instead of allocating a full fiber with all of the necessary data structures like continuation and finalizer stacks which are needed to support the run loop, a special fiber is created that starts from a bespoke state that only runs the provided runnable and exits. I've managed to bring the implementation down to a single allocation of the `IOFiber` wrapper object around the runnable. Unfortunately, I don't think that anything better can be achieved due to the following reasons.

1. The `IOFiber` code nicely interacts with the provided `IORuntime` and shuts it down on a fatal error, this complicated code path is reused.
2. There is an alternative world where the whole WSTP, LocalQueue and WorkerThreads are reworked to hold `Runnable` instances instead of `IOFiber` instances. While this might look nice in theory, it doesn't interact well with the live fiber snapshots (runnables are simply not full `IOFibers`) and this creates additional branches when assigning fibers as active. Furthermore, the WorkerThreads need to add branches before every `run()` (which also becomes an `invokeinterface` instead of the current `invokevirtual`) so that they can wrap it in a `try/catch` to recreate the runtime shutdown code path on fatal errors. All in all, I don't feel comfortable adding all of these branches on the hot path, which I've worked so hard to optimize before. (I tried this whole approach and I didn't like it). The upside to this approach is that there's no wrapping of external `Runnables` executed on our runtime (think using the WSTP for execution of `Future`s without any overhead), but ultimately I think this is a wrong optimization to pursue, as it is inherently slowing down our own fibers.

I think this PR adds enough performance to still make our runtime an extremely safe general purpose EC with very good performance.

FWIW, here's how much one layer of wrapping is worth:
```scala
Benchmark                                             (size)   Mode  Cnt     Score    Error    Units
WorkStealingBenchmark.runnableSchedulingScalaGlobal  1000000  thrpt   20  1363.152 ± 12.125  ops/min
```