### PR TITLE
Override `memoize` for `Resource`

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1246,6 +1246,13 @@ abstract private[effect] class ResourceConcurrent[F[_]]
 
   override def both[A, B](fa: Resource[F, A], fb: Resource[F, B]): Resource[F, (A, B)] =
     fa.both(fb)
+
+  override def memoize[A](fa: Resource[F, A]): Resource[F, Resource[F, A]] = {
+    Resource
+      .makeCaseFull[F, F[(A, Resource.ExitCase => F[Unit])]](poll =>
+        poll(F.memoize(fa.allocatedCase))) { (memo, exit) => memo.flatMap(_._2.apply(exit)) }
+      .map(memo => Resource.eval(memo.map(_._1)))
+  }
 }
 
 private[effect] trait ResourceClock[F[_]] extends Clock[Resource[F, *]] {

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -977,6 +977,18 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
           .flatten
           .void must completeAs(())
       }
+      "does not allocate if not used" in ticked { implicit ticker =>
+        (IO.ref(0), IO.ref(0))
+          .mapN { (acquired, released) =>
+            val r = Resource.make(acquired.update(_ + 1).void)(_ => released.update(_ + 1))
+            def acquiredMustBe(i: Int) = acquired.get.map(_ must be_==(i)).void
+            def releasedMustBe(i: Int) = released.get.map(_ must be_==(i)).void
+            r.memoize.surround(acquiredMustBe(0) *> releasedMustBe(0)) *>
+              acquiredMustBe(0) *> releasedMustBe(0)
+          }
+          .flatten
+          .void must completeAs(())
+      }
     }
   }
 

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -960,6 +960,9 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
     }
 
     "memoize" >> {
+      "memoize and then flatten is identity" in ticked { implicit ticker =>
+        forAll { (r: Resource[IO, Int]) => r.memoize.flatten eqv r }
+      }
       "allocates once and releases at end" in ticked { implicit ticker =>
         (IO.ref(0), IO.ref(0))
           .mapN { (acquired, released) =>


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/3079#issuecomment-1177844860. Or so I thought 🤔 