### PR TITLE
Handle `Uncancelable` and `OnCancel` in `syncStep` interpreter in 3.x

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -869,6 +869,11 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
             }
             .handleErrorWith(t => interpret(f(t)))
 
+        case IO.Uncancelable(body, _) =>
+          interpret(body(new Poll[IO] {
+            def apply[A](ioa: IO[A]): IO[A] = ioa
+          }))
+
         case _ => SyncIO.pure(Left(io))
       }
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1961,13 +1961,16 @@ private object SyncStep {
             }
             .handleErrorWith(t => interpret(f(t), limit - 1))
 
-        case IO.Uncancelable(body, _) =>
+        case IO.Uncancelable(body, _)
+            if G.isInstanceOf[MonadCancel.Uncancelable[G, Throwable] @unchecked] =>
           val ioa = body(new Poll[IO] {
             def apply[C](ioc: IO[C]): IO[C] = ioc
           })
           interpret(ioa, limit)
 
-        case IO.OnCancel(ioa, _) => interpret(ioa, limit)
+        case IO.OnCancel(ioa, _)
+            if G.isInstanceOf[MonadCancel.Uncancelable[G, Throwable] @unchecked] =>
+          interpret(ioa, limit)
 
         case _ => G.pure(Left(io))
       }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -874,6 +874,8 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
             def apply[C](ioc: IO[C]): IO[C] = ioc
           }))
 
+        case IO.OnCancel(ioa, _) => interpret(ioa)
+
         case _ => SyncIO.pure(Left(io))
       }
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -871,7 +871,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
 
         case IO.Uncancelable(body, _) =>
           interpret(body(new Poll[IO] {
-            def apply[A](ioa: IO[A]): IO[A] = ioa
+            def apply[C](ioc: IO[C]): IO[C] = ioc
           }))
 
         case _ => SyncIO.pure(Left(io))

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1455,6 +1455,11 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
           i must beEqualTo(1)
       }
 
+      "handle uncancelable" in {
+        val sio = IO.unit.uncancelable.syncStep
+        sio.map(_.bimap(_ => (), _ => ())) must completeAsSync(Right(()))
+      }
+
       "synchronously allocate a vanilla resource" in {
         val sio = Resource.make(IO.unit)(_ => IO.unit).allocated.map(_._1).syncStep
         sio.map(_.bimap(_ => (), _ => ())) must completeAsSync(Right(()))

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1460,8 +1460,23 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         sio.map(_.bimap(_ => (), _ => ())) must completeAsSync(Right(()))
       }
 
+      "handle onCancel" in {
+        val sio = IO.unit.onCancel(IO.unit).syncStep
+        sio.map(_.bimap(_ => (), _ => ())) must completeAsSync(Right(()))
+      }
+
       "synchronously allocate a vanilla resource" in {
         val sio = Resource.make(IO.unit)(_ => IO.unit).allocated.map(_._1).syncStep
+        sio.map(_.bimap(_ => (), _ => ())) must completeAsSync(Right(()))
+      }
+
+      "synchronously allocate a evalMapped resource" in {
+        val sio = Resource
+          .make(IO.unit)(_ => IO.unit)
+          .evalMap(_ => IO.unit)
+          .allocated
+          .map(_._1)
+          .syncStep
         sio.map(_.bimap(_ => (), _ => ())) must completeAsSync(Right(()))
       }
     }

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1454,6 +1454,11 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
           io must completeAs(())
           i must beEqualTo(1)
       }
+
+      "synchronously allocate a vanilla resource" in {
+        val sio = Resource.make(IO.unit)(_ => IO.unit).allocated.map(_._1).syncStep
+        sio.map(_.bimap(_ => (), _ => ())) must completeAsSync(Right(()))
+      }
     }
 
     "fiber repeated yielding test" in real {


### PR DESCRIPTION
Forward merge of https://github.com/typelevel/cats-effect/pull/3064.