### PR TITLE
The `WSTP` can run Futures just as fast as `ExecutionContext.global`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -466,7 +466,25 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
         "cats.effect.IOApp.cats$effect$IOApp$$queue"),
       // introduced by #2844, Thread local fallback weak bag
       // changes to `cats.effect.unsafe` package private code
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.SynchronizedWeakBag")
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.SynchronizedWeakBag"),
+      // introduced by #2873, The WSTP can run Futures just as fast as ExecutionContext.global
+      // changes to `cats.effect.unsafe` package private code
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "cats.effect.unsafe.LocalQueue.bufferForwarder"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "cats.effect.unsafe.LocalQueue.dequeue"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "cats.effect.unsafe.LocalQueue.enqueue"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "cats.effect.unsafe.LocalQueue.enqueueBatch"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "cats.effect.unsafe.LocalQueue.stealInto"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "cats.effect.unsafe.WorkerThread.monitor"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "cats.effect.unsafe.WorkerThread.reschedule"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "cats.effect.unsafe.WorkerThread.schedule")
     ) ++ {
       if (isDotty.value) {
         // Scala 3 specific exclusions
@@ -496,7 +514,19 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
           // introduced by #2853, Configurable caching of blocking threads, properly
           // changes to `cats.effect.unsafe` package private code
           ProblemFilters.exclude[IncompatibleMethTypeProblem](
-            "cats.effect.unsafe.WorkStealingThreadPool.this")
+            "cats.effect.unsafe.WorkStealingThreadPool.this"),
+          // introduced by #2873, The WSTP can run Futures just as fast as ExecutionContext.global
+          // changes to `cats.effect.unsafe` package private code
+          ProblemFilters.exclude[IncompatibleResultTypeProblem](
+            "cats.effect.unsafe.WorkerThread.active"),
+          ProblemFilters.exclude[IncompatibleMethTypeProblem](
+            "cats.effect.unsafe.WorkerThread.active_="),
+          ProblemFilters.exclude[DirectMissingMethodProblem](
+            "cats.effect.unsafe.WorkStealingThreadPool.rescheduleFiber"),
+          ProblemFilters.exclude[DirectMissingMethodProblem](
+            "cats.effect.unsafe.WorkStealingThreadPool.scheduleFiber"),
+          ProblemFilters.exclude[IncompatibleResultTypeProblem](
+            "cats.effect.unsafe.WorkStealingThreadPool.stealFromOtherWorkerThread")
         )
       } else Seq()
     }

--- a/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -26,7 +26,6 @@ private[effect] sealed abstract class WorkStealingThreadPool private ()
     extends ExecutionContext {
   def execute(runnable: Runnable): Unit
   def reportFailure(cause: Throwable): Unit
-  private[effect] def rescheduleFiber(fiber: IOFiber[_]): Unit
-  private[effect] def scheduleFiber(fiber: IOFiber[_]): Unit
+  private[effect] def reschedule(runnable: Runnable): Unit
   private[effect] def canExecuteBlockingCode(): Boolean
 }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1275,7 +1275,7 @@ private final class IOFiber[A] private (
   private[this] def rescheduleFiber(ec: ExecutionContext, fiber: IOFiber[_]): Unit = {
     if (ec.isInstanceOf[WorkStealingThreadPool]) {
       val wstp = ec.asInstanceOf[WorkStealingThreadPool]
-      wstp.rescheduleFiber(fiber)
+      wstp.reschedule(fiber)
     } else {
       scheduleOnForeignEC(ec, fiber)
     }
@@ -1284,7 +1284,7 @@ private final class IOFiber[A] private (
   private[this] def scheduleFiber(ec: ExecutionContext, fiber: IOFiber[_]): Unit = {
     if (ec.isInstanceOf[WorkStealingThreadPool]) {
       val wstp = ec.asInstanceOf[WorkStealingThreadPool]
-      wstp.scheduleFiber(fiber)
+      wstp.execute(fiber)
     } else {
       scheduleOnForeignEC(ec, fiber)
     }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -64,53 +64,32 @@ import java.util.concurrent.atomic.AtomicBoolean
  * by the Executor read/write barriers, but their writes are
  * merely a fast-path and are not necessary for correctness.
  */
-private final class IOFiber[A] private (
-    private[this] var localState: IOLocalState,
-    private[this] val objectState: ArrayStack[AnyRef],
-    private[this] var currentCtx: ExecutionContext,
-    private[this] val finalizers: ArrayStack[IO[Unit]],
-    private[this] val callbacks: CallbackStack[A],
-    private[this] var resumeTag: Byte,
-    private[this] var resumeIO: AnyRef,
-    private[this] val tracingEvents: RingBuffer,
-    private[this] val runtime: IORuntime
+private final class IOFiber[A](
+    initState: IOLocalState,
+    cb: OutcomeIO[A] => Unit,
+    startIO: IO[A],
+    startEC: ExecutionContext,
+    rt: IORuntime
 ) extends IOFiberPlatform[A]
     with FiberIO[A]
     with Runnable {
   /* true when semantically blocking (ensures that we only unblock *once*) */
   suspended: AtomicBoolean =>
 
-  def this(
-      localState: IOLocalState,
-      cb: OutcomeIO[A] => Unit,
-      startIO: IO[A],
-      startEC: ExecutionContext,
-      runtime: IORuntime) = this(
-    localState,
-    new ArrayStack(),
-    startEC,
-    new ArrayStack(),
-    new CallbackStack(cb),
-    IOFiberConstants.ExecR,
-    startIO,
-    if (TracingConstants.isStackTracing) RingBuffer.empty(runtime.traceBufferLogSize) else null,
-    runtime
-  )
-
-  def this(runnable: Runnable, startEC: ExecutionContext) = this(
-    null,
-    null,
-    startEC,
-    null,
-    null,
-    IOFiberConstants.ExecuteRunnableR,
-    runnable,
-    null,
-    null)
-
   import IO._
   import IOFiberConstants._
   import TracingConstants._
+
+  private[this] var localState: IOLocalState = initState
+  private[this] var currentCtx: ExecutionContext = startEC
+  private[this] val objectState: ArrayStack[AnyRef] = new ArrayStack()
+  private[this] val finalizers: ArrayStack[IO[Unit]] = new ArrayStack()
+  private[this] val callbacks: CallbackStack[A] = new CallbackStack(cb)
+  private[this] var resumeTag: Byte = ExecR
+  private[this] var resumeIO: AnyRef = startIO
+  private[this] val runtime: IORuntime = rt
+  private[this] val tracingEvents: RingBuffer =
+    if (TracingConstants.isStackTracing) RingBuffer.empty(runtime.traceBufferLogSize) else null
 
   /*
    * Ideally these would be on the stack, but they can't because we sometimes need to


### PR DESCRIPTION
Not ready for prime time, opening to show some benchmark results. If no one objects, I would still need to fix live fiber snapshots (which I mostly commented out) and handling of fatal exceptions.

If anyone feels like bikeshedding, I would appreciate input on how to (or if at all) present external runnables, since they are not instances of `IOFiber`.