### PR TITLE
Updated native image config for GraalVM 21.0

### DIFF
--- a/core/jvm/src/main/resources/META-INF/native-image/org.typelevel/cats-effect/sun-misc-signal-proxy-config.json
+++ b/core/jvm/src/main/resources/META-INF/native-image/org.typelevel/cats-effect/sun-misc-signal-proxy-config.json
@@ -1,3 +1,3 @@
 [
-    ["sun.misc.SignalHandler"]
+    { "interfaces": [ "sun.misc.SignalHandler" ] }
 ]

--- a/docs/core/native-image.md
+++ b/docs/core/native-image.md
@@ -13,4 +13,7 @@ reflective approach.
 
 Luckily, GraalVM Native Image has full support for both `Proxy` and POSIX
 signals. Cats Effect jars contain extra metadata that makes building native
-images seamless, without the need of extra configuration.
+images seamless, without the need of extra configuration. The only caveat
+is that this configuration metadata is specific to GraalVM 21.0 and later.
+Previous versions of GraalVM are supported, but Native Image support requires
+at least 21.0.


### PR DESCRIPTION
Fixes #3051

Note that Scala itself still has some issues with Native Image, as noted in the linked issue. This fixes the Cats Effect specific issues. Note that using Native Image with Cats Effect will now require GraalVM 21.0 or higher.