### PR TITLE
add `useEval` (`useIt`) method to `Resource`

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -211,7 +211,7 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
    * release it.
    */
 
-  def useIt[B](implicit ev: A <:< F[B], F: MonadCancel[F, Throwable]): F[B] =
+  def useEval[B](implicit ev: A <:< F[B], F: MonadCancel[F, Throwable]): F[B] =
     use(ev)
 
   /**

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -207,6 +207,14 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
     fold(f, identity)
 
   /**
+   * For a resource that allocates an action (type `F[B]`), allocate that action, run it and
+   * release it.
+   */
+
+  def useIt[B](implicit ev: A <:< F[B], F: MonadCancel[F, Throwable]): F[B] =
+    use(ev)
+
+  /**
    * Allocates a resource with a non-terminating use action. Useful to run programs that are
    * expressed entirely in `Resource`.
    *


### PR DESCRIPTION
Hey there,

I've added a method I call `useIt`, which is equivalent to `use(identity)`. As a motivation, consider this example from the cats-effect documentation:

```scala
  (
    for {
      in1 <- file("file1")
      in2 <- file("file2")
      out <- file("file3")
    } yield (in1, in2, out)
  ).use { case (file1, file2, file3) =>
    for {
      bytes1 <- read(file1)
      bytes2 <- read(file2)
      _ <- write(file3, bytes1 ++ bytes2)
    } yield ()
  }
```
This looks very clumsy to me. Every allocated resource is mentioned at least 3 times here: once to the left of `<-`, once to the right of `yield`, and then again to the right of `case`. The reader also needs to keep track of the fact that `in1` is the same as `file1` etc., creating opportunities for confusion.

I find it more elegant to simply `yield` the action to be performed and then call `useIt`. 

```scala
  (
    for {
      in1 <- file("file1")
      in2 <- file("file2")
      out <- file("file3")
    } yield for {
      bytes1 <- read(in1)
      bytes2 <- read(in2)
      _ <- write(out, bytes1 ++ bytes2)
    } yield ()
  ).useIt
```

There is precedent for this kind of shortcut, e. g. `combineAll` is a shortcut for `foldMap(identity)`, and I hope that having this method, along with an example in the documentation, helps people discover what I consider to be a neat little trick.