### PR TITLE
Docs: Use "fiber blocking" instead of "semantic blocking"

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -78,7 +78,7 @@ private final class IOFiber[A] private (
 ) extends IOFiberPlatform[A]
     with FiberIO[A]
     with Runnable {
-  /* true when semantically blocking (ensures that we only unblock *once*) */
+  /* true when fiber blocking (ensures that we only unblock *once*) */
   suspended: AtomicBoolean =>
 
   def this(

--- a/docs/std/dequeue.md
+++ b/docs/std/dequeue.md
@@ -39,7 +39,7 @@ trait Dequeue[F[_], A] extends Queue[F, A] {
 
 A `Dequeue` may be constructed as `bounded` or `unbounded`. If bounded then
 `offer` may semantically block if the pqueue is already full. `take` is
-semantically blocking if the pqueue is empty.
+fiber blocking if the pqueue is empty.
 
 ## Variance
 

--- a/docs/std/pqueue.md
+++ b/docs/std/pqueue.md
@@ -22,7 +22,7 @@ trait PQueue[F[_], A : Order] {
 
 A `PQueue` may be constructed as `bounded` or `unbounded`. If bounded then
 `offer` may semantically block if the pqueue is already full. `take` is
-semantically blocking if the pqueue is empty.
+fiber blocking if the pqueue is empty.
 
 ```scala mdoc
 import cats.Order
@@ -50,7 +50,7 @@ absurdlyOverengineeredSort(list).flatMap(IO.println(_)).unsafeRunSync()
 
 `PQueue` is split into a `PQueueSource` with a `Functor` instance and a
 `PQueueSink` with a `Contravariant` functor instance. This allows us to
-treat a `PQueue[F, A]` as a `PQueueSource[F, B]` by mapping with `A => B` 
+treat a `PQueue[F, A]` as a `PQueueSource[F, B]` by mapping with `A => B`
 or as a `PQueueSink[F, B]` by contramapping with `B => A`.
 
 ```scala mdoc:reset

--- a/docs/std/queue.md
+++ b/docs/std/queue.md
@@ -19,10 +19,11 @@ trait Queue[F[_], A] {
 }
 ```
 
-`take` is semantically blocking when the queue is empty. A `Queue` may be constructed
+`take` is fiber blocking when the queue is empty. A `Queue` may be constructed
 with different policies for the behaviour of `offer` when the queue has reached
 capacity:
-- `bounded(capacity: Int)`: `offer` is semantically blocking when the queue is full
+
+- `bounded(capacity: Int)`: `offer` is fiber blocking when the queue is full
 - `synchronous`: equivalent to `bounded(0)` - `offer` and `take` are both blocking
   until another fiber invokes the opposite action
 - `unbounded`: `offer` never blocks
@@ -35,7 +36,7 @@ capacity:
 
 `Queue` is split into a `QueueSource` with a `Functor` instance and a
 `QueueSink` with a `Contravariant` functor instance. This allows us to
-treat a `Queue[F, A]` as a `QueueSource[F, B]` by mapping with `A => B` 
+treat a `Queue[F, A]` as a `QueueSource[F, B]` by mapping with `A => B`
 or as a `QueueSink[F, B]` by contramapping with `B => A`.
 
 ```scala mdoc:reset
@@ -68,4 +69,3 @@ def contravariant(list: List[Boolean]): IO[List[Int]] = (
 
 contravariant(List(true, false)).flatMap(IO.println(_)).unsafeRunSync()
 ```
-

--- a/docs/std/semaphore.md
+++ b/docs/std/semaphore.md
@@ -5,7 +5,7 @@ title:  Semaphore
 
 ![](assets/semaphore.png)
 
-A semaphore has a non-negative number of permits available. Acquiring a permit decrements the current number of permits and releasing a permit increases the current number of permits. An acquire that occurs when there are no permits available results in semantic blocking until a permit becomes available.
+A semaphore has a non-negative number of permits available. Acquiring a permit decrements the current number of permits and releasing a permit increases the current number of permits. An acquire that occurs when there are no permits available results in fiber blocking until a permit becomes available.
 
 ```scala
 abstract class Semaphore[F[_]] {
@@ -16,9 +16,9 @@ abstract class Semaphore[F[_]] {
 }
 ```
 
-## Semantic Blocking and Cancellation
+## Fiber Blocking and Cancellation
 
-Semaphore does what we call "semantic" blocking, meaning that no actual threads are 
+Semaphore does what we call "fiber" blocking (aka "semantic" blocking), meaning that no actual threads are
 being blocked while waiting to acquire a permit. Blocking acquires are cancelable.
 
 ## Shared Resource

--- a/docs/thread-model.md
+++ b/docs/thread-model.md
@@ -105,7 +105,7 @@ unbounded, cached threadpool and then shift computation back to the compute pool
 once the blocking call has completed.  We'll see code samples for this later as
 it is quite different between CE2 and CE3.
 
-### Fiber blocking
+### Fiber blocking (previously "Semantic Blocking")
 
 Of course, we do also need the ability to tell fibers to wait for conditions to
 be fulfilled. If we can't call thread blocking operations (eg Java/Scala builtin
@@ -345,7 +345,7 @@ numerous benefits over the `FixedThreadpool` used in CE2:
    every fixed number of iterations of the runloop, stopping a rogue cpu-bound fiber
    from inadvertently pinning a CPU core
 
-## And that's it
+## And that's it!
 
 CE3 drastically simplifies threadpool usage and removes a number of significant
 gotchas, whilst significantly improving performance.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Cont.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Cont.scala
@@ -34,8 +34,8 @@ import cats.~>
  * `Either[Throwable, A] => Unit`, and an (interruptible) operation to semantically block until
  * resumption, of type `F[A]`. We will refer to the former as `resume`, and the latter as `get`.
  *
- * These two operations capture the essence of semantic blocking, and can be used to build
- * `async`, which in turn can be used to build `Fiber`, `start`, `Deferred` and so on.
+ * These two operations capture the essence of fiber blocking, and can be used to build `async`,
+ * which in turn can be used to build `Fiber`, `start`, `Deferred` and so on.
  *
  * Refer to the default implementation to `Async[F].async` for an example of usage.
  *

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenTemporal.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenTemporal.scala
@@ -25,8 +25,7 @@ import scala.concurrent.duration.FiniteDuration
 
 /**
  * A typeclass that encodes the notion of suspending fibers for a given duration. Analogous to
- * `Thread.sleep` but is only semantically blocking rather than blocking an underlying OS
- * pthread.
+ * `Thread.sleep` but is only fiber blocking rather than blocking an underlying OS pthread.
  */
 trait GenTemporal[F[_], E] extends GenConcurrent[F, E] with Clock[F] {
   override def applicative: Applicative[F] = this

--- a/std/shared/src/main/scala/cats/effect/std/CountDownLatch.scala
+++ b/std/shared/src/main/scala/cats/effect/std/CountDownLatch.scala
@@ -21,9 +21,9 @@ import cats.syntax.all._
 import cats.effect.kernel.{Deferred, GenConcurrent, Ref}
 
 /**
- * Concurrency abstraction that supports semantically blocking until n latches are released.
- * Note that this has 'one-shot' semantics - once the counter reaches 0 then [[release]] and
- * [[await]] will forever be no-ops
+ * Concurrency abstraction that supports fiber blocking until n latches are released. Note that
+ * this has 'one-shot' semantics - once the counter reaches 0 then [[release]] and [[await]]
+ * will forever be no-ops
  *
  * See https://typelevel.org/blog/2020/10/30/concurrency-in-ce3.html for a walkthrough of
  * building something like this

--- a/std/shared/src/main/scala/cats/effect/std/Dequeue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dequeue.scala
@@ -263,14 +263,14 @@ object Dequeue {
 trait DequeueSource[F[_], A] extends QueueSource[F, A] {
 
   /**
-   * Dequeues an element from the back of the dequeue, possibly semantically blocking until an
-   * element becomes available.
+   * Dequeues an element from the back of the dequeue, possibly fiber blocking until an element
+   * becomes available.
    */
   def takeBack: F[A]
 
   /**
    * Attempts to dequeue an element from the back of the dequeue, if one is available without
-   * semantically blocking.
+   * fiber blocking.
    *
    * @return
    *   an effect that describes whether the dequeueing of an element from the dequeue succeeded
@@ -279,14 +279,14 @@ trait DequeueSource[F[_], A] extends QueueSource[F, A] {
   def tryTakeBack: F[Option[A]]
 
   /**
-   * Dequeues an element from the front of the dequeue, possibly semantically blocking until an
-   * element becomes available.
+   * Dequeues an element from the front of the dequeue, possibly fiber blocking until an element
+   * becomes available.
    */
   def takeFront: F[A]
 
   /**
    * Attempts to dequeue an element from the front of the dequeue, if one is available without
-   * semantically blocking.
+   * fiber blocking.
    *
    * @return
    *   an effect that describes whether the dequeueing of an element from the dequeue succeeded
@@ -332,7 +332,7 @@ object DequeueSource {
 trait DequeueSink[F[_], A] extends QueueSink[F, A] {
 
   /**
-   * Enqueues the given element at the back of the dequeue, possibly semantically blocking until
+   * Enqueues the given element at the back of the dequeue, possibly fiber blocking until
    * sufficient capacity becomes available.
    *
    * @param a
@@ -353,8 +353,8 @@ trait DequeueSink[F[_], A] extends QueueSink[F, A] {
   def tryOfferBack(a: A): F[Boolean]
 
   /**
-   * Enqueues the given element at the front of the dequeue, possibly semantically blocking
-   * until sufficient capacity becomes available.
+   * Enqueues the given element at the front of the dequeue, possibly fiber blocking until
+   * sufficient capacity becomes available.
    *
    * @param a
    *   the element to be put at the back of the dequeue

--- a/std/shared/src/main/scala/cats/effect/std/PQueue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/PQueue.scala
@@ -204,7 +204,7 @@ object PQueue {
 trait PQueueSource[F[_], A] {
 
   /**
-   * Dequeues the least element from the PQueue, possibly semantically blocking until an element
+   * Dequeues the least element from the PQueue, possibly fiber blocking until an element
    * becomes available.
    *
    * O(log(n))
@@ -217,8 +217,8 @@ trait PQueueSource[F[_], A] {
   def take: F[A]
 
   /**
-   * Attempts to dequeue the least element from the PQueue, if one is available without
-   * semantically blocking.
+   * Attempts to dequeue the least element from the PQueue, if one is available without fiber
+   * blocking.
    *
    * O(log(n))
    *
@@ -254,8 +254,8 @@ object PQueueSource {
 trait PQueueSink[F[_], A] {
 
   /**
-   * Enqueues the given element, possibly semantically blocking until sufficient capacity
-   * becomes available.
+   * Enqueues the given element, possibly fiber blocking until sufficient capacity becomes
+   * available.
    *
    * O(log(n))
    *
@@ -265,7 +265,7 @@ trait PQueueSink[F[_], A] {
   def offer(a: A): F[Unit]
 
   /**
-   * Attempts to enqueue the given element without semantically blocking.
+   * Attempts to enqueue the given element without fiber blocking.
    *
    * O(log(n))
    *

--- a/std/shared/src/main/scala/cats/effect/std/Queue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Queue.scala
@@ -33,8 +33,8 @@ import scala.collection.immutable.{Queue => ScalaQueue}
  *
  * The [[Queue#take]] operation semantically blocks when the queue is empty.
  *
- * The [[Queue#tryOffer]] and [[Queue#tryTake]] allow for usecases which want to avoid
- * semantically blocking a fiber.
+ * The [[Queue#tryOffer]] and [[Queue#tryTake]] allow for usecases which want to avoid fiber
+ * blocking a fiber.
  */
 abstract class Queue[F[_], A] extends QueueSource[F, A] with QueueSink[F, A] { self =>
 
@@ -335,14 +335,14 @@ object Queue {
 trait QueueSource[F[_], A] {
 
   /**
-   * Dequeues an element from the front of the queue, possibly semantically blocking until an
-   * element becomes available.
+   * Dequeues an element from the front of the queue, possibly fiber blocking until an element
+   * becomes available.
    */
   def take: F[A]
 
   /**
    * Attempts to dequeue an element from the front of the queue, if one is available without
-   * semantically blocking.
+   * fiber blocking.
    *
    * @return
    *   an effect that describes whether the dequeueing of an element from the queue succeeded
@@ -372,7 +372,7 @@ object QueueSource {
 trait QueueSink[F[_], A] {
 
   /**
-   * Enqueues the given element at the back of the queue, possibly semantically blocking until
+   * Enqueues the given element at the back of the queue, possibly fiber blocking until
    * sufficient capacity becomes available.
    *
    * @param a

--- a/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
@@ -29,7 +29,7 @@ import scala.collection.immutable.{Queue => Q}
  *
  * A semaphore has a non-negative number of permits available. Acquiring a permit decrements the
  * current number of permits and releasing a permit increases the current number of permits. An
- * acquire that occurs when there are no permits available results in semantic blocking until a
+ * acquire that occurs when there are no permits available results in fiber blocking until a
  * permit becomes available.
  */
 abstract class Semaphore[F[_]] {


### PR DESCRIPTION
From the discord discussions, everyone seems to like this phrasing better - it
helps avoid confusion for newcomers, about the difference between thread
blocking and fiber blocking