### PR TITLE
Native Image documentation example

### DIFF
--- a/docs/core/native-image.md
+++ b/docs/core/native-image.md
@@ -53,7 +53,8 @@ object Main extends IOApp.Simple {
 
 The code can be compiled using `sbt nativeImage` and a native-image executable can then
 be found under `target/native-image/cats-effect-3-hello-world`, and executed as any native
-executable with the benefit of a really fast startup time
+executable with the benefit of a really fast startup time ([hyperfine](https://github.com/sharkdp/hyperfine) 
+is a command line benchmarking tool written in Rust)
 
 ```sh
 $ ./target/native-image/cats-effect-3-hello-world

--- a/docs/core/native-image.md
+++ b/docs/core/native-image.md
@@ -66,4 +66,4 @@ Benchmark 1: ./target/native-image/cats-effect-3-hello-world
 ```
 
 Another way to get your cats effect app compiled with native-image is to leverage
-the package command of scala-cli, like in the [example](../scala-cli.md#Native-Image-Example)
+the package command of scala-cli, like in the [example](../faq.md#Native-Image-Example)

--- a/docs/core/native-image.md
+++ b/docs/core/native-image.md
@@ -17,3 +17,53 @@ images seamless, without the need of extra configuration. The only caveat
 is that this configuration metadata is specific to GraalVM 21.0 and later.
 Previous versions of GraalVM are supported, but Native Image support requires
 at least 21.0.
+
+## Native Image example
+
+Here's an example of an Hello world project compiled with GraalVM Native Image 
+using [sbt-native-image plugin](https://github.com/scalameta/sbt-native-image).
+
+```scala
+// project/plugins.sbt
+addSbtPlugin("org.scalameta" % "sbt-native-image" % "0.3.1")
+
+// build.sbt
+ThisBuild / organization := "com.example"
+ThisBuild / scalaVersion := "2.13.8"
+
+lazy val root = (project in file(".")).enablePlugins(NativeImagePlugin).settings(
+  name                := "cats-effect-3-hello-world",
+  libraryDependencies += "org.typelevel" %% "cats-effect" % "3.3.13",
+  Compile / mainClass := Some("com.example.Main"),
+  nativeImageOptions  += "--no-fallback",
+  nativeImageVersion  := "22.1.0" // It should be at least version 21.0.0
+)
+
+// src/main/scala/com/example/Main.scala
+package com.example
+
+import cats.effect.{IO, IOApp}
+
+object Main extends IOApp.Simple {
+  def run: IO[Unit] = IO.println("Hello Cats Effect!")
+}
+```
+
+> Note: `nativeImageOptions += "--no-fallback"` is required, otherwise native-image will try searching a static reflection configuration for [this Enumeration method](https://github.com/scala/scala/blob/v2.13.8/src/library/scala/Enumeration.scala#L190-L215=). Thus using this flag is safe only if you're not using `Enumeration`s in your codebase, see [this comment](https://github.com/typelevel/cats-effect/issues/3051#issuecomment-1167026949) for more info.
+
+The code can be compiled using `sbt nativeImage` and a native-image executable can then
+be found under `target/native-image/cats-effect-3-hello-world`, and executed as any native
+executable with the benefit of a really fast startup time
+
+```sh
+$ ./target/native-image/cats-effect-3-hello-world
+Hello Cats Effect!
+
+$ hyperfine ./target/native-image/cats-effect-3-hello-world
+Benchmark 1: ./target/native-image/cats-effect-3-hello-world
+  Time   (mean ± σ):    11.2 ms ±   0.6 ms    [User: 6.7 ms, System: 4.8 ms]
+  Range (min … max):     9.4 ms …  12.9 ms    182 runs
+```
+
+Another way to get your cats effect app compiled with native-image is to leverage
+the package command of scala-cli, like in the [example](../scala-cli.md#Native-Image-Example)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,5 +19,19 @@ object HelloWorld extends IOApp.Simple {
 ```
 
 ```sh
-scala-cli Hello.scala
+$ scala-cli Hello.scala
+Hello world
 ```
+
+### Native Image Example
+
+[Scala CLI](https://scala-cli.virtuslab.org/) can be leveraged to produce a native-image executable using the [package command](https://scala-cli.virtuslab.org/docs/commands/package#native-image):
+
+```sh
+$ scala-cli package --native-image --graalvm-version 22.1.0 -f Hello.scala -- --no-fallback
+[...]
+$ ./HelloWorld
+Hello world
+```
+
+> Note: GraalVm Native Image > 21.0.0 and `--no-fallback` are mandatory: see [here](core/native-image.md) for details


### PR DESCRIPTION
Hello! 👋
I added an example of how to use `sbt-native-image` to produce a native-image executable, including some brief information about what was discovered/explained in #3051 (and a link).

<details>
<summary>SPOILER: Opinionated addition</summary>
A little addition to the docs may be the usage of `hyperfine` (a tool written in Rust) to measure the startup time of the native executable. I added it since its report is so much more detailed compared to the one of `time`:

```sh
$ time ./HelloWorld
Hello world
./HelloWorld  0.01s user 0.01s system 99% cpu 0.022 total

$ hyperfine --warmup 30 ./HelloWorld
Benchmark 1: ./HelloWorld
  Time (mean ± σ):      20.4 ms ±   0.5 ms    [User: 11.3 ms, System: 10.0 ms]
  Range (min … max):    19.3 ms …  21.9 ms    110 runs
```
I can replace that piece with the `time` output if we don't want to advertise external tools
</details>

The `scala-cli` section in `faq.md` can IMHO be extracted in its file so that #2989 can be closed and the doc tidied up a bit.