### PR TITLE
Add Ref.empty Monoid-based shortcut

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
@@ -178,7 +178,7 @@ object Ref {
   /**
    * Creates a Ref with empty content
    */
-  def empty[F[_]: Make, A: Monoid]: F[Ref[F, A]] = of(Monoid[A].empty)
+  def ofEmpty[F[_]: Make, A: Monoid]: F[Ref[F, A]] = of(Monoid[A].empty)
 
   /**
    * Creates a Ref starting with the value of the one in `source`.
@@ -279,9 +279,9 @@ object Ref {
      * Creates a thread-safe, concurrent mutable reference initialized to the empty value.
      *
      * @see
-     *   [[Ref.empty]]
+     *   [[Ref.ofEmpty]]
      */
-    def empty[A: Monoid]: F[Ref[F, A]] = of(Monoid[A].empty)
+    def ofEmpty[A: Monoid]: F[Ref[F, A]] = of(Monoid[A].empty)
   }
 
   final private class SyncRef[F[_], A](ar: AtomicReference[A])(implicit F: Sync[F])

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
@@ -178,7 +178,7 @@ object Ref {
   /**
    * Creates a Ref with empty content
    */
-  def ofEmpty[F[_]: Make, A: Monoid]: F[Ref[F, A]] = of(Monoid[A].empty)
+  def empty[F[_]: Make, A: Monoid]: F[Ref[F, A]] = of(Monoid[A].empty)
 
   /**
    * Creates a Ref starting with the value of the one in `source`.
@@ -279,9 +279,9 @@ object Ref {
      * Creates a thread-safe, concurrent mutable reference initialized to the empty value.
      *
      * @see
-     *   [[Ref.ofEmpty]]
+     *   [[Ref.empty]]
      */
-    def ofEmpty[A: Monoid]: F[Ref[F, A]] = of(Monoid[A].empty)
+    def empty[A: Monoid]: F[Ref[F, A]] = of(Monoid[A].empty)
   }
 
   final private class SyncRef[F[_], A](ar: AtomicReference[A])(implicit F: Sync[F])

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
@@ -176,6 +176,11 @@ object Ref {
   def of[F[_], A](a: A)(implicit mk: Make[F]): F[Ref[F, A]] = mk.refOf(a)
 
   /**
+   * Creates a Ref with empty content
+   */
+  def empty[F[_]: Make, A: Monoid]: F[Ref[F, A]] = of(Monoid[A].empty)
+
+  /**
    * Creates a Ref starting with the value of the one in `source`.
    *
    * Updates of either of the Refs will not have an effect on the other (assuming A is
@@ -269,6 +274,14 @@ object Ref {
      *   [[Ref.of]]
      */
     def of[A](a: A): F[Ref[F, A]] = mk.refOf(a)
+
+    /**
+     * Creates a thread-safe, concurrent mutable reference initialized to the empty value.
+     *
+     * @see
+     *   [[Ref.empty]]
+     */
+    def empty[A: Monoid]: F[Ref[F, A]] = of(Monoid[A].empty)
   }
 
   final private class SyncRef[F[_], A](ar: AtomicReference[A])(implicit F: Sync[F])

--- a/std/shared/src/test/scala/cats/effect/std/SyntaxSpec.scala
+++ b/std/shared/src/test/scala/cats/effect/std/SyntaxSpec.scala
@@ -25,9 +25,9 @@ class SyntaxSpec extends Specification {
 
   def async[F[_]: Async] = {
     Ref.of[F, String]("foo")
-    Ref.ofEmpty[F, String]
+    Ref.empty[F, String]
     Ref[F].of(15)
-    Ref[F].ofEmpty[String]
+    Ref[F].empty[String]
     Deferred[F, Unit]
     Semaphore[F](15)
   }
@@ -44,8 +44,8 @@ class SyntaxSpec extends Specification {
   def preciseConstraints[F[_]: Ref.Make] = {
     Ref.of[F, String]("foo")
     Ref[F].of(15)
-    Ref.ofEmpty[F, String]
-    Ref[F].ofEmpty[String]
+    Ref.empty[F, String]
+    Ref[F].empty[String]
   }
 
   def semaphoreIsDeriveable[F[_]](implicit F: Concurrent[F]) =

--- a/std/shared/src/test/scala/cats/effect/std/SyntaxSpec.scala
+++ b/std/shared/src/test/scala/cats/effect/std/SyntaxSpec.scala
@@ -25,9 +25,9 @@ class SyntaxSpec extends Specification {
 
   def async[F[_]: Async] = {
     Ref.of[F, String]("foo")
-    Ref.empty[F, String]
+    Ref.ofEmpty[F, String]
     Ref[F].of(15)
-    Ref[F].empty[String]
+    Ref[F].ofEmpty[String]
     Deferred[F, Unit]
     Semaphore[F](15)
   }
@@ -44,8 +44,8 @@ class SyntaxSpec extends Specification {
   def preciseConstraints[F[_]: Ref.Make] = {
     Ref.of[F, String]("foo")
     Ref[F].of(15)
-    Ref.empty[F, String]
-    Ref[F].empty[String]
+    Ref.ofEmpty[F, String]
+    Ref[F].ofEmpty[String]
   }
 
   def semaphoreIsDeriveable[F[_]](implicit F: Concurrent[F]) =

--- a/std/shared/src/test/scala/cats/effect/std/SyntaxSpec.scala
+++ b/std/shared/src/test/scala/cats/effect/std/SyntaxSpec.scala
@@ -25,7 +25,9 @@ class SyntaxSpec extends Specification {
 
   def async[F[_]: Async] = {
     Ref.of[F, String]("foo")
+    Ref.empty[F, String]
     Ref[F].of(15)
+    Ref[F].empty[String]
     Deferred[F, Unit]
     Semaphore[F](15)
   }
@@ -42,6 +44,8 @@ class SyntaxSpec extends Specification {
   def preciseConstraints[F[_]: Ref.Make] = {
     Ref.of[F, String]("foo")
     Ref[F].of(15)
+    Ref.empty[F, String]
+    Ref[F].empty[String]
   }
 
   def semaphoreIsDeriveable[F[_]](implicit F: Concurrent[F]) =


### PR DESCRIPTION
In practice, it's very common to initialize Ref with some empty values - e.g. with empty Option, Vector, Map, etc.
I find this builder method to be useful