### PR TITLE
Non-effectful `IOLocal` allocation based on a user-supplied key

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOLocal.scala
+++ b/core/shared/src/main/scala/cats/effect/IOLocal.scala
@@ -17,6 +17,7 @@
 package cats.effect
 
 import cats.kernel.Hash
+
 import scala.reflect.ClassTag
 
 sealed trait IOLocal[A] {

--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -79,7 +79,7 @@ package object effect {
   type Ref[F[_], A] = cekernel.Ref[F, A]
   val Ref = cekernel.Ref
 
-  private[effect] type IOLocalState = scala.collection.immutable.Map[Any, Any]
+  private[effect] type IOLocalState = scala.collection.immutable.Map[IOLocal[_], Any]
 
   private[effect] type ByteStack = Array[Int]
 }

--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -79,7 +79,7 @@ package object effect {
   type Ref[F[_], A] = cekernel.Ref[F, A]
   val Ref = cekernel.Ref
 
-  private[effect] type IOLocalState = scala.collection.immutable.Map[IOLocal[_], Any]
+  private[effect] type IOLocalState = scala.collection.immutable.Map[Any, Any]
 
   private[effect] type ByteStack = Array[Int]
 }


### PR DESCRIPTION
This is intended to allow instantiating `IOLocal` in a non-effectful but referentially transparent way.

The diff is ugly 😕

An alternative to #2827 