### PR TITLE
Add documentation to IO.blocking, IO.interruptible, IO.interruptibleMany

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -77,7 +77,7 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
 
   /**
    * Like [[blocking]] but will attempt to abort the blocking operation using thread interrupts
-   * in the event of cancellation. The interrupt will be attempted repeatedly until the blocking
+   * in the event of cancelation. The interrupt will be attempted repeatedly until the blocking
    * operation completes or exits.
    *
    * @param thunk

--- a/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -62,7 +62,7 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
 
   /**
    * Like [[blocking]] but will attempt to abort the blocking operation using thread interrupts
-   * in the event of cancellation. The interrupt will be attempted only once.
+   * in the event of cancelation. The interrupt will be attempted only once.
    *
    * @param thunk
    *   The side effect which is to be suspended in `IO` and evaluated on a blocking execution

--- a/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -64,6 +64,12 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
    * Like [[blocking]] but will attempt to abort the blocking operation using thread interrupts
    * in the event of cancelation. The interrupt will be attempted only once.
    *
+   * Note the following tradeoffs:
+   *  - this has slightly more overhead than [[blocking]] due to the machinery necessary for the interrupt coordination,
+   *  - thread interrupts are very often poorly considered by Java (and Scala!) library authors, and it is possible
+   *    for interrupts to result in resource leaks or invalid states. It is important to be certain that this
+   *    will not be the case before using this mechanism.
+   *
    * @param thunk
    *   The side effect which is to be suspended in `IO` and evaluated on a blocking execution
    *   context
@@ -79,6 +85,12 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
    * Like [[blocking]] but will attempt to abort the blocking operation using thread interrupts
    * in the event of cancelation. The interrupt will be attempted repeatedly until the blocking
    * operation completes or exits.
+   *
+   * Note the following tradeoffs:
+   *  - this has slightly more overhead than [[blocking]] due to the machinery necessary for the interrupt coordination,
+   *  - thread interrupts are very often poorly considered by Java (and Scala!) library authors, and it is possible
+   *    for interrupts to result in resource leaks or invalid states. It is important to be certain that this
+   *    will not be the case before using this mechanism.
    *
    * @param thunk
    *   The side effect which is to be suspended in `IO` and evaluated on a blocking execution

--- a/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -28,6 +28,23 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
   private[this] val TypeInterruptibleOnce = Sync.Type.InterruptibleOnce
   private[this] val TypeInterruptibleMany = Sync.Type.InterruptibleMany
 
+  /**
+   * Intended for thread blocking operations. `blocking` will shift the execution of the
+   * blocking operation to a separate threadpool to avoid blocking on the main execution
+   * context. See the thread-model documentation for more information on why this is necessary.
+   * Note that the created effect will be uncancelable; if you need cancellation then you should
+   * use [[interruptible]] or [[interruptibleMany]].
+   *
+   * {{{
+   * IO.blocking(scala.io.Source.fromFile("path").mkString)
+   * }}}
+   *
+   * @param thunk
+   *   The side effect which is to be suspended in `IO` and evaluated on a blocking execution
+   *   context
+   *
+   * Implements [[Sync#blocking]].
+   */
   def blocking[A](thunk: => A): IO[A] = {
     val fn = Thunk.asFunction0(thunk)
     Blocking(TypeBlocking, fn, Tracing.calculateTracingEvent(fn.getClass))
@@ -43,11 +60,32 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
       Tracing.calculateTracingEvent(fn.getClass))
   }
 
+  /**
+   * Like [[blocking]] but will attempt to abort the blocking operation using thread interrupts
+   * in the event of cancellation. The interrupt will be attempted only once.
+   *
+   * @param thunk
+   *   The side effect which is to be suspended in `IO` and evaluated on a blocking execution
+   *   context
+   *
+   * Implements [[Sync#interruptible]]
+   */
   def interruptible[A](thunk: => A): IO[A] = {
     val fn = Thunk.asFunction0(thunk)
     Blocking(TypeInterruptibleOnce, fn, Tracing.calculateTracingEvent(fn.getClass))
   }
 
+  /**
+   * Like [[blocking]] but will attempt to abort the blocking operation using thread interrupts
+   * in the event of cancellation. The interrupt will be attempted repeatedly until the blocking
+   * operation completes or exits.
+   *
+   * @param thunk
+   *   The side effect which is to be suspended in `IO` and evaluated on a blocking execution
+   *   context
+   *
+   * Implements [[Sync#interruptibleMany]]
+   */
   def interruptibleMany[A](thunk: => A): IO[A] = {
     val fn = Thunk.asFunction0(thunk)
     Blocking(TypeInterruptibleMany, fn, Tracing.calculateTracingEvent(fn.getClass))

--- a/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -33,7 +33,7 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
    * blocking operation to a separate threadpool to avoid blocking on the main execution
    * context. See the thread-model documentation for more information on why this is necessary.
    * Note that the created effect will be uncancelable; if you need cancelation then you should
-   * use [[interruptible]] or [[interruptibleMany]].
+   * use [[interruptible[A](thunk:=>A):*]] or [[interruptibleMany]].
    *
    * {{{
    * IO.blocking(scala.io.Source.fromFile("path").mkString)
@@ -43,7 +43,7 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
    *   The side effect which is to be suspended in `IO` and evaluated on a blocking execution
    *   context
    *
-   * Implements [[Sync#blocking]].
+   * Implements [[cats.effect.kernel.Sync.blocking]].
    */
   def blocking[A](thunk: => A): IO[A] = {
     val fn = Thunk.asFunction0(thunk)
@@ -76,7 +76,7 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
    *   The side effect which is to be suspended in `IO` and evaluated on a blocking execution
    *   context
    *
-   * Implements [[Sync#interruptible]]
+   * Implements [[cats.effect.kernel.Sync.interruptible[A](thunk:=>A):*]]
    */
   def interruptible[A](thunk: => A): IO[A] = {
     val fn = Thunk.asFunction0(thunk)
@@ -100,7 +100,7 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
    *   The side effect which is to be suspended in `IO` and evaluated on a blocking execution
    *   context
    *
-   * Implements [[Sync#interruptibleMany]]
+   * Implements [[cats.effect.kernel.Sync!.interruptibleMany]]
    */
   def interruptibleMany[A](thunk: => A): IO[A] = {
     val fn = Thunk.asFunction0(thunk)

--- a/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -32,7 +32,7 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
    * Intended for thread blocking operations. `blocking` will shift the execution of the
    * blocking operation to a separate threadpool to avoid blocking on the main execution
    * context. See the thread-model documentation for more information on why this is necessary.
-   * Note that the created effect will be uncancelable; if you need cancellation then you should
+   * Note that the created effect will be uncancelable; if you need cancelation then you should
    * use [[interruptible]] or [[interruptibleMany]].
    *
    * {{{

--- a/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -65,10 +65,12 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
    * in the event of cancelation. The interrupt will be attempted only once.
    *
    * Note the following tradeoffs:
-   *  - this has slightly more overhead than [[blocking]] due to the machinery necessary for the interrupt coordination,
-   *  - thread interrupts are very often poorly considered by Java (and Scala!) library authors, and it is possible
-   *    for interrupts to result in resource leaks or invalid states. It is important to be certain that this
-   *    will not be the case before using this mechanism.
+   *   - this has slightly more overhead than [[blocking]] due to the machinery necessary for
+   *     the interrupt coordination,
+   *   - thread interrupts are very often poorly considered by Java (and Scala!) library
+   *     authors, and it is possible for interrupts to result in resource leaks or invalid
+   *     states. It is important to be certain that this will not be the case before using this
+   *     mechanism.
    *
    * @param thunk
    *   The side effect which is to be suspended in `IO` and evaluated on a blocking execution
@@ -87,10 +89,12 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
    * operation completes or exits.
    *
    * Note the following tradeoffs:
-   *  - this has slightly more overhead than [[blocking]] due to the machinery necessary for the interrupt coordination,
-   *  - thread interrupts are very often poorly considered by Java (and Scala!) library authors, and it is possible
-   *    for interrupts to result in resource leaks or invalid states. It is important to be certain that this
-   *    will not be the case before using this mechanism.
+   *   - this has slightly more overhead than [[blocking]] due to the machinery necessary for
+   *     the interrupt coordination,
+   *   - thread interrupts are very often poorly considered by Java (and Scala!) library
+   *     authors, and it is possible for interrupts to result in resource leaks or invalid
+   *     states. It is important to be certain that this will not be the case before using this
+   *     mechanism.
    *
    * @param thunk
    *   The side effect which is to be suspended in `IO` and evaluated on a blocking execution


### PR DESCRIPTION
Copy & paste of Sync#blocking docs, with small modfications.