### PR TITLE
Add `Sync.Type.BlockingOrInterruptible`

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
@@ -290,8 +290,9 @@ object Sync {
 
   object Type {
     case object Delay extends Type
-    case object Blocking extends Type
-    case object InterruptibleOnce extends Type
-    case object InterruptibleMany extends Type
+    sealed trait BlockingOrInterruptible extends Type
+    case object Blocking extends BlockingOrInterruptible
+    case object InterruptibleOnce extends BlockingOrInterruptible
+    case object InterruptibleMany extends BlockingOrInterruptible
   }
 }


### PR DESCRIPTION
For example this might be useful in https://github.com/typelevel/fs2/pull/2932 to allow the user to configure what kind of blocking they want, without being allowed to pass `Delay`.