### PR TITLE
Relax `LensRef` constraints

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
@@ -257,7 +257,7 @@ object Ref {
    * }}}
    */
   def lens[F[_], A, B](ref: Ref[F, A])(get: A => B, set: A => B => A)(
-      implicit F: Monad[F]): Ref[F, B] =
+      implicit F: Functor[F]): Ref[F, B] =
     new LensRef[F, A, B](ref)(get, set)
 
   @deprecated("Signature preserved for bincompat", "3.4.0")
@@ -385,7 +385,7 @@ object Ref {
   final private[kernel] class LensRef[F[_], A, B](underlying: Ref[F, A])(
       lensGet: A => B,
       lensSet: A => B => A
-  )(implicit F: Monad[F])
+  )(implicit F: Functor[F])
       extends Ref[F, B] {
 
     def this(underlying: Ref[F, A], lensGet: A => B, lensSet: A => B => A, F: Sync[F]) =

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
@@ -256,9 +256,17 @@ object Ref {
    *     Ref.lens[IO, Foo, String](refA)(_.bar, (foo: Foo) => (bar: String) => foo.copy(bar = bar))
    * }}}
    */
-  def lens[F[_], A, B <: AnyRef](ref: Ref[F, A])(get: A => B, set: A => B => A)(
-      implicit F: Sync[F]): Ref[F, B] =
+  def lens[F[_], A, B](ref: Ref[F, A])(get: A => B, set: A => B => A)(
+      implicit F: Monad[F]): Ref[F, B] =
     new LensRef[F, A, B](ref)(get, set)
+
+  @deprecated("Signature preserved for bincompat", "3.4.0")
+  def lens[F[_], A, B <: AnyRef](
+      ref: Ref[F, A],
+      get: A => B,
+      set: A => B => A,
+      F: Sync[F]): Ref[F, B] =
+    new LensRef[F, A, B](ref)(get, set)(F)
 
   final class ApplyBuilders[F[_]](val mk: Make[F]) extends AnyVal {
 
@@ -374,11 +382,14 @@ object Ref {
       trans(F.compose[(A, *)].compose[A => *].map(underlying.access)(trans(_)))
   }
 
-  final private[kernel] class LensRef[F[_], A, B <: AnyRef](underlying: Ref[F, A])(
+  final private[kernel] class LensRef[F[_], A, B](underlying: Ref[F, A])(
       lensGet: A => B,
       lensSet: A => B => A
-  )(implicit F: Sync[F])
+  )(implicit F: Monad[F])
       extends Ref[F, B] {
+
+    def this(underlying: Ref[F, A], lensGet: A => B, lensSet: A => B => A, F: Sync[F]) =
+      this(underlying)(lensGet, lensSet)(F)
     override def get: F[B] = F.map(underlying.get)(a => lensGet(a))
 
     override def set(b: B): F[Unit] = underlying.update(a => lensModify(a)(_ => b))
@@ -417,23 +428,9 @@ object Ref {
     }
 
     override val access: F[(B, B => F[Boolean])] =
-      F.flatMap(underlying.get) { snapshotA =>
-        val snapshotB = lensGet(snapshotA)
-        val setter = F.delay {
-          val hasBeenCalled = new AtomicBoolean(false)
-
-          (b: B) => {
-            F.flatMap(F.delay(hasBeenCalled.compareAndSet(false, true))) { hasBeenCalled =>
-              F.map(underlying.tryModify { a =>
-                if (hasBeenCalled && (lensGet(a) eq snapshotB))
-                  (lensSet(a)(b), true)
-                else
-                  (a, false)
-              })(_.getOrElse(false))
-            }
-          }
-        }
-        setter.tupleLeft(snapshotB)
+      F.map(underlying.access) {
+        case (a, update) =>
+          (lensGet(a), b => update(lensSet(a)(b)))
       }
 
     private def lensModify(s: A)(f: B => B): A = lensSet(s)(f(lensGet(s)))

--- a/tests/shared/src/test/scala/cats/effect/kernel/LensRefSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/LensRefSpec.scala
@@ -214,21 +214,6 @@ class LensRefSpec extends BaseSpec { outer =>
       op must completeAs((true, Foo(1, -1)))
     }
 
-    "access - successfully modifies underlying Ref after A is modified without affecting B" in ticked {
-      implicit ticker =>
-        val op = for {
-          refA <- Ref[IO].of(Foo(0, -1))
-          refB = Ref.lens[IO, Foo, Integer](refA)(Foo.get, Foo.set)
-          valueAndSetter <- refB.access
-          (value, setter) = valueAndSetter
-          _ <- refA.update(_.copy(baz = -2))
-          success <- setter(value + 1)
-          a <- refA.get
-        } yield (success, a)
-
-        op must completeAs((true, Foo(1, -2)))
-    }
-
     "access - setter fails to modify underlying Ref if value is modified before setter is called" in ticked {
       implicit ticker =>
         val op = for {


### PR DESCRIPTION
Follow-up to https://github.com/typelevel/cats-effect/pull/2901#issuecomment-1100936339.

This drops the semantic from https://github.com/typelevel/cats-effect/pull/827#discussion_r404018298 that:
> writes to A that don't touch B don't break `access`'s setter

As a result, we are able to relax the constraints from `Sync[F]` to `Functor[F]` (!!) and drop the requirement that `B <: AnyRef`, both of which were very annoying in practice.

Thoughts? /cc @kubukoz who reviewed https://github.com/typelevel/cats-effect/pull/827.