### PR TITLE
Experiment: subclass `IO.Delay`, skip `thunk` allocation

### DIFF
--- a/tests/shared/src/test/scala/cats/effect/tracing/TracingSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/tracing/TracingSpec.scala
@@ -27,7 +27,7 @@ class TracingSpec extends BaseSpec with TestInstances {
       val a = IO(f())
       val b = IO(f())
       (a, b) match {
-        case (IO.Delay(_, eventA), IO.Delay(_, eventB)) => eventA eq eventB
+        case (IO.Delay(eventA), IO.Delay(eventB)) => eventA eq eventB
         case _ => false
       }
     }
@@ -36,7 +36,7 @@ class TracingSpec extends BaseSpec with TestInstances {
       val a = IO(println("foo"))
       val b = IO(println("bar"))
       (a, b) match {
-        case (IO.Delay(_, eventA), IO.Delay(_, eventB)) => eventA ne eventB
+        case (IO.Delay(eventA), IO.Delay(eventB)) => eventA ne eventB
         case _ => false
       }
     }
@@ -48,7 +48,7 @@ class TracingSpec extends BaseSpec with TestInstances {
       val a = Async[IO].delay(f())
       val b = Async[IO].delay(f())
       (a, b) match {
-        case (IO.Delay(_, eventA), IO.Delay(_, eventB)) => eventA eq eventB
+        case (IO.Delay(eventA), IO.Delay(eventB)) => eventA eq eventB
         case _ => false
       }
     }
@@ -57,7 +57,7 @@ class TracingSpec extends BaseSpec with TestInstances {
       val a = Async[IO].delay(println("foo"))
       val b = Async[IO].delay(println("bar"))
       (a, b) match {
-        case (IO.Delay(_, eventA), IO.Delay(_, eventB)) => eventA ne eventB
+        case (IO.Delay(eventA), IO.Delay(eventB)) => eventA ne eventB
         case _ => false
       }
     }


### PR DESCRIPTION
This is an experiment that uses `inline` to transparently subclass `IO.Delay`. Inspired by a Discord question.

The results are really good, since effectively it reduces the overhead of `IO.Delay` to match the overhead of `IO.Pure`.

#### This PR

```
[info] Benchmark                (size)   Mode  Cnt     Score     Error  Units
[info] DeepBindBenchmark.async   10000  thrpt   20  1150.461 ±  33.122  ops/s
[info] DeepBindBenchmark.delay   10000  thrpt   20  4636.526 ±  95.142  ops/s
[info] DeepBindBenchmark.pure    10000  thrpt   20  4578.873 ± 182.701  ops/s
```

#### `series/3.x`

```
[info] Benchmark                (size)   Mode  Cnt     Score     Error  Units
[info] DeepBindBenchmark.async   10000  thrpt   20  1056.442 ±  27.546  ops/s
[info] DeepBindBenchmark.delay   10000  thrpt   20  3374.185 ± 422.683  ops/s
[info] DeepBindBenchmark.pure    10000  thrpt   20  4642.148 ±  87.353  ops/s
```

Caveats:
1. Scala 3 only, obviously, and JVM only (see caveat 4).
2. I don't see how this can work with typeclasses 😕 
3. Sub-classes of `Delay` would now be living in downstream bytecode. So that invokes bincompatibility constraints.
4. Bytecode size, since now every invocation of `Delay` generates its own class. If we make `Delay` a SAM by changing `val event` to `def event`, then that would curtail this. However, JS doesn't have SAMs and is extremely sensitive to artifact size, so we wouldn't want to do this there.

We could also use a similar trick for `IO.FlatMap` I think.

Sadly I didn't fully think through caveat (2) before embarking on this experiment (conveniently fooled myself into thinking we can just slap an `inline` modifier on `Sync#delay`). So unless we care specifically about optimizing for concrete `IO`, this is a lot of complexity for no gain.