### PR TITLE
Add peek method to all queue interfaces and implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ metals.sbt
 
 # npm
 node_modules/
+
+# mill
+out/

--- a/std/shared/src/main/scala/cats/effect/std/internal/BankersQueue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/internal/BankersQueue.scala
@@ -53,6 +53,16 @@ private[std] final case class BankersQueue[A](
     } else if (frontLen > 0) BankersQueue(Nil, 0, back, backLen) -> Some(front.head)
     else this -> None
 
+  def peekFront: Option[A] =
+    if (frontLen > 0) Some(front.head)
+    else if (backLen > 0) Some(back.head)
+    else None
+
+  def peekBack: Option[A] =
+    if (backLen > 0) Some(back.head)
+    else if (frontLen > 0) Some(front.head)
+    else None
+
   def reverse: BankersQueue[A] = BankersQueue(back, backLen, front, frontLen)
 
   private def rebalance(): BankersQueue[A] =

--- a/std/shared/src/main/scala/cats/effect/std/internal/BinomialHeap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/internal/BinomialHeap.scala
@@ -58,6 +58,8 @@ private[std] abstract case class BinomialHeap[A](trees: List[BinomialTree[A]]) {
     val (ts, head) = BinomialHeap.take(trees)
     BinomialHeap(ts) -> head
   }
+
+  def peek: Option[A] = BinomialHeap.peek(trees)
 }
 
 private[std] object BinomialHeap {
@@ -118,6 +120,26 @@ private[std] object BinomialHeap {
         val (t, ts) = min(l)
         merge(t.children.reverse, ts) -> Some(t.value)
       }
+    }
+
+  }
+
+  def peek[A](trees: List[BinomialTree[A]])(implicit Ord: Order[A]): Option[A] = {
+    // Note this is partial but we don't want to allocate a NonEmptyList
+    def min(trees: List[BinomialTree[A]]): BinomialTree[A] =
+      trees match {
+        case t :: Nil => t
+        case t :: ts =>
+          val t1 = min(ts)
+          if (Ord.lteqv(t.value, t1.value)) t else t1
+        case _ => throw new AssertionError
+      }
+
+    trees match {
+      case Nil => None
+      case l =>
+        val t = min(l)
+        Some(t.value)
     }
 
   }

--- a/tests/shared/src/test/scala/cats/effect/std/DequeueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DequeueSpec.scala
@@ -39,6 +39,7 @@ class BoundedDequeueSpec extends BaseSpec with DequeueTests {
       _.tryOfferBack(_),
       _.takeFront,
       _.tryTakeFront,
+      _.peekFront,
       _.size
     )
     boundedDequeueTests(
@@ -48,6 +49,7 @@ class BoundedDequeueSpec extends BaseSpec with DequeueTests {
       _.tryOfferFront(_),
       _.takeBack,
       _.tryTakeBack,
+      _.peekBack,
       _.size
     )
     boundedDequeueTests(
@@ -57,6 +59,7 @@ class BoundedDequeueSpec extends BaseSpec with DequeueTests {
       _.tryOfferBack(_),
       _.takeFront,
       _.tryTakeFront,
+      _.peekFront,
       _.size
     )
     boundedDequeueTests(
@@ -66,6 +69,7 @@ class BoundedDequeueSpec extends BaseSpec with DequeueTests {
       _.tryOfferFront(_),
       _.takeBack,
       _.tryTakeBack,
+      _.peekBack,
       _.size
     )
   }
@@ -77,6 +81,7 @@ class BoundedDequeueSpec extends BaseSpec with DequeueTests {
       tryOffer: (Dequeue[IO, Int], Int) => IO[Boolean],
       take: Dequeue[IO, Int] => IO[Int],
       tryTake: Dequeue[IO, Int] => IO[Option[Int]],
+      peek: Dequeue[IO, Int] => IO[Option[Int]],
       size: Dequeue[IO, Int] => IO[Int]
   ): Fragments = {
     s"$name - demonstrate offer and take with zero capacity" in real {
@@ -137,7 +142,7 @@ class BoundedDequeueSpec extends BaseSpec with DequeueTests {
     tryOfferOnFullTests(name, constructor, offer, tryOffer, false)
     cancelableOfferTests(name, constructor, offer, take, tryTake)
     tryOfferTryTakeTests(name, constructor, tryOffer, tryTake)
-    commonTests(name, constructor, offer, tryOffer, take, tryTake, size)
+    commonTests(name, constructor, offer, tryOffer, take, tryTake, peek, size)
     batchTakeTests(name, constructor, _.offer(_), _.tryTakeFrontN(_))
     batchTakeTests(name, constructor, _.offer(_), _.tryTakeBackN(_), _.reverse)
     batchOfferTests(name, constructor, _.tryOfferBackN(_), _.tryTakeFrontN(_))
@@ -161,6 +166,7 @@ class UnboundedDequeueSpec extends BaseSpec with QueueTests[Dequeue] {
       _.tryOfferBack(_),
       _.takeFront,
       _.tryTakeFront,
+      _.peekFront,
       _.size)
 
     unboundedDequeueTests(
@@ -170,6 +176,7 @@ class UnboundedDequeueSpec extends BaseSpec with QueueTests[Dequeue] {
       _.tryOfferFront(_),
       _.takeBack,
       _.tryTakeBack,
+      _.peekBack,
       _.size)
 
     unboundedDequeueTests(
@@ -179,6 +186,7 @@ class UnboundedDequeueSpec extends BaseSpec with QueueTests[Dequeue] {
       _.tryOfferBack(_),
       _.takeFront,
       _.tryTakeFront,
+      _.peekFront,
       _.size
     )
 
@@ -189,6 +197,7 @@ class UnboundedDequeueSpec extends BaseSpec with QueueTests[Dequeue] {
       _.tryOfferFront(_),
       _.takeBack,
       _.tryTakeBack,
+      _.peekBack,
       _.size
     )
   }
@@ -200,10 +209,11 @@ class UnboundedDequeueSpec extends BaseSpec with QueueTests[Dequeue] {
       tryOffer: (Dequeue[IO, Int], Int) => IO[Boolean],
       take: Dequeue[IO, Int] => IO[Int],
       tryTake: Dequeue[IO, Int] => IO[Option[Int]],
+      peek: Dequeue[IO, Int] => IO[Option[Int]],
       size: Dequeue[IO, Int] => IO[Int]): Fragments = {
     tryOfferOnFullTests(name, _ => constructor, offer, tryOffer, true)
     tryOfferTryTakeTests(name, _ => constructor, tryOffer, tryTake)
-    commonTests(name, _ => constructor, offer, tryOffer, take, tryTake, size)
+    commonTests(name, _ => constructor, offer, tryOffer, take, tryTake, peek, size)
     batchTakeTests(name, _ => constructor, _.offer(_), _.tryTakeFrontN(_))
     batchTakeTests(name, _ => constructor, _.offer(_), _.tryTakeBackN(_), _.reverse)
     batchOfferTests(name, _ => constructor, _.tryOfferBackN(_), _.tryTakeFrontN(_))

--- a/tests/shared/src/test/scala/cats/effect/std/PQueueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/PQueueSpec.scala
@@ -108,7 +108,7 @@ class BoundedPQueueSpec extends BaseSpec with PQueueTests {
     tryOfferOnFullTests(name, constructor, _.offer(_), _.tryOffer(_), false)
     cancelableOfferTests(name, constructor, _.offer(_), _.take, _.tryTake)
     tryOfferTryTakeTests(name, constructor, _.tryOffer(_), _.tryTake)
-    commonTests(name, constructor, _.offer(_), _.tryOffer(_), _.take, _.tryTake, _.size)
+    commonTests(name, constructor, _.offer(_), _.tryOffer(_), _.take, _.tryTake, _.peek, _.size)
     dequeueInPriorityOrder(name, constructor)
     batchTakeTests(name, constructor, _.offer(_), _.tryTakeN(_))
     batchOfferTests(name, constructor, _.tryOfferN(_), _.tryTakeN(_))
@@ -134,7 +134,15 @@ class UnboundedPQueueSpec extends BaseSpec with PQueueTests {
       constructor: IO[PQueue[IO, Int]]): Fragments = {
     tryOfferOnFullTests(name, _ => constructor, _.offer(_), _.tryOffer(_), true)
     tryOfferTryTakeTests(name, _ => constructor, _.tryOffer(_), _.tryTake)
-    commonTests(name, _ => constructor, _.offer(_), _.tryOffer(_), _.take, _.tryTake, _.size)
+    commonTests(
+      name,
+      _ => constructor,
+      _.offer(_),
+      _.tryOffer(_),
+      _.take,
+      _.tryTake,
+      _.peek,
+      _.size)
     dequeueInPriorityOrder(name, _ => constructor)
     batchTakeTests(name, _ => constructor, _.offer(_), _.tryTakeN(_))
     batchOfferTests(name, _ => constructor, _.tryOfferN(_), _.tryTakeN(_))

--- a/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
@@ -101,7 +101,7 @@ class BoundedQueueSpec extends BaseSpec with QueueTests[Queue] {
     tryOfferOnFullTests(name, constructor, _.offer(_), _.tryOffer(_), false)
     cancelableOfferTests(name, constructor, _.offer(_), _.take, _.tryTake)
     tryOfferTryTakeTests(name, constructor, _.tryOffer(_), _.tryTake)
-    commonTests(name, constructor, _.offer(_), _.tryOffer(_), _.take, _.tryTake, _.size)
+    commonTests(name, constructor, _.offer(_), _.tryOffer(_), _.take, _.tryTake, _.peek, _.size)
     batchTakeTests(name, constructor, _.offer(_), _.tryTakeN(_))
     batchOfferTests(name, constructor, _.tryOfferN(_), _.tryTakeN(_))
     boundedBatchOfferTests(name, constructor, _.tryOfferN(_), _.tryTakeN(_))
@@ -121,7 +121,15 @@ class UnboundedQueueSpec extends BaseSpec with QueueTests[Queue] {
   private def unboundedQueueTests(name: String, constructor: IO[Queue[IO, Int]]): Fragments = {
     tryOfferOnFullTests(name, _ => constructor, _.offer(_), _.tryOffer(_), true)
     tryOfferTryTakeTests(name, _ => constructor, _.tryOffer(_), _.tryTake)
-    commonTests(name, _ => constructor, _.offer(_), _.tryOffer(_), _.take, _.tryTake, _.size)
+    commonTests(
+      name,
+      _ => constructor,
+      _.offer(_),
+      _.tryOffer(_),
+      _.take,
+      _.tryTake,
+      _.peek,
+      _.size)
     batchTakeTests(name, _ => constructor, _.offer(_), _.tryTakeN(_))
     batchOfferTests(name, _ => constructor, _.tryOfferN(_), _.tryTakeN(_))
   }
@@ -146,7 +154,7 @@ class DroppingQueueSpec extends BaseSpec with QueueTests[Queue] {
     tryOfferOnFullTests(name, constructor, _.offer(_), _.tryOffer(_), false)
     cancelableOfferTests(name, constructor, _.offer(_), _.take, _.tryTake)
     tryOfferTryTakeTests(name, constructor, _.tryOffer(_), _.tryTake)
-    commonTests(name, constructor, _.offer(_), _.tryOffer(_), _.take, _.tryTake, _.size)
+    commonTests(name, constructor, _.offer(_), _.tryOffer(_), _.take, _.tryTake, _.peek, _.size)
     batchTakeTests(name, constructor, _.offer(_), _.tryTakeN(_))
     batchOfferTests(name, constructor, _.tryOfferN(_), _.tryTakeN(_))
   }
@@ -169,7 +177,7 @@ class CircularBufferQueueSpec extends BaseSpec with QueueTests[Queue] {
     negativeCapacityConstructionTests(name, constructor)
     zeroCapacityConstructionTests(name, constructor)
     tryOfferOnFullTests(name, constructor, _.offer(_), _.tryOffer(_), true)
-    commonTests(name, constructor, _.offer(_), _.tryOffer(_), _.take, _.tryTake, _.size)
+    commonTests(name, constructor, _.offer(_), _.tryOffer(_), _.take, _.tryTake, _.peek, _.size)
     batchTakeTests(name, constructor, _.offer(_), _.tryTakeN(_))
     batchOfferTests(name, constructor, _.tryOfferN(_), _.tryTakeN(_))
   }
@@ -456,6 +464,7 @@ trait QueueTests[Q[_[_], _]] { self: BaseSpec =>
       tryOffer: (Q[IO, Int], Int) => IO[Boolean],
       take: Q[IO, Int] => IO[Int],
       tryTake: Q[IO, Int] => IO[Option[Int]],
+      peek: Q[IO, Int] => IO[Option[Int]],
       size: Q[IO, Int] => IO[Int]): Fragments = {
 
     name >> {
@@ -466,6 +475,26 @@ trait QueueTests[Q[_[_], _]] { self: BaseSpec =>
           _ <- offer(q, 1)
           _ <- take(q)
           _ <- offer(q, 2)
+          sz <- size(q)
+          r <- IO(sz must beEqualTo(1))
+        } yield r
+      }
+
+      "peek should return first element" in real {
+        for {
+          q <- constructor(1)
+          a1 <- peek(q)
+          _ <- offer(q, 1)
+          a2 <- peek(q)
+          r <- IO((a1 must beEqualTo(None)) and (a2 must beEqualTo(Some(1))))
+        } yield r
+      }
+
+      "peek should not affect size" in real {
+        for {
+          q <- constructor(1)
+          _ <- offer(q, 1)
+          _ <- peek(q)
           sz <- size(q)
           r <- IO(sz must beEqualTo(1))
         } yield r

--- a/tests/shared/src/test/scala/cats/effect/std/internal/BankersQueueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/internal/BankersQueueSpec.scala
@@ -60,6 +60,13 @@ class BankersQueueSpec extends Specification with ScalaCheck {
 
       toListFromFront(queue.reverse) must beEqualTo(elems.reverse)
     }
+
+    "peek" in prop { (elems: List[Int]) =>
+      val queue = buildQueue(elems)
+      queue.peekFront must beEqualTo(elems.headOption)
+      queue.peekBack must beEqualTo(elems.lastOption)
+      toListFromFront(queue) must beEqualTo(elems)
+    }
   }
 
   private def buildQueue[A](elems: List[A]): BankersQueue[A] =


### PR DESCRIPTION
This implements #2639 

This only adds methods, but it seems it may break backwards-compatibility according to that discussion. Is that because it adds methods to an interface?