### PR TITLE
Add Semaphore#tryPermit

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
@@ -255,7 +255,7 @@ object Semaphore {
           Resource.makeFull { (poll: Poll[F]) => poll(acquire) } { _ => release }
 
         def tryPermit: Resource[F, Boolean] =
-          Resource.makeFull { (poll: Poll[F]) => poll(tryAcquire) } { _ => release }
+          Resource.makeFull { (poll: Poll[F]) => poll(tryAcquire) } { acquired => release.whenA(acquired) }
 
         def tryAcquireN(n: Long): F[Boolean] = {
           requireNonNegative(n)

--- a/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
@@ -255,9 +255,7 @@ object Semaphore {
           Resource.makeFull { (poll: Poll[F]) => poll(acquire) } { _ => release }
 
         def tryPermit: Resource[F, Boolean] =
-          Resource.makeFull { (poll: Poll[F]) => poll(tryAcquire) } { acquired =>
-            release.whenA(acquired)
-          }
+          Resource.make(tryAcquire) { acquired => release.whenA(acquired) }
 
         def tryAcquireN(n: Long): F[Boolean] = {
           requireNonNegative(n)

--- a/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
@@ -255,7 +255,9 @@ object Semaphore {
           Resource.makeFull { (poll: Poll[F]) => poll(acquire) } { _ => release }
 
         def tryPermit: Resource[F, Boolean] =
-          Resource.makeFull { (poll: Poll[F]) => poll(tryAcquire) } { acquired => release.whenA(acquired) }
+          Resource.makeFull { (poll: Poll[F]) => poll(tryAcquire) } { acquired =>
+            release.whenA(acquired)
+          }
 
         def tryAcquireN(n: Long): F[Boolean] = {
           requireNonNegative(n)

--- a/tests/shared/src/test/scala/cats/effect/kernel/SemaphoreSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/SemaphoreSpec.scala
@@ -108,6 +108,17 @@ class SemaphoreSpec extends BaseSpec { outer =>
       } yield res
     }
 
+    "not release permit if tryPermit completes without acquiring a permit" in ticked {
+      implicit ticker =>
+        val p = for {
+          sem <- sc(0)
+          _ <- sem.tryPermit.surround(IO.unit)
+          res <- sem.permit.surround(IO.unit)
+        } yield res
+
+        p must nonTerminate
+    }
+
     "release permit if action gets canceled" in ticked { implicit ticker =>
       val p =
         for {


### PR DESCRIPTION
A hopefully safer abstraction over `Semaphore#tryAcquire` which ensures that we always release the permit