### PR TITLE
Refine derived type classes

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -148,40 +148,68 @@ object GenConcurrent {
   }
 
   implicit def genConcurrentForOptionT[F[_], E](
-      implicit F0: GenConcurrent[F, E]): GenConcurrent[OptionT[F, *], E] =
-    new OptionTGenConcurrent[F, E] {
-      override implicit protected def F: GenConcurrent[F, E] = F0
-    }
+      implicit F0: GenConcurrent[F, E]): GenConcurrent[OptionT[F, *], E] = F0 match {
+    case async: Async[F @unchecked] =>
+      Async.asyncForOptionT[F](async)
+    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+      GenTemporal.genTemporalForOptionT[F, E](temporal)
+    case concurrent =>
+      new OptionTGenConcurrent[F, E] {
+        override implicit protected def F: GenConcurrent[F, E] = concurrent
+      }
+  }
 
   implicit def genConcurrentForEitherT[F[_], E0, E](
-      implicit F0: GenConcurrent[F, E]): GenConcurrent[EitherT[F, E0, *], E] =
-    new EitherTGenConcurrent[F, E0, E] {
-      override implicit protected def F: GenConcurrent[F, E] = F0
-    }
+      implicit F0: GenConcurrent[F, E]): GenConcurrent[EitherT[F, E0, *], E] = F0 match {
+    case async: Async[F @unchecked] =>
+      Async.asyncForEitherT[F, E0](async)
+    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+      GenTemporal.genTemporalForEitherT[F, E0, E](temporal)
+    case concurrent =>
+      new EitherTGenConcurrent[F, E0, E] {
+        override implicit protected def F: GenConcurrent[F, E] = concurrent
+      }
+  }
 
   implicit def genConcurrentForKleisli[F[_], R, E](
-      implicit F0: GenConcurrent[F, E]): GenConcurrent[Kleisli[F, R, *], E] =
-    new KleisliGenConcurrent[F, R, E] {
-      override implicit protected def F: GenConcurrent[F, E] = F0
-    }
+      implicit F0: GenConcurrent[F, E]): GenConcurrent[Kleisli[F, R, *], E] = F0 match {
+    case async: Async[F @unchecked] =>
+      Async.asyncForKleisli[F, R](async)
+    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+      GenTemporal.genTemporalForKleisli[F, R, E](temporal)
+    case concurrent =>
+      new KleisliGenConcurrent[F, R, E] {
+        override implicit protected def F: GenConcurrent[F, E] = concurrent
+      }
+  }
 
   implicit def genConcurrentForIorT[F[_], L, E](
       implicit F0: GenConcurrent[F, E],
-      L0: Semigroup[L]): GenConcurrent[IorT[F, L, *], E] =
-    new IorTGenConcurrent[F, L, E] {
-      override implicit protected def F: GenConcurrent[F, E] = F0
-
-      override implicit protected def L: Semigroup[L] = L0
-    }
+      L0: Semigroup[L]): GenConcurrent[IorT[F, L, *], E] = F0 match {
+    case async: Async[F @unchecked] =>
+      Async.asyncForIorT[F, L](async, L0)
+    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+      GenTemporal.genTemporalForIorT[F, L, E](temporal, L0)
+    case concurrent =>
+      new IorTGenConcurrent[F, L, E] {
+        override implicit protected def F: GenConcurrent[F, E] = concurrent
+        override implicit protected def L: Semigroup[L] = L0
+      }
+  }
 
   implicit def genConcurrentForWriterT[F[_], L, E](
       implicit F0: GenConcurrent[F, E],
-      L0: Monoid[L]): GenConcurrent[WriterT[F, L, *], E] =
-    new WriterTGenConcurrent[F, L, E] {
-      override implicit protected def F: GenConcurrent[F, E] = F0
-
-      override implicit protected def L: Monoid[L] = L0
-    }
+      L0: Monoid[L]): GenConcurrent[WriterT[F, L, *], E] = F0 match {
+    case async: Async[F @unchecked] =>
+      Async.asyncForWriterT[F, L](async, L0)
+    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+      GenTemporal.genTemporalForWriterT[F, L, E](temporal, L0)
+    case concurrent =>
+      new WriterTGenConcurrent[F, L, E] {
+        override implicit protected def F: GenConcurrent[F, E] = concurrent
+        override implicit protected def L: Monoid[L] = L0
+      }
+  }
 
   private[kernel] trait OptionTGenConcurrent[F[_], E]
       extends GenConcurrent[OptionT[F, *], E]

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -148,86 +148,91 @@ object GenConcurrent {
   }
 
   implicit def genConcurrentForOptionT[F[_], E](
-      implicit F0: GenConcurrent[F, E]): GenConcurrent[OptionT[F, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForOptionT[F](async)
-    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.instantiateGenTemporalForOptionT[F, E](temporal)
-    case concurrent =>
-      instantiateGenConcurrentForOptionT(concurrent)
-  }
+      implicit F0: GenConcurrent[F, E]): GenConcurrent[OptionT[F, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForOptionT[F](async)
+      case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+        GenTemporal.instantiateGenTemporalForOptionT[F, E](temporal)
+      case concurrent =>
+        instantiateGenConcurrentForOptionT(concurrent)
+    }
 
   private[kernel] def instantiateGenConcurrentForOptionT[F[_], E](
-      concurrent: GenConcurrent[F, E]): OptionTGenConcurrent[F, E] =
+      F0: GenConcurrent[F, E]): OptionTGenConcurrent[F, E] =
     new OptionTGenConcurrent[F, E] {
-      override implicit protected def F: GenConcurrent[F, E] = concurrent
+      override implicit protected def F: GenConcurrent[F, E] = F0
     }
 
   implicit def genConcurrentForEitherT[F[_], E0, E](
-      implicit F0: GenConcurrent[F, E]): GenConcurrent[EitherT[F, E0, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForEitherT[F, E0](async)
-    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.instantiateGenTemporalForEitherT[F, E0, E](temporal)
-    case concurrent =>
-      instantiateGenConcurrentForEitherT(concurrent)
-  }
+      implicit F0: GenConcurrent[F, E]): GenConcurrent[EitherT[F, E0, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForEitherT[F, E0](async)
+      case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+        GenTemporal.instantiateGenTemporalForEitherT[F, E0, E](temporal)
+      case concurrent =>
+        instantiateGenConcurrentForEitherT(concurrent)
+    }
 
   private[kernel] def instantiateGenConcurrentForEitherT[F[_], E0, E](
-      concurrent: GenConcurrent[F, E]): EitherTGenConcurrent[F, E0, E] =
+      F0: GenConcurrent[F, E]): EitherTGenConcurrent[F, E0, E] =
     new EitherTGenConcurrent[F, E0, E] {
-      override implicit protected def F: GenConcurrent[F, E] = concurrent
+      override implicit protected def F: GenConcurrent[F, E] = F0
     }
 
   implicit def genConcurrentForKleisli[F[_], R, E](
-      implicit F0: GenConcurrent[F, E]): GenConcurrent[Kleisli[F, R, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForKleisli[F, R](async)
-    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.instantiateGenTemporalForKleisli[F, R, E](temporal)
-    case concurrent =>
-      instantiateGenConcurrentForKleisli(concurrent)
-  }
+      implicit F0: GenConcurrent[F, E]): GenConcurrent[Kleisli[F, R, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForKleisli[F, R](async)
+      case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+        GenTemporal.instantiateGenTemporalForKleisli[F, R, E](temporal)
+      case concurrent =>
+        instantiateGenConcurrentForKleisli(concurrent)
+    }
 
   private[kernel] def instantiateGenConcurrentForKleisli[F[_], R, E](
-      concurrent: GenConcurrent[F, E]): KleisliGenConcurrent[F, R, E] =
+      F0: GenConcurrent[F, E]): KleisliGenConcurrent[F, R, E] =
     new KleisliGenConcurrent[F, R, E] {
-      override implicit protected def F: GenConcurrent[F, E] = concurrent
+      override implicit protected def F: GenConcurrent[F, E] = F0
     }
 
   implicit def genConcurrentForIorT[F[_], L, E](
       implicit F0: GenConcurrent[F, E],
-      L0: Semigroup[L]): GenConcurrent[IorT[F, L, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForIorT[F, L](async, L0)
-    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.instantiateGenTemporalForIorT[F, L, E](temporal)
-    case concurrent =>
-      instantiateGenConcurrentForIorT(concurrent)
-  }
+      L0: Semigroup[L]): GenConcurrent[IorT[F, L, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForIorT[F, L](async, L0)
+      case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+        GenTemporal.instantiateGenTemporalForIorT[F, L, E](temporal)
+      case concurrent =>
+        instantiateGenConcurrentForIorT(concurrent)
+    }
 
-  private[kernel] def instantiateGenConcurrentForIorT[F[_], L, E](
-      concurrent: GenConcurrent[F, E])(implicit L0: Semigroup[L]): IorTGenConcurrent[F, L, E] =
+  private[kernel] def instantiateGenConcurrentForIorT[F[_], L, E](F0: GenConcurrent[F, E])(
+      implicit L0: Semigroup[L]): IorTGenConcurrent[F, L, E] =
     new IorTGenConcurrent[F, L, E] {
-      override implicit protected def F: GenConcurrent[F, E] = concurrent
+      override implicit protected def F: GenConcurrent[F, E] = F0
       override implicit protected def L: Semigroup[L] = L0
     }
 
   implicit def genConcurrentForWriterT[F[_], L, E](
       implicit F0: GenConcurrent[F, E],
-      L0: Monoid[L]): GenConcurrent[WriterT[F, L, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForWriterT[F, L](async, L0)
-    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.instantiateGenTemporalForWriterT[F, L, E](temporal)
-    case concurrent =>
-      instantiateGenConcurrentForWriterT(concurrent)
-  }
+      L0: Monoid[L]): GenConcurrent[WriterT[F, L, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForWriterT[F, L](async, L0)
+      case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+        GenTemporal.instantiateGenTemporalForWriterT[F, L, E](temporal)
+      case concurrent =>
+        instantiateGenConcurrentForWriterT(concurrent)
+    }
 
-  private[kernel] def instantiateGenConcurrentForWriterT[F[_], L, E](
-      concurrent: GenConcurrent[F, E])(implicit L0: Monoid[L]): WriterTGenConcurrent[F, L, E] =
+  private[kernel] def instantiateGenConcurrentForWriterT[F[_], L, E](F0: GenConcurrent[F, E])(
+      implicit L0: Monoid[L]): WriterTGenConcurrent[F, L, E] =
     new WriterTGenConcurrent[F, L, E] {
-      override implicit protected def F: GenConcurrent[F, E] = concurrent
+      override implicit protected def F: GenConcurrent[F, E] = F0
       override implicit protected def L: Monoid[L] = L0
     }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -152,36 +152,48 @@ object GenConcurrent {
     case async: Async[F @unchecked] =>
       Async.asyncForOptionT[F](async)
     case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.genTemporalForOptionT[F, E](temporal)
+      GenTemporal.instantiateGenTemporalForOptionT[F, E](temporal)
     case concurrent =>
-      new OptionTGenConcurrent[F, E] {
-        override implicit protected def F: GenConcurrent[F, E] = concurrent
-      }
+      instantiateGenConcurrentForOptionT(concurrent)
   }
+
+  private[kernel] def instantiateGenConcurrentForOptionT[F[_], E](
+      concurrent: GenConcurrent[F, E]): OptionTGenConcurrent[F, E] =
+    new OptionTGenConcurrent[F, E] {
+      override implicit protected def F: GenConcurrent[F, E] = concurrent
+    }
 
   implicit def genConcurrentForEitherT[F[_], E0, E](
       implicit F0: GenConcurrent[F, E]): GenConcurrent[EitherT[F, E0, *], E] = F0 match {
     case async: Async[F @unchecked] =>
       Async.asyncForEitherT[F, E0](async)
     case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.genTemporalForEitherT[F, E0, E](temporal)
+      GenTemporal.instantiateGenTemporalForEitherT[F, E0, E](temporal)
     case concurrent =>
-      new EitherTGenConcurrent[F, E0, E] {
-        override implicit protected def F: GenConcurrent[F, E] = concurrent
-      }
+      instantiateGenConcurrentForEitherT(concurrent)
   }
+
+  private[kernel] def instantiateGenConcurrentForEitherT[F[_], E0, E](
+      concurrent: GenConcurrent[F, E]): EitherTGenConcurrent[F, E0, E] =
+    new EitherTGenConcurrent[F, E0, E] {
+      override implicit protected def F: GenConcurrent[F, E] = concurrent
+    }
 
   implicit def genConcurrentForKleisli[F[_], R, E](
       implicit F0: GenConcurrent[F, E]): GenConcurrent[Kleisli[F, R, *], E] = F0 match {
     case async: Async[F @unchecked] =>
       Async.asyncForKleisli[F, R](async)
     case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.genTemporalForKleisli[F, R, E](temporal)
+      GenTemporal.instantiateGenTemporalForKleisli[F, R, E](temporal)
     case concurrent =>
-      new KleisliGenConcurrent[F, R, E] {
-        override implicit protected def F: GenConcurrent[F, E] = concurrent
-      }
+      instantiateGenConcurrentForKleisli(concurrent)
   }
+
+  private[kernel] def instantiateGenConcurrentForKleisli[F[_], R, E](
+      concurrent: GenConcurrent[F, E]): KleisliGenConcurrent[F, R, E] =
+    new KleisliGenConcurrent[F, R, E] {
+      override implicit protected def F: GenConcurrent[F, E] = concurrent
+    }
 
   implicit def genConcurrentForIorT[F[_], L, E](
       implicit F0: GenConcurrent[F, E],
@@ -189,13 +201,17 @@ object GenConcurrent {
     case async: Async[F @unchecked] =>
       Async.asyncForIorT[F, L](async, L0)
     case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.genTemporalForIorT[F, L, E](temporal, L0)
+      GenTemporal.instantiateGenTemporalForIorT[F, L, E](temporal)
     case concurrent =>
-      new IorTGenConcurrent[F, L, E] {
-        override implicit protected def F: GenConcurrent[F, E] = concurrent
-        override implicit protected def L: Semigroup[L] = L0
-      }
+      instantiateGenConcurrentForIorT(concurrent)
   }
+
+  private[kernel] def instantiateGenConcurrentForIorT[F[_], L, E](
+      concurrent: GenConcurrent[F, E])(implicit L0: Semigroup[L]): IorTGenConcurrent[F, L, E] =
+    new IorTGenConcurrent[F, L, E] {
+      override implicit protected def F: GenConcurrent[F, E] = concurrent
+      override implicit protected def L: Semigroup[L] = L0
+    }
 
   implicit def genConcurrentForWriterT[F[_], L, E](
       implicit F0: GenConcurrent[F, E],
@@ -203,13 +219,17 @@ object GenConcurrent {
     case async: Async[F @unchecked] =>
       Async.asyncForWriterT[F, L](async, L0)
     case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.genTemporalForWriterT[F, L, E](temporal, L0)
+      GenTemporal.instantiateGenTemporalForWriterT[F, L, E](temporal)
     case concurrent =>
-      new WriterTGenConcurrent[F, L, E] {
-        override implicit protected def F: GenConcurrent[F, E] = concurrent
-        override implicit protected def L: Monoid[L] = L0
-      }
+      instantiateGenConcurrentForWriterT(concurrent)
   }
+
+  private[kernel] def instantiateGenConcurrentForWriterT[F[_], L, E](
+      concurrent: GenConcurrent[F, E])(implicit L0: Monoid[L]): WriterTGenConcurrent[F, L, E] =
+    new WriterTGenConcurrent[F, L, E] {
+      override implicit protected def F: GenConcurrent[F, E] = concurrent
+      override implicit protected def L: Monoid[L] = L0
+    }
 
   private[kernel] trait OptionTGenConcurrent[F[_], E]
       extends GenConcurrent[OptionT[F, *], E]

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -430,45 +430,78 @@ object GenSpawn {
   def apply[F[_]](implicit F: GenSpawn[F, _], d: DummyImplicit): F.type = F
 
   implicit def genSpawnForOptionT[F[_], E](
-      implicit F0: GenSpawn[F, E]): GenSpawn[OptionT[F, *], E] =
-    new OptionTGenSpawn[F, E] {
-
-      override implicit protected def F: GenSpawn[F, E] = F0
-    }
+      implicit F0: GenSpawn[F, E]): GenSpawn[OptionT[F, *], E] = F0 match {
+    case async: Async[F @unchecked] =>
+      Async.asyncForOptionT[F](async)
+    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+      GenTemporal.genTemporalForOptionT[F, E](temporal)
+    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+      GenConcurrent.genConcurrentForOptionT[F, E](concurrent)
+    case spawn =>
+      new OptionTGenSpawn[F, E] {
+        override implicit protected def F: GenSpawn[F, E] = spawn
+      }
+  }
 
   implicit def genSpawnForEitherT[F[_], E0, E](
-      implicit F0: GenSpawn[F, E]): GenSpawn[EitherT[F, E0, *], E] =
-    new EitherTGenSpawn[F, E0, E] {
-
-      override implicit protected def F: GenSpawn[F, E] = F0
-    }
+      implicit F0: GenSpawn[F, E]): GenSpawn[EitherT[F, E0, *], E] = F0 match {
+    case async: Async[F @unchecked] =>
+      Async.asyncForEitherT[F, E0](async)
+    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+      GenTemporal.genTemporalForEitherT[F, E0, E](temporal)
+    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+      GenConcurrent.genConcurrentForEitherT[F, E0, E](concurrent)
+    case spawn =>
+      new EitherTGenSpawn[F, E0, E] {
+        override implicit protected def F: GenSpawn[F, E] = spawn
+      }
+  }
 
   implicit def genSpawnForKleisli[F[_], R, E](
-      implicit F0: GenSpawn[F, E]): GenSpawn[Kleisli[F, R, *], E] =
-    new KleisliGenSpawn[F, R, E] {
-
-      override implicit protected def F: GenSpawn[F, E] = F0
-    }
+      implicit F0: GenSpawn[F, E]): GenSpawn[Kleisli[F, R, *], E] = F0 match {
+    case async: Async[F @unchecked] =>
+      Async.asyncForKleisli[F, R](async)
+    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+      GenTemporal.genTemporalForKleisli[F, R, E](temporal)
+    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+      GenConcurrent.genConcurrentForKleisli[F, R, E](concurrent)
+    case spawn =>
+      new KleisliGenSpawn[F, R, E] {
+        override implicit protected def F: GenSpawn[F, E] = spawn
+      }
+  }
 
   implicit def genSpawnForIorT[F[_], L, E](
       implicit F0: GenSpawn[F, E],
-      L0: Semigroup[L]): GenSpawn[IorT[F, L, *], E] =
-    new IorTGenSpawn[F, L, E] {
-
-      override implicit protected def F: GenSpawn[F, E] = F0
-
-      override implicit protected def L: Semigroup[L] = L0
-    }
+      L0: Semigroup[L]): GenSpawn[IorT[F, L, *], E] = F0 match {
+    case async: Async[F @unchecked] =>
+      Async.asyncForIorT[F, L](async, L0)
+    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+      GenTemporal.genTemporalForIorT[F, L, E](temporal, L0)
+    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+      GenConcurrent.genConcurrentForIorT[F, L, E](concurrent, L0)
+    case spawn =>
+      new IorTGenSpawn[F, L, E] {
+        override implicit protected def F: GenSpawn[F, E] = spawn
+        override implicit protected def L: Semigroup[L] = L0
+      }
+  }
 
   implicit def genSpawnForWriterT[F[_], L, E](
       implicit F0: GenSpawn[F, E],
-      L0: Monoid[L]): GenSpawn[WriterT[F, L, *], E] =
-    new WriterTGenSpawn[F, L, E] {
-
-      override implicit protected def F: GenSpawn[F, E] = F0
-
-      override implicit protected def L: Monoid[L] = L0
-    }
+      L0: Monoid[L]): GenSpawn[WriterT[F, L, *], E] = F0 match {
+    case async: Async[F @unchecked] =>
+      Async.asyncForWriterT[F, L](async, L0)
+    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+      GenTemporal.genTemporalForWriterT[F, L, E](temporal, L0)
+    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+      GenConcurrent.genConcurrentForWriterT[F, L, E](concurrent, L0)
+    case spawn =>
+      new WriterTGenSpawn[F, L, E] {
+        override implicit protected def F: GenSpawn[F, E] = spawn
+        override implicit protected def L: Monoid[L] = L0
+      }
+  }
 
   private[kernel] trait OptionTGenSpawn[F[_], E]
       extends GenSpawn[OptionT[F, *], E]

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -430,96 +430,101 @@ object GenSpawn {
   def apply[F[_]](implicit F: GenSpawn[F, _], d: DummyImplicit): F.type = F
 
   implicit def genSpawnForOptionT[F[_], E](
-      implicit F0: GenSpawn[F, E]): GenSpawn[OptionT[F, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForOptionT[F](async)
-    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.instantiateGenTemporalForOptionT[F, E](temporal)
-    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.instantiateGenConcurrentForOptionT[F, E](concurrent)
-    case spawn =>
-      instantiateGenSpawnForOptionT(spawn)
-  }
+      implicit F0: GenSpawn[F, E]): GenSpawn[OptionT[F, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForOptionT[F](async)
+      case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+        GenTemporal.instantiateGenTemporalForOptionT[F, E](temporal)
+      case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+        GenConcurrent.instantiateGenConcurrentForOptionT[F, E](concurrent)
+      case spawn =>
+        instantiateGenSpawnForOptionT(spawn)
+    }
 
   private[kernel] def instantiateGenSpawnForOptionT[F[_], E](
-      spawn: GenSpawn[F, E]): OptionTGenSpawn[F, E] =
+      F0: GenSpawn[F, E]): OptionTGenSpawn[F, E] =
     new OptionTGenSpawn[F, E] {
-      override implicit protected def F: GenSpawn[F, E] = spawn
+      override implicit protected def F: GenSpawn[F, E] = F0
     }
 
   implicit def genSpawnForEitherT[F[_], E0, E](
-      implicit F0: GenSpawn[F, E]): GenSpawn[EitherT[F, E0, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForEitherT[F, E0](async)
-    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.instantiateGenTemporalForEitherT[F, E0, E](temporal)
-    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.instantiateGenConcurrentForEitherT[F, E0, E](concurrent)
-    case spawn =>
-      instantiateGenSpawnForEitherT(spawn)
-  }
+      implicit F0: GenSpawn[F, E]): GenSpawn[EitherT[F, E0, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForEitherT[F, E0](async)
+      case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+        GenTemporal.instantiateGenTemporalForEitherT[F, E0, E](temporal)
+      case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+        GenConcurrent.instantiateGenConcurrentForEitherT[F, E0, E](concurrent)
+      case spawn =>
+        instantiateGenSpawnForEitherT(spawn)
+    }
 
   private[kernel] def instantiateGenSpawnForEitherT[F[_], E0, E](
-      spawn: GenSpawn[F, E]): EitherTGenSpawn[F, E0, E] =
+      F0: GenSpawn[F, E]): EitherTGenSpawn[F, E0, E] =
     new EitherTGenSpawn[F, E0, E] {
-      override implicit protected def F: GenSpawn[F, E] = spawn
+      override implicit protected def F: GenSpawn[F, E] = F0
     }
 
   implicit def genSpawnForKleisli[F[_], R, E](
-      implicit F0: GenSpawn[F, E]): GenSpawn[Kleisli[F, R, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForKleisli[F, R](async)
-    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.instantiateGenTemporalForKleisli[F, R, E](temporal)
-    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.instantiateGenConcurrentForKleisli[F, R, E](concurrent)
-    case spawn =>
-      instantiateGenSpawnForKleisli(spawn)
-  }
+      implicit F0: GenSpawn[F, E]): GenSpawn[Kleisli[F, R, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForKleisli[F, R](async)
+      case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+        GenTemporal.instantiateGenTemporalForKleisli[F, R, E](temporal)
+      case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+        GenConcurrent.instantiateGenConcurrentForKleisli[F, R, E](concurrent)
+      case spawn =>
+        instantiateGenSpawnForKleisli(spawn)
+    }
 
   private[kernel] def instantiateGenSpawnForKleisli[F[_], R, E](
-      spawn: GenSpawn[F, E]): KleisliGenSpawn[F, R, E] =
+      F0: GenSpawn[F, E]): KleisliGenSpawn[F, R, E] =
     new KleisliGenSpawn[F, R, E] {
-      override implicit protected def F: GenSpawn[F, E] = spawn
+      override implicit protected def F: GenSpawn[F, E] = F0
     }
 
   implicit def genSpawnForIorT[F[_], L, E](
       implicit F0: GenSpawn[F, E],
-      L0: Semigroup[L]): GenSpawn[IorT[F, L, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForIorT[F, L](async, L0)
-    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.instantiateGenTemporalForIorT[F, L, E](temporal)
-    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.instantiateGenConcurrentForIorT[F, L, E](concurrent)
-    case spawn =>
-      instantiateGenSpawnForIorT(spawn)
-  }
+      L0: Semigroup[L]): GenSpawn[IorT[F, L, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForIorT[F, L](async, L0)
+      case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+        GenTemporal.instantiateGenTemporalForIorT[F, L, E](temporal)
+      case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+        GenConcurrent.instantiateGenConcurrentForIorT[F, L, E](concurrent)
+      case spawn =>
+        instantiateGenSpawnForIorT(spawn)
+    }
 
-  private[kernel] def instantiateGenSpawnForIorT[F[_], L, E](spawn: GenSpawn[F, E])(
+  private[kernel] def instantiateGenSpawnForIorT[F[_], L, E](F0: GenSpawn[F, E])(
       implicit L0: Semigroup[L]): IorTGenSpawn[F, L, E] =
     new IorTGenSpawn[F, L, E] {
-      override implicit protected def F: GenSpawn[F, E] = spawn
+      override implicit protected def F: GenSpawn[F, E] = F0
       override implicit protected def L: Semigroup[L] = L0
     }
 
   implicit def genSpawnForWriterT[F[_], L, E](
       implicit F0: GenSpawn[F, E],
-      L0: Monoid[L]): GenSpawn[WriterT[F, L, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForWriterT[F, L](async, L0)
-    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.instantiateGenTemporalForWriterT[F, L, E](temporal)
-    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.instantiateGenConcurrentForWriterT[F, L, E](concurrent)
-    case spawn =>
-      instantiateGenSpawnForWriterT(spawn)
-  }
+      L0: Monoid[L]): GenSpawn[WriterT[F, L, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForWriterT[F, L](async, L0)
+      case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+        GenTemporal.instantiateGenTemporalForWriterT[F, L, E](temporal)
+      case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+        GenConcurrent.instantiateGenConcurrentForWriterT[F, L, E](concurrent)
+      case spawn =>
+        instantiateGenSpawnForWriterT(spawn)
+    }
 
-  private[kernel] def instantiateGenSpawnForWriterT[F[_], L, E](spawn: GenSpawn[F, E])(
+  private[kernel] def instantiateGenSpawnForWriterT[F[_], L, E](F0: GenSpawn[F, E])(
       implicit L0: Monoid[L]): WriterTGenSpawn[F, L, E] =
     new WriterTGenSpawn[F, L, E] {
-      override implicit protected def F: GenSpawn[F, E] = spawn
+      override implicit protected def F: GenSpawn[F, E] = F0
       override implicit protected def L: Monoid[L] = L0
     }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -434,42 +434,54 @@ object GenSpawn {
     case async: Async[F @unchecked] =>
       Async.asyncForOptionT[F](async)
     case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.genTemporalForOptionT[F, E](temporal)
+      GenTemporal.instantiateGenTemporalForOptionT[F, E](temporal)
     case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.genConcurrentForOptionT[F, E](concurrent)
+      GenConcurrent.instantiateGenConcurrentForOptionT[F, E](concurrent)
     case spawn =>
-      new OptionTGenSpawn[F, E] {
-        override implicit protected def F: GenSpawn[F, E] = spawn
-      }
+      instantiateGenSpawnForOptionT(spawn)
   }
+
+  private[kernel] def instantiateGenSpawnForOptionT[F[_], E](
+      spawn: GenSpawn[F, E]): OptionTGenSpawn[F, E] =
+    new OptionTGenSpawn[F, E] {
+      override implicit protected def F: GenSpawn[F, E] = spawn
+    }
 
   implicit def genSpawnForEitherT[F[_], E0, E](
       implicit F0: GenSpawn[F, E]): GenSpawn[EitherT[F, E0, *], E] = F0 match {
     case async: Async[F @unchecked] =>
       Async.asyncForEitherT[F, E0](async)
     case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.genTemporalForEitherT[F, E0, E](temporal)
+      GenTemporal.instantiateGenTemporalForEitherT[F, E0, E](temporal)
     case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.genConcurrentForEitherT[F, E0, E](concurrent)
+      GenConcurrent.instantiateGenConcurrentForEitherT[F, E0, E](concurrent)
     case spawn =>
-      new EitherTGenSpawn[F, E0, E] {
-        override implicit protected def F: GenSpawn[F, E] = spawn
-      }
+      instantiateGenSpawnForEitherT(spawn)
   }
+
+  private[kernel] def instantiateGenSpawnForEitherT[F[_], E0, E](
+      spawn: GenSpawn[F, E]): EitherTGenSpawn[F, E0, E] =
+    new EitherTGenSpawn[F, E0, E] {
+      override implicit protected def F: GenSpawn[F, E] = spawn
+    }
 
   implicit def genSpawnForKleisli[F[_], R, E](
       implicit F0: GenSpawn[F, E]): GenSpawn[Kleisli[F, R, *], E] = F0 match {
     case async: Async[F @unchecked] =>
       Async.asyncForKleisli[F, R](async)
     case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.genTemporalForKleisli[F, R, E](temporal)
+      GenTemporal.instantiateGenTemporalForKleisli[F, R, E](temporal)
     case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.genConcurrentForKleisli[F, R, E](concurrent)
+      GenConcurrent.instantiateGenConcurrentForKleisli[F, R, E](concurrent)
     case spawn =>
-      new KleisliGenSpawn[F, R, E] {
-        override implicit protected def F: GenSpawn[F, E] = spawn
-      }
+      instantiateGenSpawnForKleisli(spawn)
   }
+
+  private[kernel] def instantiateGenSpawnForKleisli[F[_], R, E](
+      spawn: GenSpawn[F, E]): KleisliGenSpawn[F, R, E] =
+    new KleisliGenSpawn[F, R, E] {
+      override implicit protected def F: GenSpawn[F, E] = spawn
+    }
 
   implicit def genSpawnForIorT[F[_], L, E](
       implicit F0: GenSpawn[F, E],
@@ -477,15 +489,19 @@ object GenSpawn {
     case async: Async[F @unchecked] =>
       Async.asyncForIorT[F, L](async, L0)
     case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.genTemporalForIorT[F, L, E](temporal, L0)
+      GenTemporal.instantiateGenTemporalForIorT[F, L, E](temporal)
     case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.genConcurrentForIorT[F, L, E](concurrent, L0)
+      GenConcurrent.instantiateGenConcurrentForIorT[F, L, E](concurrent)
     case spawn =>
-      new IorTGenSpawn[F, L, E] {
-        override implicit protected def F: GenSpawn[F, E] = spawn
-        override implicit protected def L: Semigroup[L] = L0
-      }
+      instantiateGenSpawnForIorT(spawn)
   }
+
+  private[kernel] def instantiateGenSpawnForIorT[F[_], L, E](spawn: GenSpawn[F, E])(
+      implicit L0: Semigroup[L]): IorTGenSpawn[F, L, E] =
+    new IorTGenSpawn[F, L, E] {
+      override implicit protected def F: GenSpawn[F, E] = spawn
+      override implicit protected def L: Semigroup[L] = L0
+    }
 
   implicit def genSpawnForWriterT[F[_], L, E](
       implicit F0: GenSpawn[F, E],
@@ -493,15 +509,19 @@ object GenSpawn {
     case async: Async[F @unchecked] =>
       Async.asyncForWriterT[F, L](async, L0)
     case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.genTemporalForWriterT[F, L, E](temporal, L0)
+      GenTemporal.instantiateGenTemporalForWriterT[F, L, E](temporal)
     case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.genConcurrentForWriterT[F, L, E](concurrent, L0)
+      GenConcurrent.instantiateGenConcurrentForWriterT[F, L, E](concurrent)
     case spawn =>
-      new WriterTGenSpawn[F, L, E] {
-        override implicit protected def F: GenSpawn[F, E] = spawn
-        override implicit protected def L: Monoid[L] = L0
-      }
+      instantiateGenSpawnForWriterT(spawn)
   }
+
+  private[kernel] def instantiateGenSpawnForWriterT[F[_], L, E](spawn: GenSpawn[F, E])(
+      implicit L0: Monoid[L]): WriterTGenSpawn[F, L, E] =
+    new WriterTGenSpawn[F, L, E] {
+      override implicit protected def F: GenSpawn[F, E] = spawn
+      override implicit protected def L: Monoid[L] = L0
+    }
 
   private[kernel] trait OptionTGenSpawn[F[_], E]
       extends GenSpawn[OptionT[F, *], E]

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenTemporal.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenTemporal.scala
@@ -147,20 +147,28 @@ object GenTemporal {
     case async: Async[F @unchecked] =>
       Async.asyncForOptionT[F](async)
     case temporal =>
-      new OptionTTemporal[F, E] {
-        override implicit protected def F: GenTemporal[F, E] = temporal
-      }
+      instantiateGenTemporalForOptionT(temporal)
   }
+
+  private[kernel] def instantiateGenTemporalForOptionT[F[_], E](
+      temporal: GenTemporal[F, E]): OptionTTemporal[F, E] =
+    new OptionTTemporal[F, E] {
+      override implicit protected def F: GenTemporal[F, E] = temporal
+    }
 
   implicit def genTemporalForEitherT[F[_], E0, E](
       implicit F0: GenTemporal[F, E]): GenTemporal[EitherT[F, E0, *], E] = F0 match {
     case async: Async[F @unchecked] =>
       Async.asyncForEitherT[F, E0](async)
     case temporal =>
-      new EitherTTemporal[F, E0, E] {
-        override implicit protected def F: GenTemporal[F, E] = temporal
-      }
+      instantiateGenTemporalForEitherT(temporal)
   }
+
+  private[kernel] def instantiateGenTemporalForEitherT[F[_], E0, E](
+      temporal: GenTemporal[F, E]): EitherTTemporal[F, E0, E] =
+    new EitherTTemporal[F, E0, E] {
+      override implicit protected def F: GenTemporal[F, E] = temporal
+    }
 
   implicit def genTemporalForKleisli[F[_], R, E](
       implicit F0: GenTemporal[F, E]): GenTemporal[Kleisli[F, R, *], E] = F0 match {
@@ -172,17 +180,27 @@ object GenTemporal {
       }
   }
 
+  private[kernel] def instantiateGenTemporalForKleisli[F[_], R, E](
+      temporal: GenTemporal[F, E]): KleisliTemporal[F, R, E] =
+    new KleisliTemporal[F, R, E] {
+      override implicit protected def F: GenTemporal[F, E] = temporal
+    }
+
   implicit def genTemporalForIorT[F[_], L, E](
       implicit F0: GenTemporal[F, E],
       L0: Semigroup[L]): GenTemporal[IorT[F, L, *], E] = F0 match {
     case async: Async[F @unchecked] =>
       Async.asyncForIorT[F, L](async, L0)
     case temporal =>
-      new IorTTemporal[F, L, E] {
-        override implicit protected def F: GenTemporal[F, E] = temporal
-        override implicit protected def L: Semigroup[L] = L0
-      }
+      instantiateGenTemporalForIorT(temporal)
   }
+
+  private[kernel] def instantiateGenTemporalForIorT[F[_], L, E](temporal: GenTemporal[F, E])(
+      implicit L0: Semigroup[L]): IorTTemporal[F, L, E] =
+    new IorTTemporal[F, L, E] {
+      override implicit protected def F: GenTemporal[F, E] = temporal
+      override implicit protected def L: Semigroup[L] = L0
+    }
 
   implicit def genTemporalForWriterT[F[_], L, E](
       implicit F0: GenTemporal[F, E],
@@ -190,11 +208,15 @@ object GenTemporal {
     case async: Async[F @unchecked] =>
       Async.asyncForWriterT[F, L](async, L0)
     case temporal =>
-      new WriterTTemporal[F, L, E] {
-        override implicit protected def F: GenTemporal[F, E] = temporal
-        override implicit protected def L: Monoid[L] = L0
-      }
+      instantiateGenTemporalForWriterT(temporal)
   }
+
+  private[kernel] def instantiateGenTemporalForWriterT[F[_], L, E](temporal: GenTemporal[F, E])(
+      implicit L0: Monoid[L]): WriterTTemporal[F, L, E] =
+    new WriterTTemporal[F, L, E] {
+      override implicit protected def F: GenTemporal[F, E] = temporal
+      override implicit protected def L: Monoid[L] = L0
+    }
 
   private[kernel] trait OptionTTemporal[F[_], E]
       extends GenTemporal[OptionT[F, *], E]

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenTemporal.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenTemporal.scala
@@ -143,78 +143,81 @@ object GenTemporal {
   def apply[F[_]](implicit F: GenTemporal[F, _], d: DummyImplicit): F.type = F
 
   implicit def genTemporalForOptionT[F[_], E](
-      implicit F0: GenTemporal[F, E]): GenTemporal[OptionT[F, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForOptionT[F](async)
-    case temporal =>
-      instantiateGenTemporalForOptionT(temporal)
-  }
+      implicit F0: GenTemporal[F, E]): GenTemporal[OptionT[F, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForOptionT[F](async)
+      case temporal =>
+        instantiateGenTemporalForOptionT(temporal)
+    }
 
   private[kernel] def instantiateGenTemporalForOptionT[F[_], E](
-      temporal: GenTemporal[F, E]): OptionTTemporal[F, E] =
+      F0: GenTemporal[F, E]): OptionTTemporal[F, E] =
     new OptionTTemporal[F, E] {
-      override implicit protected def F: GenTemporal[F, E] = temporal
+      override implicit protected def F: GenTemporal[F, E] = F0
     }
 
   implicit def genTemporalForEitherT[F[_], E0, E](
-      implicit F0: GenTemporal[F, E]): GenTemporal[EitherT[F, E0, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForEitherT[F, E0](async)
-    case temporal =>
-      instantiateGenTemporalForEitherT(temporal)
-  }
+      implicit F0: GenTemporal[F, E]): GenTemporal[EitherT[F, E0, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForEitherT[F, E0](async)
+      case temporal =>
+        instantiateGenTemporalForEitherT(temporal)
+    }
 
   private[kernel] def instantiateGenTemporalForEitherT[F[_], E0, E](
-      temporal: GenTemporal[F, E]): EitherTTemporal[F, E0, E] =
+      F0: GenTemporal[F, E]): EitherTTemporal[F, E0, E] =
     new EitherTTemporal[F, E0, E] {
-      override implicit protected def F: GenTemporal[F, E] = temporal
+      override implicit protected def F: GenTemporal[F, E] = F0
     }
 
   implicit def genTemporalForKleisli[F[_], R, E](
-      implicit F0: GenTemporal[F, E]): GenTemporal[Kleisli[F, R, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForKleisli[F, R](async)
-    case temporal =>
-      new KleisliTemporal[F, R, E] {
-        override implicit protected def F: GenTemporal[F, E] = temporal
-      }
-  }
+      implicit F0: GenTemporal[F, E]): GenTemporal[Kleisli[F, R, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForKleisli[F, R](async)
+      case temporal =>
+        instantiateGenTemporalForKleisli(temporal)
+    }
 
   private[kernel] def instantiateGenTemporalForKleisli[F[_], R, E](
-      temporal: GenTemporal[F, E]): KleisliTemporal[F, R, E] =
+      F0: GenTemporal[F, E]): KleisliTemporal[F, R, E] =
     new KleisliTemporal[F, R, E] {
-      override implicit protected def F: GenTemporal[F, E] = temporal
+      override implicit protected def F: GenTemporal[F, E] = F0
     }
 
   implicit def genTemporalForIorT[F[_], L, E](
       implicit F0: GenTemporal[F, E],
-      L0: Semigroup[L]): GenTemporal[IorT[F, L, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForIorT[F, L](async, L0)
-    case temporal =>
-      instantiateGenTemporalForIorT(temporal)
-  }
+      L0: Semigroup[L]): GenTemporal[IorT[F, L, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForIorT[F, L](async, L0)
+      case temporal =>
+        instantiateGenTemporalForIorT(temporal)
+    }
 
-  private[kernel] def instantiateGenTemporalForIorT[F[_], L, E](temporal: GenTemporal[F, E])(
+  private[kernel] def instantiateGenTemporalForIorT[F[_], L, E](F0: GenTemporal[F, E])(
       implicit L0: Semigroup[L]): IorTTemporal[F, L, E] =
     new IorTTemporal[F, L, E] {
-      override implicit protected def F: GenTemporal[F, E] = temporal
+      override implicit protected def F: GenTemporal[F, E] = F0
       override implicit protected def L: Semigroup[L] = L0
     }
 
   implicit def genTemporalForWriterT[F[_], L, E](
       implicit F0: GenTemporal[F, E],
-      L0: Monoid[L]): GenTemporal[WriterT[F, L, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForWriterT[F, L](async, L0)
-    case temporal =>
-      instantiateGenTemporalForWriterT(temporal)
-  }
+      L0: Monoid[L]): GenTemporal[WriterT[F, L, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForWriterT[F, L](async, L0)
+      case temporal =>
+        instantiateGenTemporalForWriterT(temporal)
+    }
 
-  private[kernel] def instantiateGenTemporalForWriterT[F[_], L, E](temporal: GenTemporal[F, E])(
+  private[kernel] def instantiateGenTemporalForWriterT[F[_], L, E](F0: GenTemporal[F, E])(
       implicit L0: Monoid[L]): WriterTTemporal[F, L, E] =
     new WriterTTemporal[F, L, E] {
-      override implicit protected def F: GenTemporal[F, E] = temporal
+      override implicit protected def F: GenTemporal[F, E] = F0
       override implicit protected def L: Monoid[L] = L0
     }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -468,13 +468,13 @@ object MonadCancel {
     case async: Async[F @unchecked] =>
       Async.asyncForOptionT[F](async)
     case sync: Sync[F @unchecked] =>
-      Sync.syncForOptionT[F](sync)
+      Sync.instantiateSyncForOptionT[F](sync)
     case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.genTemporalForOptionT[F, E](temporal)
+      GenTemporal.instantiateGenTemporalForOptionT[F, E](temporal)
     case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.genConcurrentForOptionT[F, E](concurrent)
+      GenConcurrent.instantiateGenConcurrentForOptionT[F, E](concurrent)
     case spawn: GenSpawn[F @unchecked, E @unchecked] =>
-      GenSpawn.genSpawnForOptionT[F, E](spawn)
+      GenSpawn.instantiateGenSpawnForOptionT[F, E](spawn)
     case cancel =>
       new OptionTMonadCancel[F, E] {
         def rootCancelScope = F0.rootCancelScope
@@ -487,13 +487,13 @@ object MonadCancel {
     case async: Async[F @unchecked] =>
       Async.asyncForEitherT[F, E0](async)
     case sync: Sync[F @unchecked] =>
-      Sync.syncForEitherT[F, E0](sync)
+      Sync.instantiateSyncForEitherT[F, E0](sync)
     case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.genTemporalForEitherT[F, E0, E](temporal)
+      GenTemporal.instantiateGenTemporalForEitherT[F, E0, E](temporal)
     case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.genConcurrentForEitherT[F, E0, E](concurrent)
+      GenConcurrent.instantiateGenConcurrentForEitherT[F, E0, E](concurrent)
     case spawn: GenSpawn[F @unchecked, E @unchecked] =>
-      GenSpawn.genSpawnForEitherT[F, E0, E](spawn)
+      GenSpawn.instantiateGenSpawnForEitherT[F, E0, E](spawn)
     case cancel =>
       new EitherTMonadCancel[F, E0, E] {
         def rootCancelScope = F0.rootCancelScope
@@ -506,13 +506,13 @@ object MonadCancel {
     case async: Async[F @unchecked] =>
       Async.asyncForKleisli[F, R](async)
     case sync: Sync[F @unchecked] =>
-      Sync.syncForKleisli[F, R](sync)
+      Sync.instantiateSyncForKleisli[F, R](sync)
     case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.genTemporalForKleisli[F, R, E](temporal)
+      GenTemporal.instantiateGenTemporalForKleisli[F, R, E](temporal)
     case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.genConcurrentForKleisli[F, R, E](concurrent)
+      GenConcurrent.instantiateGenConcurrentForKleisli[F, R, E](concurrent)
     case spawn: GenSpawn[F @unchecked, E @unchecked] =>
-      GenSpawn.genSpawnForKleisli[F, R, E](spawn)
+      GenSpawn.instantiateGenSpawnForKleisli[F, R, E](spawn)
     case cancel =>
       new KleisliMonadCancel[F, R, E] {
         def rootCancelScope = F0.rootCancelScope
@@ -526,13 +526,13 @@ object MonadCancel {
     case async: Async[F @unchecked] =>
       Async.asyncForIorT[F, L](async, L0)
     case sync: Sync[F @unchecked] =>
-      Sync.syncForIorT[F, L](sync, L0)
+      Sync.instantiateSyncForIorT[F, L](sync)
     case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.genTemporalForIorT[F, L, E](temporal, L0)
+      GenTemporal.instantiateGenTemporalForIorT[F, L, E](temporal)
     case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.genConcurrentForIorT[F, L, E](concurrent, L0)
+      GenConcurrent.instantiateGenConcurrentForIorT[F, L, E](concurrent)
     case spawn: GenSpawn[F @unchecked, E @unchecked] =>
-      GenSpawn.genSpawnForIorT[F, L, E](spawn, L0)
+      GenSpawn.instantiateGenSpawnForIorT[F, L, E](spawn)
     case cancel =>
       new IorTMonadCancel[F, L, E] {
         def rootCancelScope = F0.rootCancelScope
@@ -547,13 +547,13 @@ object MonadCancel {
     case async: Async[F @unchecked] =>
       Async.asyncForWriterT[F, L](async, L0)
     case sync: Sync[F @unchecked] =>
-      Sync.syncForWriterT[F, L](sync, L0)
+      Sync.instantiateSyncForWriterT[F, L](sync)
     case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.genTemporalForWriterT[F, L, E](temporal, L0)
+      GenTemporal.instantiateGenTemporalForWriterT[F, L, E](temporal)
     case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.genConcurrentForWriterT[F, L, E](concurrent, L0)
+      GenConcurrent.instantiateGenConcurrentForWriterT[F, L, E](concurrent)
     case spawn: GenSpawn[F @unchecked, E @unchecked] =>
-      GenSpawn.genSpawnForWriterT[F, L, E](spawn, L0)
+      GenSpawn.instantiateGenSpawnForWriterT[F, L, E](spawn)
     case cancel =>
       new WriterTMonadCancel[F, L, E] {
         def rootCancelScope = F0.rootCancelScope
@@ -565,7 +565,7 @@ object MonadCancel {
   implicit def monadCancelForStateT[F[_], S, E](
       implicit F0: MonadCancel[F, E]): MonadCancel[StateT[F, S, *], E] = F0 match {
     case sync: Sync[F @unchecked] =>
-      Sync.syncForStateT[F, S](sync)
+      Sync.instantiateSyncForStateT[F, S](sync)
     case cancel =>
       new StateTMonadCancel[F, S, E] {
         def rootCancelScope = F0.rootCancelScope
@@ -577,7 +577,7 @@ object MonadCancel {
       implicit F0: MonadCancel[F, E],
       L0: Monoid[L]): MonadCancel[ReaderWriterStateT[F, E0, L, S, *], E] = F0 match {
     case sync: Sync[F @unchecked] =>
-      Sync.syncForReaderWriterStateT[F, E0, L, S](sync, L0)
+      Sync.instantiateSyncForReaderWriterStateT[F, E0, L, S](sync)
     case cancel =>
       new ReaderWriterStateTMonadCancel[F, E0, L, S, E] {
         def rootCancelScope = F0.rootCancelScope

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -464,127 +464,134 @@ object MonadCancel {
   def apply[F[_]](implicit F: MonadCancel[F, _], d: DummyImplicit): F.type = F
 
   implicit def monadCancelForOptionT[F[_], E](
-      implicit F0: MonadCancel[F, E]): MonadCancel[OptionT[F, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForOptionT[F](async)
-    case sync: Sync[F @unchecked] =>
-      Sync.instantiateSyncForOptionT[F](sync)
-    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.instantiateGenTemporalForOptionT[F, E](temporal)
-    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.instantiateGenConcurrentForOptionT[F, E](concurrent)
-    case spawn: GenSpawn[F @unchecked, E @unchecked] =>
-      GenSpawn.instantiateGenSpawnForOptionT[F, E](spawn)
-    case cancel =>
-      new OptionTMonadCancel[F, E] {
-        def rootCancelScope = F0.rootCancelScope
-        override implicit protected def F: MonadCancel[F, E] = cancel
-      }
-  }
+      implicit F0: MonadCancel[F, E]): MonadCancel[OptionT[F, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForOptionT[F](async)
+      case sync: Sync[F @unchecked] =>
+        Sync.instantiateSyncForOptionT[F](sync)
+      case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+        GenTemporal.instantiateGenTemporalForOptionT[F, E](temporal)
+      case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+        GenConcurrent.instantiateGenConcurrentForOptionT[F, E](concurrent)
+      case spawn: GenSpawn[F @unchecked, E @unchecked] =>
+        GenSpawn.instantiateGenSpawnForOptionT[F, E](spawn)
+      case cancel =>
+        new OptionTMonadCancel[F, E] {
+          def rootCancelScope = F0.rootCancelScope
+          override implicit protected def F: MonadCancel[F, E] = cancel
+        }
+    }
 
   implicit def monadCancelForEitherT[F[_], E0, E](
-      implicit F0: MonadCancel[F, E]): MonadCancel[EitherT[F, E0, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForEitherT[F, E0](async)
-    case sync: Sync[F @unchecked] =>
-      Sync.instantiateSyncForEitherT[F, E0](sync)
-    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.instantiateGenTemporalForEitherT[F, E0, E](temporal)
-    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.instantiateGenConcurrentForEitherT[F, E0, E](concurrent)
-    case spawn: GenSpawn[F @unchecked, E @unchecked] =>
-      GenSpawn.instantiateGenSpawnForEitherT[F, E0, E](spawn)
-    case cancel =>
-      new EitherTMonadCancel[F, E0, E] {
-        def rootCancelScope = F0.rootCancelScope
-        override implicit protected def F: MonadCancel[F, E] = cancel
-      }
-  }
+      implicit F0: MonadCancel[F, E]): MonadCancel[EitherT[F, E0, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForEitherT[F, E0](async)
+      case sync: Sync[F @unchecked] =>
+        Sync.instantiateSyncForEitherT[F, E0](sync)
+      case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+        GenTemporal.instantiateGenTemporalForEitherT[F, E0, E](temporal)
+      case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+        GenConcurrent.instantiateGenConcurrentForEitherT[F, E0, E](concurrent)
+      case spawn: GenSpawn[F @unchecked, E @unchecked] =>
+        GenSpawn.instantiateGenSpawnForEitherT[F, E0, E](spawn)
+      case cancel =>
+        new EitherTMonadCancel[F, E0, E] {
+          def rootCancelScope = F0.rootCancelScope
+          override implicit protected def F: MonadCancel[F, E] = cancel
+        }
+    }
 
   implicit def monadCancelForKleisli[F[_], R, E](
-      implicit F0: MonadCancel[F, E]): MonadCancel[Kleisli[F, R, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForKleisli[F, R](async)
-    case sync: Sync[F @unchecked] =>
-      Sync.instantiateSyncForKleisli[F, R](sync)
-    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.instantiateGenTemporalForKleisli[F, R, E](temporal)
-    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.instantiateGenConcurrentForKleisli[F, R, E](concurrent)
-    case spawn: GenSpawn[F @unchecked, E @unchecked] =>
-      GenSpawn.instantiateGenSpawnForKleisli[F, R, E](spawn)
-    case cancel =>
-      new KleisliMonadCancel[F, R, E] {
-        def rootCancelScope = F0.rootCancelScope
-        override implicit protected def F: MonadCancel[F, E] = cancel
-      }
-  }
+      implicit F0: MonadCancel[F, E]): MonadCancel[Kleisli[F, R, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForKleisli[F, R](async)
+      case sync: Sync[F @unchecked] =>
+        Sync.instantiateSyncForKleisli[F, R](sync)
+      case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+        GenTemporal.instantiateGenTemporalForKleisli[F, R, E](temporal)
+      case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+        GenConcurrent.instantiateGenConcurrentForKleisli[F, R, E](concurrent)
+      case spawn: GenSpawn[F @unchecked, E @unchecked] =>
+        GenSpawn.instantiateGenSpawnForKleisli[F, R, E](spawn)
+      case cancel =>
+        new KleisliMonadCancel[F, R, E] {
+          def rootCancelScope = F0.rootCancelScope
+          override implicit protected def F: MonadCancel[F, E] = cancel
+        }
+    }
 
   implicit def monadCancelForIorT[F[_], L, E](
       implicit F0: MonadCancel[F, E],
-      L0: Semigroup[L]): MonadCancel[IorT[F, L, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForIorT[F, L](async, L0)
-    case sync: Sync[F @unchecked] =>
-      Sync.instantiateSyncForIorT[F, L](sync)
-    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.instantiateGenTemporalForIorT[F, L, E](temporal)
-    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.instantiateGenConcurrentForIorT[F, L, E](concurrent)
-    case spawn: GenSpawn[F @unchecked, E @unchecked] =>
-      GenSpawn.instantiateGenSpawnForIorT[F, L, E](spawn)
-    case cancel =>
-      new IorTMonadCancel[F, L, E] {
-        def rootCancelScope = F0.rootCancelScope
-        override implicit protected def F: MonadCancel[F, E] = cancel
-        override implicit protected def L: Semigroup[L] = L0
-      }
-  }
+      L0: Semigroup[L]): MonadCancel[IorT[F, L, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForIorT[F, L](async, L0)
+      case sync: Sync[F @unchecked] =>
+        Sync.instantiateSyncForIorT[F, L](sync)
+      case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+        GenTemporal.instantiateGenTemporalForIorT[F, L, E](temporal)
+      case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+        GenConcurrent.instantiateGenConcurrentForIorT[F, L, E](concurrent)
+      case spawn: GenSpawn[F @unchecked, E @unchecked] =>
+        GenSpawn.instantiateGenSpawnForIorT[F, L, E](spawn)
+      case cancel =>
+        new IorTMonadCancel[F, L, E] {
+          def rootCancelScope = F0.rootCancelScope
+          override implicit protected def F: MonadCancel[F, E] = cancel
+          override implicit protected def L: Semigroup[L] = L0
+        }
+    }
 
   implicit def monadCancelForWriterT[F[_], L, E](
       implicit F0: MonadCancel[F, E],
-      L0: Monoid[L]): MonadCancel[WriterT[F, L, *], E] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForWriterT[F, L](async, L0)
-    case sync: Sync[F @unchecked] =>
-      Sync.instantiateSyncForWriterT[F, L](sync)
-    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
-      GenTemporal.instantiateGenTemporalForWriterT[F, L, E](temporal)
-    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
-      GenConcurrent.instantiateGenConcurrentForWriterT[F, L, E](concurrent)
-    case spawn: GenSpawn[F @unchecked, E @unchecked] =>
-      GenSpawn.instantiateGenSpawnForWriterT[F, L, E](spawn)
-    case cancel =>
-      new WriterTMonadCancel[F, L, E] {
-        def rootCancelScope = F0.rootCancelScope
-        override implicit protected def F: MonadCancel[F, E] = cancel
-        override implicit protected def L: Monoid[L] = L0
-      }
-  }
+      L0: Monoid[L]): MonadCancel[WriterT[F, L, *], E] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForWriterT[F, L](async, L0)
+      case sync: Sync[F @unchecked] =>
+        Sync.instantiateSyncForWriterT[F, L](sync)
+      case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+        GenTemporal.instantiateGenTemporalForWriterT[F, L, E](temporal)
+      case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+        GenConcurrent.instantiateGenConcurrentForWriterT[F, L, E](concurrent)
+      case spawn: GenSpawn[F @unchecked, E @unchecked] =>
+        GenSpawn.instantiateGenSpawnForWriterT[F, L, E](spawn)
+      case cancel =>
+        new WriterTMonadCancel[F, L, E] {
+          def rootCancelScope = F0.rootCancelScope
+          override implicit protected def F: MonadCancel[F, E] = cancel
+          override implicit protected def L: Monoid[L] = L0
+        }
+    }
 
   implicit def monadCancelForStateT[F[_], S, E](
-      implicit F0: MonadCancel[F, E]): MonadCancel[StateT[F, S, *], E] = F0 match {
-    case sync: Sync[F @unchecked] =>
-      Sync.syncForStateT[F, S](sync)
-    case cancel =>
-      new StateTMonadCancel[F, S, E] {
-        def rootCancelScope = F0.rootCancelScope
-        override implicit protected def F: MonadCancel[F, E] = cancel
-      }
-  }
+      implicit F0: MonadCancel[F, E]): MonadCancel[StateT[F, S, *], E] =
+    F0 match {
+      case sync: Sync[F @unchecked] =>
+        Sync.syncForStateT[F, S](sync)
+      case cancel =>
+        new StateTMonadCancel[F, S, E] {
+          def rootCancelScope = F0.rootCancelScope
+          override implicit protected def F: MonadCancel[F, E] = cancel
+        }
+    }
 
   implicit def monadCancelForReaderWriterStateT[F[_], E0, L, S, E](
       implicit F0: MonadCancel[F, E],
-      L0: Monoid[L]): MonadCancel[ReaderWriterStateT[F, E0, L, S, *], E] = F0 match {
-    case sync: Sync[F @unchecked] =>
-      Sync.syncForReaderWriterStateT[F, E0, L, S](sync, L0)
-    case cancel =>
-      new ReaderWriterStateTMonadCancel[F, E0, L, S, E] {
-        def rootCancelScope = F0.rootCancelScope
-        override implicit protected def F: MonadCancel[F, E] = cancel
-        override implicit protected def L: Monoid[L] = L0
-      }
-  }
+      L0: Monoid[L]): MonadCancel[ReaderWriterStateT[F, E0, L, S, *], E] =
+    F0 match {
+      case sync: Sync[F @unchecked] =>
+        Sync.syncForReaderWriterStateT[F, E0, L, S](sync, L0)
+      case cancel =>
+        new ReaderWriterStateTMonadCancel[F, E0, L, S, E] {
+          def rootCancelScope = F0.rootCancelScope
+          override implicit protected def F: MonadCancel[F, E] = cancel
+          override implicit protected def L: Monoid[L] = L0
+        }
+    }
 
   trait Uncancelable[F[_], E] { this: MonadCancel[F, E] =>
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -565,7 +565,7 @@ object MonadCancel {
   implicit def monadCancelForStateT[F[_], S, E](
       implicit F0: MonadCancel[F, E]): MonadCancel[StateT[F, S, *], E] = F0 match {
     case sync: Sync[F @unchecked] =>
-      Sync.instantiateSyncForStateT[F, S](sync)
+      Sync.syncForStateT[F, S](sync)
     case cancel =>
       new StateTMonadCancel[F, S, E] {
         def rootCancelScope = F0.rootCancelScope
@@ -577,7 +577,7 @@ object MonadCancel {
       implicit F0: MonadCancel[F, E],
       L0: Monoid[L]): MonadCancel[ReaderWriterStateT[F, E0, L, S, *], E] = F0 match {
     case sync: Sync[F @unchecked] =>
-      Sync.instantiateSyncForReaderWriterStateT[F, E0, L, S](sync)
+      Sync.syncForReaderWriterStateT[F, E0, L, S](sync, L0)
     case cancel =>
       new ReaderWriterStateTMonadCancel[F, E0, L, S, E] {
         def rootCancelScope = F0.rootCancelScope

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -464,75 +464,127 @@ object MonadCancel {
   def apply[F[_]](implicit F: MonadCancel[F, _], d: DummyImplicit): F.type = F
 
   implicit def monadCancelForOptionT[F[_], E](
-      implicit F0: MonadCancel[F, E]): MonadCancel[OptionT[F, *], E] =
-    new OptionTMonadCancel[F, E] {
-
-      def rootCancelScope = F0.rootCancelScope
-
-      override implicit protected def F: MonadCancel[F, E] = F0
-    }
+      implicit F0: MonadCancel[F, E]): MonadCancel[OptionT[F, *], E] = F0 match {
+    case async: Async[F @unchecked] =>
+      Async.asyncForOptionT[F](async)
+    case sync: Sync[F @unchecked] =>
+      Sync.syncForOptionT[F](sync)
+    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+      GenTemporal.genTemporalForOptionT[F, E](temporal)
+    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+      GenConcurrent.genConcurrentForOptionT[F, E](concurrent)
+    case spawn: GenSpawn[F @unchecked, E @unchecked] =>
+      GenSpawn.genSpawnForOptionT[F, E](spawn)
+    case cancel =>
+      new OptionTMonadCancel[F, E] {
+        def rootCancelScope = F0.rootCancelScope
+        override implicit protected def F: MonadCancel[F, E] = cancel
+      }
+  }
 
   implicit def monadCancelForEitherT[F[_], E0, E](
-      implicit F0: MonadCancel[F, E]): MonadCancel[EitherT[F, E0, *], E] =
-    new EitherTMonadCancel[F, E0, E] {
-
-      def rootCancelScope = F0.rootCancelScope
-
-      override implicit protected def F: MonadCancel[F, E] = F0
-    }
+      implicit F0: MonadCancel[F, E]): MonadCancel[EitherT[F, E0, *], E] = F0 match {
+    case async: Async[F @unchecked] =>
+      Async.asyncForEitherT[F, E0](async)
+    case sync: Sync[F @unchecked] =>
+      Sync.syncForEitherT[F, E0](sync)
+    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+      GenTemporal.genTemporalForEitherT[F, E0, E](temporal)
+    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+      GenConcurrent.genConcurrentForEitherT[F, E0, E](concurrent)
+    case spawn: GenSpawn[F @unchecked, E @unchecked] =>
+      GenSpawn.genSpawnForEitherT[F, E0, E](spawn)
+    case cancel =>
+      new EitherTMonadCancel[F, E0, E] {
+        def rootCancelScope = F0.rootCancelScope
+        override implicit protected def F: MonadCancel[F, E] = cancel
+      }
+  }
 
   implicit def monadCancelForKleisli[F[_], R, E](
-      implicit F0: MonadCancel[F, E]): MonadCancel[Kleisli[F, R, *], E] =
-    new KleisliMonadCancel[F, R, E] {
-
-      def rootCancelScope = F0.rootCancelScope
-
-      override implicit protected def F: MonadCancel[F, E] = F0
-    }
+      implicit F0: MonadCancel[F, E]): MonadCancel[Kleisli[F, R, *], E] = F0 match {
+    case async: Async[F @unchecked] =>
+      Async.asyncForKleisli[F, R](async)
+    case sync: Sync[F @unchecked] =>
+      Sync.syncForKleisli[F, R](sync)
+    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+      GenTemporal.genTemporalForKleisli[F, R, E](temporal)
+    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+      GenConcurrent.genConcurrentForKleisli[F, R, E](concurrent)
+    case spawn: GenSpawn[F @unchecked, E @unchecked] =>
+      GenSpawn.genSpawnForKleisli[F, R, E](spawn)
+    case cancel =>
+      new KleisliMonadCancel[F, R, E] {
+        def rootCancelScope = F0.rootCancelScope
+        override implicit protected def F: MonadCancel[F, E] = cancel
+      }
+  }
 
   implicit def monadCancelForIorT[F[_], L, E](
       implicit F0: MonadCancel[F, E],
-      L0: Semigroup[L]): MonadCancel[IorT[F, L, *], E] =
-    new IorTMonadCancel[F, L, E] {
-
-      def rootCancelScope = F0.rootCancelScope
-
-      override implicit protected def F: MonadCancel[F, E] = F0
-
-      override implicit protected def L: Semigroup[L] = L0
-    }
+      L0: Semigroup[L]): MonadCancel[IorT[F, L, *], E] = F0 match {
+    case async: Async[F @unchecked] =>
+      Async.asyncForIorT[F, L](async, L0)
+    case sync: Sync[F @unchecked] =>
+      Sync.syncForIorT[F, L](sync, L0)
+    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+      GenTemporal.genTemporalForIorT[F, L, E](temporal, L0)
+    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+      GenConcurrent.genConcurrentForIorT[F, L, E](concurrent, L0)
+    case spawn: GenSpawn[F @unchecked, E @unchecked] =>
+      GenSpawn.genSpawnForIorT[F, L, E](spawn, L0)
+    case cancel =>
+      new IorTMonadCancel[F, L, E] {
+        def rootCancelScope = F0.rootCancelScope
+        override implicit protected def F: MonadCancel[F, E] = cancel
+        override implicit protected def L: Semigroup[L] = L0
+      }
+  }
 
   implicit def monadCancelForWriterT[F[_], L, E](
       implicit F0: MonadCancel[F, E],
-      L0: Monoid[L]): MonadCancel[WriterT[F, L, *], E] =
-    new WriterTMonadCancel[F, L, E] {
-
-      def rootCancelScope = F0.rootCancelScope
-
-      override implicit protected def F: MonadCancel[F, E] = F0
-
-      override implicit protected def L: Monoid[L] = L0
-    }
+      L0: Monoid[L]): MonadCancel[WriterT[F, L, *], E] = F0 match {
+    case async: Async[F @unchecked] =>
+      Async.asyncForWriterT[F, L](async, L0)
+    case sync: Sync[F @unchecked] =>
+      Sync.syncForWriterT[F, L](sync, L0)
+    case temporal: GenTemporal[F @unchecked, E @unchecked] =>
+      GenTemporal.genTemporalForWriterT[F, L, E](temporal, L0)
+    case concurrent: GenConcurrent[F @unchecked, E @unchecked] =>
+      GenConcurrent.genConcurrentForWriterT[F, L, E](concurrent, L0)
+    case spawn: GenSpawn[F @unchecked, E @unchecked] =>
+      GenSpawn.genSpawnForWriterT[F, L, E](spawn, L0)
+    case cancel =>
+      new WriterTMonadCancel[F, L, E] {
+        def rootCancelScope = F0.rootCancelScope
+        override implicit protected def F: MonadCancel[F, E] = cancel
+        override implicit protected def L: Monoid[L] = L0
+      }
+  }
 
   implicit def monadCancelForStateT[F[_], S, E](
-      implicit F0: MonadCancel[F, E]): MonadCancel[StateT[F, S, *], E] =
-    new StateTMonadCancel[F, S, E] {
-
-      def rootCancelScope = F0.rootCancelScope
-
-      override implicit protected def F = F0
-    }
+      implicit F0: MonadCancel[F, E]): MonadCancel[StateT[F, S, *], E] = F0 match {
+    case sync: Sync[F @unchecked] =>
+      Sync.syncForStateT[F, S](sync)
+    case cancel =>
+      new StateTMonadCancel[F, S, E] {
+        def rootCancelScope = F0.rootCancelScope
+        override implicit protected def F: MonadCancel[F, E] = cancel
+      }
+  }
 
   implicit def monadCancelForReaderWriterStateT[F[_], E0, L, S, E](
       implicit F0: MonadCancel[F, E],
-      L0: Monoid[L]): MonadCancel[ReaderWriterStateT[F, E0, L, S, *], E] =
-    new ReaderWriterStateTMonadCancel[F, E0, L, S, E] {
-
-      def rootCancelScope = F0.rootCancelScope
-
-      override implicit protected def F = F0
-      override implicit protected def L = L0
-    }
+      L0: Monoid[L]): MonadCancel[ReaderWriterStateT[F, E0, L, S, *], E] = F0 match {
+    case sync: Sync[F @unchecked] =>
+      Sync.syncForReaderWriterStateT[F, E0, L, S](sync, L0)
+    case cancel =>
+      new ReaderWriterStateTMonadCancel[F, E0, L, S, E] {
+        def rootCancelScope = F0.rootCancelScope
+        override implicit protected def F: MonadCancel[F, E] = cancel
+        override implicit protected def L: Monoid[L] = L0
+      }
+  }
 
   trait Uncancelable[F[_], E] { this: MonadCancel[F, E] =>
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
@@ -110,17 +110,18 @@ object Sync {
 
   def apply[F[_]](implicit F: Sync[F]): F.type = F
 
-  implicit def syncForOptionT[F[_]](implicit F0: Sync[F]): Sync[OptionT[F, *]] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForOptionT[F](async)
-    case sync =>
-      instantiateSyncForOptionT(sync)
-  }
+  implicit def syncForOptionT[F[_]](implicit F0: Sync[F]): Sync[OptionT[F, *]] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForOptionT[F](async)
+      case sync =>
+        instantiateSyncForOptionT(sync)
+    }
 
-  private[kernel] def instantiateSyncForOptionT[F[_]](sync: Sync[F]): OptionTSync[F] =
+  private[kernel] def instantiateSyncForOptionT[F[_]](F0: Sync[F]): OptionTSync[F] =
     new OptionTSync[F] {
-      def rootCancelScope = sync.rootCancelScope
-      implicit protected def F: Sync[F] = sync
+      def rootCancelScope = F0.rootCancelScope
+      implicit protected def F: Sync[F] = F0
     }
 
   implicit def syncForEitherT[F[_], E](implicit F0: Sync[F]): Sync[EitherT[F, E, *]] =
@@ -131,10 +132,10 @@ object Sync {
         instantiateSyncForEitherT(sync)
     }
 
-  private[kernel] def instantiateSyncForEitherT[F[_], E](sync: Sync[F]): EitherTSync[F, E] =
+  private[kernel] def instantiateSyncForEitherT[F[_], E](F0: Sync[F]): EitherTSync[F, E] =
     new EitherTSync[F, E] {
-      def rootCancelScope = sync.rootCancelScope
-      implicit protected def F: Sync[F] = sync
+      def rootCancelScope = F0.rootCancelScope
+      implicit protected def F: Sync[F] = F0
     }
 
   implicit def syncForStateT[F[_], S](implicit F0: Sync[F]): Sync[StateT[F, S, *]] =
@@ -145,35 +146,37 @@ object Sync {
 
   implicit def syncForWriterT[F[_], L](
       implicit F0: Sync[F],
-      L0: Monoid[L]): Sync[WriterT[F, L, *]] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForWriterT[F, L](async, L0)
-    case sync =>
-      instantiateSyncForWriterT(sync)
-  }
+      L0: Monoid[L]): Sync[WriterT[F, L, *]] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForWriterT[F, L](async, L0)
+      case sync =>
+        instantiateSyncForWriterT(sync)
+    }
 
-  private[kernel] def instantiateSyncForWriterT[F[_], L](sync: Sync[F])(
+  private[kernel] def instantiateSyncForWriterT[F[_], L](F0: Sync[F])(
       implicit L0: Monoid[L]): WriterTSync[F, L] =
     new WriterTSync[F, L] {
-      def rootCancelScope = sync.rootCancelScope
-      implicit protected def F: Sync[F] = sync
+      def rootCancelScope = F0.rootCancelScope
+      implicit protected def F: Sync[F] = F0
       implicit def L: Monoid[L] = L0
     }
 
   implicit def syncForIorT[F[_], L](
       implicit F0: Sync[F],
-      L0: Semigroup[L]): Sync[IorT[F, L, *]] = F0 match {
-    case async: Async[F @unchecked] =>
-      Async.asyncForIorT[F, L](async, L0)
-    case sync =>
-      instantiateSyncForIorT(sync)
-  }
+      L0: Semigroup[L]): Sync[IorT[F, L, *]] =
+    F0 match {
+      case async: Async[F @unchecked] =>
+        Async.asyncForIorT[F, L](async, L0)
+      case sync =>
+        instantiateSyncForIorT(sync)
+    }
 
-  private[kernel] def instantiateSyncForIorT[F[_], L](sync: Sync[F])(
+  private[kernel] def instantiateSyncForIorT[F[_], L](F0: Sync[F])(
       implicit L0: Semigroup[L]): IorTSync[F, L] =
     new IorTSync[F, L] {
-      def rootCancelScope = sync.rootCancelScope
-      implicit protected def F: Sync[F] = sync
+      def rootCancelScope = F0.rootCancelScope
+      implicit protected def F: Sync[F] = F0
       implicit def L: Semigroup[L] = L0
     }
 
@@ -185,10 +188,10 @@ object Sync {
         instantiateSyncForKleisli(sync)
     }
 
-  private[kernel] def instantiateSyncForKleisli[F[_], R](sync: Sync[F]): KleisliSync[F, R] =
+  private[kernel] def instantiateSyncForKleisli[F[_], R](F0: Sync[F]): KleisliSync[F, R] =
     new KleisliSync[F, R] {
-      def rootCancelScope = sync.rootCancelScope
-      implicit protected def F: Sync[F] = sync
+      def rootCancelScope = F0.rootCancelScope
+      implicit protected def F: Sync[F] = F0
     }
 
   implicit def syncForReaderWriterStateT[F[_], R, L, S](

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
@@ -138,12 +138,9 @@ object Sync {
     }
 
   implicit def syncForStateT[F[_], S](implicit F0: Sync[F]): Sync[StateT[F, S, *]] =
-    instantiateSyncForStateT(F0)
-
-  private[kernel] def instantiateSyncForStateT[F[_], S](sync: Sync[F]): StateTSync[F, S] =
     new StateTSync[F, S] {
-      def rootCancelScope = sync.rootCancelScope
-      implicit protected def F: Sync[F] = sync
+      def rootCancelScope = F0.rootCancelScope
+      implicit protected def F: Sync[F] = F0
     }
 
   implicit def syncForWriterT[F[_], L](
@@ -197,10 +194,6 @@ object Sync {
   implicit def syncForReaderWriterStateT[F[_], R, L, S](
       implicit F0: Sync[F],
       L0: Monoid[L]): Sync[ReaderWriterStateT[F, R, L, S, *]] =
-    instantiateSyncForReaderWriterStateT(F0)
-
-  private[kernel] def instantiateSyncForReaderWriterStateT[F[_], R, L, S](F0: Sync[F])(
-      implicit L0: Monoid[L]): ReaderWriterStateTSync[F, R, L, S] =
     new ReaderWriterStateTSync[F, R, L, S] {
       def rootCancelScope = F0.rootCancelScope
       implicit override def F: Sync[F] = F0

--- a/tests/shared/src/test/scala/cats/effect/kernel/DerivationRefinementSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/DerivationRefinementSpec.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.kernel
+
+import cats.data._
+import cats.effect.{BaseSpec, IO, SyncIO}
+import org.specs2.matcher.Matchers
+
+import scala.reflect.ClassTag
+
+class DerivationRefinementSpec extends BaseSpec with Matchers {
+
+  type AsyncStack[F[_], A] = Kleisli[OptionT[EitherT[IorT[F, Int, *], String, *], *], Unit, A]
+  type SyncStack[F[_], A] = StateT[ReaderWriterStateT[F, String, Int, Unit, *], Boolean, A]
+
+  "refined derived type class instances" >> {
+
+    "returns Async for OptionT at runtime if possible" in {
+      check[IO, OptionT, Sync, Async]
+      check[IO, OptionT, Temporal, Async]
+      check[IO, OptionT, Concurrent, Async]
+      check[IO, OptionT, Spawn, Async]
+      check[IO, OptionT, MonadCancelThrow, Async]
+    }
+
+    "returns Async for EitherT at runtime if possible" in {
+      type EitherTString[F[_], A] = EitherT[F, String, A]
+      check[IO, EitherTString, Sync, Async]
+      check[IO, EitherTString, Temporal, Async]
+      check[IO, EitherTString, Concurrent, Async]
+      check[IO, EitherTString, Spawn, Async]
+      check[IO, EitherTString, MonadCancelThrow, Async]
+    }
+
+    "returns Async for Kleisli at runtime if possible" in {
+      type StringKleisli[F[_], A] = Kleisli[F, String, A]
+      check[IO, StringKleisli, Sync, Async]
+      check[IO, StringKleisli, Temporal, Async]
+      check[IO, StringKleisli, Concurrent, Async]
+      check[IO, StringKleisli, Spawn, Async]
+      check[IO, StringKleisli, MonadCancelThrow, Async]
+    }
+
+    "returns Async for IorT at runtime if possible" in {
+      type StringIorT[F[_], A] = IorT[F, String, A]
+      check[IO, StringIorT, Sync, Async]
+      check[IO, StringIorT, Temporal, Async]
+      check[IO, StringIorT, Concurrent, Async]
+      check[IO, StringIorT, Spawn, Async]
+      check[IO, StringIorT, MonadCancelThrow, Async]
+    }
+
+    "returns Async for WriterT at runtime if possible" in {
+      type StringWriterT[F[_], A] = WriterT[F, String, A]
+      check[IO, StringWriterT, Sync, Async]
+      check[IO, StringWriterT, Temporal, Async]
+      check[IO, StringWriterT, Concurrent, Async]
+      check[IO, StringWriterT, Spawn, Async]
+      check[IO, StringWriterT, MonadCancelThrow, Async]
+    }
+
+    "returns Sync for StateT at runtime if possible" in {
+      type StringStateT[F[_], A] = StateT[F, String, A]
+      check[IO, StringStateT, MonadCancelThrow, Sync]
+      check[SyncIO, StringStateT, MonadCancelThrow, Sync]
+    }
+
+    "returns Sync for ReaderWriterStateT at runtime if possible" in {
+      type TestRWST[F[_], A] = ReaderWriterStateT[F, String, Int, Unit, A]
+      check[IO, TestRWST, MonadCancelThrow, Sync]
+      check[SyncIO, TestRWST, MonadCancelThrow, Sync]
+    }
+
+    "returns Async for stacked transformers at runtime if possible" in {
+      check[IO, AsyncStack, Sync, Async]
+      check[IO, AsyncStack, Temporal, Async]
+      check[IO, AsyncStack, Concurrent, Async]
+      check[IO, AsyncStack, Spawn, Async]
+      check[IO, AsyncStack, MonadCancelThrow, Async]
+    }
+
+    "returns Sync for stacked transformers at runtime if possible" in {
+      check[IO, SyncStack, MonadCancelThrow, Sync]
+      check[SyncIO, SyncStack, MonadCancelThrow, Sync]
+      check[SyncIO, AsyncStack, MonadCancelThrow, Sync]
+    }
+  }
+
+  // read as: for base effect F, ensure the T instance for monad transformer M is actually of its subtype R
+  def check[F[_], M[_[_], *], T[a[_]] <: MonadCancel[a, Throwable], R[a[_]] <: T[a]](
+      implicit T: T[M[F, *]],
+      ct: ClassTag[R[F]]) =
+    T must beAnInstanceOf[R[F]]
+
+}

--- a/tests/shared/src/test/scala/cats/effect/kernel/DerivationRefinementSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/DerivationRefinementSpec.scala
@@ -18,6 +18,7 @@ package cats.effect.kernel
 
 import cats.data._
 import cats.effect.{BaseSpec, IO, SyncIO}
+
 import org.specs2.matcher.Matchers
 
 import scala.reflect.ClassTag


### PR DESCRIPTION
When deriving type class instances for monad transformers, pattern match at runtime to find out the strongest type class instance that can be derived and return this one instead.

Open questions: 
1. Do `Clock` and `Unique` need the same treatment? Currently they don't get it (why would you want an `Async` if you ask for `Clock` other than general consistency?). `Unique` doesn't even define instances for monad transformers directly. But I might overlook valid use cases.
2. When pattern matching (let's say for `OptionT` in `GenSpawn`), a naive version would call `GenTemporal.genTemporalForOptionT` if it detects a runtime type of `GenTemporal`. But as `GenTemporal.genTemporalForOptionT` itself also pattern matches to see whether it's actually an `Async`, there'd be two pattern matches happening before the actual instance is created. To avoid this, this PR introduces methods like `GenTemporal.instantiateGenTemporalForOptionT` that don't pattern match, but directly instantiate. So the derivation in `GenSpawn` that pattern matched already can use this to avoid the second pattern match from happening (this duplication would happen for every transformer in a stack, so it's a bigger problem with huge stacks). So one method call is added – is that a performance problem? One could easily inline all the `instantiateXYZ` methods, but that leads to code duplication and (if I'm not mistaken) to more anonymous classes being created. Opinions on what's the better tradeoff here?

Closes #2772