### PR TITLE
Remove workaround for broken Macrotask sourcemaps

### DIFF
--- a/core/js/src/main/scala/cats/effect/tracing/TracingPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/tracing/TracingPlatform.scala
@@ -69,8 +69,7 @@ private[tracing] abstract class TracingPlatform { self: Tracing.type =>
     "githubusercontent.com/typelevel/cats-effect/",
     "githubusercontent.com/typelevel/cats/",
     "githubusercontent.com/scala-js/",
-    "githubusercontent.com/scala/",
-    "MacrotaskExecutor.scala" // TODO temporary workaround
+    "githubusercontent.com/scala/"
   )
 
   private[this] def isInternalFile(fileName: String): Boolean = {


### PR DESCRIPTION
Closes https://github.com/typelevel/cats-effect/issues/2551.