### PR TITLE
Add combinators for choosing random elements of collections

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/RandomBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/RandomBenchmark.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.benchmarks
+
+import cats.effect.IO
+import cats.effect.std.Random
+import cats.effect.unsafe.implicits.global
+
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * To do comparative benchmarks between versions:
+ *
+ * benchmarks/run-benchmark RandomBenchmark
+ *
+ * This will generate results in `benchmarks/results`.
+ *
+ * Or to run the benchmark from within sbt:
+ *
+ * jmh:run -i 10 -wi 10 -f 2 -t 1 cats.effect.benchmarks.RandomBenchmark
+ *
+ * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread". Please note that
+ * benchmarks should be usually executed at least in 10 iterations (as a rule of thumb), but
+ * more is better.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class RandomBenchmark {
+
+  @Param(Array("10000", "100000", "1000000"))
+  var size: Int = _
+
+  @Param(Array("true", "false"))
+  var reservoir: Boolean = _
+
+  var xs: List[Int] = _
+
+  @Setup
+  def setup(): Unit = {
+    xs = (1 to size).toList
+  }
+
+  val random: Random[IO] = Random.scalaUtilRandom[IO].unsafeRunSync()
+
+  @Benchmark
+  def elementOf(): Int = {
+    random.elementOf(xs, reservoir).unsafeRunSync()
+  }
+
+}

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/RandomBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/RandomBenchmark.scala
@@ -47,21 +47,25 @@ class RandomBenchmark {
   @Param(Array("10000", "100000", "1000000"))
   var size: Int = _
 
-  @Param(Array("true", "false"))
-  var reservoir: Boolean = _
-
-  var xs: List[Int] = _
+  var list: List[Int] = _
+  var vector: Vector[Int] = _
 
   @Setup
   def setup(): Unit = {
-    xs = (1 to size).toList
+    list = (1 to size).toList
+    vector = (1 to size).toVector
   }
 
   val random: Random[IO] = Random.scalaUtilRandom[IO].unsafeRunSync()
 
   @Benchmark
-  def elementOf(): Int = {
-    random.elementOf(xs, reservoir).unsafeRunSync()
+  def elementOfList(): Int = {
+    random.elementOf(list).unsafeRunSync()
+  }
+
+  @Benchmark
+  def elementOfVector(): Int = {
+    random.elementOf(vector).unsafeRunSync()
   }
 
 }

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/RandomBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/RandomBenchmark.scala
@@ -49,11 +49,13 @@ class RandomBenchmark {
 
   var list: List[Int] = _
   var vector: Vector[Int] = _
+  var map: Map[String, Int] = _
 
   @Setup
   def setup(): Unit = {
     list = (1 to size).toList
     vector = (1 to size).toVector
+    map = (1 to size).map(x => (x.toString, x)).toMap
   }
 
   val random: Random[IO] = Random.scalaUtilRandom[IO].unsafeRunSync()
@@ -66,6 +68,11 @@ class RandomBenchmark {
   @Benchmark
   def elementOfVector(): Int = {
     random.elementOf(vector).unsafeRunSync()
+  }
+
+  @Benchmark
+  def elementOfMap(): (String, Int) = {
+    random.elementOf(map).unsafeRunSync()
   }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -823,7 +823,7 @@ lazy val example = crossProject(JSPlatform, JVMPlatform)
  */
 lazy val benchmarks = project
   .in(file("benchmarks"))
-  .dependsOn(core.jvm)
+  .dependsOn(core.jvm, std.jvm)
   .settings(
     name := "cats-effect-benchmarks",
     javaOptions ++= Seq(

--- a/std/shared/src/main/scala/cats/effect/std/Random.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Random.scala
@@ -31,8 +31,8 @@ import cats.data.{
 import cats.effect.kernel._
 import cats.syntax.all._
 
-import scala.util.{Random => SRandom}
 import scala.annotation.tailrec
+import scala.util.{Random => SRandom}
 
 /**
  * Random is the ability to get random information, each time getting a different result.

--- a/tests/shared/src/test/scala/cats/effect/std/RandomSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/RandomSpec.scala
@@ -75,14 +75,14 @@ class RandomSpec extends BaseSpec {
       "reject an empty collection" in real {
         for {
           random <- Random.scalaUtilRandom[IO]
-          result <- random.elementOf(Nil, reservoir = true).attempt
+          result <- random.elementOf(Nil).attempt
         } yield result.isLeft
       }
 
       "eventually choose all elements of the given collection at least once" in real {
         val xs = List(1, 2, 3, 4, 5)
         def chooseAndAccumulate(random: Random[IO], ref: Ref[IO, Set[Int]]): IO[Set[Int]] =
-          random.elementOf(xs, reservoir = true).flatMap(x => ref.updateAndGet(_ + x))
+          random.elementOf(xs).flatMap(x => ref.updateAndGet(_ + x))
         def haveChosenAllElements(ref: Ref[IO, Set[Int]]): IO[Boolean] =
           ref.get.map(_ == xs.toSet)
 


### PR DESCRIPTION
This PR adds a couple of handy functions to `Random` for choosing a random value from a collection.

I'm open to bikeshedding on the naming.

## oneOf

```scala
def oneOf[A](x: A, xs: A*): F[A]
```

Hopefully fairly self-explanatory.

But I wonder if it would make more sense to require at least 2 arguments like Scalacheck does:

```scala
def oneOf[A](x1: A, x2: A, xs: A*): F[A]
```

## elementOf

```scala
def elementOf[A](xs: Iterable[A]): F[A]
```

This takes an `Iterable` so you can choose a random element directly from e.g. a `Map` or a `Set` without having to first copy the contents to an intermediate `Seq`.

## Benchmarks

Performance summary:

* Choosing a random element from a `Vector` is O(1). This is as expected, since `Vector#size` and `Vector#apply` are both O(1).
* For `List` it's O(n). Also expected, because we need to traverse the list twice: once to calculate its size, and again to select the element at the randomly chosen index
* For `Map` it's slightly worse than O(n). Not quite sure why. I'd expect it to be O(n) and faster than `List` because we only do one traversal, not two (`HashMap#size` is O(1)).

Details:

Throughput, so higher is better.

```
[info] Benchmark                         (size)   Mode  Cnt       Score      Error  Units
[info] RandomBenchmark.elementOfList      10000  thrpt   10   21269.536 ±  848.270  ops/s
[info] RandomBenchmark.elementOfList     100000  thrpt   10    1865.345 ±  495.658  ops/s
[info] RandomBenchmark.elementOfList    1000000  thrpt   10     175.340 ±    3.155  ops/s
[info] RandomBenchmark.elementOfMap       10000  thrpt   10   21222.837 ± 2378.972  ops/s
[info] RandomBenchmark.elementOfMap      100000  thrpt   10    1432.057 ±  796.681  ops/s
[info] RandomBenchmark.elementOfMap     1000000  thrpt   10     114.991 ±    9.787  ops/s
[info] RandomBenchmark.elementOfVector    10000  thrpt   10  103479.262 ± 4450.984  ops/s
[info] RandomBenchmark.elementOfVector   100000  thrpt   10   96840.616 ± 7714.952  ops/s
[info] RandomBenchmark.elementOfVector  1000000  thrpt   10   93826.712 ± 5311.399  ops/s
```

## Alternative implementation: reservoir sampling

In an attempt to avoid traversing a List twice, I experimented with [reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling) (specifically Algorithm R, with k=1). That only does one traversal, as you doesn't need to calculate the list's length. On the other hand, it needs to generate one random integer per element of the list. Benchmarks confirmed it is dog slow, so I removed this implementation. Take a look at b022844fc37f384d6e9b8490b8147ab31584dee8 if you're interested.

Algorithm L ([Wikipedia](https://en.wikipedia.org/wiki/Reservoir_sampling#An_optimal_algorithm), [paper](https://dl.acm.org/doi/10.1145/198429.198435)) might be worth a try, as it doesn't require as many random numbers to be generated.