### PR TITLE
Introduce `GenDeferred`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -299,6 +299,16 @@ lazy val kernel = crossProject(JSPlatform, JVMPlatform)
   .jsSettings(
     libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % MacrotaskExecutorVersion % Test
   )
+  .settings(
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.kernel.Deferred$State"),
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.kernel.Deferred$State$"),
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.kernel.Deferred$State$Set"),
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.kernel.Deferred$State$Set$"),
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.kernel.Deferred$State$Unset"),
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.kernel.Deferred$State$Unset$")
+    )
+  )
 
 /**
  * Reference implementations (including a pure ConcurrentBracket), generic ScalaCheck


### PR DESCRIPTION
This PR introduces `GenDeferred` as a generalization of `Deferred`:

```scala
trait GenDeferred[F[_], G[_], A] extends DeferredSource[F, A] with DeferredSink[G, A]
```

Conceptually, this enables two independent effect systems to communicate/synchronize via a shared data structure.

In practice, there are often situations where it is useful to instantiate a `GenDeferred` where `F` is any `Async` type and `G` is `SyncIO` when interopping with unsafe code. This makes it possible to complete the deferred "in-place" via `SyncIO#unsafeRunSync` without requiring a `Dispatcher` and avoiding a thread-shift to the compute pool to run this trivial operation.

I would like to follow-up with a similar `GenQueue[F, G, A]` such that an unbounded queue can be implemented for `Async[F]` and `Sync[G]`.

Example use-cases include fs2-grpc (cc @ahjohannessen) and fs2-io.js which both rely heavily on `Deferred` and `Queue` to interop with unsafe code.

Credit to @ChristopherDavenport for first exploring this idea in https://github.com/davenverse/condemned.