### PR TITLE
Print fatal errors

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -797,9 +797,10 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    * impure side effects.
    *
    * Any exceptions raised within the effect will be passed to the callback in the `Either`. The
-   * callback will be invoked at most *once*. Note that it is very possible to construct an IO
-   * which never returns while still never blocking a thread, and attempting to evaluate that IO
-   * with this method will result in a situation where the callback is *never* invoked.
+   * callback will be invoked at most *once*. In addition, fatal errors will be printed. Note
+   * that it is very possible to construct an IO which never returns while still never blocking
+   * a thread, and attempting to evaluate that IO with this method will result in a situation
+   * where the callback is *never* invoked.
    *
    * As the name says, this is an UNSAFE function as it is impure and performs side effects. You
    * should ideally only call this function ''once'', at the very end of your program.
@@ -808,8 +809,12 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
       implicit runtime: unsafe.IORuntime): Unit = {
     unsafeRunFiber(
       cb(Left(new CancellationException("The fiber was canceled"))),
-      t => cb(Left(t)),
-      a => cb(Right(a)))
+      t => {
+        if (NonFatal(t)) t.printStackTrace()
+        cb(Left(t))
+      },
+      a => cb(Right(a))
+    )
     ()
   }
 
@@ -817,7 +822,10 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
       implicit runtime: unsafe.IORuntime): Unit = {
     unsafeRunFiber(
       cb(Outcome.canceled),
-      t => cb(Outcome.errored(t)),
+      t => {
+        if (NonFatal(t)) t.printStackTrace()
+        cb(Outcome.errored(t))
+      },
       a => cb(Outcome.succeeded(a: Id[A])))
     ()
   }
@@ -833,11 +841,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    * should never be totally silent.
    */
   def unsafeRunAndForget()(implicit runtime: unsafe.IORuntime): Unit =
-    unsafeRunAsync {
-      case Left(NonFatal(_)) => ()
-      case Left(e) => e.printStackTrace()
-      case _ => ()
-    }
+    unsafeRunAsync(_ => ())
 
   /**
    * Evaluates the effect and produces the result in a `Future`.

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -810,7 +810,9 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
     unsafeRunFiber(
       cb(Left(new CancellationException("The fiber was canceled"))),
       t => {
-        if (NonFatal(t)) t.printStackTrace()
+        if (!NonFatal(t)) {
+          t.printStackTrace()
+        }
         cb(Left(t))
       },
       a => cb(Right(a))
@@ -823,7 +825,9 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
     unsafeRunFiber(
       cb(Outcome.canceled),
       t => {
-        if (NonFatal(t)) t.printStackTrace()
+        if (!NonFatal(t)) {
+          t.printStackTrace()
+        }
         cb(Outcome.errored(t))
       },
       a => cb(Outcome.succeeded(a: Id[A])))

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -833,7 +833,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    */
   def unsafeRunAndForget()(implicit runtime: unsafe.IORuntime): Unit =
     unsafeRunAsync {
-      case Left(NonFatal(e)) => ()
+      case Left(NonFatal(_)) => ()
       case Left(e) => System.err.println(e)
       case _ => ()
     }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -17,42 +17,43 @@
 package cats.effect
 
 import cats.{
-  Monoid,
-  Id,
   Align,
-  SemigroupK,
+  Alternative,
+  Applicative,
   CommutativeApplicative,
+  Eval,
+  Functor,
+  Id,
+  Monad,
+  Monoid,
+  Now,
   Parallel,
   Semigroup,
-  StackSafeMonad,
-  Eval,
-  Now,
-  Monad,
-  Applicative,
-  Functor,
+  SemigroupK,
   Show,
-  Alternative,
+  StackSafeMonad,
   Traverse
 }
 import cats.data.Ior
 import cats.effect.instances.spawn
-import cats.effect.std.{UUIDGen, Console, Env}
-import cats.effect.tracing.{TracingEvent, Tracing}
+import cats.effect.std.{Console, Env, UUIDGen}
+import cats.effect.tracing.{Tracing, TracingEvent}
 import cats.syntax.all._
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.{
-  TimeoutException,
   CancellationException,
   ExecutionContext,
   Future,
-  Promise
+  Promise,
+  TimeoutException
 }
 import scala.concurrent.duration._
-import scala.util.{Try, Success, Failure}
+import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
+
 import java.util.UUID
 import java.util.concurrent.Executor
-import scala.util.control.NonFatal
 
 /**
  * A pure abstraction representing the intention to perform a side effect, where the result of
@@ -834,7 +835,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
   def unsafeRunAndForget()(implicit runtime: unsafe.IORuntime): Unit =
     unsafeRunAsync {
       case Left(NonFatal(_)) => ()
-      case Left(e) => System.err.println(e)
+      case Left(e) => e.printStackTrace()
       case _ => ()
     }
 


### PR DESCRIPTION
This is meant to address #2961. This is my first PR. I'm not sure I understood the ticket correctly. I'm not sure if this is the right place to address the issue, or if it needs to be done deeper, inside the IO runloop. Could I get some feedback? Thank you

I wrote a test for this locally to observe the behavior, but it seems with or without the change fatal errors get printed, which I think might be because of the test framework though. So I'm not sure how to test this behavior 