### PR TITLE
Add `IOLocal.unsafeCreate`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOLocal.scala
+++ b/core/shared/src/main/scala/cats/effect/IOLocal.scala
@@ -37,6 +37,14 @@ sealed trait IOLocal[A] {
 object IOLocal {
   def apply[A](default: A): IO[IOLocal[A]] = IO(unsafeCreate(default))
 
+  /**
+   * Not referentially transparent.
+   * {{{
+   *   val local = IOLocal.unsafeCreate(0)
+   *   local.set(3) *> local.get                   // 3
+   *   IOLocal.unsafeCreate(0).set(3) *> local.get // 0
+   * }}}
+   */
   def unsafeCreate[A](default: A): IOLocal[A] =
     new IOLocal[A] { self =>
       override def get: IO[A] =

--- a/tests/shared/src/test/scala/cats/effect/IOLocalSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOLocalSpec.scala
@@ -81,6 +81,23 @@ class IOLocalSpec extends BaseSpec {
 
       io must completeAs(0)
     }
+
+    "share state with itself when allocated with unsafeCreate" in ticked { implicit ticker =>
+      val local = IOLocal.unsafeCreate(0)
+
+      val io = local.set(3) *> local.get
+
+      io must completeAs(3)
+    }
+
+    "not share state with other instance allocated with unsafeCreate" in ticked {
+      implicit ticker =>
+        def mkLocal = IOLocal.unsafeCreate(0)
+
+        val io = mkLocal.set(3) *> mkLocal.get
+
+        io must completeAs(0)
+    }
   }
 
 }


### PR DESCRIPTION
The use case I have in mind is to be able to create a global instance for tracing purposes:

```
type TraceCtx
object TraceCtx {
  def empty: TraceCtx = ???
  val ioLocalInstance: IOLocal[TraceCtx] = IOLocal.unsafeCreate(empty)
}
```