### PR TITLE
Try to fix #3075

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -72,6 +72,8 @@ private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
                     null
 
                   case NonFatal(t) =>
+                    canInterrupt.acquire()
+                    manyDone.set(true) // in this case, we weren't interrupted
                     Left(t)
                 } finally {
                   canInterrupt.tryAcquire()

--- a/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOFiberPlatform.scala
@@ -104,47 +104,62 @@ private[effect] abstract class IOFiberPlatform[A] extends AtomicBoolean(false) {
       } yield {
         Some {
           IO async { finCb =>
-            val trigger = IO {
+            val trigger = IO.defer {
               if (!many) {
                 cb.set(finCb)
               }
 
               // if done is false, and we can't get the semaphore, it means
               // that the action hasn't *yet* started, so we busy-wait for it
-              var break = true
-              while (break && !done.get()) {
-                if (canInterrupt.tryAcquire()) {
+
+              def busyWait(): IO[Unit] = { // NB: side-effecting, see `defer` above
+                if (done.get()) {
+                  IO.unit // ok, we're done
+                } else if (canInterrupt.tryAcquire()) {
                   try {
                     target.interrupt()
                   } finally {
-                    break = false
                     canInterrupt.release()
                   }
+                  IO.unit // ok, we've interrupted it
+                } else {
+                  IO.defer(busyWait()) // retry
                 }
               }
+
+              busyWait()
             }
 
             val repeat = if (many) {
-              IO {
-                // we need the outer try because we may be done *before* we enter
-                try {
-                  while (!done.get()) {
-                    if (canInterrupt.tryAcquire()) {
-                      try {
-                        while (!done.get()) {
-                          target.interrupt() // it's hammer time!
-                        }
-                      } finally {
-                        canInterrupt.release()
-                      }
-                    }
-                  }
-                } finally {
-                  manyDone.set(true) // signal that we're done looping
-                }
 
-                finCb(RightUnit)
+              def reallyTryToInterrupt(): Boolean = {
+                if (canInterrupt.tryAcquire()) {
+                  try {
+                    while (!done.get()) {
+                      target.interrupt() // it's hammer time!
+                    }
+                  } finally {
+                    canInterrupt.release()
+                  }
+                  true // ok
+                } else {
+                  false // retry
+                }
               }
+
+              def loop(): IO[Unit] = IO.defer {
+                if (done.get() || reallyTryToInterrupt()) {
+                  IO {
+                    manyDone.set(true) // signal that we're done looping
+                    finCb(RightUnit)
+                  }
+                } else {
+                  loop()
+                }
+              }
+
+              loop()
+
             } else {
               IO {
                 if (done.get() && cb.get() != null) {


### PR DESCRIPTION
This PR tries to fix #3075. It is on top of #3074.

I've left alone two `while` loops:
- One of them is in a `blocking` call, so it seems ok.
- The other one loops while holding the semaphore. It seemed dangerous to break it up.

Hopefully there are no semantic changes ~~(I've moved a `manyDone.set(true)` from a `finally`, which might be a problem. But I didn't understand why it was in a `finally`...)~~.