### PR TITLE
Fix `Async#fromCompletableFuture` cancelation

### DIFF
--- a/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
@@ -40,14 +40,14 @@ private[kernel] trait AsyncPlatform[F[_]] { this: Async[F] =>
               }))
           }
 
-          Some(flatMap(delay(cf.cancel(false))) {
-            case true => unit
-            case false => // failed to cancel - block until completion
+          Some(
+            ifM(delay(cf.cancel(false)))(
+              unit,
               async_[Unit] { cb =>
                 cf.handle[Unit]((_, _) => cb(Right(())))
                 ()
               }
-          })
+            ))
         }
       }
     }

--- a/tests/jvm/src/test/scala/cats/effect/kernel/AsyncPlatformSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/kernel/AsyncPlatformSpec.scala
@@ -47,7 +47,13 @@ class AsyncPlatformSpec extends BaseSpec {
         override def cancel(mayInterruptIfRunning: Boolean) = false
       }
 
-      IO.fromCompletableFuture(IO(cf)).start.flatMap(_.cancel) must nonTerminate
+      val io = for {
+        fiber <- IO.fromCompletableFuture(IO(cf)).start
+        _ <- IO.cede
+        _ <- fiber.cancel
+      } yield ()
+
+      io must nonTerminate
     }
   }
 }

--- a/tests/jvm/src/test/scala/cats/effect/kernel/AsyncPlatformSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/kernel/AsyncPlatformSpec.scala
@@ -40,5 +40,14 @@ class AsyncPlatformSpec extends BaseSpec {
         _ <- IO(cf.join() must throwA[CancellationException])
       } yield ok
     }
+
+    "backpressure on CompletableFuture cancelation" in ticked { implicit ticker =>
+      // a non-cancelable, never-completing CompletableFuture
+      def cf = new CompletableFuture[Unit] {
+        override def cancel(mayInterruptIfRunning: Boolean) = false
+      }
+
+      IO.fromCompletableFuture(IO(cf)).start.flatMap(_.cancel) must nonTerminate
+    }
   }
 }

--- a/tests/jvm/src/test/scala/cats/effect/kernel/AsyncPlatformSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/kernel/AsyncPlatformSpec.scala
@@ -49,7 +49,7 @@ class AsyncPlatformSpec extends BaseSpec {
 
       val io = for {
         fiber <- IO.fromCompletableFuture(IO(cf)).start
-        _ <- IO.cede
+        _ <- smallDelay // time for the callback to be set-up
         _ <- fiber.cancel
       } yield ()
 


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/2903. Supersedes https://github.com/typelevel/cats-effect/pull/2904.

The bad news is, my test doesn't pass with @bplommer's fix 🤔 opening in case anyone has some ideas.

/cc @Daenyth for the test