### PR TITLE
Add `cats-effect` name to root project.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -261,6 +261,7 @@ lazy val root = project
   .enablePlugins(NoPublishPlugin)
   .enablePlugins(ScalaUnidocPlugin)
   .settings(
+    name := "cats-effect",
     ScalaUnidoc / unidoc / unidocProjectFilter := {
       undocumentedRefs.foldLeft(inAnyProject)((acc, a) => acc -- inProjects(a))
     }


### PR DESCRIPTION
So that IntelliJ shows `cats-effect` instead of `root`.