### PR TITLE
Added orElse combinator to IO

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -457,7 +457,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    *   IO to be executed (if the current IO fails)
    * @return
    */
-  def orElse[B >: A](other: IO[B]): IO[B] =
+  def orElse[B >: A](other: => IO[B]): IO[B] =
     handleErrorWith(_ => other)
 
   /**

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -452,13 +452,13 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
     handleErrorWith[B](t => IO.pure(f(t)))
 
   /**
-   * Runs the current IO, if it fails with an error(exception), the other IO  will be executed.
+   * Runs the current IO, if it fails with an error(exception), the other IO will be executed.
    * @param other
-   * IO to be executed (if the current IO fails)  
+   *   IO to be executed (if the current IO fails)
    * @return
    */
   def orElse[B >: A](other: IO[B]): IO[B] =
-    SemigroupK[IO].combineK(this, other)
+    handleErrorWith(_ => other)
 
   /**
    * Handle any error, potentially recovering from it, by mapping it to another `IO` value.
@@ -1493,7 +1493,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
   protected class IOSemigroupK extends SemigroupK[IO] {
     final override def combineK[A](a: IO[A], b: IO[A]): IO[A] =
-      a.handleErrorWith(_ => b)
+      a orElse b
   }
 
   implicit def alignForIO: Align[IO] = _alignForIO

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -458,7 +458,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    * @return
    */
   def orElse[B >: A](other: IO[B]): IO[B] =
-    handleErrorWith(_ => other)
+    SemigroupK[IO].combineK(this, other)
 
   /**
    * Handle any error, potentially recovering from it, by mapping it to another `IO` value.

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -452,6 +452,15 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
     handleErrorWith[B](t => IO.pure(f(t)))
 
   /**
+   * Runs the current IO, if it fails with an error(exception), the other IO  will be executed.
+   * @param other
+   * IO to be executed (if the current IO fails)  
+   * @return
+   */
+  def orElse[B >: A](other: IO[B]): IO[B] =
+    handleErrorWith(_ => other)
+
+  /**
    * Handle any error, potentially recovering from it, by mapping it to another `IO` value.
    *
    * Implements `ApplicativeError.handleErrorWith`.

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -84,6 +84,16 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         IO.raiseError[Unit](TestException).attempt must completeAs(Left(TestException))
       }
 
+      "orElse must return other if previous IO Fails" in ticked { implicit ticker =>
+        case object TestException extends RuntimeException
+        (IO.raiseError[Int](TestException) orElse IO.pure(42)) must completeAs(42)
+      }
+
+      "Return current IO if successful" in ticked { implicit ticker =>
+        case object TestException extends RuntimeException
+        (IO.pure(42)  orElse IO.raiseError[Int](TestException)) must completeAs(42)
+      }
+
       "attempt is redeem with Left(_) for recover and Right(_) for map" in ticked {
         implicit ticker =>
           forAll { (io: IO[Int]) => io.attempt eqv io.redeem(Left(_), Right(_)) }

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -91,7 +91,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
 
       "Return current IO if successful" in ticked { implicit ticker =>
         case object TestException extends RuntimeException
-        (IO.pure(42)  orElse IO.raiseError[Int](TestException)) must completeAs(42)
+        (IO.pure(42) orElse IO.raiseError[Int](TestException)) must completeAs(42)
       }
 
       "attempt is redeem with Left(_) for recover and Right(_) for map" in ticked {


### PR DESCRIPTION
Added orElse combinator to IO. 

Example of Usage 
`val firstIO = IO.raiseError[Int]`
 `val secondIO = IO.pure(42)`
 `val program = firstIO orElse secondIO // this would result to secondIO `

