### PR TITLE
Add explanations for why `canceled` has a return type of `F[Unit]`

### DIFF
--- a/docs/typeclasses/monadcancel.md
+++ b/docs/typeclasses/monadcancel.md
@@ -162,7 +162,7 @@ The primary differences between self-cancelation and `raiseError` are two-fold. 
 IO.uncancelable { poll =>
   val cancelation: IO[Unit] = IO.canceled
   cancelation.flatMap { x =>
-    IO.println(s"This will print, meaning $x is not a Nothing")
+    IO.println(s"This will print, meaning $x cannot be Nothing")
   }
 }
 ```

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -286,11 +286,12 @@ trait MonadCancel[F[_], E] extends MonadError[F, E] {
   /**
    * An effect that requests self-cancelation on the current fiber.
    *
-   * `canceled` has a return type of `F[Unit]` instead of `F[Nothing]` due to execution continuing
-   * in a masked region. In the following example, the fiber requests self-cancelation in a masked
-   * region, so cancelation is suppressed until the fiber is completely unmasked. `fa` will run but
-   * `fb` will not. If `canceled` had a return type of `F[Nothing]`, then it would not be possible
-   * to continue execution to `fa` (there would be no `Nothing` value to pass to the `flatMap`).
+   * `canceled` has a return type of `F[Unit]` instead of `F[Nothing]` due to execution
+   * continuing in a masked region. In the following example, the fiber requests
+   * self-cancelation in a masked region, so cancelation is suppressed until the fiber is
+   * completely unmasked. `fa` will run but `fb` will not. If `canceled` had a return type of
+   * `F[Nothing]`, then it would not be possible to continue execution to `fa` (there would be
+   * no `Nothing` value to pass to the `flatMap`).
    *
    * {{{
    *

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -286,9 +286,11 @@ trait MonadCancel[F[_], E] extends MonadError[F, E] {
   /**
    * An effect that requests self-cancelation on the current fiber.
    *
-   * In the following example, the fiber requests self-cancelation in a masked region, so
-   * cancelation is suppressed until the fiber is completely unmasked. `fa` will run but `fb`
-   * will not.
+   * `canceled` has a return type of `F[Unit]` instead of `F[Nothing]` due to execution continuing
+   * in a masked region. In the following example, the fiber requests self-cancelation in a masked
+   * region, so cancelation is suppressed until the fiber is completely unmasked. `fa` will run but
+   * `fb` will not. If `canceled` had a return type of `F[Nothing]`, then it would not be possible
+   * to continue execution to `fa` (there would be no `Nothing` value to pass to the `flatMap`).
    *
    * {{{
    *


### PR DESCRIPTION
Adds explanations for why `canceled` has a return type of `F[Unit]` instead of `F[Nothing]` (due to its behavior inside of `uncancelable`).

Please nitpick this! I'd like this to be as solid as possible, and I don't mind having to go back and change little things to make it perfect.