### PR TITLE
Resolve race condition in `interruptibleMany` after interruption

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -59,30 +59,33 @@ private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
               val result =
                 try {
                   canInterrupt.release()
-                  val back = Right(cur.thunk())
+
+                  val back =
+                    try {
+                      Right(cur.thunk())
+                    } catch {
+                      // this won't suppress the interruption
+                      case NonFatal(t) => Left(t)
+                    }
 
                   // this is why it has to be a semaphore rather than an atomic boolean
                   // this needs to hard-block if we're in the process of being interrupted
                   // once we acquire this lock, we cannot be interrupted
                   canInterrupt.acquire()
-                  manyDone.set(true) // in this case, we weren't interrupted
+
+                  if (many) {
+                    manyDone.set(true) // in this case, we weren't interrupted
+                  }
+
                   back
                 } catch {
                   case _: InterruptedException =>
                     null
-
-                  case NonFatal(t) =>
-                    Left(t)
                 } finally {
                   canInterrupt.tryAcquire()
                   done.set(true)
 
-                  if (!many) {
-                    val cb0 = cb.getAndSet(null)
-                    if (cb0 != null) {
-                      cb0(RightUnit)
-                    }
-                  } else {
+                  if (many) {
                     // wait for the hot loop to finish
                     // we can probably also do this with canInterrupt, but that seems confusing
                     // this needs to be a busy-wait otherwise it will be interrupted
@@ -90,6 +93,11 @@ private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
                     Thread.interrupted() // clear the status
 
                     ()
+                  } else {
+                    val cb0 = cb.getAndSet(null)
+                    if (cb0 != null) {
+                      cb0(RightUnit)
+                    }
                   }
                 }
 


### PR DESCRIPTION
The race condition here is that the busy-loop which spams interruption on the worker thread can continue to run *after* the interruption has been caught and handled. That… actually literally the point. This is problematic though because it means the worker thread will be returned to the pool in an interrupted state, which in turn shuts down the pool. The solution is to busy-wait (we can't hard-block because that would, itself, be interrupted) until the interruption loop is finished, and then finally clear the interrupted bit at the very end.

Fixes #3073 