### PR TITLE
Add `Async#executor`

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -33,7 +33,7 @@ package unsafe
 import cats.effect.tracing.TracingConstants
 
 import scala.collection.mutable
-import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.Duration
 
 import java.util.Comparator
@@ -60,7 +60,7 @@ private[effect] final class WorkStealingThreadPool(
     threadCount: Int, // number of worker threads
     private[unsafe] val threadPrefix: String, // prefix for the name of worker threads
     private[unsafe] val runtimeBlockingExpiration: Duration
-) extends ExecutionContext {
+) extends ExecutionContextExecutor {
 
   import TracingConstants._
   import WorkStealingThreadPoolConstants._

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -52,6 +52,7 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
 import java.util.UUID
+import java.util.concurrent.Executor
 
 /**
  * A pure abstraction representing the intention to perform a side effect, where the result of
@@ -1128,6 +1129,8 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     IOCont[K, R](body, Tracing.calculateTracingEvent(body))
 
   def executionContext: IO[ExecutionContext] = ReadEC
+
+  def executor: IO[Executor] = _asyncForIO.executor
 
   def monotonic: IO[FiniteDuration] = Monotonic
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -141,7 +141,7 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
   def executionContext: F[ExecutionContext]
 
   /**
-   * Obtain a reference to the current execution context as a `java.util.concurrent.Executor]]`.
+   * Obtain a reference to the current execution context as a `java.util.concurrent.Executor`.
    */
   def executor: F[Executor] = map(executionContext) {
     case exec: Executor => exec

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -141,7 +141,7 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
   def executionContext: F[ExecutionContext]
 
   /**
-   * Obtain a reference to the current execution context as a [[java.util.concurrent.Executor]].
+   * Obtain a reference to the current execution context as a `java.util.concurrent.Executor]]`.
    */
   def executor: F[Executor] = map(executionContext) {
     case exec: Executor => exec

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -25,6 +25,7 @@ import scala.annotation.{nowarn, tailrec}
 import scala.concurrent.{ExecutionContext, Future}
 
 import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.Executor
 
 /**
  * A typeclass that encodes the notion of suspending asynchronous side effects in the `F[_]`
@@ -138,6 +139,14 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
    * Obtain a reference to the current execution context.
    */
   def executionContext: F[ExecutionContext]
+
+  /**
+   * Obtain a reference to the current execution context as a [[java.util.concurrent.Executor]].
+   */
+  def executor: F[Executor] = map(executionContext) {
+    case exec: Executor => exec
+    case ec => ec.execute(_)
+  }
 
   /**
    * Lifts a [[scala.concurrent.Future]] into an `F` effect.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -24,8 +24,8 @@ import cats.implicits._
 import scala.annotation.{nowarn, tailrec}
 import scala.concurrent.{ExecutionContext, Future}
 
-import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * A typeclass that encodes the notion of suspending asynchronous side effects in the `F[_]`


### PR DESCRIPTION
This is helpful for Java interop. See:
- https://github.com/typelevel/cats-effect/pull/2919#issuecomment-1101390355
- https://github.com/http4s/http4s-jdk-http-client/pull/641

/cc @wjoel 