### PR TITLE
Use a ConcurrentHashMap for Supervisor state if F is Async 

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -20,6 +20,9 @@ import cats.effect.kernel._
 import cats.effect.kernel.implicits._
 import cats.syntax.all._
 
+import java.util.concurrent.ConcurrentHashMap
+import scala.collection.mutable.ListBuffer
+
 /**
  * A fiber-based supervisor that monitors the lifecycle of all fibers that are started via its
  * interface. The supervisor is managed by a singular fiber to which the lifecycles of all
@@ -104,33 +107,73 @@ object Supervisor {
    * this scope exits, all supervised fibers will be finalized.
    */
   def apply[F[_]](implicit F: Concurrent[F]): Resource[F, Supervisor[F]] = {
+    F match {
+      case asyncF: Async[F] => applyForAsync(asyncF)
+      case _ => applyForConcurrent
+    }
+  }
+
+  private trait State[F[_]] {
+    def remove(token: Unique.Token): F[Unit]
+    def add(token: Unique.Token, cancel: F[Unit]): F[Unit]
+    // run all the finalizers
+    def cancelAll(): F[Unit]
+  }
+
+  private def supervisor[F[_]](mkState: F[State[F]])(implicit F: Concurrent[F]): Resource[F, Supervisor[F]] = {
     // It would have preferable to use Scope here but explicit cancelation is
     // intertwined with resource management
     for {
-      stateRef <- Resource.make(F.ref[Map[Unique.Token, F[Unit]]](Map.empty)) { state =>
-        state
-          .get
-          .flatMap { fibers =>
-            // run all the finalizers
-            fibers.values.toList.parSequence
-          }
-          .void
-      }
-    } yield {
-      new Supervisor[F] {
-        override def supervise[A](fa: F[A]): F[Fiber[F, Throwable, A]] =
-          F.uncancelable { _ =>
-            for {
-              done <- Ref.of[F, Boolean](false)
-              token <- F.unique
-              cleanup = stateRef.update(_ - token)
-              action = fa.guarantee(done.set(true) >> cleanup)
-              fiber <- F.start(action)
-              _ <- stateRef.update(_ + (token -> fiber.cancel))
-              _ <- done.get.ifM(cleanup, F.unit)
-            } yield fiber
-          }
+      state <- Resource.make(mkState)(_.cancelAll())
+    } yield new Supervisor[F] {
+      override def supervise[A](fa: F[A]): F[Fiber[F, Throwable, A]] =
+        F.uncancelable { _ =>
+          for {
+            done <- Ref.of[F, Boolean](false)
+            token <- F.unique
+            cleanup = state.remove(token)
+            action = fa.guarantee(done.set(true) >> cleanup)
+            fiber <- F.start(action)
+            _ <- state.add(token, fiber.cancel)
+            _ <- done.get.ifM(cleanup, F.unit)
+          } yield fiber
+        }
+    }
+  }
+
+  private def applyForConcurrent[F[_]](implicit F: Concurrent[F]): Resource[F, Supervisor[F]] = {
+    val mkState = F.ref[Map[Unique.Token, F[Unit]]](Map.empty).map { stateRef =>
+      new State[F] {
+        override def remove(token: Unique.Token): F[Unit] = stateRef.update(_ - token)
+        override def add(token: Unique.Token, cancel: F[Unit]): F[Unit] = stateRef.update(_ + (token -> cancel))
+        override def cancelAll(): F[Unit] =
+          stateRef
+            .get
+            .flatMap { fibers =>
+              fibers.values.toList.parUnorderedSequence.void
+            }
       }
     }
+    supervisor(mkState)
+  }
+
+  private def applyForAsync[F[_]](implicit F: Async[F]): Resource[F, Supervisor[F]] = {
+    val mkState = F.delay {
+      val state = new ConcurrentHashMap[Unique.Token, F[Unit]]
+      new State[F] {
+        override def remove(token: Unique.Token): F[Unit] = F.delay(state.remove(token)).void
+        override def add(token: Unique.Token, cancel: F[Unit]): F[Unit] = F.delay(state.put(token, cancel)).void
+        override def cancelAll(): F[Unit] = F.defer {
+          val fibersToCancel = ListBuffer.empty[F[Unit]]
+          fibersToCancel.sizeHint(state.size())
+          val values = state.values().iterator()
+          while (values.hasNext) {
+            fibersToCancel += values.next()
+          }
+          fibersToCancel.result().parUnorderedSequence.void
+        }
+      }
+    }
+    supervisor(mkState)
   }
 }


### PR DESCRIPTION
Replaces https://github.com/typelevel/cats-effect/pull/2875 (targeted for 3.3.x)

In programs that use the same dispatcher a lot, the `stateRef` in `Supervisor` ends up being a hotspot, and a significant amount of time is spent in `spin` attempting to update it.

While the documentation says that dispatchers are cheap and should be constructed often, web servers like blaze-server, jetty-server, http4s-netty, and fs2-netty, use one `Dispatcher` per server.
I don't think that's wrong, and I've also experienced problems with "dispatcher already shutdown" when trying to use shorter-lived ones, as reported in https://github.com/typelevel/cats-effect/issues/2727

Given that, we can fix the hotspot in `Dispatcher` by creating one `Supervisor` for each CPU/worker, which is what this PR does.

Results (from a Ryzen 5900X, I expect the improvement to scale with the number of cores) look good:

Baseline on `series/3.x`:
```
DispatcherBenchmark.scheduling    1000  thrpt   20  167.852 ± 1.801  ops/min
```
This PR:
```
DispatcherBenchmark.scheduling    1000  thrpt   20  600.486 ± 6.002  ops/min
```

I'm also doing some work with Techempower HTTP benchmarks, and this change results in a 5% increase in performance on plaintext using blaze (but interestingly, gets the best result on 16384 concurrent requests while it otherwise peaks at 4096 concurrent requests), and an even greater increase when using a modified http4s-netty backend.

It's possible that there's a better fix for the underlying issue, but this one is simple, and a 3x improvement in (benchmark) performance makes it worth considering, in my opinion. Even if it does making constructing a `Dispatcher` a tiny bit less cheap.