### PR TITLE
Add scope to IOLocal

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOLocal.scala
+++ b/core/shared/src/main/scala/cats/effect/IOLocal.scala
@@ -233,4 +233,22 @@ object IOLocal {
       }
     }
 
+  /**
+   * Alters the `T` value that is observed by an `IO[G]` value using [[IOLocal]].
+   *
+   * The updated value can only be observed from within that `IO[G]` value.
+   *
+   * @param local
+   *   The [[IOLocal]] to update
+   * @param value
+   *   The new value to use as the context for task
+   * @param task
+   *   The task to be executed with the update context.
+   * @tparam G
+   *   The type of the task result
+   * @tparam T
+   *   The type of the local value
+   */
+  def scope[G, T](local: IOLocal[T], value: T)(task: IO[G]): IO[G] =
+    local.getAndSet(value).bracket(_ => task)(local.set)
 }


### PR DESCRIPTION
Thought it could be useful to have a way to update the value of an `IOLocal` within the scope of some task `IO[A]`

Motivation was being able to set log context here: https://github.com/typelevel/log4cats/pull/676