### PR TITLE
Implement `Random#javaSecuritySecureRandom` on Scala.js

### DIFF
--- a/project/CI.scala
+++ b/project/CI.scala
@@ -69,7 +69,7 @@ object CI {
         command = "ciFirefox",
         rootProject = "rootJS",
         jsEnv = Some(JSEnv.Firefox),
-        testCommands = List("testOnly *tracing*"),
+        testCommands = List("testOnly *tracing*", "testOnly *.RandomSpec"),
         mimaReport = false,
         suffixCommands = List())
 
@@ -78,7 +78,7 @@ object CI {
         command = "ciChrome",
         rootProject = "rootJS",
         jsEnv = Some(JSEnv.Chrome),
-        testCommands = List("testOnly *tracing*"),
+        testCommands = List("testOnly *tracing*", "testOnly *.RandomSpec"),
         mimaReport = false,
         suffixCommands = List())
 

--- a/std/js/src/main/scala/cats/effect/std/JavaSecureRandom.scala
+++ b/std/js/src/main/scala/cats/effect/std/JavaSecureRandom.scala
@@ -18,7 +18,7 @@ package cats.effect.std
 
 import scala.scalajs.js
 
-private final class SecureRandom extends java.util.Random {
+private final class JavaSecureRandom extends java.util.Random {
 
   private val nextBytes: Int => js.typedarray.Int8Array =
     if (js.typeOf(js.Dynamic.global.crypto) != "undefined") // browsers

--- a/std/js/src/main/scala/cats/effect/std/JavaSecureRandom.scala
+++ b/std/js/src/main/scala/cats/effect/std/JavaSecureRandom.scala
@@ -20,7 +20,7 @@ import scala.scalajs.js
 
 private final class JavaSecureRandom extends java.util.Random {
 
-  private val nextBytes: Int => js.typedarray.Int8Array =
+  private[this] val nextBytes: Int => js.typedarray.Int8Array =
     if (js.typeOf(js.Dynamic.global.crypto) != "undefined") // browsers
       { numBytes =>
         val bytes = new js.typedarray.Int8Array(numBytes)

--- a/std/js/src/main/scala/cats/effect/std/RandomCompanionPlatform.scala
+++ b/std/js/src/main/scala/cats/effect/std/RandomCompanionPlatform.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.std
+
+private[std] trait RandomCompanionPlatform

--- a/std/js/src/main/scala/cats/effect/std/SecureRandom.scala
+++ b/std/js/src/main/scala/cats/effect/std/SecureRandom.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.std
+
+import java.util.Random
+import scala.scalajs.js
+
+private final class SecureRandom extends Random {
+
+  private val nextBytes: Int => js.typedarray.Int8Array =
+    if (js.typeOf(js.Dynamic.global.crypto) != "undefined") // browsers
+      { numBytes =>
+        val bytes = new js.typedarray.Int8Array(numBytes)
+        js.Dynamic.global.crypto.getRandomValues(bytes)
+        bytes
+      } else {
+      val crypto = js.Dynamic.global.require("crypto")
+
+      // Node.js
+      { numBytes =>
+        val bytes = crypto.randomBytes(numBytes).asInstanceOf[js.typedarray.Uint8Array]
+        new js.typedarray.Int8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+
+      }
+    }
+
+  override def nextBytes(bytes: Array[Byte]): Unit = {
+    nextBytes(bytes.length).copyToArray(bytes)
+    ()
+  }
+
+  override protected final def next(numBits: Int): Int = {
+    val numBytes = (numBits + 7) / 8
+    val b = new js.typedarray.Int8Array(nextBytes(numBytes).buffer)
+    var next = 0
+
+    var i = 0
+    while (i < numBytes) {
+      next = (next << 8) + (b(i) & 0xff)
+      i += 1
+    }
+
+    next >>> (numBytes * 8 - numBits)
+  }
+
+}

--- a/std/js/src/main/scala/cats/effect/std/SecureRandom.scala
+++ b/std/js/src/main/scala/cats/effect/std/SecureRandom.scala
@@ -16,10 +16,9 @@
 
 package cats.effect.std
 
-import java.util.Random
 import scala.scalajs.js
 
-private final class SecureRandom extends Random {
+private final class SecureRandom extends java.util.Random {
 
   private val nextBytes: Int => js.typedarray.Int8Array =
     if (js.typeOf(js.Dynamic.global.crypto) != "undefined") // browsers

--- a/std/jvm/src/main/scala/cats/effect/std/RandomCompanionPlatform.scala
+++ b/std/jvm/src/main/scala/cats/effect/std/RandomCompanionPlatform.scala
@@ -17,5 +17,5 @@
 package cats.effect.std
 
 private[std] trait RandomCompanionPlatform {
-  private[std] type SecureRandom = java.security.SecureRandom
+  private[std] type JavaSecureRandom = java.security.SecureRandom
 }

--- a/std/jvm/src/main/scala/cats/effect/std/RandomCompanionPlatform.scala
+++ b/std/jvm/src/main/scala/cats/effect/std/RandomCompanionPlatform.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.std
+
+private[std] trait RandomCompanionPlatform {
+  private[std] type SecureRandom = java.security.SecureRandom
+}

--- a/std/shared/src/main/scala/cats/effect/std/Random.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Random.scala
@@ -208,7 +208,7 @@ trait Random[F[_]] { self =>
     }
 }
 
-object Random {
+object Random extends RandomCompanionPlatform {
 
   def apply[F[_]](implicit ev: Random[F]): Random[F] = ev
 
@@ -334,7 +334,7 @@ object Random {
   def javaSecuritySecureRandom[F[_]: Sync](n: Int): F[Random[F]] =
     for {
       ref <- Ref[F].of(0)
-      array <- Sync[F].delay(Array.fill(n)(new SRandom(new java.security.SecureRandom)))
+      array <- Sync[F].delay(Array.fill(n)(new SRandom(new SecureRandom)))
     } yield {
       def incrGet = ref.modify(i => (if (i < (n - 1)) i + 1 else 0, i))
       def selectRandom = incrGet.map(array(_))
@@ -342,7 +342,7 @@ object Random {
     }
 
   def javaSecuritySecureRandom[F[_]: Sync]: F[Random[F]] =
-    Sync[F].delay(new java.security.SecureRandom).flatMap(r => javaUtilRandom(r))
+    Sync[F].delay(new SecureRandom).flatMap(r => javaUtilRandom(r))
 
   private sealed abstract class RandomCommon[F[_]: Sync] extends Random[F] {
     def betweenDouble(minInclusive: Double, maxExclusive: Double): F[Double] =

--- a/tests/shared/src/test/scala/cats/effect/std/RandomSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/RandomSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package std
+
+class RandomSpec extends BaseSpec {
+  
+  "Random" should {
+    "securely generate random bytes" in real {
+      for {
+        random1 <- Random.javaSecuritySecureRandom[IO]
+        bytes1 <- random1.nextBytes(128)
+        random2 <- Random.javaSecuritySecureRandom[IO](2)
+        bytes2 <- random2.nextBytes(256)
+      } yield bytes1.length == 128 && bytes2.length == 256
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/2902 by implementing our own `java.security.SecureRandom` shim that delegates to browser and Node.js crypto APIs.

While working on this I noticed there are other APIs that won't link on Scala.js, like the thread local stuff. Those really should be moved to platform traits in a PR targeting series/3.x.