### PR TITLE
Use Sync[F].blocking instead of Sync[F].delay for randomUUID

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
+++ b/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
@@ -38,9 +38,11 @@ trait UUIDGen[F[_]] {
 object UUIDGen {
   def apply[F[_]](implicit ev: UUIDGen[F]): UUIDGen[F] = ev
 
-  implicit def fromSync[F[_]: Sync]: UUIDGen[F] = new UUIDGen[F] {
-    override def randomUUID: F[UUID] = Sync[F].delay(UUID.randomUUID())
+  implicit def fromSync[F[_]](implicit ev: Sync[F]): UUIDGen[F] = new UUIDGen[F] {
+    override final val randomUUID: F[UUID] =
+      ev.blocking(UUID.randomUUID())
   }
+
   def randomUUID[F[_]: UUIDGen]: F[UUID] = UUIDGen[F].randomUUID
   def randomString[F[_]: UUIDGen: Functor]: F[String] = randomUUID.map(_.toString)
 }


### PR DESCRIPTION
Relates to https://github.com/typelevel/cats-effect/issues/2865#issuecomment-1062523959

I know it could be better, I just think the quick fix is worth it and it can be superseded later with a better version.

_(I hope I didn't break bincompat with the unrelated changes)_