### PR TITLE
Use Java release option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -255,6 +255,10 @@ val jsProjects: Seq[ProjectReference] =
 val undocumentedRefs =
   jsProjects ++ Seq[ProjectReference](benchmarks, example.jvm, tests.jvm, tests.js)
 
+lazy val releaseSettings = Seq(
+  scalacOptions ++= Seq("-release", "8")
+)
+
 lazy val root = project
   .in(file("."))
   .aggregate(rootJVM, rootJS)
@@ -296,6 +300,7 @@ lazy val kernel = crossProject(JSPlatform, JVMPlatform)
       .cross(CrossVersion.for3Use2_13)
       .exclude("org.scala-js", "scala-js-macrotask-executor_sjs1_2.13")
   )
+  .settings(releaseSettings)
   .jsSettings(
     libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % MacrotaskExecutorVersion % Test
   )
@@ -317,6 +322,7 @@ lazy val kernelTestkit = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "cats.effect.kernel.testkit.TestContext.this"))
   )
+  .settings(releaseSettings)
 
 /**
  * The laws which constrain the abstractions. This is split from kernel to avoid jar file and
@@ -332,6 +338,7 @@ lazy val laws = crossProject(JSPlatform, JVMPlatform)
       "org.typelevel" %%% "cats-laws" % CatsVersion,
       "org.typelevel" %%% "discipline-specs2" % DisciplineVersion % Test)
   )
+  .settings(releaseSettings)
 
 /**
  * Concrete, production-grade implementations of the abstractions. Or, more simply-put: IO. Also
@@ -473,6 +480,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       } else Seq()
     }
   )
+  .settings(releaseSettings)
   .jvmSettings(
     javacOptions ++= {
       val version = System.getProperty("java.version")
@@ -501,6 +509,7 @@ lazy val testkit = crossProject(JSPlatform, JVMPlatform)
         .exclude("org.scala-js", "scala-js-macrotask-executor_sjs1_2.13")
     )
   )
+  .settings(releaseSettings)
 
 /**
  * Unit tests for the core project, utilizing the support provided by testkit.
@@ -529,6 +538,7 @@ lazy val tests: CrossProject = crossProject(JSPlatform, JVMPlatform)
         Seq.empty
     }
   )
+  .settings(releaseSettings)
   .jsSettings(
     Compile / scalaJSUseMainModuleInitializer := true,
     Compile / mainClass := Some("catseffect.examples.JSRunner"),
@@ -582,6 +592,7 @@ lazy val std = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Console$SyncConsole")
     )
   )
+  .settings(releaseSettings)
   .jsSettings(
     libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % MacrotaskExecutorVersion % Test
   )
@@ -595,6 +606,7 @@ lazy val example = crossProject(JSPlatform, JVMPlatform)
   .dependsOn(core)
   .enablePlugins(NoPublishPlugin)
   .settings(name := "cats-effect-example")
+  .settings(releaseSettings)
   .jsSettings(scalaJSUseMainModuleInitializer := true)
 
 /**
@@ -608,6 +620,11 @@ lazy val benchmarks = project
     javaOptions ++= Seq(
       "-Dcats.effect.tracing.mode=none",
       "-Dcats.effect.tracing.exceptions.enhanced=false"))
+  .settings(releaseSettings)
   .enablePlugins(NoPublishPlugin, JmhPlugin)
 
-lazy val docs = project.in(file("site-docs")).dependsOn(core.jvm).enablePlugins(MdocPlugin)
+lazy val docs = project
+  .in(file("site-docs"))
+  .dependsOn(core.jvm)
+  .settings(releaseSettings)
+  .enablePlugins(MdocPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -270,10 +270,12 @@ lazy val releaseSettings = Seq(
     // The target flag is not implied by `-release` on Scala 2. We need to set it explicitly.
     // The target flag controls the JVM bytecode version that is output by scalac.
     val targetFlag =
-      if (!isDotty.value && !version.startsWith("1.8"))
-        Seq("-target:8")
-      else
+      if (isDotty.value || version.startsWith("1.8"))
         Seq()
+      else if (scalaVersion.value.startsWith("2.12"))
+        Seq("-target:jvm-1.8")
+      else
+        Seq("-target:8")
 
     releaseFlag ++ targetFlag
   }

--- a/build.sbt
+++ b/build.sbt
@@ -258,10 +258,24 @@ val undocumentedRefs =
 lazy val releaseSettings = Seq(
   scalacOptions ++= {
     val version = System.getProperty("java.version")
-    if (version.startsWith("1.8"))
-      Seq()
-    else
-      Seq("-release", "8")
+
+    // The release flag controls what JVM platform APIs are called. We only want JDK 8 APIs
+    // in order to maintain compability with JDK 8.
+    val releaseFlag =
+      if (version.startsWith("1.8"))
+        Seq()
+      else
+        Seq("-release", "8")
+
+    // The target flag is not implied by `-release` on Scala 2. We need to set it explicitly.
+    // The target flag controls the JVM bytecode version that is output by scalac.
+    val targetFlag =
+      if (!isDotty.value)
+        Seq("-target:8")
+      else
+        Seq()
+
+    releaseFlag ++ targetFlag
   }
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -270,7 +270,7 @@ lazy val releaseSettings = Seq(
     // The target flag is not implied by `-release` on Scala 2. We need to set it explicitly.
     // The target flag controls the JVM bytecode version that is output by scalac.
     val targetFlag =
-      if (!isDotty.value)
+      if (!isDotty.value && !version.startsWith("1.8"))
         Seq("-target:8")
       else
         Seq()

--- a/build.sbt
+++ b/build.sbt
@@ -255,32 +255,6 @@ val jsProjects: Seq[ProjectReference] =
 val undocumentedRefs =
   jsProjects ++ Seq[ProjectReference](benchmarks, example.jvm, tests.jvm, tests.js)
 
-lazy val releaseSettings = Seq(
-  scalacOptions ++= {
-    val version = System.getProperty("java.version")
-
-    // The release flag controls what JVM platform APIs are called. We only want JDK 8 APIs
-    // in order to maintain compability with JDK 8.
-    val releaseFlag =
-      if (version.startsWith("1.8"))
-        Seq()
-      else
-        Seq("-release", "8")
-
-    // The target flag is not implied by `-release` on Scala 2. We need to set it explicitly.
-    // The target flag controls the JVM bytecode version that is output by scalac.
-    val targetFlag =
-      if (isDotty.value || version.startsWith("1.8"))
-        Seq()
-      else if (scalaVersion.value.startsWith("2.12"))
-        Seq("-target:jvm-1.8")
-      else
-        Seq("-target:8")
-
-    releaseFlag ++ targetFlag
-  }
-)
-
 lazy val root = project
   .in(file("."))
   .aggregate(rootJVM, rootJS)
@@ -322,7 +296,6 @@ lazy val kernel = crossProject(JSPlatform, JVMPlatform)
       .cross(CrossVersion.for3Use2_13)
       .exclude("org.scala-js", "scala-js-macrotask-executor_sjs1_2.13")
   )
-  .settings(releaseSettings)
   .jsSettings(
     libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % MacrotaskExecutorVersion % Test
   )
@@ -344,7 +317,6 @@ lazy val kernelTestkit = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "cats.effect.kernel.testkit.TestContext.this"))
   )
-  .settings(releaseSettings)
 
 /**
  * The laws which constrain the abstractions. This is split from kernel to avoid jar file and
@@ -360,7 +332,6 @@ lazy val laws = crossProject(JSPlatform, JVMPlatform)
       "org.typelevel" %%% "cats-laws" % CatsVersion,
       "org.typelevel" %%% "discipline-specs2" % DisciplineVersion % Test)
   )
-  .settings(releaseSettings)
 
 /**
  * Concrete, production-grade implementations of the abstractions. Or, more simply-put: IO. Also
@@ -502,16 +473,6 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       } else Seq()
     }
   )
-  .settings(releaseSettings)
-  .jvmSettings(
-    javacOptions ++= {
-      val version = System.getProperty("java.version")
-      if (version.startsWith("1.8"))
-        Seq()
-      else
-        Seq("--release", "8")
-    }
-  )
   .jsSettings(
     libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % MacrotaskExecutorVersion)
 
@@ -531,7 +492,6 @@ lazy val testkit = crossProject(JSPlatform, JVMPlatform)
         .exclude("org.scala-js", "scala-js-macrotask-executor_sjs1_2.13")
     )
   )
-  .settings(releaseSettings)
 
 /**
  * Unit tests for the core project, utilizing the support provided by testkit.
@@ -560,7 +520,6 @@ lazy val tests: CrossProject = crossProject(JSPlatform, JVMPlatform)
         Seq.empty
     }
   )
-  .settings(releaseSettings)
   .jsSettings(
     Compile / scalaJSUseMainModuleInitializer := true,
     Compile / mainClass := Some("catseffect.examples.JSRunner"),
@@ -614,7 +573,6 @@ lazy val std = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Console$SyncConsole")
     )
   )
-  .settings(releaseSettings)
   .jsSettings(
     libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % MacrotaskExecutorVersion % Test
   )
@@ -628,7 +586,6 @@ lazy val example = crossProject(JSPlatform, JVMPlatform)
   .dependsOn(core)
   .enablePlugins(NoPublishPlugin)
   .settings(name := "cats-effect-example")
-  .settings(releaseSettings)
   .jsSettings(scalaJSUseMainModuleInitializer := true)
 
 /**
@@ -642,11 +599,9 @@ lazy val benchmarks = project
     javaOptions ++= Seq(
       "-Dcats.effect.tracing.mode=none",
       "-Dcats.effect.tracing.exceptions.enhanced=false"))
-  .settings(releaseSettings)
   .enablePlugins(NoPublishPlugin, JmhPlugin)
 
 lazy val docs = project
   .in(file("site-docs"))
   .dependsOn(core.jvm)
-  .settings(releaseSettings)
   .enablePlugins(MdocPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -474,7 +474,13 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     }
   )
   .jvmSettings(
-    javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
+    javacOptions ++= {
+      val version = System.getProperty("java.version")
+      if (version.startsWith("1.8"))
+        Seq()
+      else
+        Seq("--release", "8")
+    }
   )
   .jsSettings(
     libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % MacrotaskExecutorVersion)

--- a/build.sbt
+++ b/build.sbt
@@ -256,7 +256,13 @@ val undocumentedRefs =
   jsProjects ++ Seq[ProjectReference](benchmarks, example.jvm, tests.jvm, tests.js)
 
 lazy val releaseSettings = Seq(
-  scalacOptions ++= Seq("-release", "8")
+  scalacOptions ++= {
+    val version = System.getProperty("java.version")
+    if (version.startsWith("1.8"))
+      Seq()
+    else
+      Seq("-release", "8")
+  }
 )
 
 lazy val root = project

--- a/project/Java8Target.scala
+++ b/project/Java8Target.scala
@@ -1,0 +1,41 @@
+import sbt._, Keys._
+import sbtspiewak.SpiewakPlugin, SpiewakPlugin.autoImport._
+
+object Java8Target extends AutoPlugin {
+
+  override def requires = SpiewakPlugin
+  override def trigger = allRequirements
+
+  override def projectSettings = Seq(
+    scalacOptions ++= {
+      val version = System.getProperty("java.version")
+
+      // The release flag controls what JVM platform APIs are called. We only want JDK 8 APIs
+      // in order to maintain compability with JDK 8.
+      val releaseFlag =
+        if (version.startsWith("1.8"))
+          Seq()
+        else
+          Seq("-release", "8")
+
+      // The target flag is not implied by `-release` on Scala 2. We need to set it explicitly.
+      // The target flag controls the JVM bytecode version that is output by scalac.
+      val targetFlag =
+        if (isDotty.value || version.startsWith("1.8"))
+          Seq()
+        else if (scalaVersion.value.startsWith("2.12"))
+          Seq("-target:jvm-1.8")
+        else
+          Seq("-target:8")
+
+      releaseFlag ++ targetFlag
+    },
+
+    javacOptions ++= {
+      val version = System.getProperty("java.version")
+      if (version.startsWith("1.8"))
+        Seq()
+      else
+        Seq("--release", "8")
+    })
+}


### PR DESCRIPTION
## Example 1

The easy example first, APIs that don't exist on JDK 8 (`VarHandle`):

```java
package io.vasilev;

import java.lang.invoke.MethodHandles;
import java.lang.invoke.VarHandle;

public class VarHandles {
    private volatile int n;

    private static final VarHandle N;

    static {
        try {
            N = MethodHandles.lookup().findVarHandle(VarHandles.class, "n", int.class);
        } catch (Exception e) {
            throw new ExceptionInInitializerError(e);
        }
    }
}
```

Compiling:
```sh
javac io/vasilev/VarHandles.java --release 8
io/vasilev/VarHandles.java:4: error: cannot find symbol
import java.lang.invoke.VarHandle;
                       ^
  symbol:   class VarHandle
  location: package java.lang.invoke
io/vasilev/VarHandles.java:9: error: cannot find symbol
    private static final VarHandle N;
                         ^
  symbol:   class VarHandle
  location: class VarHandles
io/vasilev/VarHandles.java:13: error: cannot find symbol
            N = MethodHandles.lookup().findVarHandle(VarHandles.class, "n", int.class);
                                      ^
  symbol:   method findVarHandle(Class<VarHandles>,String,Class<Integer>)
  location: class Lookup
3 errors
```

---
## Example 2

Our favorite example, `ByteBuffer#flip()` on JDK 9+ overrides `Buffer#flip()` with a more specific type.

- On JDK 8 we have:
    1. `Buffer.flip()` has the JVM signature `java/nio/Buffer.flip:()Ljava/nio/Buffer`
    2. `ByteBuffer.flip()` has the JVM signature `java/nio/ByteBuffer.flip:()L/java/nio/Buffer`

- On JDK 9+ we have:
    1. `Buffer.flip()` has the same JVM signature `java/nio/Buffer.flip:()Ljava/nio/Buffer`
    2. `ByteBuffer.flip()` has the new JVM signature `java/nio/ByteBuffer.flip:()L/java/nio/ByteBuffer` and thus cannot be called on JDK 8.

Let's examine the output of `javac --relase 8` in this case, when we have an explicit return type in the code.

```java
package io.vasilev;

import java.nio.ByteBuffer;

public class Buffers {

    private static final ByteBuffer buffer = ByteBuffer.allocate(16);

    static {
        ByteBuffer flipped = buffer.flip();
    }
}
```

```sh
io/vasilev/Buffers.java:10: error: incompatible types: Buffer cannot be converted to ByteBuffer
        ByteBuffer flipped = buffer.flip();
                                        ^
1 error
```

---
## Example 3

Final example, what if we do not have an explicit return type and let Java figure it out. In this case we have to examine the produced bytecode, because `javac` won't complain in this case, because we have a method in JDK 8 that syntactically matches the code.

```java
package io.vasilev;

import java.nio.ByteBuffer;

public class Buffers {

    private static final ByteBuffer buffer = ByteBuffer.allocate(16);

    static {
        buffer.flip();
    }
}
```

1. Let's compile with JDK 17, without the `--release 8` option.
```sh
javac io/vasilev/Buffers.java  

javap -p -c io.vasilev.Buffers 

Compiled from "Buffers.java"
public class io.vasilev.Buffers {
  private static final java.nio.ByteBuffer buffer;

  public io.vasilev.Buffers();
    Code:
       0: aload_0
       1: invokespecial #1                  // Method java/lang/Object."<init>":()V
       4: return

  static {};
    Code:
       0: bipush        16
       2: invokestatic  #7                  // Method java/nio/ByteBuffer.allocate:(I)Ljava/nio/ByteBuffer;
       5: putstatic     #13                 // Field buffer:Ljava/nio/ByteBuffer;
       8: getstatic     #13                 // Field buffer:Ljava/nio/ByteBuffer;
      11: invokevirtual #19                 // Method java/nio/ByteBuffer.flip:()Ljava/nio/ByteBuffer; <------- notice the new JDK 9+ method with overloaded return type, which cannot be called on JDK 8.
      14: pop
      15: return
}
```

2. Let's now compile with JDK 17 with the `--release 8` option.
```sh
javac io/vasilev/Buffers.java --release 8

javap -p -c io.vasilev.Buffers

Compiled from "Buffers.java"
public class io.vasilev.Buffers {
  private static final java.nio.ByteBuffer buffer;

  public io.vasilev.Buffers();
    Code:
       0: aload_0
       1: invokespecial #1                  // Method java/lang/Object."<init>":()V
       4: return

  static {};
    Code:
       0: bipush        16
       2: invokestatic  #7                  // Method java/nio/ByteBuffer.allocate:(I)Ljava/nio/ByteBuffer;
       5: putstatic     #13                 // Field buffer:Ljava/nio/ByteBuffer;
       8: getstatic     #13                 // Field buffer:Ljava/nio/ByteBuffer;
      11: invokevirtual #19                 // Method java/nio/ByteBuffer.flip:()Ljava/nio/Buffer;  <------ notice that javac used the JDK 8 compatible method
      14: pop
      15: return
}

```