### PR TITLE
Use `--no-fallback` flag in `nativeImageOptions`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -744,7 +744,7 @@ lazy val graalVMExample = project
   .enablePlugins(NoPublishPlugin, NativeImagePlugin)
   .settings(
     name := "cats-effect-graalvm-example",
-    nativeImageOptions += "-H:+ReportExceptionStackTraces",
+    nativeImageOptions ++= Seq("--no-fallback", "-H:+ReportExceptionStackTraces"),
     nativeImageInstalled := true
   )
 


### PR DESCRIPTION
Our docs say this is required, so this is how we should test it in CI.

https://github.com/typelevel/cats-effect/blob/e20b70a21766a33dee4c20ce9921539335554c52/docs/core/native-image.md?plain=1#L52