### PR TITLE
Close cancelation leak in fromCompletableFuture

### DIFF
--- a/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
@@ -28,8 +28,8 @@ private[kernel] trait AsyncPlatform[F[_]] { this: Async[F] =>
    *   The `java.util.concurrent.CompletableFuture` to suspend in `F[_]`
    */
   def fromCompletableFuture[A](fut: F[CompletableFuture[A]]): F[A] =
-    flatMap(fut) { cf =>
-      async[A] { cb =>
+    async[A] { cb =>
+      flatMap(fut) { cf =>
         delay {
           cf.handle[Unit] {
             case (a, null) => cb(Right(a))


### PR DESCRIPTION
The fiber could be canceled between sequencing the completable future and sequencing the `async` node that installs the finalizer.

Moving sequencing the completable future inside the `async` node means that it's run inside an `uncancelable` and hence safe