### PR TITLE
Add `Async#syncStep`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1647,8 +1647,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
     override def syncStep[G[_], A](fa: IO[A], limit: Int)(
         implicit G: Sync[G]): G[Either[IO[A], A]] = {
-      type G0[+A] = G[A @uncheckedVariance] // helps with type inference
-      def interpret[B](io: IO[B], limit: Int): G0[Either[IO[B], (B, Int)]] = {
+      def interpret[B](io: IO[B], limit: Int): G[Either[IO[B], (B, Int)]] = {
         if (limit <= 0) {
           G.pure(Left(io))
         } else {
@@ -1675,7 +1674,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
               interpret(ioe, limit - 1)
                 .map {
                   case Left(_) => Left(io)
-                  case Right((a, limit)) => Right((a.asRight[Throwable], limit))
+                  case Right((a, limit)) => Right((a.asRight[Throwable].asInstanceOf[B], limit))
                 }
                 .handleError(t => Right((t.asLeft[IO[B]], limit - 1)))
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -36,6 +36,7 @@ import cats.{
 }
 import cats.data.Ior
 import cats.effect.instances.spawn
+import cats.effect.kernel.Sync
 import cats.effect.std.{Console, Env}
 import cats.effect.tracing.{Tracing, TracingEvent}
 import cats.syntax.all._
@@ -914,53 +915,8 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    * @param limit
    *   The number of stages to evaluate prior to forcibly yielding to `IO`
    */
-  def syncStep(limit: Int): SyncIO[Either[IO[A], A]] = {
-    def interpret[B](io: IO[B], limit: Int): SyncIO[Either[IO[B], (B, Int)]] = {
-      if (limit <= 0) {
-        SyncIO.pure(Left(io))
-      } else {
-        io match {
-          case IO.Pure(a) => SyncIO.pure(Right((a, limit)))
-          case IO.Error(t) => SyncIO.raiseError(t)
-          case IO.Delay(thunk, _) => SyncIO.delay(thunk()).map(a => Right((a, limit)))
-          case IO.RealTime => SyncIO.realTime.map(a => Right((a, limit)))
-          case IO.Monotonic => SyncIO.monotonic.map(a => Right((a, limit)))
-
-          case IO.Map(ioe, f, _) =>
-            interpret(ioe, limit - 1).map {
-              case Left(_) => Left(io)
-              case Right((a, limit)) => Right((f(a), limit))
-            }
-
-          case IO.FlatMap(ioe, f, _) =>
-            interpret(ioe, limit - 1).flatMap {
-              case Left(_) => SyncIO.pure(Left(io))
-              case Right((a, limit)) => interpret(f(a), limit - 1)
-            }
-
-          case IO.Attempt(ioe) =>
-            interpret(ioe, limit - 1)
-              .map {
-                case Left(_) => Left(io)
-                case Right((a, limit)) => Right((a.asRight[Throwable], limit))
-              }
-              .handleError(t => Right((t.asLeft[IO[B]], limit - 1)))
-
-          case IO.HandleErrorWith(ioe, f, _) =>
-            interpret(ioe, limit - 1)
-              .map {
-                case Left(_) => Left(io)
-                case r @ Right(_) => r
-              }
-              .handleErrorWith(t => interpret(f(t), limit - 1))
-
-          case _ => SyncIO.pure(Left(io))
-        }
-      }
-    }
-
-    interpret(this, limit).map(_.map(_._1))
-  }
+  def syncStep(limit: Int): SyncIO[Either[IO[A], A]] =
+    IO.asyncForIO.syncStep[SyncIO, A](this, limit)
 
   /**
    * Evaluates the current `IO` in an infinite loop, terminating only on error or cancelation.
@@ -1689,6 +1645,55 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
           b <- fb.value
         } yield fn(a, b)
       )
+
+    override def syncStep[G[_], A](fa: IO[A], limit: Int)(
+        implicit G: Sync[G]): G[Either[IO[A], A]] = {
+      def interpret[B](io: IO[B], limit: Int): G[Either[IO[B], (B, Int)]] = {
+        if (limit <= 0) {
+          G.pure(Left(io))
+        } else {
+          io match {
+            case IO.Pure(a) => G.pure(Right((a, limit)))
+            case IO.Error(t) => G.raiseError(t)
+            case IO.Delay(thunk, _) => G.delay(thunk()).map(a => Right((a, limit)))
+            case IO.RealTime => G.realTime.map(a => Right((a, limit)))
+            case IO.Monotonic => G.monotonic.map(a => Right((a, limit)))
+
+            case IO.Map(ioe, f, _) =>
+              interpret(ioe, limit - 1).map {
+                case Left(_) => Left(io)
+                case Right((a, limit)) => Right((f(a), limit))
+              }
+
+            case IO.FlatMap(ioe, f, _) =>
+              interpret(ioe, limit - 1).flatMap {
+                case Left(_) => G.pure(Left(io))
+                case Right((a, limit)) => interpret(f(a), limit - 1)
+              }
+
+            case IO.Attempt(ioe) =>
+              interpret(ioe, limit - 1)
+                .map {
+                  case Left(_) => Left(io)
+                  case Right((a, limit)) => Right((a.asRight[Throwable].asInstanceOf[B], limit))
+                }
+                .handleError(t => Right((t.asLeft[IO[B]], limit - 1)))
+
+            case IO.HandleErrorWith(ioe, f, _) =>
+              interpret(ioe, limit - 1)
+                .map {
+                  case Left(_) => Left(io)
+                  case r @ Right(_) => r
+                }
+                .handleErrorWith(t => interpret(f(t), limit - 1))
+
+            case _ => G.pure(Left(io))
+          }
+        }
+      }
+
+      interpret(fa, limit).map(_.map(_._1))
+    }
   }
 
   implicit def asyncForIO: kernel.Async[IO] = _asyncForIO

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -908,11 +908,11 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
 
   /**
    * Translates this `IO[A]` into a `SyncIO` value which, when evaluated, runs the original `IO`
-   * to its completion, the `limit` number of stages, or until the first asynchronous boundary,
-   * whichever is encountered first.
+   * to its completion, the `limit` number of stages, or until the first stage that cannot be
+   * expressed with `SyncIO` (typically an asynchronous boundary).
    *
    * @param limit
-   *   The number of stages to evaluate prior to forcibly yielding to `IO`
+   *   The maximum number of stages to evaluate prior to forcibly yielding to `IO`
    */
   def syncStep(limit: Int): SyncIO[Either[IO[A], A]] =
     IO.asyncForIO.syncStep[SyncIO, A](this, limit)

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -36,7 +36,6 @@ import cats.{
 }
 import cats.data.Ior
 import cats.effect.instances.spawn
-import cats.effect.kernel.Sync
 import cats.effect.std.{Console, Env}
 import cats.effect.tracing.{Tracing, TracingEvent}
 import cats.syntax.all._

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -160,7 +160,7 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
    * the original `F[A]` value is returned unchanged.
    *
    * @param limit
-   *   The number of stages to evaluate prior to forcibly yielding to `F`
+   *   The maximum number of stages to evaluate prior to forcibly yielding to `F`
    */
   @nowarn("cat=unused")
   def syncStep[G[_], A](fa: F[A], limit: Int)(implicit G: Sync[G]): G[Either[F[A], A]] =

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -151,8 +151,8 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
 
   /**
    * Translates this `F[A]` into a `G` value which, when evaluated, runs the original `F` to its
-   * completion, the `limit` number of stages, or until the first stage which cannot be
-   * expressed with [[Sync]] (typically an asynchronous boundary).
+   * completion, the `limit` number of stages, or until the first stage that cannot be expressed
+   * with [[Sync]] (typically an asynchronous boundary).
    *
    * Note that `syncStep` is merely a hint to the runtime system; implementations have the
    * liberty to interpret this method to their liking as long as it obeys the respective laws.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -21,7 +21,7 @@ import cats.arrow.FunctionK
 import cats.data.{EitherT, Ior, IorT, Kleisli, OptionT, WriterT}
 import cats.implicits._
 
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.concurrent.{ExecutionContext, Future}
 
 import java.util.concurrent.atomic.AtomicReference
@@ -149,6 +149,23 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
       }
     }
 
+  /**
+   * Translates this `F[A]` into a `G` value which, when evaluated, runs the original `F` to its
+   * completion, the `limit` number of stages, or until the first asynchronous boundary,
+   * whichever is encountered first.
+   *
+   * Note that `syncStep` is merely a hint to the runtime system; implementations have the
+   * liberty to interpret this method to their liking as long as it obeys the respective laws.
+   * For example, a lawful implementation of this function is `G.pure(Left(fa))`, in which case
+   * the original `F[A]` value is returned unchanged.
+   *
+   * @param limit
+   *   The number of stages to evaluate prior to forcibly yielding to `F`
+   */
+  @nowarn("cat=unused")
+  def syncStep[G[_], A](fa: F[A], limit: Int)(implicit G: Sync[G]): G[Either[F[A], A]] =
+    G.pure(Left(fa))
+
   /*
    * NOTE: This is a very low level api, end users should use `async` instead.
    * See cats.effect.kernel.Cont for more detail.
@@ -271,6 +288,14 @@ object Async {
     override def unique: OptionT[F, Unique.Token] =
       delay(new Unique.Token())
 
+    override def syncStep[G[_], A](fa: OptionT[F, A], limit: Int)(
+        implicit G: Sync[G]): G[Either[OptionT[F, A], A]] =
+      G.map(F.syncStep[G, Option[A]](fa.value, limit)) {
+        case Left(fa) => Left(OptionT(fa))
+        case Right(None) => Left(OptionT.none)
+        case Right(Some(a)) => Right(a)
+      }
+
     def cont[K, R](body: Cont[OptionT[F, *], K, R]): OptionT[F, R] =
       OptionT(
         F.cont(
@@ -333,6 +358,14 @@ object Async {
 
     override def unique: EitherT[F, E, Unique.Token] =
       delay(new Unique.Token())
+
+    override def syncStep[G[_], A](fa: EitherT[F, E, A], limit: Int)(
+        implicit G: Sync[G]): G[Either[EitherT[F, E, A], A]] =
+      G.map(F.syncStep[G, Either[E, A]](fa.value, limit)) {
+        case Left(fa) => Left(EitherT(fa))
+        case Right(Left(e)) => Left(EitherT.leftT(e))
+        case Right(Right(a)) => Right(a)
+      }
 
     def cont[K, R](body: Cont[EitherT[F, E, *], K, R]): EitherT[F, E, R] =
       EitherT(
@@ -398,6 +431,14 @@ object Async {
     override def unique: IorT[F, L, Unique.Token] =
       delay(new Unique.Token())
 
+    override def syncStep[G[_], A](fa: IorT[F, L, A], limit: Int)(
+        implicit G: Sync[G]): G[Either[IorT[F, L, A], A]] =
+      G.map(F.syncStep[G, Ior[L, A]](fa.value, limit)) {
+        case Left(ior) => Left(IorT(ior))
+        case Right(Ior.Right(a)) => Right(a)
+        case Right(right) => Left(IorT.fromIor(right))
+      }
+
     def cont[K, R](body: Cont[IorT[F, L, *], K, R]): IorT[F, L, R] =
       IorT(
         F.cont(
@@ -460,6 +501,10 @@ object Async {
 
     override def unique: WriterT[F, L, Unique.Token] =
       delay(new Unique.Token())
+
+    override def syncStep[G[_], A](fa: WriterT[F, L, A], limit: Int)(
+        implicit G: Sync[G]): G[Either[WriterT[F, L, A], A]] =
+      G.pure(Left(fa))
 
     def cont[K, R](body: Cont[WriterT[F, L, *], K, R]): WriterT[F, L, R] =
       WriterT(
@@ -524,6 +569,10 @@ object Async {
 
     override def unique: Kleisli[F, R, Unique.Token] =
       delay(new Unique.Token())
+
+    override def syncStep[G[_], A](fa: Kleisli[F, R, A], limit: Int)(
+        implicit G: Sync[G]): G[Either[Kleisli[F, R, A], A]] =
+      G.pure(Left(fa))
 
     def cont[K, R2](body: Cont[Kleisli[F, R, *], K, R2]): Kleisli[F, R, R2] =
       Kleisli(r =>

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -291,7 +291,7 @@ object Async {
     override def syncStep[G[_], A](fa: OptionT[F, A], limit: Int)(
         implicit G: Sync[G]): G[Either[OptionT[F, A], A]] =
       G.map(F.syncStep[G, Option[A]](fa.value, limit)) {
-        case Left(fa) => Left(OptionT(fa))
+        case Left(foption) => Left(OptionT(foption))
         case Right(None) => Left(OptionT.none)
         case Right(Some(a)) => Right(a)
       }
@@ -362,7 +362,7 @@ object Async {
     override def syncStep[G[_], A](fa: EitherT[F, E, A], limit: Int)(
         implicit G: Sync[G]): G[Either[EitherT[F, E, A], A]] =
       G.map(F.syncStep[G, Either[E, A]](fa.value, limit)) {
-        case Left(fa) => Left(EitherT(fa))
+        case Left(feither) => Left(EitherT(feither))
         case Right(Left(e)) => Left(EitherT.leftT(e))
         case Right(Right(a)) => Right(a)
       }
@@ -434,9 +434,9 @@ object Async {
     override def syncStep[G[_], A](fa: IorT[F, L, A], limit: Int)(
         implicit G: Sync[G]): G[Either[IorT[F, L, A], A]] =
       G.map(F.syncStep[G, Ior[L, A]](fa.value, limit)) {
-        case Left(ior) => Left(IorT(ior))
+        case Left(fior) => Left(IorT(fior))
         case Right(Ior.Right(a)) => Right(a)
-        case Right(right) => Left(IorT.fromIor(right))
+        case Right(ior) => Left(IorT.fromIor(ior))
       }
 
     def cont[K, R](body: Cont[IorT[F, L, *], K, R]): IorT[F, L, R] =

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -151,8 +151,8 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
 
   /**
    * Translates this `F[A]` into a `G` value which, when evaluated, runs the original `F` to its
-   * completion, the `limit` number of stages, or until the first asynchronous boundary,
-   * whichever is encountered first.
+   * completion, the `limit` number of stages, or until the first stage which cannot be
+   * expressed with [[Sync]] (typically an asynchronous boundary).
    *
    * Note that `syncStep` is merely a hint to the runtime system; implementations have the
    * liberty to interpret this method to their liking as long as it obeys the respective laws.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1286,6 +1286,10 @@ abstract private[effect] class ResourceAsync[F[_]]
   override def unique: Resource[F, Unique.Token] =
     Resource.unique
 
+  override def syncStep[G[_], A](fa: Resource[F, A], limit: Int)(
+      implicit G: Sync[G]): G[Either[Resource[F, A], A]] =
+    G.pure(Left(fa))
+
   override def never[A]: Resource[F, A] =
     Resource.never
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -18,6 +18,7 @@ package cats.effect.kernel
 
 import cats._
 import cats.data.Kleisli
+import cats.effect.kernel.Resource.Pure
 import cats.effect.kernel.implicits._
 import cats.effect.kernel.instances.spawn
 import cats.syntax.all._
@@ -1288,7 +1289,15 @@ abstract private[effect] class ResourceAsync[F[_]]
 
   override def syncStep[G[_], A](fa: Resource[F, A], limit: Int)(
       implicit G: Sync[G]): G[Either[Resource[F, A], A]] =
-    G.pure(Left(fa))
+    fa match {
+      case Pure(a) => G.pure(Right(a))
+      case Resource.Eval(fa) =>
+        G.map(F.syncStep[G, A](F.widen(fa), limit)) {
+          case Left(fa) => Left(Resource.eval(fa))
+          case Right(a) => Right(a)
+        }
+      case r => G.pure(Left(r))
+    }
 
   override def never[A]: Resource[F, A] =
     Resource.never

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AsyncSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/AsyncSyntax.scala
@@ -16,7 +16,7 @@
 
 package cats.effect.kernel.syntax
 
-import cats.effect.kernel.{Async, Fiber, Outcome, Resource}
+import cats.effect.kernel.{Async, Fiber, Outcome, Resource, Sync}
 
 import scala.concurrent.ExecutionContext
 
@@ -36,4 +36,7 @@ final class AsyncOps[F[_], A] private[syntax] (private[syntax] val wrapped: F[A]
   def backgroundOn(ec: ExecutionContext)(
       implicit F: Async[F]): Resource[F, F[Outcome[F, Throwable, A]]] =
     Async[F].backgroundOn(wrapped, ec)
+
+  def syncStep[G[_]: Sync](limit: Int)(implicit F: Async[F]): G[Either[F[A], A]] =
+    Async[F].syncStep[G, A](wrapped, limit)
 }

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncLaws.scala
@@ -17,7 +17,7 @@
 package cats.effect
 package laws
 
-import cats.effect.kernel.{Async, Sync}
+import cats.effect.kernel.Async
 import cats.syntax.all._
 
 import scala.concurrent.ExecutionContext
@@ -67,30 +67,10 @@ trait AsyncLaws[F[_]] extends GenTemporalLaws[F, Throwable] with SyncLaws[F] {
     F.evalOn(F.never[Unit], ec) <-> F.never[Unit]
 
   def syncStepIdentity[A](fa: F[A], limit: Int) =
-    F.syncStep[F, A](fa, limit)(syncF).flatMap {
+    F.syncStep(fa, limit).flatMap {
       case Left(fa) => fa
       case Right(a) => F.pure(a)
     } <-> fa
-
-  // a mild hack, in case a `syncStep[G]` implementation
-  // special-cases `F eq G` and thus short-circuits the law
-  private[this] def syncF: Sync[F] = new Sync[F] {
-    import cats.effect.kernel._
-    import scala.concurrent.duration._
-    def pure[A](x: A): F[A] = F.pure(x)
-    def handleErrorWith[A](fa: F[A])(f: Throwable => F[A]): F[A] = F.handleErrorWith(fa)(f)
-    def raiseError[A](e: Throwable): F[A] = F.raiseError(e)
-    def monotonic: F[FiniteDuration] = F.monotonic
-    def realTime: F[FiniteDuration] = F.realTime
-    def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B] = F.flatMap(fa)(f)
-    def tailRecM[A, B](a: A)(f: A => F[Either[A, B]]): F[B] = F.tailRecM(a)(f)
-    def canceled: F[Unit] = F.canceled
-    def forceR[A, B](fa: F[A])(fb: F[B]): F[B] = F.forceR(fa)(fb)
-    def onCancel[A](fa: F[A], fin: F[Unit]): F[A] = F.onCancel(fa, fin)
-    def rootCancelScope: CancelScope = F.rootCancelScope
-    def uncancelable[A](body: Poll[F] => F[A]): F[A] = F.uncancelable(body)
-    def suspend[A](hint: Sync.Type)(thunk: => A): F[A] = F.suspend(hint)(thunk)
-  }
 }
 
 object AsyncLaws {

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
@@ -254,7 +254,8 @@ trait AsyncTests[F[_]] extends GenTemporalTests[F, Throwable] with SyncTests[F] 
         "evalOn pure identity" -> forAll(laws.evalOnPureIdentity[A] _),
         "evalOn raiseError identity" -> forAll(laws.evalOnRaiseErrorIdentity _),
         "evalOn canceled identity" -> forAll(laws.evalOnCanceledIdentity _),
-        "evalOn never identity" -> forAll(laws.evalOnNeverIdentity _)
+        "evalOn never identity" -> forAll(laws.evalOnNeverIdentity _),
+        "syncStep identity" -> forAll(laws.syncStepIdentity[A] _)
       )
     }
   }


### PR DESCRIPTION
Takes the ideas from https://github.com/typelevel/cats-effect/pull/1945 and https://github.com/typelevel/cats-effect/pull/2613 and replays it for `Async[F]`. I think this is the law we are aiming for:

```scala
F.syncStep[G, A](fa, limit).to[F].flatMap {
  case Left(fa) => fa
  case Right(a) => F.pure(a)
} <-> fa
```

We should also consider adding `Dispatcher#unsafeRunSyncToFuture` and `Dispatcher#unsafeRunSyncToPromise` to match the methods on `IO`. Slightly annoying is the need to explicitly pass a `limit` since it cannot be retrieved from the `IORuntime` in this case.