### PR TITLE
Implemented configurability for `Supervisor` scope termination

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -777,7 +777,18 @@ lazy val std = crossProject(JSPlatform, JVMPlatform)
     mimaBinaryIssueFilters ++= Seq(
       // introduced by #2604, Fix Console on JS
       // changes to `cats.effect.std` package private code
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Console$SyncConsole")
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Console$SyncConsole"),
+      // introduced by #2951
+      // added configurability to Supervisor's scope termination behavior
+      // Java static forwarder
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.std.Supervisor.apply"),
+      // the following are package-private APIs
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "cats.effect.std.Supervisor#State.add"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "cats.effect.std.Supervisor#State.add"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "cats.effect.std.Supervisor#State.joinAll")
     )
   )
   .jsSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -780,8 +780,6 @@ lazy val std = crossProject(JSPlatform, JVMPlatform)
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Console$SyncConsole"),
       // introduced by #2951
       // added configurability to Supervisor's scope termination behavior
-      // Java static forwarder
-      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.std.Supervisor.apply"),
       // the following are package-private APIs
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
         "cats.effect.std.Supervisor#State.add"),

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -111,7 +111,7 @@ object Dispatcher {
     final case class CancelToken(cancelToken: () => Future[Unit]) extends CancelState
 
     for {
-      supervisor <- Supervisor[F]()
+      supervisor <- Supervisor[F]
       latches <- Resource.eval(F delay {
         val latches = new Array[AtomicReference[() => Unit]](Cpus)
         var i = 0

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -111,7 +111,7 @@ object Dispatcher {
     final case class CancelToken(cancelToken: () => Future[Unit]) extends CancelState
 
     for {
-      supervisor <- Supervisor[F]
+      supervisor <- Supervisor[F]()
       latches <- Resource.eval(F delay {
         val latches = new Array[AtomicReference[() => Unit]](Cpus)
         var i = 0

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -107,8 +107,7 @@ object Supervisor {
    * Creates a [[cats.effect.kernel.Resource]] scope within which fibers can be monitored. When
    * this scope exits, all supervised fibers will be finalized.
    */
-  def apply[F[_]](await: Boolean)(
-      implicit F: Concurrent[F]): Resource[F, Supervisor[F]] = {
+  def apply[F[_]](await: Boolean)(implicit F: Concurrent[F]): Resource[F, Supervisor[F]] = {
     F match {
       case asyncF: Async[F] => applyForAsync(await)(asyncF)
       case _ => applyForConcurrent(await)

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -107,7 +107,7 @@ object Supervisor {
    * Creates a [[cats.effect.kernel.Resource]] scope within which fibers can be monitored. When
    * this scope exits, all supervised fibers will be finalized.
    */
-  def apply[F[_]](await: Boolean = false)(
+  def apply[F[_]](await: Boolean)(
       implicit F: Concurrent[F]): Resource[F, Supervisor[F]] = {
     F match {
       case asyncF: Async[F] => applyForAsync(await)(asyncF)
@@ -115,8 +115,8 @@ object Supervisor {
     }
   }
 
-  private[effect] def apply[F[_]: Concurrent]: Resource[F, Supervisor[F]] =
-    apply[F]()
+  def apply[F[_]: Concurrent]: Resource[F, Supervisor[F]] =
+    apply[F](false)
 
   private trait State[F[_]] {
     def remove(token: Unique.Token): F[Unit]

--- a/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
@@ -21,7 +21,7 @@ class SupervisorSpec extends BaseSpec {
 
   "Supervisor" should {
     "start a fiber that completes successfully" in ticked { implicit ticker =>
-      val test = Supervisor[IO]().use { supervisor =>
+      val test = Supervisor[IO].use { supervisor =>
         supervisor.supervise(IO(1)).flatMap(_.join)
       }
 
@@ -30,7 +30,7 @@ class SupervisorSpec extends BaseSpec {
 
     "start a fiber that raises an error" in ticked { implicit ticker =>
       val t = new Throwable("failed")
-      val test = Supervisor[IO]().use { supervisor =>
+      val test = Supervisor[IO].use { supervisor =>
         supervisor.supervise(IO.raiseError[Unit](t)).flatMap(_.join)
       }
 
@@ -38,7 +38,7 @@ class SupervisorSpec extends BaseSpec {
     }
 
     "start a fiber that self-cancels" in ticked { implicit ticker =>
-      val test = Supervisor[IO]().use { supervisor =>
+      val test = Supervisor[IO].use { supervisor =>
         supervisor.supervise(IO.canceled).flatMap(_.join)
       }
 
@@ -47,7 +47,7 @@ class SupervisorSpec extends BaseSpec {
 
     "cancel active fibers when supervisor exits" in ticked { implicit ticker =>
       val test = for {
-        fiber <- Supervisor[IO]().use { supervisor => supervisor.supervise(IO.never[Unit]) }
+        fiber <- Supervisor[IO].use { supervisor => supervisor.supervise(IO.never[Unit]) }
         outcome <- fiber.join
       } yield outcome
 


### PR DESCRIPTION
This implements an `await` flag on the `Supervisor` constructor. This will in turn be added to `Dispatcher`'s parameters as a follow up to #2854. Specifically, this changes the scope termination semantics from `_.parTraverse(_.cancel)` to `_.traverse(_.join).void`, which should resolve some of the most common cases that lead to `dispatcher already shutdown`.

Note that I'm cheating a bit with binary compatibility since this removes the static forwarder (only used from Java) for `Supervisor`'s constructor.

Fixes #1881 