### PR TITLE
docs(tutorial): delete git conflict markers

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -509,8 +509,6 @@ info as a hint to optimize `IO` scheduling.
 Another difference with threads is that fibers are very cheap entities. We can
 spawn millions of them at ease without impacting the performance.
 
-<<<<<<< Updated upstream
-=======
 A worthy note is that you do not have to explicitly shut down fibers. If you spawn
 a fiber and it finishes actively running its `IO` it will get cleaned up by the
 garbage collector unless there is some other active memory reference to it. So basically
@@ -523,7 +521,6 @@ references anywhere else (i.e. you did some sort of fire-and-forget thing), then
 itself is the only strong reference to the fiber. Meaning if the registration fails or the
 system you registered with throws it away, the fiber will just gracefully disappear.
 
->>>>>>> Stashed changes
 Cats-effect implements some concurrency primitives to coordinate concurrent
 fibers: [Deferred](std/deferred.md), [Ref](std/ref.md), `Semaphore`...
 


### PR DESCRIPTION
The current website tutorial pages include `git conflict markers`.

> https://typelevel.org/cats-effect/docs/tutorial

It is mixed by below commit.

> https://github.com/typelevel/cats-effect/commit/a8dbc2d3555db5f9335913dc1627e5475dcb26c0#diff-abe1e09771cc949a765515b0f1ae2d0c4a6ab90fceae133c7ea3efdc49fb65a6R510

This problem has only `3.3.x` branch, other branches seems no problem.

Thank you :)