### PR TITLE
Documentation: use `IO` in examples

### DIFF
--- a/kernel/jvm/src/main/scala/cats/effect/kernel/ResourcePlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/ResourcePlatform.scala
@@ -27,17 +27,29 @@ private[effect] trait ResourcePlatform extends Serializable {
    * Creates a [[Resource]] by wrapping a Java
    * [[https://docs.oracle.com/javase/8/docs/api/javax/security/auth/Destroyable.html Destroyable]].
    *
-   * Example:
-   * {{{
+   * @example
+   *   {{{
    *   import java.security.KeyStore.PasswordProtection
-   *   import cats.effect._
+   *   import cats.effect.{IO, Resource}
+   *
+   *   def passwordProtection(getPassword: IO[Array[Char]]): Resource[IO, PasswordProtection] =
+   *     Resource.fromDestroyable(
+   *       getPassword.map(new PasswordProtection(_))
+   *     )
+   *   }}}
+   *
+   * @example
+   *   {{{
+   *   import java.security.KeyStore.PasswordProtection
+   *   import cats.effect.{Resource, Sync}
    *   import cats.syntax.all._
    *
    *   def passwordProtection[F[_]](getPassword: F[Array[Char]])(implicit F: Sync[F]): Resource[F, PasswordProtection] =
    *     Resource.fromDestroyable(
    *       getPassword.map(new PasswordProtection(_))
    *     )
-   * }}}
+   *   }}}
+   *
    * @param acquire
    *   The effect with the resource to acquire.
    * @param F

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Cont.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Cont.scala
@@ -20,13 +20,13 @@ import cats.~>
 
 /**
  * This construction supports `Async.cont`
- * ```
+ * {{{
  * trait Async[F[_]] {
- * ...
+ *   ...
  *
- * def cont[A](body: Cont[F, A]): F[A]
+ *   def cont[A](body: Cont[F, A]): F[A]
  * }
- * ```
+ * }}}
  * It's a low level operation meant for implementors, end users should use `async`, `start` or
  * `Deferred` instead, depending on the use case.
  *

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -902,8 +902,19 @@ object Resource extends ResourceFOInstances0 with ResourceHOInstances0 with Reso
    * In most real world cases, implementors of AutoCloseable are blocking as well, so the close
    * action runs in the blocking context.
    *
-   * Example:
-   * {{{
+   * @example
+   *   {{{
+   *   import cats.effect._
+   *   import scala.io.Source
+   *
+   *   def reader(data: String): Resource[IO, Source] =
+   *     Resource.fromAutoCloseable(IO.blocking {
+   *       Source.fromString(data)
+   *     })
+   *   }}}
+   *
+   * @example
+   *   {{{
    *   import cats.effect._
    *   import scala.io.Source
    *
@@ -911,7 +922,8 @@ object Resource extends ResourceFOInstances0 with ResourceHOInstances0 with Reso
    *     Resource.fromAutoCloseable(F.blocking {
    *       Source.fromString(data)
    *     })
-   * }}}
+   *   }}}
+   *
    * @param acquire
    *   The effect with the resource to acquire.
    * @param F

--- a/std/js/src/main/scala/cats/effect/std/Console.scala
+++ b/std/js/src/main/scala/cats/effect/std/Console.scala
@@ -32,6 +32,19 @@ import java.nio.charset.Charset
  *
  * @example
  *   {{{
+ *  import cats.effect.IO
+ *  import cats.effect.std.Console
+ *
+ *  def myProgram: IO[Unit] =
+ *    for {
+ *      _ <- Console[IO].println("Please enter your name: ")
+ *      n <- Console[IO].readLine
+ *      _ <- if (n.nonEmpty) Console[IO].println("Hello, " + n) else Console[IO].errorln("Name is empty!")
+ *    } yield ()
+ *   }}}
+ *
+ * @example
+ *   {{{
  *  import cats.Monad
  *  import cats.effect.std.Console
  *  import cats.syntax.all._

--- a/std/jvm/src/main/scala/cats/effect/std/Console.scala
+++ b/std/jvm/src/main/scala/cats/effect/std/Console.scala
@@ -27,11 +27,24 @@ import java.nio.charset.Charset
  *
  * @example
  *   {{{
+ *  import cats.effect.IO
+ *  import cats.effect.std.Console
+ *
+ *  def myProgram: IO[Unit] =
+ *    for {
+ *      _ <- Console[IO].println("Please enter your name: ")
+ *      n <- Console[IO].readLine
+ *      _ <- if (n.nonEmpty) Console[IO].println("Hello, " + n) else Console[IO].errorln("Name is empty!")
+ *    } yield ()
+ *   }}}
+ *
+ * @example
+ *   {{{
  *  import cats.Monad
  *  import cats.effect.std.Console
  *  import cats.syntax.all._
  *
- *  def myProgram[F[_] : Console : Monad]: F[Unit] =
+ *  def myProgram[F[_]: Console: Monad]: F[Unit] =
  *    for {
  *      _ <- Console[F].println("Please enter your name: ")
  *      n <- Console[F].readLine

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -177,9 +177,9 @@ object Dispatcher {
    *   termination policy, the termination of the `Dispatcher` is indefinitely suspended
    *   {{{
    *   val io: IO[Unit] = // never completes
-   *     Dispatcher.sequential[F](await = true).use { dispatcher =>
-   *       dispatcher.unsafeRunAndForget(Concurrent[F].never)
-   *       Concurrent[F].unit
+   *     Dispatcher.sequential[IO](await = true).use { dispatcher =>
+   *       dispatcher.unsafeRunAndForget(IO.never)
+   *       IO.unit
    *     }
    *   }}}
    *

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -111,9 +111,9 @@ object Supervisor {
    *   if an effect that never completes, is supervised by a `Supervisor` with awaiting
    *   termination policy, the termination of the `Supervisor` is indefinitely suspended
    *   {{{
-   *   val io: F[Unit] = // never completes
-   *     Supervisor[F](await = true).use { supervisor =>
-   *       supervisor.supervise(Concurrent[F].never).void
+   *   val io: IO[Unit] = // never completes
+   *     Supervisor[IO](await = true).use { supervisor =>
+   *       supervisor.supervise(IO.never).void
    *     }
    *   }}}
    *


### PR DESCRIPTION
Closes #3133. 

I went through the Scaladoc and that's what I found. Give me a hint if I missed something.