### PR TITLE
Disable tracing for browsers by default on JS

### DIFF
--- a/core/js/src/main/scala/cats/effect/tracing/TracingConstants.scala
+++ b/core/js/src/main/scala/cats/effect/tracing/TracingConstants.scala
@@ -20,7 +20,7 @@ package tracing
 private[effect] object TracingConstants {
 
   private[this] final val stackTracingMode: String =
-    process.env("CATS_EFFECT_TRACING_MODE").filterNot(_.isEmpty).getOrElse("cached")
+    process.env("CATS_EFFECT_TRACING_MODE").filterNot(_.isEmpty).getOrElse("none")
 
   final val isCachedStackTracing: Boolean = stackTracingMode.equalsIgnoreCase("cached")
 

--- a/core/js/src/main/scala/cats/effect/tracing/TracingConstants.scala
+++ b/core/js/src/main/scala/cats/effect/tracing/TracingConstants.scala
@@ -17,10 +17,19 @@
 package cats.effect
 package tracing
 
+import scala.scalajs.js
+
 private[effect] object TracingConstants {
 
   private[this] final val stackTracingMode: String =
-    process.env("CATS_EFFECT_TRACING_MODE").filterNot(_.isEmpty).getOrElse("none")
+    process.env("CATS_EFFECT_TRACING_MODE").filterNot(_.isEmpty).getOrElse {
+      if (js.typeOf(js.Dynamic.global.process) != "undefined"
+        && js.typeOf(js.Dynamic.global.process.release) != "undefined"
+        && js.Dynamic.global.process.release.name == "node".asInstanceOf[js.Any])
+        "cached"
+      else
+        "none"
+    }
 
   final val isCachedStackTracing: Boolean = stackTracingMode.equalsIgnoreCase("cached")
 

--- a/tests/js/src/test/scala/cats/effect/exports.scala
+++ b/tests/js/src/test/scala/cats/effect/exports.scala
@@ -23,7 +23,7 @@ import scala.scalajs.js.annotation._
 @JSExportTopLevel("dummy")
 object exports extends js.Object {
   if (js.typeOf(js.Dynamic.global.process) == "undefined")
-    js.Dynamic.global.process = js.Object()
+    js.special.fileLevelThis.asInstanceOf[js.Dynamic].process = js.Object()
   if (js.typeOf(js.Dynamic.global.process.env) == "undefined")
     js.Dynamic.global.process.env = js.Object()
   js.Dynamic.global.process.env.CATS_EFFECT_TRACING_MODE = "cached"

--- a/tests/js/src/test/scala/cats/effect/exports.scala
+++ b/tests/js/src/test/scala/cats/effect/exports.scala
@@ -22,9 +22,10 @@ import scala.scalajs.js.annotation._
 // we don't care about this object, but we want to run its initializer
 @JSExportTopLevel("dummy")
 object exports extends js.Object {
-  if (js.typeOf(js.Dynamic.global.process) == "undefined")
+  if (js.typeOf(js.Dynamic.global.process) == "undefined") {
     js.special.fileLevelThis.asInstanceOf[js.Dynamic].process = js.Object()
-  if (js.typeOf(js.Dynamic.global.process.env) == "undefined")
-    js.Dynamic.global.process.env = js.Object()
-  js.Dynamic.global.process.env.CATS_EFFECT_TRACING_MODE = "cached"
+    if (js.typeOf(js.Dynamic.global.process.env) == "undefined")
+      js.Dynamic.global.process.env = js.Object()
+    js.Dynamic.global.process.env.CATS_EFFECT_TRACING_MODE = "cached"
+  }
 }

--- a/tests/js/src/test/scala/cats/effect/exports.scala
+++ b/tests/js/src/test/scala/cats/effect/exports.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+// we don't care about this object, but we want to run its initializer
+@JSExportTopLevel("dummy")
+object exports extends js.Object {
+  if (js.typeOf(js.Dynamic.global.process) == "undefined")
+    js.Dynamic.global.process = js.Object()
+  if (js.typeOf(js.Dynamic.global.process.env) == "undefined")
+    js.Dynamic.global.process.env = js.Object()
+  js.Dynamic.global.process.env.CATS_EFFECT_TRACING_MODE = "cached"
+}


### PR DESCRIPTION
So this is kind of sad, and this PR is definitely intended to be a RFC. Right now the performance impact is just too detrimental, particularly in browsers/frontend where Scala.js is most popular. Many frontend projects are running into this and manually disabling it anyway, if not being totally turned off from using CE.js because it seems super slow. So at least at this point in time, I wonder if tracing enabled by default in dev mode is doing more harm than good, and it should be opt-in for when you're actively trying to debug something 😕

Linking to:
- https://github.com/typelevel/cats-effect/issues/2634#issuecomment-991202431
- https://github.com/typelevel/cats-effect/issues/2284
- https://github.com/typelevel/cats-effect/issues/2558
