### PR TITLE
Released 3.3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 
 ## Getting Started
 
-- Wired: **3.3.6**
+- Wired: **3.3.7**
 - Tired: **2.5.4**
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-effect" % "3.3.6"
+libraryDependencies += "org.typelevel" %% "cats-effect" % "3.3.7"
 ```
 
 The above represents the core, stable dependency which brings in the entirety of Cats Effect. This is *most likely* what you want. All current Cats Effect releases are published for Scala 2.12, 2.13, 3.0, and Scala.js 1.7.
@@ -30,22 +30,22 @@ Depending on your use-case, you may want to consider one of the several other mo
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats-effect-kernel" % "3.3.6",
-  "org.typelevel" %% "cats-effect-laws"   % "3.3.6" % Test)
+  "org.typelevel" %% "cats-effect-kernel" % "3.3.7",
+  "org.typelevel" %% "cats-effect-laws"   % "3.3.7" % Test)
 ```
 
 If you're a middleware framework (like [Fs2](https://fs2.io/)), you probably want to depend on **std**, which gives you access to `Queue`, `Semaphore`, and much more without introducing a hard-dependency on `IO` outside of your tests:
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats-effect-std" % "3.3.6",
-  "org.typelevel" %% "cats-effect"     % "3.3.6" % Test)
+  "org.typelevel" %% "cats-effect-std" % "3.3.7",
+  "org.typelevel" %% "cats-effect"     % "3.3.7" % Test)
 ```
 
 You may also find some utility in the **testkit** and **kernel-testkit** projects, which contain `TestContext`, generators for `IO`, and a few other things:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-effect-testkit" % "3.3.6" % Test
+libraryDependencies += "org.typelevel" %% "cats-effect-testkit" % "3.3.7" % Test
 ```
 
 Cats Effect provides backward binary compatibility within the 2.x and 3.x version lines, and both forward and backward compatibility within any major/minor line. This is analogous to the versioning scheme used by Cats itself, as well as other major projects such as Scala.js. Thus, any project depending upon Cats Effect 2.2.1 can be used with libraries compiled against Cats Effect 2.0.0 or 2.2.3, but *not* with libraries compiled against 2.3.0 or higher.

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1657,8 +1657,9 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
     override def syncStep[G[_], A](fa: IO[A], limit: Int)(
         implicit G: Sync[G]): G[Either[IO[A], A]] = {
-      type H[+A] = G[A @uncheckedVariance]
-      SyncStep.interpret[H, A](fa, limit)(G).map(_.map(_._1))
+      type H[+B] = G[B @uncheckedVariance]
+      val H = G.asInstanceOf[Sync[H]]
+      G.map(SyncStep.interpret[H, A](fa, limit)(H))(_.map(_._1))
     }
   }
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1658,53 +1658,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     override def syncStep[G[_], A](fa: IO[A], limit: Int)(
         implicit G: Sync[G]): G[Either[IO[A], A]] = {
       type H[+A] = G[A @uncheckedVariance]
-      interpret[H, A](fa, limit)(G).map(_.map(_._1))
-    }
-
-    private[this] def interpret[G[+_], B](io: IO[B], limit: Int)(
-        implicit G: Sync[G]): G[Either[IO[B], (B, Int)]] = {
-      if (limit <= 0) {
-        G.pure(Left(io))
-      } else {
-        io match {
-          case IO.Pure(a) => G.pure(Right((a, limit)))
-          case IO.Error(t) => G.raiseError(t)
-          case IO.Delay(thunk, _) => G.delay(thunk()).map(a => Right((a, limit)))
-          case IO.RealTime => G.realTime.map(a => Right((a, limit)))
-          case IO.Monotonic => G.monotonic.map(a => Right((a, limit)))
-
-          case IO.Map(ioe, f, _) =>
-            interpret[G, Any](ioe, limit - 1).map {
-              case Left(io) => Left(io.map(f))
-              case Right((a, limit)) => Right((f(a), limit))
-            }
-
-          case IO.FlatMap(ioe, f, _) =>
-            interpret[G, Any](ioe, limit - 1).flatMap {
-              case Left(io) => G.pure(Left(io.flatMap(f)))
-              case Right((a, limit)) => interpret[G, B](f(a), limit - 1)
-            }
-
-          case IO.Attempt(ioe) =>
-            interpret[G, Any](ioe, limit - 1)
-              .map {
-                case Left(io) => Left(io.attempt)
-                case Right((a, limit)) => Right((a.asRight[Throwable], limit))
-              }
-              .handleError(t => Right((t.asLeft[IO[B]], limit - 1)))
-
-          case IO.HandleErrorWith(ioe, f, _) =>
-            interpret[G, Any](ioe, limit - 1)
-              .map {
-                case Left(io) => Left(io.handleErrorWith(f))
-                case r @ Right(_) => r
-              }
-              .handleErrorWith(t => interpret[G, Any](f(t), limit - 1))
-              .asInstanceOf[G[Either[IO[B], (B, Int)]]]
-
-          case _ => G.pure(Left(io))
-        }
-      }
+      SyncStep.interpret[H, A](fa, limit)(G).map(_.map(_._1))
     }
   }
 
@@ -1852,6 +1806,54 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
   // INTERNAL, only created by the runloop itself as the terminal state of several operations
   private[effect] case object EndFiber extends IO[Nothing] {
     def tag = -1
+  }
+
+}
+
+private object SyncStep {
+  def interpret[G[+_], B](io: IO[B], limit: Int)(
+      implicit G: Sync[G]): G[Either[IO[B], (B, Int)]] = {
+    if (limit <= 0) {
+      G.pure(Left(io))
+    } else {
+      io match {
+        case IO.Pure(a) => G.pure(Right((a, limit)))
+        case IO.Error(t) => G.raiseError(t)
+        case IO.Delay(thunk, _) => G.delay(thunk()).map(a => Right((a, limit)))
+        case IO.RealTime => G.realTime.map(a => Right((a, limit)))
+        case IO.Monotonic => G.monotonic.map(a => Right((a, limit)))
+
+        case IO.Map(ioe, f, _) =>
+          interpret(ioe, limit - 1).map {
+            case Left(io) => Left(io.map(f))
+            case Right((a, limit)) => Right((f(a), limit))
+          }
+
+        case IO.FlatMap(ioe, f, _) =>
+          interpret(ioe, limit - 1).flatMap {
+            case Left(io) => G.pure(Left(io.flatMap(f)))
+            case Right((a, limit)) => interpret(f(a), limit - 1)
+          }
+
+        case IO.Attempt(ioe) =>
+          interpret(ioe, limit - 1)
+            .map {
+              case Left(io) => Left(io.attempt)
+              case Right((a, limit)) => Right((a.asRight[Throwable], limit))
+            }
+            .handleError(t => Right((t.asLeft[IO[B]], limit - 1)))
+
+        case IO.HandleErrorWith(ioe, f, _) =>
+          interpret(ioe, limit - 1)
+            .map {
+              case Left(io) => Left(io.handleErrorWith(f))
+              case r @ Right(_) => r
+            }
+            .handleErrorWith(t => interpret(f(t), limit - 1))
+
+        case _ => G.pure(Left(io))
+      }
+    }
   }
 
 }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -843,7 +843,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
 
         case IO.Map(ioe, f, _) =>
           interpret(ioe).map {
-            case Left(_) => Left(io)
+            case Left(io) => Left(io.map(f))
             case Right(a) => Right(f(a))
           }
 
@@ -919,7 +919,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
    * Newtype encoding for an `IO` datatype that has a `cats.Applicative` capable of doing
    * parallel processing in `ap` and `map2`, needed for implementing `cats.Parallel`.
    *
-   * For converting back and forth you can use either the `Parallel[IO]` instance or 
+   * For converting back and forth you can use either the `Parallel[IO]` instance or
    * the methods `cats.effect.kernel.Par.ParallelF.apply` for wrapping any `IO` value and
    * `cats.effect.kernel.Par.ParallelF.value` for unwrapping it.
    *

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -849,7 +849,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
 
         case IO.FlatMap(ioe, f, _) =>
           interpret(ioe).flatMap {
-            case Left(_) => SyncIO.pure(Left(io))
+            case Left(io) => SyncIO.pure(Left(io.flatMap(f)))
             case Right(a) => interpret(f(a))
           }
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -864,7 +864,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
         case IO.HandleErrorWith(ioe, f, _) =>
           interpret(ioe)
             .map {
-              case Left(_) => Left(io)
+              case Left(io) => Left(io.handleErrorWith(f))
               case Right(a) => Right(a)
             }
             .handleErrorWith(t => interpret(f(t)))

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -856,7 +856,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
         case IO.Attempt(ioe) =>
           interpret(ioe)
             .map {
-              case Left(_) => Left(io)
+              case Left(io) => Left(io.attempt)
               case Right(a) => Right(a.asRight[Throwable])
             }
             .handleError(t => Right(t.asLeft[IO[B]]))

--- a/docs/core/test-runtime.md
+++ b/docs/core/test-runtime.md
@@ -28,7 +28,7 @@ For those migrating code from Cats Effect 2, `TestControl` is a considerably mor
 In order to use `TestControl`, you will need to bring in the **cats-effect-testkit** dependency:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-effect-testkit" % "3.3.6" % Test
+libraryDependencies += "org.typelevel" %% "cats-effect-testkit" % "3.3.7" % Test
 ```
 
 ## Example

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ title: Getting Started
 Add the following to your **build.sbt**:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-effect" % "3.3.6"
+libraryDependencies += "org.typelevel" %% "cats-effect" % "3.3.7"
 ```
 
 Naturally, if you're using ScalaJS, you should replace the double `%%` with a triple `%%%`. If you're on Scala 2, it is *highly* recommended that you enable the [better-monadic-for](https://github.com/oleg-py/better-monadic-for) plugin, which fixes a number of surprising elements of the `for`-comprehension syntax in the Scala language:
@@ -62,7 +62,7 @@ We will learn more about constructs like `start` and `*>` in later pages, but fo
 Of course, the easiest way to play with Cats Effect is to try it out in a Scala REPL. We recommend using [Ammonite](https://ammonite.io/#Ammonite-REPL) for this kind of thing. To get started, run the following lines (if not using Ammonite, skip the first line and make sure that Cats Effect and its dependencies are correctly configured on the classpath):
 
 ```scala
-import $ivy.`org.typelevel::cats-effect:3.3.6`
+import $ivy.`org.typelevel::cats-effect:3.3.7`
 
 import cats.effect.unsafe.implicits._
 import cats.effect.IO

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -16,7 +16,7 @@ Here is an overview of the steps you should take to migrate your application to 
 ### Before You Begin: This Isn't A "Quick Start" Guide
 
 This guide is meant for existing users of Cats Effect 2 who want to upgrade their applications
-to 3.3.6.
+to 3.3.7.
 
 > If you haven't used Cats Effect before and want to give it a try,
 > please follow the [getting started guide](./getting-started.md) instead!
@@ -81,9 +81,9 @@ Cats Effect 3 splits the code dependency into multiple modules. If you were prev
 The current non-test modules are:
 
 ```scala
-"org.typelevel" %% "cats-effect-kernel" % "3.3.6",
-"org.typelevel" %% "cats-effect-std"    % "3.3.6",
-"org.typelevel" %% "cats-effect"        % "3.3.6",
+"org.typelevel" %% "cats-effect-kernel" % "3.3.7",
+"org.typelevel" %% "cats-effect-std"    % "3.3.7",
+"org.typelevel" %% "cats-effect"        % "3.3.7",
 ```
 
 - `kernel` - type class definitions, simple concurrency primitives
@@ -96,7 +96,7 @@ The current non-test modules are:
 libraryDependencies ++= Seq(
   //...
 -  "org.typelevel" %% "cats-effect" % "2.4.0",
-+  "org.typelevel" %% "cats-effect" % "3.3.6",
++  "org.typelevel" %% "cats-effect" % "3.3.7",
   //...
 )
 ```
@@ -108,8 +108,8 @@ sbt:demo> update
 [error] stack trace is suppressed; run last core / update for the full output
 [error] (core / update) found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
 [error]
-[error] 	* org.typelevel:cats-effect_2.13:3.3.6 (early-semver) is selected over {2.3.1, 2.1.4}
-[error] 	    +- com.example:core-core_2.13:0.0.7-26-3183519d       (depends on 3.3.6)
+[error] 	* org.typelevel:cats-effect_2.13:3.3.7 (early-semver) is selected over {2.3.1, 2.1.4}
+[error] 	    +- com.example:core-core_2.13:0.0.7-26-3183519d       (depends on 3.3.7)
 [error] 	    +- io.monix:monix-catnap_2.13:3.3.0                   (depends on 2.1.4)
 [error] 	    +- com.github.valskalla:odin-core_2.13:0.11.0         (depends on 2.3.1)
 [error]

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -42,11 +42,11 @@ running the code snippets in this tutorial, it is recommended to use the same
 ```scala
 name := "cats-effect-tutorial"
 
-version := "3.3.6"
+version := "3.3.7"
 
 scalaVersion := "2.13.6"
 
-libraryDependencies += "org.typelevel" %% "cats-effect" % "3.3.6" withSources() withJavadoc()
+libraryDependencies += "org.typelevel" %% "cats-effect" % "3.3.7" withSources() withJavadoc()
 
 scalacOptions ++= Seq(
   "-feature",

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -1,0 +1,12 @@
+import sbt._, Keys._
+
+import sbtspiewak.SpiewakSonatypePlugin
+import xerial.sbt.Sonatype.SonatypeKeys._
+
+object Publish extends AutoPlugin {
+
+  override def requires = SpiewakSonatypePlugin
+  override def trigger = allRequirements
+
+  override def projectSettings = Seq(sonatypeCredentialHost := "s01.oss.sonatype.org")
+}

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1345,7 +1345,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
 
       "should not execute side-effects twice (#2858)" in ticked { implicit ticker =>
         var i = 0
-        val io = (IO(i += 1) *> IO.cede).syncStep.unsafeRunSync() match {
+        val io = (IO(i += 1) *> IO.cede as ()).syncStep.unsafeRunSync() match {
           case Left(io) => io
           case Right(_) => IO.unit
         }

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1343,9 +1343,19 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
           } must completeAsSync(())
       }
 
-      "should not execute side-effects twice (#2858)" in ticked { implicit ticker =>
+      "should not execute side-effects twice for map (#2858)" in ticked { implicit ticker =>
         var i = 0
         val io = (IO(i += 1) *> IO.cede as ()).syncStep.unsafeRunSync() match {
+          case Left(io) => io
+          case Right(_) => IO.unit
+        }
+        io must completeAs(())
+        i must beEqualTo(1)
+      }
+
+      "should not execute side-effects twice for flatMap (#2858)" in ticked { implicit ticker =>
+        var i = 0
+        val io = (IO(i += 1) *> IO.cede *> IO.unit).syncStep.unsafeRunSync() match {
           case Left(io) => io
           case Right(_) => IO.unit
         }

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1345,7 +1345,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
 
       "should not execute side-effects twice for map (#2858)" in ticked { implicit ticker =>
         var i = 0
-        val io = (IO(i += 1) *> IO.cede as ()).syncStep.unsafeRunSync() match {
+        val io = (IO(i += 1) *> IO.cede).void.syncStep.unsafeRunSync() match {
           case Left(io) => io
           case Right(_) => IO.unit
         }
@@ -1365,7 +1365,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
 
       "should not execute side-effects twice for attempt (#2858)" in ticked { implicit ticker =>
         var i = 0
-        val io = ((IO(i += 1) *> IO.cede).attempt.void).syncStep.unsafeRunSync() match {
+        val io = (IO(i += 1) *> IO.cede).attempt.void.syncStep.unsafeRunSync() match {
           case Left(io) => io
           case Right(_) => IO.unit
         }
@@ -1376,8 +1376,8 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
       "should not execute side-effects twice for handleErrorWith (#2858)" in ticked {
         implicit ticker =>
           var i = 0
-          val io = ((IO(i += 1) *> IO.cede)
-            .handleErrorWith(_ => IO.unit))
+          val io = (IO(i += 1) *> IO.cede)
+            .handleErrorWith(_ => IO.unit)
             .syncStep
             .unsafeRunSync() match {
             case Left(io) => io

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1343,7 +1343,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
           } must completeAsSync(())
       }
 
-      "should not execute side-effects twice for map (#2858)" in ticked { implicit ticker =>
+      "should not execute effects twice for map (#2858)" in ticked { implicit ticker =>
         var i = 0
         val io = (IO(i += 1) *> IO.cede).void.syncStep.unsafeRunSync() match {
           case Left(io) => io
@@ -1353,7 +1353,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         i must beEqualTo(1)
       }
 
-      "should not execute side-effects twice for flatMap (#2858)" in ticked { implicit ticker =>
+      "should not execute effects twice for flatMap (#2858)" in ticked { implicit ticker =>
         var i = 0
         val io = (IO(i += 1) *> IO.cede *> IO.unit).syncStep.unsafeRunSync() match {
           case Left(io) => io
@@ -1363,7 +1363,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         i must beEqualTo(1)
       }
 
-      "should not execute side-effects twice for attempt (#2858)" in ticked { implicit ticker =>
+      "should not execute effects twice for attempt (#2858)" in ticked { implicit ticker =>
         var i = 0
         val io = (IO(i += 1) *> IO.cede).attempt.void.syncStep.unsafeRunSync() match {
           case Left(io) => io
@@ -1373,7 +1373,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         i must beEqualTo(1)
       }
 
-      "should not execute side-effects twice for handleErrorWith (#2858)" in ticked {
+      "should not execute effects twice for handleErrorWith (#2858)" in ticked {
         implicit ticker =>
           var i = 0
           val io = (IO(i += 1) *> IO.cede)

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1362,6 +1362,16 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         io must completeAs(())
         i must beEqualTo(1)
       }
+
+      "should not execute side-effects twice for attempt (#2858)" in ticked { implicit ticker =>
+        var i = 0
+        val io = ((IO(i += 1) *> IO.cede).attempt.void).syncStep.unsafeRunSync() match {
+          case Left(io) => io
+          case Right(_) => IO.unit
+        }
+        io must completeAs(())
+        i must beEqualTo(1)
+      }
     }
 
     "fiber repeated yielding test" in real {

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1392,7 +1392,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
 
       "should not execute effects twice for map (#2858)" in ticked { implicit ticker =>
         var i = 0
-        val io = (IO(i += 1) *> IO.cede).void.syncStep.unsafeRunSync() match {
+        val io = (IO(i += 1) *> IO.cede).void.syncStep(Int.MaxValue).unsafeRunSync() match {
           case Left(io) => io
           case Right(_) => IO.unit
         }
@@ -1402,20 +1402,22 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
 
       "should not execute effects twice for flatMap (#2858)" in ticked { implicit ticker =>
         var i = 0
-        val io = (IO(i += 1) *> IO.cede *> IO.unit).syncStep.unsafeRunSync() match {
-          case Left(io) => io
-          case Right(_) => IO.unit
-        }
+        val io =
+          (IO(i += 1) *> IO.cede *> IO.unit).syncStep(Int.MaxValue).unsafeRunSync() match {
+            case Left(io) => io
+            case Right(_) => IO.unit
+          }
         io must completeAs(())
         i must beEqualTo(1)
       }
 
       "should not execute effects twice for attempt (#2858)" in ticked { implicit ticker =>
         var i = 0
-        val io = (IO(i += 1) *> IO.cede).attempt.void.syncStep.unsafeRunSync() match {
-          case Left(io) => io
-          case Right(_) => IO.unit
-        }
+        val io =
+          (IO(i += 1) *> IO.cede).attempt.void.syncStep(Int.MaxValue).unsafeRunSync() match {
+            case Left(io) => io
+            case Right(_) => IO.unit
+          }
         io must completeAs(())
         i must beEqualTo(1)
       }
@@ -1425,7 +1427,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
           var i = 0
           val io = (IO(i += 1) *> IO.cede)
             .handleErrorWith(_ => IO.unit)
-            .syncStep
+            .syncStep(Int.MaxValue)
             .unsafeRunSync() match {
             case Left(io) => io
             case Right(_) => IO.unit

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1372,6 +1372,20 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         io must completeAs(())
         i must beEqualTo(1)
       }
+
+      "should not execute side-effects twice for handleErrorWith (#2858)" in ticked {
+        implicit ticker =>
+          var i = 0
+          val io = ((IO(i += 1) *> IO.cede)
+            .handleErrorWith(_ => IO.unit))
+            .syncStep
+            .unsafeRunSync() match {
+            case Left(io) => io
+            case Right(_) => IO.unit
+          }
+          io must completeAs(())
+          i must beEqualTo(1)
+      }
     }
 
     "fiber repeated yielding test" in real {

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1342,6 +1342,16 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
             case Right(_) => SyncIO.raiseError[Unit](new RuntimeException("Boom!"))
           } must completeAsSync(())
       }
+
+      "should not execute side-effects twice (#2858)" in ticked { implicit ticker =>
+        var i = 0
+        val io = (IO(i += 1) *> IO.cede).syncStep.unsafeRunSync() match {
+          case Left(io) => io
+          case Right(_) => IO.unit
+        }
+        io must completeAs(())
+        i must beEqualTo(1)
+      }
     }
 
     "fiber repeated yielding test" in real {


### PR DESCRIPTION
Following up on https://github.com/typelevel/cats-effect/pull/2862.

The compiler is giving me a really hard time with the effect-agnostic `syncStep` :( I tried shuffling things again but still ended up with an unsafe cast in there. It works fine with concrete `SyncIO` so there must be some way to make it work ...