### PR TITLE
Support shutting down multiple runtimes

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/WorkStealingBenchmark.scala
@@ -175,7 +175,7 @@ class WorkStealingBenchmark {
       (Scheduler.fromScheduledExecutor(executor), () => executor.shutdown())
     }
 
-    val compute = new WorkStealingThreadPool(256, "io-compute", manyThreadsRuntime)
+    val compute = new WorkStealingThreadPool(256, "io-compute")
 
     val cancelationCheckThreshold =
       System.getProperty("cats.effect.cancelation.check.threshold", "512").toInt

--- a/build.sbt
+++ b/build.sbt
@@ -468,7 +468,23 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
           ProblemFilters.exclude[DirectMissingMethodProblem](
             "cats.effect.unsafe.WorkStealingThreadPool.localQueuesForwarder"),
           ProblemFilters.exclude[DirectMissingMethodProblem](
-            "cats.effect.unsafe.WorkerThread.NullData")
+            "cats.effect.unsafe.WorkerThread.NullData"),
+          // introduced by #2811, Support shutting down multiple runtimes
+          // changes to `cats.effect.unsafe` package private code
+          ProblemFilters.exclude[IncompatibleMethTypeProblem](
+            "cats.effect.unsafe.ThreadSafeHashtable.put"),
+          ProblemFilters.exclude[DirectMissingMethodProblem](
+            "cats.effect.unsafe.IORuntime.apply"),
+          ProblemFilters.exclude[DirectMissingMethodProblem](
+            "cats.effect.unsafe.IORuntimeCompanionPlatform.apply"),
+          ProblemFilters.exclude[IncompatibleMethTypeProblem](
+            "cats.effect.unsafe.ThreadSafeHashtable.remove"),
+          ProblemFilters.exclude[IncompatibleResultTypeProblem](
+            "cats.effect.unsafe.ThreadSafeHashtable.unsafeHashtable"),
+          ProblemFilters.exclude[IncompatibleResultTypeProblem](
+            "cats.effect.unsafe.ThreadSafeHashtable.Tombstone"),
+          ProblemFilters.exclude[DirectMissingMethodProblem](
+            "cats.effect.unsafe.WorkStealingThreadPool.this")
         )
       } else Seq()
     }

--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -61,4 +61,9 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
 
     _global
   }
+
+  private[effect] def registerFiberMonitorMBean(fiberMonitor: FiberMonitor): () => Unit = {
+    val _ = fiberMonitor
+    () => ()
+  }
 }

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -17,7 +17,6 @@
 package cats.effect
 
 import cats.effect.tracing.TracingConstants._
-import cats.effect.unsafe.FiberMonitor
 
 import scala.concurrent.{blocking, CancellationException}
 import scala.util.control.NonFatal
@@ -217,13 +216,10 @@ trait IOApp {
         val (scheduler, schedDown) =
           IORuntime.createDefaultScheduler()
 
-        val fiberMonitor = FiberMonitor(compute)
-
         IORuntime(
           compute,
           blocking,
           scheduler,
-          fiberMonitor,
           { () =>
             compDown()
             blockDown()

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -208,7 +208,7 @@ trait IOApp {
 
       val installed = IORuntime installGlobal {
         val (compute, compDown) =
-          IORuntime.createDefaultComputeThreadPool(threads = computeWorkerThreadCount)
+          IORuntime.createWorkStealingComputeThreadPool(threads = computeWorkerThreadCount)
 
         val (blocking, blockDown) =
           IORuntime.createDefaultBlockingExecutionContext()

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -219,15 +219,12 @@ trait IOApp {
 
         val fiberMonitor = FiberMonitor(compute)
 
-        val unregisterFiberMonitorMBean = IORuntime.registerFiberMonitorMBean(fiberMonitor)
-
         IORuntime(
           compute,
           blocking,
           scheduler,
           fiberMonitor,
           { () =>
-            unregisterFiberMonitorMBean()
             compDown()
             blockDown()
             schedDown()

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -208,7 +208,7 @@ trait IOApp {
 
       val installed = IORuntime installGlobal {
         val (compute, compDown) =
-          IORuntime.createDefaultComputeThreadPool(runtime, threads = computeWorkerThreadCount)
+          IORuntime.createDefaultComputeThreadPool(threads = computeWorkerThreadCount)
 
         val (blocking, blockDown) =
           IORuntime.createDefaultBlockingExecutionContext()

--- a/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -43,7 +43,7 @@ import java.util.concurrent.ThreadLocalRandom
  *      contention between threads. A particular instance is selected using a thread local
  *      source of randomness using an instance of `java.util.concurrent.ThreadLocalRandom`.
  */
-private[effect] final class FiberMonitor(
+private[effect] sealed class FiberMonitor(
     // A reference to the compute pool of the `IORuntime` in which this suspended fiber bag
     // operates. `null` if the compute pool of the `IORuntime` is not a `WorkStealingThreadPool`.
     private[this] val compute: WorkStealingThreadPool
@@ -161,6 +161,12 @@ private[effect] final class FiberMonitor(
 
     foreign.toSet
   }
+}
+
+private[effect] final class NoOpFiberMonitor extends FiberMonitor(null) {
+  private final val noop: WeakBag.Handle = () => ()
+  override def monitorSuspended(fiber: IOFiber[_]): WeakBag.Handle = noop
+  override def liveFiberSnapshot(print: String => Unit): Unit = {}
 }
 
 private[effect] object FiberMonitor {

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
@@ -21,7 +21,7 @@ private[unsafe] abstract class IORuntimeBuilderPlatform { self: IORuntimeBuilder
   protected def platformSpecificBuild = {
     var runtime: IORuntime = null
     val (compute, computeShutdown) =
-      customCompute.getOrElse(IORuntime.createDefaultComputeThreadPool())
+      customCompute.getOrElse(IORuntime.createWorkStealingComputeThreadPool())
     val (blocking, blockingShutdown) =
       customBlocking.getOrElse(IORuntime.createDefaultBlockingExecutionContext())
     val (scheduler, schedulerShutdown) =

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeBuilderPlatform.scala
@@ -21,7 +21,7 @@ private[unsafe] abstract class IORuntimeBuilderPlatform { self: IORuntimeBuilder
   protected def platformSpecificBuild = {
     var runtime: IORuntime = null
     val (compute, computeShutdown) =
-      customCompute.getOrElse(IORuntime.createDefaultComputeThreadPool(runtime))
+      customCompute.getOrElse(IORuntime.createDefaultComputeThreadPool())
     val (blocking, blockingShutdown) =
       customBlocking.getOrElse(IORuntime.createDefaultBlockingExecutionContext())
     val (scheduler, schedulerShutdown) =

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -32,7 +32,7 @@ import javax.management.ObjectName
 private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type =>
 
   // The default compute thread pool on the JVM is now a work stealing thread pool.
-  def createDefaultComputeThreadPool(
+  def createWorkStealingComputeThreadPool(
       threads: Int = Math.max(2, Runtime.getRuntime().availableProcessors()),
       threadPrefix: String = "io-compute"): (WorkStealingThreadPool, () => Unit) = {
     val threadPool =
@@ -106,9 +106,9 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
   @nowarn("cat=unused-params")
   private[unsafe] def createDefaultComputeThreadPool(
       self: => IORuntime,
-      threads: Int,
-      threadPrefix: String): (WorkStealingThreadPool, () => Unit) =
-    createDefaultComputeThreadPool(threads, threadPrefix)
+      threads: Int = Math.max(2, Runtime.getRuntime().availableProcessors()),
+      threadPrefix: String = "io-compute"): (WorkStealingThreadPool, () => Unit) =
+    createWorkStealingComputeThreadPool(threads, threadPrefix)
 
   def createDefaultBlockingExecutionContext(
       threadPrefix: String = "io-blocking"): (ExecutionContext, () => Unit) = {
@@ -155,7 +155,7 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
   lazy val global: IORuntime = {
     if (_global == null) {
       installGlobal {
-        val (compute, _) = createDefaultComputeThreadPool()
+        val (compute, _) = createWorkStealingComputeThreadPool()
         val (blocking, _) = createDefaultBlockingExecutionContext()
         val (scheduler, _) = createDefaultScheduler()
         IORuntime(compute, blocking, scheduler, () => (), IORuntimeConfig())

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -158,15 +158,6 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
     _global
   }
 
-  private[effect] def apply(
-      compute: ExecutionContext,
-      blocking: ExecutionContext,
-      scheduler: Scheduler,
-      fiberMonitor: FiberMonitor,
-      shutdown: () => Unit,
-      config: IORuntimeConfig): IORuntime =
-    new IORuntime(compute, blocking, scheduler, fiberMonitor, shutdown, config)
-
   private[effect] def registerFiberMonitorMBean(fiberMonitor: FiberMonitor): () => Unit = {
     if (isStackTracing) {
       val mBeanServer =

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -19,7 +19,6 @@ package cats.effect.unsafe
 import cats.effect.tracing.TracingConstants._
 import cats.effect.unsafe.metrics._
 
-import scala.annotation.nowarn
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 
@@ -103,8 +102,11 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
       })
   }
 
-  @nowarn("cat=unused-params")
-  private[unsafe] def createDefaultComputeThreadPool(
+  @deprecated(
+    message = "Replaced by the simpler and safer `createWorkStealingComputePool`",
+    since = "3.4.0"
+  )
+  def createDefaultComputeThreadPool(
       self: => IORuntime,
       threads: Int = Math.max(2, Runtime.getRuntime().availableProcessors()),
       threadPrefix: String = "io-compute"): (WorkStealingThreadPool, () => Unit) =

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -151,9 +151,6 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
         val (compute, _) = createDefaultComputeThreadPool(global)
         val (blocking, _) = createDefaultBlockingExecutionContext()
         val (scheduler, _) = createDefaultScheduler()
-        val fiberMonitor = FiberMonitor(compute)
-        registerFiberMonitorMBean(fiberMonitor)
-
         IORuntime(compute, blocking, scheduler, () => (), IORuntimeConfig())
       }
     }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -57,18 +57,11 @@ import java.util.concurrent.locks.LockSupport
  */
 private[effect] final class WorkStealingThreadPool(
     threadCount: Int, // number of worker threads
-    private[unsafe] val threadPrefix: String, // prefix for the name of worker threads
-    self0: => IORuntime
+    private[unsafe] val threadPrefix: String // prefix for the name of worker threads
 ) extends ExecutionContext {
 
   import TracingConstants._
   import WorkStealingThreadPoolConstants._
-
-  /**
-   * A forward reference to the [[cats.effect.unsafe.IORuntime]] of which this thread pool is a
-   * part. Used for starting fibers in [[WorkStealingThreadPool#execute]].
-   */
-  private[this] lazy val self: IORuntime = self0
 
   /**
    * References to worker threads and their local queues.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -518,7 +518,7 @@ private[effect] final class WorkStealingThreadPool(
       scheduleFiber(fiber)
     } else {
       // Executing a general purpose computation on the thread pool.
-      val fiber = new IOFiber[Unit](runnable, this, self)
+      val fiber = new IOFiber[Unit](runnable, this)
       scheduleFiber(fiber)
     }
   }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -97,7 +97,7 @@ private final class IOFiber[A] private (
     runtime
   )
 
-  def this(runnable: Runnable, startEC: ExecutionContext, runtime: IORuntime) = this(
+  def this(runnable: Runnable, startEC: ExecutionContext) = this(
     null,
     null,
     startEC,
@@ -106,7 +106,7 @@ private final class IOFiber[A] private (
     IOFiberConstants.ExecuteRunnableR,
     runnable,
     null,
-    runtime)
+    null)
 
   import IO._
   import IOFiberConstants._

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1502,8 +1502,9 @@ private final class IOFiber[A] private (
         val len = hashtable.length
         var i = 0
         while (i < len) {
-          val cb = hashtable(i)
-          if (cb ne null) {
+          val ref = hashtable(i)
+          if (ref.isInstanceOf[_ => _]) {
+            val cb = ref.asInstanceOf[Throwable => Unit]
             cb(t)
           }
           i += 1

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -65,4 +65,7 @@ object IORuntime extends IORuntimeCompanionPlatform {
 
   def builder(): IORuntimeBuilder =
     IORuntimeBuilder()
+
+  private[effect] def testRuntime(ec: ExecutionContext, scheduler: Scheduler): IORuntime =
+    new IORuntime(ec, ec, scheduler, new NoOpFiberMonitor(), () => (), IORuntimeConfig())
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -68,7 +68,10 @@ object IORuntime extends IORuntimeCompanionPlatform {
       shutdown()
     }
 
-    new IORuntime(compute, blocking, scheduler, fiberMonitor, unregisterAndShutdown, config)
+    val runtime =
+      new IORuntime(compute, blocking, scheduler, fiberMonitor, unregisterAndShutdown, config)
+    allRuntimes.put(runtime, runtime.hashCode())
+    runtime
   }
 
   def builder(): IORuntimeBuilder =
@@ -76,4 +79,7 @@ object IORuntime extends IORuntimeCompanionPlatform {
 
   private[effect] def testRuntime(ec: ExecutionContext, scheduler: Scheduler): IORuntime =
     new IORuntime(ec, ec, scheduler, new NoOpFiberMonitor(), () => (), IORuntimeConfig())
+
+  private[effect] final val allRuntimes: ThreadSafeHashtable[IORuntime] =
+    new ThreadSafeHashtable(4)
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -60,8 +60,16 @@ object IORuntime extends IORuntimeCompanionPlatform {
       blocking: ExecutionContext,
       scheduler: Scheduler,
       shutdown: () => Unit,
-      config: IORuntimeConfig): IORuntime =
-    new IORuntime(compute, blocking, scheduler, FiberMonitor(compute), shutdown, config)
+      config: IORuntimeConfig): IORuntime = {
+    val fiberMonitor = FiberMonitor(compute)
+    val unregister = registerFiberMonitorMBean(fiberMonitor)
+    val unregisterAndShutdown = () => {
+      unregister()
+      shutdown()
+    }
+
+    new IORuntime(compute, blocking, scheduler, fiberMonitor, unregisterAndShutdown, config)
+  }
 
   def builder(): IORuntimeBuilder =
     IORuntimeBuilder()

--- a/core/shared/src/main/scala/cats/effect/unsafe/StripedHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/StripedHashtable.scala
@@ -30,8 +30,8 @@ private[effect] final class StripedHashtable {
 
   private[this] def initialCapacity: Int = 8
 
-  val tables: Array[ThreadSafeHashtable] = {
-    val array = new Array[ThreadSafeHashtable](numTables)
+  val tables: Array[ThreadSafeHashtable[Throwable => Unit]] = {
+    val array = new Array[ThreadSafeHashtable[Throwable => Unit]](numTables)
     var i = 0
     while (i < numTables) {
       array(i) = new ThreadSafeHashtable(initialCapacity)

--- a/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/ThreadSafeHashtable.scala
@@ -29,21 +29,22 @@ package unsafe
  * @param initialCapacity
  *   the initial capacity of the hashtable, ''must'' be a power of 2
  */
-private[effect] final class ThreadSafeHashtable(private[this] val initialCapacity: Int) {
-  private[this] var hashtable: Array[Throwable => Unit] = new Array(initialCapacity)
+private[effect] final class ThreadSafeHashtable[A <: AnyRef](
+    private[this] val initialCapacity: Int) {
+  private[this] var hashtable: Array[AnyRef] = new Array(initialCapacity)
   private[this] var size: Int = 0
   private[this] var mask: Int = initialCapacity - 1
   private[this] var capacity: Int = initialCapacity
   private[this] val log2NumTables: Int = StripedHashtable.log2NumTables
-  private[this] val Tombstone: Throwable => Unit = ThreadSafeHashtable.Tombstone
+  private[this] val Tombstone: AnyRef = ThreadSafeHashtable.Tombstone
 
-  def put(cb: Throwable => Unit, hash: Int): Unit = this.synchronized {
+  def put(a: A, hash: Int): Unit = this.synchronized {
     val sz = size
     val cap = capacity
     if ((sz << 1) >= cap) { // the << 1 ensures that the load factor will remain between 0.25 and 0.5
       val newCap = cap << 1
       val newMask = newCap - 1
-      val newHashtable = new Array[Throwable => Unit](newCap)
+      val newHashtable = new Array[AnyRef](newCap)
 
       val table = hashtable
       var i = 0
@@ -62,7 +63,7 @@ private[effect] final class ThreadSafeHashtable(private[this] val initialCapacit
       capacity = newCap
     }
 
-    insert(hashtable, mask, cb, hash)
+    insert(hashtable, mask, a, hash)
     size = sz + 1
   }
 
@@ -70,11 +71,7 @@ private[effect] final class ThreadSafeHashtable(private[this] val initialCapacit
    * ''Must'' be called with the lock on the whole `ThreadSafeHashtable` object already held.
    * The `table` should contain at least one empty space to place the callback in.
    */
-  private[this] def insert(
-      table: Array[Throwable => Unit],
-      mask: Int,
-      cb: Throwable => Unit,
-      hash: Int): Unit = {
+  private[this] def insert(table: Array[AnyRef], mask: Int, a: AnyRef, hash: Int): Unit = {
     var idx = hash & mask
     var remaining = mask
 
@@ -83,7 +80,7 @@ private[effect] final class ThreadSafeHashtable(private[this] val initialCapacit
       if ((cur eq null) || (cur eq Tombstone)) {
         // Both null and `Tombstone` references are considered empty and new
         // references can be inserted in their place.
-        table(idx) = cb
+        table(idx) = a
         return
       } else {
         idx = (idx + 1) & mask
@@ -92,7 +89,7 @@ private[effect] final class ThreadSafeHashtable(private[this] val initialCapacit
     }
   }
 
-  def remove(cb: Throwable => Unit, hash: Int): Unit = this.synchronized {
+  def remove(a: A, hash: Int): Unit = this.synchronized {
     val msk = mask
     val init = hash & msk
     var idx = init
@@ -101,7 +98,7 @@ private[effect] final class ThreadSafeHashtable(private[this] val initialCapacit
 
     while (remaining >= 0) {
       val cur = table(idx)
-      if (cb eq cur) {
+      if (a eq cur) {
         // Mark the removed callback with the `Tombstone` reference.
         table(idx) = Tombstone
         size -= 1
@@ -113,7 +110,7 @@ private[effect] final class ThreadSafeHashtable(private[this] val initialCapacit
           // than 1/4 of the capacity
           val newCap = cap >>> 1
           val newMask = newCap - 1
-          val newHashtable = new Array[Throwable => Unit](newCap)
+          val newHashtable = new Array[AnyRef](newCap)
 
           val table = hashtable
           var i = 0
@@ -144,7 +141,7 @@ private[effect] final class ThreadSafeHashtable(private[this] val initialCapacit
     }
   }
 
-  def unsafeHashtable(): Array[Throwable => Unit] = hashtable
+  def unsafeHashtable(): Array[AnyRef] = hashtable
 
   /*
    * Only used in testing.
@@ -164,5 +161,5 @@ private object ThreadSafeHashtable {
    * Sentinel object for marking removed callbacks. Used to keep the linear probing chain
    * intact.
    */
-  private[ThreadSafeHashtable] final val Tombstone: Throwable => Unit = _ => ()
+  private[ThreadSafeHashtable] final val Tombstone: AnyRef = new AnyRef()
 }

--- a/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
@@ -222,10 +222,9 @@ trait TestInstances extends ParallelFGenerators with OutcomeGenerators with Sync
   implicit def materializeRuntime(implicit ticker: Ticker): unsafe.IORuntime =
     unsafe.IORuntime(ticker.ctx, ticker.ctx, scheduler, () => (), unsafe.IORuntimeConfig())
 
-  def scheduler(implicit ticker: Ticker): unsafe.Scheduler =
+  def scheduler(implicit ticker: Ticker): unsafe.Scheduler = {
+    val ctx = ticker.ctx
     new unsafe.Scheduler {
-      import ticker.ctx
-
       def sleep(delay: FiniteDuration, action: Runnable): Runnable = {
         val cancel = ctx.schedule(delay, action)
         new Runnable { def run() = cancel() }
@@ -234,6 +233,7 @@ trait TestInstances extends ParallelFGenerators with OutcomeGenerators with Sync
       def nowMillis() = ctx.now().toMillis
       def monotonicNanos() = ctx.now().toNanos
     }
+  }
 
   @implicitNotFound(
     "could not find an instance of Ticker; try using `in ticked { implicit ticker =>`")

--- a/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
@@ -187,8 +187,7 @@ trait TestInstances extends ParallelFGenerators with OutcomeGenerators with Sync
       ioa
         .flatMap(IO.pure(_))
         .handleErrorWith(IO.raiseError(_))
-        .unsafeRunAsyncOutcome { oc => results = oc.mapK(someK) }(unsafe
-          .IORuntime(ticker.ctx, ticker.ctx, scheduler, () => (), unsafe.IORuntimeConfig()))
+        .unsafeRunAsyncOutcome { oc => results = oc.mapK(someK) }(materializeRuntime)
 
       ticker.ctx.tickAll()
 

--- a/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
@@ -220,7 +220,7 @@ trait TestInstances extends ParallelFGenerators with OutcomeGenerators with Sync
   }
 
   implicit def materializeRuntime(implicit ticker: Ticker): unsafe.IORuntime =
-    unsafe.IORuntime(ticker.ctx, ticker.ctx, scheduler, () => (), unsafe.IORuntimeConfig())
+    unsafe.IORuntime.testRuntime(ticker.ctx, scheduler)
 
   def scheduler(implicit ticker: Ticker): unsafe.Scheduler = {
     val ctx = ticker.ctx

--- a/tests/jvm/src/test/scala/cats/effect/RunnersPlatform.scala
+++ b/tests/jvm/src/test/scala/cats/effect/RunnersPlatform.scala
@@ -33,9 +33,7 @@ trait RunnersPlatform extends BeforeAfterAll {
     val (scheduler, schedDown) =
       IORuntime.createDefaultScheduler(threadPrefix = s"io-scheduler-${getClass.getName}")
     val (compute, compDown) =
-      IORuntime.createDefaultComputeThreadPool(
-        runtime0,
-        threadPrefix = s"io-compute-${getClass.getName}")
+      IORuntime.createDefaultComputeThreadPool(threadPrefix = s"io-compute-${getClass.getName}")
 
     runtime0 = IORuntime(
       compute,

--- a/tests/jvm/src/test/scala/cats/effect/RunnersPlatform.scala
+++ b/tests/jvm/src/test/scala/cats/effect/RunnersPlatform.scala
@@ -33,7 +33,8 @@ trait RunnersPlatform extends BeforeAfterAll {
     val (scheduler, schedDown) =
       IORuntime.createDefaultScheduler(threadPrefix = s"io-scheduler-${getClass.getName}")
     val (compute, compDown) =
-      IORuntime.createDefaultComputeThreadPool(threadPrefix = s"io-compute-${getClass.getName}")
+      IORuntime.createWorkStealingComputeThreadPool(threadPrefix =
+        s"io-compute-${getClass.getName}")
 
     runtime0 = IORuntime(
       compute,

--- a/tests/jvm/src/test/scala/cats/effect/unsafe/HelperThreadParkSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/HelperThreadParkSpec.scala
@@ -34,8 +34,7 @@ class HelperThreadParkSpec extends BaseSpec {
           val (scheduler, schedDown) =
             IORuntime.createDefaultScheduler(threadPrefix = s"io-scheduler-${getClass.getName}")
           val (compute, compDown) =
-            IORuntime.createDefaultComputeThreadPool(
-              rt,
+            IORuntime.createWorkStealingComputeThreadPool(
               threadPrefix = s"io-compute-${getClass.getName}",
               threads = 2)
 

--- a/tests/jvm/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
@@ -36,7 +36,6 @@ class StripedHashtableSpec extends BaseSpec {
         IORuntime.createDefaultScheduler(threadPrefix = s"io-scheduler-${getClass.getName}")
       val (compute, compDown) =
         IORuntime.createDefaultComputeThreadPool(
-          rt,
           threadPrefix = s"io-compute-${getClass.getName}")
 
       IORuntime(

--- a/tests/jvm/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/StripedHashtableSpec.scala
@@ -35,7 +35,7 @@ class StripedHashtableSpec extends BaseSpec {
       val (scheduler, schedDown) =
         IORuntime.createDefaultScheduler(threadPrefix = s"io-scheduler-${getClass.getName}")
       val (compute, compDown) =
-        IORuntime.createDefaultComputeThreadPool(
+        IORuntime.createWorkStealingComputeThreadPool(
           threadPrefix = s"io-compute-${getClass.getName}")
 
       IORuntime(


### PR DESCRIPTION
This PR does many things.

1. Does #2661 properly. All runtimes can now be tracked through MBeans.
2. Adds support for shutting down _all_ `IORuntime` instances on a fatal error, not just the runtime that owns the fiber that failed with a fatal error.
3. Through the same mechanism gets rid of the `self: => IORuntime` forward reference in the WSTP. For this however, #2773 needs to be reverted first and done again.