### PR TITLE
Indicate a completed state in IOFiber#toString

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1518,7 +1518,7 @@ private final class IOFiber[A] private (
 
   // overrides the AtomicReference#toString
   override def toString: String = {
-    val state = if (suspended.get()) "SUSPENDED" else "RUNNING"
+    val state = if (suspended.get()) "SUSPENDED" else if (isDone) "COMPLETED" else "RUNNING"
     val tracingEvents = this.tracingEvents
 
     // There are race conditions here since a running fiber is writing to `tracingEvents`,
@@ -1529,6 +1529,9 @@ private final class IOFiber[A] private (
 
     s"cats.effect.IOFiber@${System.identityHashCode(this).toHexString} $state$opAndCallSite"
   }
+
+  private[this] def isDone: Boolean =
+    resumeTag == DoneR
 
   private[effect] def prettyPrintTrace(): String =
     if (isStackTracing) {

--- a/tests/shared/src/test/scala/cats/effect/IOFiberSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOFiberSpec.scala
@@ -50,5 +50,18 @@ class IOFiberSpec extends BaseSpec {
         _ <- IO(s must beMatching(pattern))
       } yield ok
     }
+
+    "toString a completed fiber" in real {
+      def done = IO.unit.start
+      val pattern = raw"cats.effect.IOFiber@[0-9a-f][0-9a-f]+ COMPLETED"
+      for {
+        f <- done.start
+        _ <- IO.sleep(1.milli)
+        s <- IO(f.toString)
+        // _ <- IO.println(s)
+        _ <- f.cancel
+        _ <- IO(s must beMatching(pattern))
+      } yield ok
+    }
   }
 }


### PR DESCRIPTION
My naive implementation of https://github.com/typelevel/cats-effect/issues/2628. 

When fiber is completed, the stack trace events are not available anymore. 
Technically, there is room for premature optimization:
```scala
val hash = System.identityHashCode(this).toHexString
if (isDone) {
  s"cats.effect.IOFiber@$hash COMPLETED"
} else {
  val state = if (suspended.get()) "SUSPENDED" else "RUNNING"

  val opAndCallSite =
    Tracing.getFrames(tracingEvents).headOption.map(frame => s": $frame").getOrElse("")

   s"cats.effect.IOFiber@$hash $state$opAndCallSite"
}
```

But I don't think it's worth it.