### PR TITLE
update Console doc string

### DIFF
--- a/std/jvm/src/main/scala/cats/effect/std/Console.scala
+++ b/std/jvm/src/main/scala/cats/effect/std/Console.scala
@@ -23,7 +23,8 @@ import java.nio.charset.Charset
 
 /**
  * Effect type agnostic `Console` with common methods to write to and read from the standard
- * console. Suited only for extremely simple console input and output.
+ * console. Due to issues around cancellation in `readLine`, suited only for extremely simple
+ * console input and output in trivial applications.
  *
  * @example
  *   {{{


### PR DESCRIPTION
After [a brief Discord convo](https://discord.com/channels/632277896739946517/895394320100761731/1018891967523983382) with @armanbilge, I thought it would be good to make the Console API docs a bit more explicit in two ways:
1. There's an issue with cancellation in `readLine`, related to #3077
2. b/c of that, Console should only be used for simple and **trivial** applications (to clarify that we don't just mean not-complex applications, but not-complex not-in-production applications)