### PR TITLE
Implemented unhandled error reporting for orphan fibers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -454,7 +454,10 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.WorkerThread$Data"),
       // introduced by #2844, Thread local fallback weak bag
       // changes to `cats.effect.unsafe` package private code
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.SynchronizedWeakBag")
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.SynchronizedWeakBag"),
+      // introduced by #2868
+      // added signaling from CallbackStack to indicate successful invocation
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.CallbackStack.apply")
     ) ++ {
       if (isDotty.value) {
         // Scala 3 specific exclusions

--- a/core/shared/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/shared/src/main/scala/cats/effect/CallbackStack.scala
@@ -45,19 +45,25 @@ private final class CallbackStack[A](private[this] var callback: OutcomeIO[A] =>
   }
 
   /**
-   * Invokes *all* non-null callbacks in the queue, starting with the current one.
+   * Invokes *all* non-null callbacks in the queue, starting with the current one. Returns true
+   * iff *any* callbacks were invoked.
    */
   @tailrec
-  def apply(oc: OutcomeIO[A]): Unit = {
+  def apply(oc: OutcomeIO[A], invoked: Boolean): Boolean = {
     val cb = callback
-    if (cb != null) {
+
+    val invoked2 = if (cb != null) {
       cb(oc)
+      true
+    } else {
+      invoked
     }
 
     val next = get()
-    if (next != null) {
-      next(oc)
-    }
+    if (next != null)
+      next(oc, invoked2)
+    else
+      invoked2
   }
 
   /**

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1022,7 +1022,12 @@ private final class IOFiber[A] private (
     outcome = oc
 
     try {
-      callbacks(oc)
+      if (!callbacks(oc, false)) {
+        oc match {
+          case Outcome.Errored(e) => currentCtx.reportFailure(e)
+          case _ => ()
+        }
+      }
     } finally {
       callbacks.lazySet(null) /* avoid leaks */
     }

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -207,7 +207,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
               def execute(r: Runnable) = ec.execute(r)
             }
 
-            IO.raiseError(TestException).start.evalOn(ec2) *> IO(ts)
+            IO.raiseError(TestException).start.evalOn(ec2) *> IO.sleep(10.millis) *> IO(ts)
           }
         }
 
@@ -227,7 +227,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
             }
 
             for {
-              f <- IO.raiseError(TestException).start.evalOn(ec2)
+              f <- (IO.sleep(10.millis) *> IO.raiseError(TestException)).start.evalOn(ec2)
               _ <- f.join
               back <- IO(ts)
             } yield back


### PR DESCRIPTION
This enriches `CallbackStack` with the ability to report when no callbacks were invoked. Note that this isn't entirely perfect, since a fiber which `join`s and is later `cancel`ed within the `join` will empty out its callback, but the `join`ed fiber may finish with an error at the exact same moment. If this happens and the `join`ing fiber is the *only* fiber, the error would have been side-channeled but might end up being missed. I think this is a fairly reasonable tradeoff though, at least for the moment. The alternative is that we force a memory barrier in this case, which I think is a bit too much deoptimization for this edge case.

Closes #2842