### PR TITLE
Add `unsafeRunSync*` syntax for JS `Dispatcher`

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOPlatform.scala
@@ -37,6 +37,17 @@ abstract private[effect] class IOPlatform[+A] { self: IO[A] =>
           ()
       })
 
+  /**
+   * Evaluates the effect and produces the result in a `Future`.
+   *
+   * This is similar to `unsafeToFuture` in that it evaluates the `IO` as a side effect in a
+   * non-blocking fashion, but begins by taking a `syncStep` limited by the runtime's auto-yield
+   * threshold. This function should really only be used if it is critical to attempt to
+   * evaluate this `IO` without first yielding to the event loop.
+   *
+   * @see
+   *   [[IO.syncStep(limit:Int)*]]
+   */
   def unsafeRunSyncToFuture()(implicit runtime: unsafe.IORuntime): Future[A] =
     self.syncStep(runtime.config.autoYieldThreshold).attempt.unsafeRunSync() match {
       case Left(t) => Future.failed(t)
@@ -44,6 +55,17 @@ abstract private[effect] class IOPlatform[+A] { self: IO[A] =>
       case Right(Right(a)) => Future.successful(a)
     }
 
+  /**
+   * Evaluates the effect and produces the result in a JavaScript `Promise`.
+   *
+   * This is similar to `unsafeToPromise` in that it evaluates the `IO` as a side effect in a
+   * non-blocking fashion, but begins by taking a `syncStep` limited by the runtime's auto-yield
+   * threshold. This function should really only be used if it is critical to attempt to
+   * evaluate this `IO` without first yielding to the event loop.
+   *
+   * @see
+   *   [[IO.syncStep(limit:Int)*]]
+   */
   def unsafeRunSyncToPromise()(implicit runtime: unsafe.IORuntime): Promise[A] =
     self.syncStep(runtime.config.autoYieldThreshold).attempt.unsafeRunSync() match {
       case Left(t) => Promise.reject(t)

--- a/core/js/src/main/scala/cats/effect/syntax/DispatcherSyntax.scala
+++ b/core/js/src/main/scala/cats/effect/syntax/DispatcherSyntax.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.syntax
+
+import cats.effect.kernel.Async
+import cats.effect.std.Dispatcher
+import cats.effect.SyncIO
+
+import scala.concurrent.Future
+import scala.scalajs.js.Promise
+
+trait DispatcherSyntax {
+  implicit def dispatcherOps[F[_]](wrapped: Dispatcher[F]): DispatcherOps[F] =
+    new DispatcherOps(wrapped)
+}
+
+final class DispatcherOps[F[_]] private[syntax] (private[syntax] val wrapped: Dispatcher[F])
+    extends AnyVal {
+
+  /**
+   * Executes an effect by first taking a `syncStep` limited by `syncLimit`, then if necessary
+   * submitting the remainder of the effect to the dispatcher to be executed asynchronously,
+   * finally returning a `Future` that holds the result of its evaluation.
+   *
+   * This function should really only be used if it is critical to attempt to evaluate this
+   * effect without first yielding to the event loop.
+   *
+   * @see
+   *   [[cats.effect.kernel.Async.syncStep]]
+   */
+  def unsafeRunSyncToFuture[A](fa: F[A], syncLimit: Int)(implicit F: Async[F]): Future[A] =
+    F.syncStep[SyncIO, A](fa, syncLimit).attempt.unsafeRunSync() match {
+      case Left(t) => Future.failed(t)
+      case Right(Left(fa)) => wrapped.unsafeToFuture(fa)
+      case Right(Right(a)) => Future.successful(a)
+    }
+
+  /**
+   * Executes an effect by first taking a `syncStep` limited by `syncLimit`, then if necessary
+   * submitting the remainder of the effect to the dispatcher to be executed asynchronously,
+   * finally returning a `Promise` that holds the result of its evaluation.
+   *
+   * This function should really only be used if it is critical to attempt to evaluate this
+   * effect without first yielding to the event loop.
+   *
+   * @see
+   *   [[cats.effect.kernel.Async.syncStep]]
+   */
+  def unsafeRunSyncToPromise[A](fa: F[A], syncLimit: Int)(implicit F: Async[F]): Promise[A] =
+    F.syncStep[SyncIO, A](fa, syncLimit).attempt.unsafeRunSync() match {
+      case Left(t) => Promise.reject(t)
+      case Right(Left(fa)) => wrapped.unsafeToPromise(fa)
+      case Right(Right(a)) => Promise.resolve[A](a)
+    }
+
+}

--- a/core/js/src/main/scala/cats/effect/syntax/DispatcherSyntax.scala
+++ b/core/js/src/main/scala/cats/effect/syntax/DispatcherSyntax.scala
@@ -16,9 +16,9 @@
 
 package cats.effect.syntax
 
+import cats.effect.SyncIO
 import cats.effect.kernel.Async
 import cats.effect.std.Dispatcher
-import cats.effect.SyncIO
 
 import scala.concurrent.Future
 import scala.scalajs.js.Promise

--- a/core/jvm/src/main/scala/cats/effect/syntax/DispatcherSyntax.scala
+++ b/core/jvm/src/main/scala/cats/effect/syntax/DispatcherSyntax.scala
@@ -14,20 +14,6 @@
  * limitations under the License.
  */
 
-package cats.effect
+package cats.effect.syntax
 
-package object syntax {
-
-  object all extends AllSyntax
-
-  object monadCancel extends kernel.syntax.MonadCancelSyntax
-  object spawn extends kernel.syntax.GenSpawnSyntax
-  object concurrent extends kernel.syntax.GenConcurrentSyntax
-  object temporal extends kernel.syntax.GenTemporalSyntax
-  object async extends kernel.syntax.AsyncSyntax
-  object resource extends kernel.syntax.ResourceSyntax
-  object clock extends kernel.syntax.ClockSyntax
-
-  object supervisor extends std.syntax.SupervisorSyntax
-  object dispatcher extends DispatcherSyntax
-}
+trait DispatcherSyntax

--- a/core/shared/src/main/scala/cats/effect/syntax/AllSyntax.scala
+++ b/core/shared/src/main/scala/cats/effect/syntax/AllSyntax.scala
@@ -17,4 +17,4 @@
 package cats.effect
 package syntax
 
-trait AllSyntax extends kernel.syntax.AllSyntax with std.syntax.AllSyntax
+trait AllSyntax extends kernel.syntax.AllSyntax with std.syntax.AllSyntax with DispatcherSyntax


### PR DESCRIPTION
Following up on https://github.com/typelevel/cats-effect/pull/2835#issuecomment-1053265252, replays the convenience methods added to `IO` in https://github.com/typelevel/cats-effect/pull/2613 for `Dispatcher` (JS-only).

It needs to be added as syntax in core due to the dependency on `SyncIO` for the `unsafeRunSync` execution.

Daniel proposed an alternative in https://github.com/typelevel/cats-effect/pull/2835#issuecomment-1053635478:

> We basically have to weigh whether a syntax enrichment in **core** is better or worse than a significantly-altered signature in **std** (e.g. taking a function of type `G[A] => A` as a parameter).

IIUC it's proposing something like this on `Dispatcher`:
```scala
def unsafeRunSyncToFuture[G[_]: Sync, A](
  fa: F[A],
  limit: Int,
  unsafeRunSync: G[A] => Either[Throwable, A]
)(implicit F: Async[F]): Future[A] = {
  unsafeRunSync(F.syncStep[G, A](fa, limit)) match {
    case Left(t) => Future.failed(t)
    case Right(Left(fa)) => unsafeToFuture(fa)
    case Right(Right(a)) => Future.successful(a)
  }
}
```
which I would then call like this:
```scala
dispatcher.unsafeRunSyncToFuture(fa, 32, (_: SyncIO[A]).attempt.unsafeRunSync())
```

But at that point, I think I could just as easily write:
```scala
fa.syncStep[SyncIO](32).unsafeRunSync().fold(
  dispatcher.unsafeRunAndForget(_),
  _ => () // whatever
)
```

This assumes I don't care about the result ... which in many cases I don't, because I'm completing a `Deferred` or `offer`ing to a `Queue`.

The syntax proposed here gets us this:
```scala
dispatcher.unsafeRunSyncToFuture(fa, 32)
```

So, subjective obviously. And not necessarily mutually exclusive.

I also wish there was a better story for the `limit` parameter, which we can't fish out of the `IORuntime` in this case. So it will almost definitely be hardcoded, which requires some iota of thinking or tempts a lazy `Int.MaxValue` which is probably fine for the `complete`/`offer` use-cases.