### PR TITLE
Simplify randomness in `TestContext`

### DIFF
--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/TestContext.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/TestContext.scala
@@ -326,10 +326,8 @@ object TestContext {
 
         def compare(x: Task, y: Task): Int =
           x.runsAt.compare(y.runsAt) match {
-            case nonZero if nonZero != 0 =>
-              nonZero
-            case _ =>
-              longOrd.compare(x.id, y.id)
+            case 0 => longOrd.compare(x.id + x.rnd, y.id + y.rnd)
+            case nonZero => nonZero
           }
       }
   }

--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/TestContext.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/TestContext.scala
@@ -135,7 +135,7 @@ final class TestContext private (_seed: Long) extends ExecutionContext { self =>
       val current = stateRef
 
       // extracting one task by taking the immediate tasks
-      extractOneTask(current, current.clock, random) match {
+      extractOneTask(current, current.clock) match {
         case Some((head, rest)) =>
           stateRef = current.copy(tasks = rest)
           // execute task
@@ -219,18 +219,11 @@ final class TestContext private (_seed: Long) extends ExecutionContext { self =>
 
   private def extractOneTask(
       current: State,
-      clock: FiniteDuration,
-      random: Random): Option[(Task, SortedSet[Task])] =
+      clock: FiniteDuration): Option[(Task, SortedSet[Task])] =
     current.tasks.headOption.filter(_.runsAt <= clock) match {
-      case Some(value) =>
-        val firstTick = value.runsAt
-        val forExecution = {
-          val arr = current.tasks.iterator.takeWhile(_.runsAt == firstTick).take(10).toArray
-          arr(random.nextInt(arr.length))
-        }
-
-        val remaining = current.tasks - forExecution
-        Some((forExecution, remaining))
+      case Some(head) =>
+        val remaining = current.tasks - head
+        Some((head, remaining))
 
       case None =>
         None

--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/TestContext.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/TestContext.scala
@@ -137,25 +137,23 @@ final class TestContext private (_seed: Long) extends ExecutionContext { self =>
     val head = synchronized {
       val current = stateRef
 
-      // extracing one task
-      current.tasks.headOption.filter(_.runsAt <= current.clock) match {
-        case Some(head) =>
-          val rest = current.tasks - head
-          stateRef = current.copy(tasks = rest)
-          head
-
-        case None =>
-          null
+      // extracting one task
+      val head = current.tasks.headOption.filter(_.runsAt <= current.clock)
+      head.foreach { head =>
+        val rest = current.tasks - head
+        stateRef = current.copy(tasks = rest)
       }
+      head
     }
 
-    if (head ne null) {
-      // execute task
-      try head.task.run()
-      catch { case NonFatal(ex) => reportFailure(ex) }
-      true
-    } else {
-      false
+    head match {
+      case Some(head) =>
+        // execute task
+        try head.task.run()
+        catch { case NonFatal(ex) => reportFailure(ex) }
+        true
+      case None =>
+        false
     }
   }
 


### PR DESCRIPTION
The idea of this PR is, instead of traversing an iterator and creating an array of up to 10 tasks and then randomly selecting one, this PR adds a random component to each task (just a `Long` value) which is used when comparing two `Task` instances, such that the random component is used when disambiguating tasks which are supposed to run at the same time, effectively enforcing a random ordering of tasks that can run at the same time, while tasks that run at different times still keep their expected temporal ordering. This further allows to simply pick the head task, because the eligible tasks have already been randomized when inserting into the sorted set by the comparator.

This PR further cuts down on unnecessary allocations.