### PR TITLE
Fix `IO#syncStep` double-execution

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -843,7 +843,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
 
         case IO.Map(ioe, f, _) =>
           interpret(ioe).map {
-            case Left(_) => Left(io)
+            case Left(io) => Left(io.map(f))
             case Right(a) => Right(f(a))
           }
 
@@ -919,7 +919,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
    * Newtype encoding for an `IO` datatype that has a `cats.Applicative` capable of doing
    * parallel processing in `ap` and `map2`, needed for implementing `cats.Parallel`.
    *
-   * For converting back and forth you can use either the `Parallel[IO]` instance or 
+   * For converting back and forth you can use either the `Parallel[IO]` instance or
    * the methods `cats.effect.kernel.Par.ParallelF.apply` for wrapping any `IO` value and
    * `cats.effect.kernel.Par.ParallelF.value` for unwrapping it.
    *

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -849,7 +849,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
 
         case IO.FlatMap(ioe, f, _) =>
           interpret(ioe).flatMap {
-            case Left(_) => SyncIO.pure(Left(io))
+            case Left(io) => SyncIO.pure(Left(io.flatMap(f)))
             case Right(a) => interpret(f(a))
           }
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -864,7 +864,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
         case IO.HandleErrorWith(ioe, f, _) =>
           interpret(ioe)
             .map {
-              case Left(_) => Left(io)
+              case Left(io) => Left(io.handleErrorWith(f))
               case Right(a) => Right(a)
             }
             .handleErrorWith(t => interpret(f(t)))

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -856,7 +856,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
         case IO.Attempt(ioe) =>
           interpret(ioe)
             .map {
-              case Left(_) => Left(io)
+              case Left(io) => Left(io.attempt)
               case Right(a) => Right(a.asRight[Throwable])
             }
             .handleError(t => Right(t.asLeft[IO[B]]))

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1345,7 +1345,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
 
       "should not execute side-effects twice (#2858)" in ticked { implicit ticker =>
         var i = 0
-        val io = (IO(i += 1) *> IO.cede).syncStep.unsafeRunSync() match {
+        val io = (IO(i += 1) *> IO.cede as ()).syncStep.unsafeRunSync() match {
           case Left(io) => io
           case Right(_) => IO.unit
         }

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1343,9 +1343,19 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
           } must completeAsSync(())
       }
 
-      "should not execute side-effects twice (#2858)" in ticked { implicit ticker =>
+      "should not execute side-effects twice for map (#2858)" in ticked { implicit ticker =>
         var i = 0
         val io = (IO(i += 1) *> IO.cede as ()).syncStep.unsafeRunSync() match {
+          case Left(io) => io
+          case Right(_) => IO.unit
+        }
+        io must completeAs(())
+        i must beEqualTo(1)
+      }
+
+      "should not execute side-effects twice for flatMap (#2858)" in ticked { implicit ticker =>
+        var i = 0
+        val io = (IO(i += 1) *> IO.cede *> IO.unit).syncStep.unsafeRunSync() match {
           case Left(io) => io
           case Right(_) => IO.unit
         }

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1345,7 +1345,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
 
       "should not execute side-effects twice for map (#2858)" in ticked { implicit ticker =>
         var i = 0
-        val io = (IO(i += 1) *> IO.cede as ()).syncStep.unsafeRunSync() match {
+        val io = (IO(i += 1) *> IO.cede).void.syncStep.unsafeRunSync() match {
           case Left(io) => io
           case Right(_) => IO.unit
         }
@@ -1365,7 +1365,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
 
       "should not execute side-effects twice for attempt (#2858)" in ticked { implicit ticker =>
         var i = 0
-        val io = ((IO(i += 1) *> IO.cede).attempt.void).syncStep.unsafeRunSync() match {
+        val io = (IO(i += 1) *> IO.cede).attempt.void.syncStep.unsafeRunSync() match {
           case Left(io) => io
           case Right(_) => IO.unit
         }
@@ -1376,8 +1376,8 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
       "should not execute side-effects twice for handleErrorWith (#2858)" in ticked {
         implicit ticker =>
           var i = 0
-          val io = ((IO(i += 1) *> IO.cede)
-            .handleErrorWith(_ => IO.unit))
+          val io = (IO(i += 1) *> IO.cede)
+            .handleErrorWith(_ => IO.unit)
             .syncStep
             .unsafeRunSync() match {
             case Left(io) => io

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1343,7 +1343,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
           } must completeAsSync(())
       }
 
-      "should not execute side-effects twice for map (#2858)" in ticked { implicit ticker =>
+      "should not execute effects twice for map (#2858)" in ticked { implicit ticker =>
         var i = 0
         val io = (IO(i += 1) *> IO.cede).void.syncStep.unsafeRunSync() match {
           case Left(io) => io
@@ -1353,7 +1353,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         i must beEqualTo(1)
       }
 
-      "should not execute side-effects twice for flatMap (#2858)" in ticked { implicit ticker =>
+      "should not execute effects twice for flatMap (#2858)" in ticked { implicit ticker =>
         var i = 0
         val io = (IO(i += 1) *> IO.cede *> IO.unit).syncStep.unsafeRunSync() match {
           case Left(io) => io
@@ -1363,7 +1363,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         i must beEqualTo(1)
       }
 
-      "should not execute side-effects twice for attempt (#2858)" in ticked { implicit ticker =>
+      "should not execute effects twice for attempt (#2858)" in ticked { implicit ticker =>
         var i = 0
         val io = (IO(i += 1) *> IO.cede).attempt.void.syncStep.unsafeRunSync() match {
           case Left(io) => io
@@ -1373,7 +1373,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         i must beEqualTo(1)
       }
 
-      "should not execute side-effects twice for handleErrorWith (#2858)" in ticked {
+      "should not execute effects twice for handleErrorWith (#2858)" in ticked {
         implicit ticker =>
           var i = 0
           val io = (IO(i += 1) *> IO.cede)

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1362,6 +1362,16 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         io must completeAs(())
         i must beEqualTo(1)
       }
+
+      "should not execute side-effects twice for attempt (#2858)" in ticked { implicit ticker =>
+        var i = 0
+        val io = ((IO(i += 1) *> IO.cede).attempt.void).syncStep.unsafeRunSync() match {
+          case Left(io) => io
+          case Right(_) => IO.unit
+        }
+        io must completeAs(())
+        i must beEqualTo(1)
+      }
     }
 
     "fiber repeated yielding test" in real {

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1372,6 +1372,20 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         io must completeAs(())
         i must beEqualTo(1)
       }
+
+      "should not execute side-effects twice for handleErrorWith (#2858)" in ticked {
+        implicit ticker =>
+          var i = 0
+          val io = ((IO(i += 1) *> IO.cede)
+            .handleErrorWith(_ => IO.unit))
+            .syncStep
+            .unsafeRunSync() match {
+            case Left(io) => io
+            case Right(_) => IO.unit
+          }
+          io must completeAs(())
+          i must beEqualTo(1)
+      }
     }
 
     "fiber repeated yielding test" in real {

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1342,6 +1342,16 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
             case Right(_) => SyncIO.raiseError[Unit](new RuntimeException("Boom!"))
           } must completeAsSync(())
       }
+
+      "should not execute side-effects twice (#2858)" in ticked { implicit ticker =>
+        var i = 0
+        val io = (IO(i += 1) *> IO.cede).syncStep.unsafeRunSync() match {
+          case Left(io) => io
+          case Right(_) => IO.unit
+        }
+        io must completeAs(())
+        i must beEqualTo(1)
+      }
     }
 
     "fiber repeated yielding test" in real {


### PR DESCRIPTION
WIP. Starts by adding a reproducer.