### PR TITLE
Sequential `Dispatcher`

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/DispatcherBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/DispatcherBenchmark.scala
@@ -66,7 +66,7 @@ class DispatcherBenchmark {
         }
       }))
 
-    Dispatcher[IO]()
+    Dispatcher.parallel[IO]
       .use { disp =>
         List
           .range(0, size)

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/DispatcherBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/DispatcherBenchmark.scala
@@ -66,7 +66,7 @@ class DispatcherBenchmark {
         }
       }))
 
-    Dispatcher[IO]
+    Dispatcher[IO]()
       .use { disp =>
         List
           .range(0, size)

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/DispatcherBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/DispatcherBenchmark.scala
@@ -66,7 +66,8 @@ class DispatcherBenchmark {
         }
       }))
 
-    Dispatcher.parallel[IO]
+    Dispatcher
+      .parallel[IO]
       .use { disp =>
         List
           .range(0, size)

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -439,7 +439,7 @@ You can get an instance of it with `Dispatcher.apply[F]` for any `F[_]: Async`:
 
 ```scala
 object Dispatcher {
-  def apply[F[_]](implicit F: Async[F]): Resource[F, Dispatcher[F]]
+  def apply[F[_]](mode: Dispatcher.Mode)(implicit F: Async[F]): Resource[F, Dispatcher[F]]
 }
 ```
 
@@ -479,7 +479,7 @@ import cats.effect.std.Dispatcher
 
 // CE3
 def consumer[F[_]: Async, A](handler: A => F[Unit]): Resource[F, Consumer[A]] =
-  Dispatcher[F].map { dispatcher =>
+  Dispatcher[F]().map { dispatcher =>
     new Consumer[A] {
       def onNext(a: A): Unit = dispatcher.unsafeRunSync(handler(a))
     }

--- a/docs/std/dispatcher.md
+++ b/docs/std/dispatcher.md
@@ -49,14 +49,14 @@ without actually executing it. (Here the `scalac` option `-Ywarn-value-discard` 
 It is in these cases that `Dispatcher` comes in handy. Here's how it could be used:
 
 ```scala
-Dispatcher[IO]() use { dispatcher =>
+Dispatcher.sequential[IO] use { dispatcher =>
   for {
     queue <- Queue.unbounded[IO, String]
     impureInterface <-
       IO.delay {
         new ImpureInterface {
           override def onMessage(msg: String): Unit =
-            dispatcher.unsafeRunSync(queue.offer(msg))
+            dispatcher.unsafeRunAndForget(queue.offer(msg))
         }
       }
     _ <- IO.delay(impureInterface.init())
@@ -70,7 +70,7 @@ Dispatcher[IO]() use { dispatcher =>
 
 It prints "Value found in queue! init"!
 
-The example above calls `unsafeRunSync` on the dispatcher, but more functions are exposed:
+The example above calls `unsafeRunAndForget` on the dispatcher, but more functions are exposed:
 
 ```scala
 

--- a/docs/std/dispatcher.md
+++ b/docs/std/dispatcher.md
@@ -49,7 +49,7 @@ without actually executing it. (Here the `scalac` option `-Ywarn-value-discard` 
 It is in these cases that `Dispatcher` comes in handy. Here's how it could be used:
 
 ```scala
-Dispatcher[IO].use { dispatcher =>
+Dispatcher[IO]() use { dispatcher =>
   for {
     queue <- Queue.unbounded[IO, String]
     impureInterface <-

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -98,7 +98,7 @@ object Dispatcher {
 
   @deprecated(
     "3.4.0",
-    "use parallel or sequential instead; the former corresponds to the previous semantics of this method")
+    "use parallel or sequential instead; the former corresponds to the current semantics of this method")
   def apply[F[_]: Async]: Resource[F, Dispatcher[F]] = parallel[F]
 
   /**

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -96,7 +96,9 @@ object Dispatcher {
 
   private[this] val Completed: Either[Throwable, Unit] = Right(())
 
-  @deprecated("3.4.0", "please use parallel or sequential instead")
+  @deprecated(
+    "3.4.0",
+    "use parallel or sequential instead; the former corresponds to the previous semantics of this method")
   def apply[F[_]: Async]: Resource[F, Dispatcher[F]] = parallel[F]
 
   /**

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -125,8 +125,8 @@ object Dispatcher {
       supervisor <- Supervisor[F]
 
       (workers, fork) = mode match {
-        case Mode.Parallel => (Cpus, supervisor.supervise(_: F[_]).map(_.cancel))
-        case Mode.Sequential => (1, (_: F[_]).as(F.unit).handleError(_ => F.unit))
+        case Mode.Parallel => (Cpus, supervisor.supervise(_: F[Unit]).map(_.cancel))
+        case Mode.Sequential => (1, (_: F[Unit]).as(F.unit).handleError(_ => F.unit))
       }
 
       latches <- Resource.eval(F delay {

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -108,7 +108,8 @@ object Dispatcher {
    * exits, all active effects will be canceled, and attempts to submit new effects will throw
    * an exception.
    */
-  def apply[F[_]](mode: Mode = Mode.Parallel)(implicit F: Async[F]): Resource[F, Dispatcher[F]] = {
+  def apply[F[_]](mode: Mode = Mode.Parallel)(
+      implicit F: Async[F]): Resource[F, Dispatcher[F]] = {
     final case class Registration(action: F[Unit], prepareCancel: F[Unit] => Unit)
         extends AtomicBoolean(true)
 
@@ -312,10 +313,41 @@ object Dispatcher {
     }
   }
 
+  /**
+   * Enumeration of all supported [[Dispatcher]] modes. The optimal mode for any given use-case
+   * is very dependent on the details of that case. It is ''usually'' safe to default to
+   * [[Mode.Parallel]], though there will be no guarantees around order of evaluation in that
+   * case. Other modes may be several orders of magnitude more performant, depending on the
+   * scenario.
+   */
   sealed trait Mode extends Product with Serializable
 
   object Mode {
+
+    /**
+     * Default [[Dispatcher]] mode. This corresponds to a pattern in which a single `Dispatcher`
+     * is being used by multiple calling threads simultaneously, with complex (potentially
+     * long-running) actions submitted for evaluation. In this mode, order of operation is not
+     * in any way guaranteed, and execution of each submitted action has some unavoidable
+     * overhead due to the forking of a new fiber for each action. This mode is most appropriate
+     * for scenarios in which a single `Dispatcher` is being widely shared across the
+     * application, and where sequencing is not assumed.
+     */
     case object Parallel extends Mode
+
+    /**
+     * A [[Dispatcher]] mode in which submitted actions are evaluated strictly in sequence
+     * (FIFO). In this mode, any actions submitted to [[Dispatcher.unsafeRunAndForget]] are
+     * guaranteed to run in exactly the order submitted, and subsequent actions will not start
+     * evaluation until previous actions are completed. This avoids a significant amount of
+     * overhead associated with the [[Parallel]] mode and allows callers to make assumptions
+     * around ordering, but the downside is that long-running actions will starve subsequent
+     * actions, and all submitters must contend for a singular coordination resource. Thus, this
+     * mode is most appropriate for cases where the actions are relatively trivial (such as
+     * [[Queue.offer]]) ''and'' the `Dispatcher` in question is ''not'' shared across multiple
+     * producers. To be clear, shared dispatchers in sequential mode will still function
+     * correctly, but performance will be suboptimal due to single-point contention.
+     */
     case object Sequential extends Mode
   }
 }

--- a/tests/jvm/src/test/scala/cats/effect/std/DispatcherJVMSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/std/DispatcherJVMSpec.scala
@@ -34,7 +34,7 @@ class DispatcherJVMSpec extends BaseSpec {
         subjects = latches.map(latch => latch.complete(()) >> awaitAll)
 
         _ <- {
-          val rec = Dispatcher[IO] flatMap { runner =>
+          val rec = Dispatcher.parallel[IO] flatMap { runner =>
             Resource.eval(subjects.parTraverse_(act => IO(runner.unsafeRunSync(act))))
           }
 

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -26,7 +26,7 @@ import scala.concurrent.duration._
 class DispatcherSpec extends BaseSpec {
 
   "sequential dispatcher" should {
-    val D = Dispatcher[IO](mode = Dispatcher.Mode.Sequential)
+    val D = Dispatcher.sequential[IO]
 
     "run a synchronous IO" in real {
       val ioa = IO(1).map(_ + 2)
@@ -116,7 +116,7 @@ class DispatcherSpec extends BaseSpec {
   }
 
   "parallel dispatcher" should {
-    val D = Dispatcher[IO](mode = Dispatcher.Mode.Parallel)
+    val D = Dispatcher.parallel[IO]
 
     "run a synchronous IO" in real {
       val ioa = IO(1).map(_ + 2)


### PR DESCRIPTION
This is a little less of an SPSC `Dispatcher` and more MPSC, and definitively a lot more about "short actions that you want to be sequential". Basically this special-cases just a bit for the `q.offer` case, which is obviously quite common in practice. Haven't added benchmarks back, but anecdotally from test runs this appears to be around a 1-2 order of magnitude improvement in those cases.

Closes #2768