### PR TITLE
Use `justFibers` helper in `foreignFibers`

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -194,7 +194,7 @@ private[effect] sealed class FiberMonitor(
       val bag = bagRef.get()
       if (bag ne null) {
         val _ = bag.synchronizationPoint.get()
-        foreign ++= bag.toSet.collect { case fiber: IOFiber[_] => fiber }.filterNot(_.isDone)
+        foreign ++= bag.toSet.collect(justFibers).filterNot(_.isDone)
       }
     }
 


### PR DESCRIPTION
The `justFibers` helper introduced in #2873 is used in all relevant places except for one.

This PR swithes the last place to use the helper function.
