### PR TITLE
Third Party Resource Links

### DIFF
--- a/docs/third-party-resources.md
+++ b/docs/third-party-resources.md
@@ -1,0 +1,35 @@
+---
+id: third-party-resources
+title: Third-Party Learning Resources
+---
+
+This page outlines known third-party learning and training material (free and paid) dedicated to Cats Effect. 
+
+## Books
+
+* [Essential Effects](https://essentialeffects.dev/) by Adam Rosien - How to safely create, compose, and execute effectful Scala programs using the Typelevel cats-effect library.
+* [Practical FP in Scala: A hands-on approach](https://leanpub.com/pfp-scala) by Gabriel Volpe  - A practical book aimed for those familiar with functional programming in Scala who are yet not confident about architecting an application from scratch.
+
+## Courses
+
+* [Scala with Cats Effect](https://rockthejvm.com/p/cats-effect/) by Daniel Ciocîrlan of [Rock the JVM](https://rockthejvm.com/) - a long-form, hands-on course covering all aspects of Cats Effect, with realistic examples and practice exercises.
+
+## Posts
+
+* [What is an Effect?](https://www.inner-product.com/posts/what-is-an-effect/), Adam Rosien, Inner Product LLC: 
+> We often use the term effect when talking about the behavior of our code. But what is an effect? Can we talk about effects in precise ways, in order to write better programs that we can better understand?
+* [Cats Effect Fibers](https://blog.rockthejvm.com/cats-effect-fibers/), Daniel Ciocîrlan, Rock the JVM
+> A beginner-friendly introduction to fibers and the parallelism model of Cats Effect, with guidance on how to use essential operators on fibers. 
+* [Time traveling in tests with Cats Effect](https://blog.softwaremill.com/time-traveling-in-tests-with-cats-effect-b22084f6a89), Krzysztof Ciesielski, SoftwareMill.
+> Timeouts, retries, and other error scenarios while testing.
+
+## Videos
+
+These are some selected videos on various topics in Cats Effect:
+
+* [Cats Effect 3](https://www.youtube.com/watch?v=KZtVBtOrP50&t=1s&ab_channel=ScalaintheCity), Daniel Spiewak
+* [Concurrency with Cats Effect](https://www.youtube.com/watch?v=Gig-f_HXvLI&ab_channel=FunctionalTV), Michael Pilquist
+* [How do Fibers work?](https://www.youtube.com/watch?v=x5_MmZVLiSM&ab_channel=ScalaWorld), Fabio Labella
+* [Cancellation in Cats Effect](https://www.youtube.com/watch?v=X9u3rgPz_zE&t=1002s&ab_channel=ScalaintheCity), Daniel Ciocîrlan
+* [Intro to Cats Effect](https://www.youtube.com/watch?v=83pXEdCpY4A&ab_channel=thoughtbot), Gavin Biesi
+* [The IO Monad for Scala](https://www.youtube.com/watch?v=8_TWM2t97r4&t=811s&ab_channel=ScalaIOFR), Gabriel Volpe

--- a/site-docs/sidebars.json
+++ b/site-docs/sidebars.json
@@ -5,7 +5,8 @@
       "concepts",
       "tutorial",
       "faq",
-      "migration-guide"
+      "migration-guide",
+      "third-party-resources"
     ],
     "Core Runtime": [
       "core/test-runtime",


### PR DESCRIPTION
cc @djspiewak 

Added learning links by third party resources in the documentation website.

For context: I run this website called [Rock the JVM](https://rockthejvm.com/) which creates free and paid learning material on all major tools in the Scala ecosystem. This Cats Effect course has been live since August 2021 with overwhelmingly positive feedback. I think the course would benefit many more people if only they knew it existed, hence this PR.

The PR also includes learning resources from other creators I'm aware of, plus some selected YouTube videos and blog posts. Please let me know in the comments if you have suggestions on what else to include, and I'll add them to the PR.