### PR TITLE
Fix leaking array ref in `Random`

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Random.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Random.scala
@@ -457,9 +457,12 @@ object Random extends RandomCompanionPlatform {
     def nextBytes(n: Int): F[Array[Byte]] =
       for {
         r <- f
-        bytes = new Array[Byte](0 max n)
-        _ <- Sync[F].delay(r.nextBytes(bytes))
-      } yield bytes
+        out <- Sync[F].delay {
+          val bytes = new Array[Byte](0 max n)
+          r.nextBytes(bytes)
+          bytes
+        }
+      } yield out
 
     def nextDouble: F[Double] =
       for {
@@ -526,9 +529,10 @@ object Random extends RandomCompanionPlatform {
     def nextBoolean: F[Boolean] =
       Sync[F].delay(localRandom().nextBoolean())
 
-    def nextBytes(n: Int): F[Array[Byte]] = {
+    def nextBytes(n: Int): F[Array[Byte]] = Sync[F].delay {
       val bytes = new Array[Byte](0 max n)
-      Sync[F].delay(localRandom().nextBytes(bytes)).as(bytes)
+      localRandom().nextBytes(bytes)
+      bytes
     }
 
     def nextDouble: F[Double] =

--- a/tests/shared/src/test/scala/cats/effect/std/RandomSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/RandomSpec.scala
@@ -28,6 +28,25 @@ class RandomSpec extends BaseSpec {
         bytes2 <- random2.nextBytes(256)
       } yield bytes1.length == 128 && bytes2.length == 256
     }
+
+    "prevent array reference from leaking in ThreadLocalRandom.nextBytes impl" in real {
+      val random = Random.javaUtilConcurrentThreadLocalRandom[IO]
+      val nextBytes = random.nextBytes(128)
+      for {
+        bytes1 <- nextBytes
+        bytes2 <- nextBytes
+      } yield bytes1 ne bytes2
+    }
+
+    "prevent array reference from leaking in ScalaRandom.nextBytes impl" in real {
+      for {
+        random <- Random.scalaUtilRandom[IO]
+        nextBytes = random.nextBytes(128)
+        bytes1 <- nextBytes
+        bytes2 <- nextBytes
+      } yield bytes1 ne bytes2
+    }
+
   }
 
 }


### PR DESCRIPTION
There's a bug in `cats.effect.std.Random` impl. In some cases `nextBytes` returns a ref to the same array. The bug is demonstrated in the newly added tests.

N.B. I changed the impl of both `ThreadLocalRandom` and `ScalaRandom`, although the bug appears only in the former. `ScalaRandom` works fine due to a delay in a preliminary `flatMap` before array creation. But I made the code identical to `ThreadLocalRandom` as to prevent the wrong pattern from being blindly copied somewhere else.

