### PR TITLE
Introduce the FFI acronym before use

### DIFF
--- a/docs/typeclasses/async.md
+++ b/docs/typeclasses/async.md
@@ -3,7 +3,7 @@ id: async
 title: Async
 ---
 
-`Async` is the asynchronous FFI for suspending side-effectful operations that
+`Async` is the asynchronous [Foreign Function Interface](https://en.wikipedia.org/wiki/Foreign_function_interface) (FFI) for suspending side-effectful operations that
 are completed elsewhere (often on another threadpool via a future-like API).
 This typeclass allows us to sequence asynchronous operations without stumbling
 into [callback hell](http://callbackhell.com/) and also gives us the ability to

--- a/docs/typeclasses/sync.md
+++ b/docs/typeclasses/sync.md
@@ -3,7 +3,8 @@ id: sync
 title: Sync
 ---
 
-`Sync` is the synchronous FFI for suspending side-effectful operations. The
+`Sync` is the synchronous [Foreign Function Interface](https://en.wikipedia.org/wiki/Foreign_function_interface) 
+(FFI) for suspending side-effectful operations. The
 means of suspension is dependent on whether the side effect you want to
 suspend is blocking or not (see the [thread model docs](../thread-model.md)
 for more details on why this is the case).


### PR DESCRIPTION
I don't think it's a safe assumption that all readers of Cats Effect docs will automatically know what "FFI" means or implies. FWIW I'm not super enthused by explaining Async in terms of another rather abstract concept, an FFI, but given that's the approach then at minimum we should unpack the acronym so unfamiliar users can get background context.

I work in a corporate environment where I'm constantly shown slides covered in acronyms where I have no idea what they refer to, and it gets tiring having to regularly ask for unpacking. My rule of thumb is, always unpack an acronym upon first use in any document/page.