### PR TITLE
Make Queue#tryTakeN, tryTakeFrontN and tryTakeBackN return F[List[A]]

### DIFF
--- a/tests/shared/src/test/scala/cats/effect/std/DequeueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DequeueSpec.scala
@@ -139,23 +139,13 @@ class BoundedDequeueSpec extends BaseSpec with DequeueTests {
     tryOfferTryTakeTests(name, constructor, tryOffer, tryTake)
     commonTests(name, constructor, offer, tryOffer, take, tryTake, size)
     batchTakeTests(name, constructor, _.offer(_), _.tryTakeFrontN(_))
-    batchTakeTests(name, constructor, _.offer(_), _.tryTakeBackN(_), _.map(_.reverse))
+    batchTakeTests(name, constructor, _.offer(_), _.tryTakeBackN(_), _.reverse)
     batchOfferTests(name, constructor, _.tryOfferBackN(_), _.tryTakeFrontN(_))
     batchOfferTests(name, constructor, _.tryOfferFrontN(_), _.tryTakeFrontN(_))
-    batchOfferTests(name, constructor, _.tryOfferBackN(_), _.tryTakeBackN(_), _.map(_.reverse))
-    batchOfferTests(name, constructor, _.tryOfferFrontN(_), _.tryTakeBackN(_), _.map(_.reverse))
-    boundedBatchOfferTests(
-      name,
-      constructor,
-      _.tryOfferBackN(_),
-      _.tryTakeBackN(_),
-      _.map(_.reverse))
-    boundedBatchOfferTests(
-      name,
-      constructor,
-      _.tryOfferFrontN(_),
-      _.tryTakeBackN(_),
-      _.map(_.reverse))
+    batchOfferTests(name, constructor, _.tryOfferBackN(_), _.tryTakeBackN(_), _.reverse)
+    batchOfferTests(name, constructor, _.tryOfferFrontN(_), _.tryTakeBackN(_), _.reverse)
+    boundedBatchOfferTests(name, constructor, _.tryOfferBackN(_), _.tryTakeBackN(_), _.reverse)
+    boundedBatchOfferTests(name, constructor, _.tryOfferFrontN(_), _.tryTakeBackN(_), _.reverse)
     reverse(name, constructor)
   }
 }
@@ -215,21 +205,11 @@ class UnboundedDequeueSpec extends BaseSpec with QueueTests[Dequeue] {
     tryOfferTryTakeTests(name, _ => constructor, tryOffer, tryTake)
     commonTests(name, _ => constructor, offer, tryOffer, take, tryTake, size)
     batchTakeTests(name, _ => constructor, _.offer(_), _.tryTakeFrontN(_))
-    batchTakeTests(name, _ => constructor, _.offer(_), _.tryTakeBackN(_), _.map(_.reverse))
+    batchTakeTests(name, _ => constructor, _.offer(_), _.tryTakeBackN(_), _.reverse)
     batchOfferTests(name, _ => constructor, _.tryOfferBackN(_), _.tryTakeFrontN(_))
     batchOfferTests(name, _ => constructor, _.tryOfferFrontN(_), _.tryTakeFrontN(_))
-    batchOfferTests(
-      name,
-      _ => constructor,
-      _.tryOfferBackN(_),
-      _.tryTakeBackN(_),
-      _.map(_.reverse))
-    batchOfferTests(
-      name,
-      _ => constructor,
-      _.tryOfferFrontN(_),
-      _.tryTakeBackN(_),
-      _.map(_.reverse))
+    batchOfferTests(name, _ => constructor, _.tryOfferBackN(_), _.tryTakeBackN(_), _.reverse)
+    batchOfferTests(name, _ => constructor, _.tryOfferFrontN(_), _.tryTakeBackN(_), _.reverse)
   }
 }
 

--- a/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
@@ -217,8 +217,8 @@ trait QueueTests[Q[_[_], _]] { self: BaseSpec =>
       name: String,
       constructor: Int => IO[Q[IO, Int]],
       tryOfferN: (Q[IO, Int], List[Int]) => IO[List[Int]],
-      tryTakeN: (Q[IO, Int], Option[Int]) => IO[Option[List[Int]]],
-      transformF: Option[List[Int]] => Option[List[Int]] = identity
+      tryTakeN: (Q[IO, Int], Option[Int]) => IO[List[Int]],
+      transform: List[Int] => List[Int] = identity
   ): Fragments = {
     name >> {
       "should offer all records when there is room" in real {
@@ -227,7 +227,7 @@ trait QueueTests[Q[_[_], _]] { self: BaseSpec =>
           offerR <- tryOfferN(q, List(1, 2, 3, 4, 5))
           takeR <- tryTakeN(q, None)
           r <- IO(
-            (transformF(takeR) must beEqualTo(Some(List(1, 2, 3, 4, 5)))) and
+            (transform(takeR) must beEqualTo(List(1, 2, 3, 4, 5))) and
               (offerR must beEqualTo(List.empty)))
         } yield r
       }
@@ -238,8 +238,8 @@ trait QueueTests[Q[_[_], _]] { self: BaseSpec =>
       name: String,
       constructor: Int => IO[Q[IO, Int]],
       tryOfferN: (Q[IO, Int], List[Int]) => IO[List[Int]],
-      tryTakeN: (Q[IO, Int], Option[Int]) => IO[Option[List[Int]]],
-      transformF: Option[List[Int]] => Option[List[Int]] = identity
+      tryTakeN: (Q[IO, Int], Option[Int]) => IO[List[Int]],
+      transform: List[Int] => List[Int] = identity
   ): Fragments = {
     name >> {
       "should offer some records when the queue is full" in real {
@@ -248,7 +248,7 @@ trait QueueTests[Q[_[_], _]] { self: BaseSpec =>
           offerR <- tryOfferN(q, List(1, 2, 3, 4, 5, 6, 7))
           takeR <- tryTakeN(q, None)
           r <- IO(
-            (transformF(takeR) must beEqualTo(Some(List(1, 2, 3, 4, 5)))) and
+            (transform(takeR) must beEqualTo(List(1, 2, 3, 4, 5))) and
               (offerR must beEqualTo(List(6, 7))))
         } yield r
       }
@@ -259,10 +259,10 @@ trait QueueTests[Q[_[_], _]] { self: BaseSpec =>
       name: String,
       constructor: Int => IO[Q[IO, Int]],
       offer: (Q[IO, Int], Int) => IO[Unit],
-      tryTakeN: (Q[IO, Int], Option[Int]) => IO[Option[List[Int]]],
-      transformF: Option[List[Int]] => Option[List[Int]] = identity): Fragments = {
+      tryTakeN: (Q[IO, Int], Option[Int]) => IO[List[Int]],
+      transform: List[Int] => List[Int] = identity): Fragments = {
     name >> {
-      "should take batches for all records when None is proided" in real {
+      "should take batches for all records when None is provided" in real {
         for {
           q <- constructor(5)
           _ <- offer(q, 1)
@@ -271,10 +271,10 @@ trait QueueTests[Q[_[_], _]] { self: BaseSpec =>
           _ <- offer(q, 4)
           _ <- offer(q, 5)
           b <- tryTakeN(q, None)
-          r <- IO(transformF(b) must beEqualTo(Some(List(1, 2, 3, 4, 5))))
+          r <- IO(transform(b) must beEqualTo(List(1, 2, 3, 4, 5)))
         } yield r
       }
-      "should take batches for all records when maxN is proided" in real {
+      "should take batches for all records when maxN is provided" in real {
         for {
           q <- constructor(5)
           _ <- offer(q, 1)
@@ -283,7 +283,7 @@ trait QueueTests[Q[_[_], _]] { self: BaseSpec =>
           _ <- offer(q, 4)
           _ <- offer(q, 5)
           b <- tryTakeN(q, Some(5))
-          r <- IO(transformF(b) must beEqualTo(Some(List(1, 2, 3, 4, 5))))
+          r <- IO(transform(b) must beEqualTo(List(1, 2, 3, 4, 5)))
         } yield r
       }
       "Should take all records when maxN > queue size" in real {
@@ -295,14 +295,14 @@ trait QueueTests[Q[_[_], _]] { self: BaseSpec =>
           _ <- offer(q, 4)
           _ <- offer(q, 5)
           b <- tryTakeN(q, Some(7))
-          r <- IO(transformF(b) must beEqualTo(Some(List(1, 2, 3, 4, 5))))
+          r <- IO(transform(b) must beEqualTo(List(1, 2, 3, 4, 5)))
         } yield r
       }
       "Should be empty when queue is empty" in real {
         for {
           q <- constructor(5)
           b <- tryTakeN(q, Some(5))
-          r <- IO(transformF(b) must beEqualTo(None))
+          r <- IO(transform(b) must beEqualTo(List.empty))
         } yield r
       }
 


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/2915. 

Decided to tackle all tryTake methods because it felt more consistent.