### PR TITLE
Add `GenConcurrent#forceStart` that guarantees a fiber will start

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -767,6 +767,9 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
   def start: IO[FiberIO[A @uncheckedVariance]] =
     IO.Start(this)
 
+  def forceStart: IO[Fiber[IO, Throwable, A @uncheckedVariance]] =
+    Concurrent[IO].forceStart(this)
+
   /**
    * Returns a resource that will start execution of this IO in the background.
    *

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -270,6 +270,14 @@ trait MonadCancel[F[_], E] extends MonadError[F, E] {
    *
    * }}}
    *
+   * Note that a masked fiber can be canceled *before* it starts executing, in which case it will
+   * not run at all. To prevent this scenario, use [[GenConcurrent.forceStart]] instead of [[start]].
+   *
+   * {{{
+   *   F.uncancelable(fa).start.flatMap(_.cancel)      // fa is not guaranteed to run
+   *   F.uncancelable(fa).forceStart.flatMap(_.cancel) // fa is guaranteed to run
+   * }}}
+   *
    * The following operations are no-ops:
    *
    *   1. Polling in the wrong order

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -270,8 +270,9 @@ trait MonadCancel[F[_], E] extends MonadError[F, E] {
    *
    * }}}
    *
-   * Note that a masked fiber can be canceled *before* it starts executing, in which case it will
-   * not run at all. To prevent this scenario, use [[GenConcurrent.forceStart]] instead of [[start]].
+   * Note that a masked fiber can be canceled *before* it starts executing, in which case it
+   * will not run at all. To prevent this scenario, use [[GenConcurrent.forceStart]] instead of
+   * [[start]].
    *
    * {{{
    *   F.uncancelable(fa).start.flatMap(_.cancel)      // fa is not guaranteed to run

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -271,8 +271,8 @@ trait MonadCancel[F[_], E] extends MonadError[F, E] {
    * }}}
    *
    * Note that a masked fiber can be canceled *before* it starts executing, in which case it
-   * will not run at all. To prevent this scenario, use [[GenConcurrent.forceStart]] instead of
-   * [[start]].
+   * will not run at all. To prevent this scenario, use [[GenConcurrent!.forceStart]] instead of
+   * [[GenSpawn!.start]].
    *
    * {{{
    *   F.uncancelable(fa).start.flatMap(_.cancel)      // fa is not guaranteed to run

--- a/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenConcurrentSyntax.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/syntax/GenConcurrentSyntax.scala
@@ -17,9 +17,16 @@
 package cats.effect.kernel.syntax
 
 import cats.Traverse
-import cats.effect.kernel.GenConcurrent
+import cats.effect.kernel.{Fiber, GenConcurrent}
 
 trait GenConcurrentSyntax {
+
+  implicit def genConcurrentOps[F[_], A, E](
+      wrapped: F[A]
+  )(implicit F: GenConcurrent[F, E]): GenConcurrentOps[F, A, E] = {
+    val _ = F
+    new GenConcurrentOps(wrapped)
+  }
 
   implicit def genConcurrentOps_[F[_], A](wrapped: F[A]): GenConcurrentOps_[F, A] =
     new GenConcurrentOps_(wrapped)
@@ -33,6 +40,14 @@ trait GenConcurrentSyntax {
       wrapped: T[F[A]]
   ): ConcurrentParSequenceNOps[T, F, A] =
     new ConcurrentParSequenceNOps(wrapped)
+
+}
+
+final class GenConcurrentOps[F[_], A, E] private[syntax] (private val wrapped: F[A])
+    extends AnyVal {
+
+  def forceStart(implicit F: GenConcurrent[F, E]): F[Fiber[F, E, A]] =
+    F.forceStart(wrapped)
 
 }
 


### PR DESCRIPTION
The possibility of an uncancelable fiber being canceled before it starts executing is, I think, a surprising footgun for many people. If nothing else, adding this `forceStart` method will help raise awareness of that possibility.