### PR TITLE
Fixed Dispatcher cancelation interactions with new modes

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -204,7 +204,8 @@ object Dispatcher {
     val (workers, makeFork) =
       mode match {
         case Mode.Parallel =>
-          (Cpus, Supervisor[F](await).map(s => s.supervise(_: F[Unit]).map(_.cancel)))
+          // TODO we have to do this for now because Scala 3 doesn't like it (lampepfl/dotty#15546)
+          (Cpus, Supervisor[F](await, None).map(s => s.supervise(_: F[Unit]).map(_.cancel)))
 
         case Mode.Sequential =>
           (

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -16,8 +16,7 @@
 
 package cats.effect.std
 
-import cats.effect.kernel.{Async, Resource}
-import cats.effect.kernel.implicits._
+import cats.effect.kernel.{Async, Outcome, Ref, Resource}
 import cats.syntax.all._
 
 import scala.annotation.tailrec
@@ -211,8 +210,7 @@ object Dispatcher {
           (
             1,
             Resource
-              .pure[F, F[Unit] => F[F[Unit]]]((_: F[Unit]).as(F.unit).handleError(_ => F.unit))
-          )
+              .pure[F, F[Unit] => F[F[Unit]]]((_: F[Unit]).as(F.unit).handleError(_ => F.unit)))
       }
 
     for {
@@ -243,11 +241,17 @@ object Dispatcher {
       ec <- Resource.eval(F.executionContext)
       alive <- Resource.make(F.delay(new AtomicBoolean(true)))(ref => F.delay(ref.set(false)))
 
+      // supervisor for the main loop, which needs to always restart unless the Supervisor itself is canceled
+      // critically, inner actions can be canceled without impacting the loop itself
+      supervisor <- Supervisor[F](await, Some((_: Outcome[F, Throwable, _]) => true))
+
       _ <- {
         def dispatcher(
+            doneR: Ref[F, Boolean],
             latch: AtomicReference[() => Unit],
-            state: Array[AtomicReference[List[Registration]]]): F[Unit] =
-          for {
+            state: Array[AtomicReference[List[Registration]]]): F[Unit] = {
+
+          val step = for {
             _ <- F.delay(latch.set(Noop)) // reset latch
 
             regs <- F delay {
@@ -257,7 +261,7 @@ object Dispatcher {
                 val st = state(i)
                 if (st.get() ne Nil) {
                   val list = st.getAndSet(Nil)
-                  buffer ++= list.reverse
+                  buffer ++= list.reverse   // FIFO order here is a form of fairness
                 }
                 i += 1
               }
@@ -273,29 +277,33 @@ object Dispatcher {
                   }
                 }
               } else {
-                val runAll = regs traverse_ {
+                regs traverse_ {
                   case r @ Registration(action, prepareCancel) =>
                     val supervise: F[Unit] =
                       fork(action).flatMap(cancel => F.delay(prepareCancel(cancel)))
 
                     // Check for task cancelation before executing.
-                    if (r.get()) supervise else F.unit
-                }
-
-                mode match {
-                  case Dispatcher.Mode.Parallel => runAll.uncancelable
-                  case Dispatcher.Mode.Sequential => if (await) runAll.uncancelable else runAll
+                    F.delay(r.get()).ifM(supervise, F.unit)
                 }
               }
           } yield ()
 
-        (0 until workers)
-          .toList
-          .traverse_(n => dispatcher(latches(n), states(n)).foreverM[Unit].background)
+          // if we're marked as done, yield immediately to give other fibers a chance to shut us down
+          // we might loop on this a few times since we're marked as done before the supervisor is canceled
+          doneR.get.ifM(F.cede, step)
+        }
+
+        0.until(workers).toList traverse_ { n =>
+          Resource.eval(F.ref(false)) flatMap { doneR =>
+            val latch = latches(n)
+            val worker = dispatcher(doneR, latch, states(n))
+            val release = F.delay(latch.getAndSet(Open)())
+            Resource.make(supervisor.supervise(worker))(_ => doneR.set(true) >> release)
+          }
+        }
       }
     } yield {
       new Dispatcher[F] {
-
         def unsafeToFutureCancelable[E](fe: F[E]): (Future[E], () => Future[Unit]) = {
           val promise = Promise[E]()
 

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -261,7 +261,7 @@ object Dispatcher {
                 val st = state(i)
                 if (st.get() ne Nil) {
                   val list = st.getAndSet(Nil)
-                  buffer ++= list.reverse   // FIFO order here is a form of fairness
+                  buffer ++= list.reverse // FIFO order here is a form of fairness
                 }
                 i += 1
               }

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -138,7 +138,10 @@ object Supervisor {
   }
 
   def apply[F[_]: Concurrent]: Resource[F, Supervisor[F]] =
-    apply[F](false)
+    apply[F](
+      false,
+      None
+    ) // TODO we have to do this for now because Scala 3 doesn't like it (lampepfl/dotty#15546)
 
   private trait State[F[_]] {
     def remove(token: Unique.Token): F[Unit]

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -162,7 +162,10 @@ object Supervisor {
       doneR <- Resource.eval(F.ref(false))
       state <- Resource.makeCase(mkState) {
         case (st, Resource.ExitCase.Succeeded) if await => doneR.set(true) >> st.joinAll
-        case (st, _) => doneR.set(true) >> {/*println("canceling all!");*/ st.cancelAll}
+        case (st, _) =>
+          doneR.set(true) >> { /*println("canceling all!");*/
+            st.cancelAll
+          }
       }
     } yield new Supervisor[F] {
 

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -274,7 +274,9 @@ class DispatcherSpec extends BaseSpec {
             _ <- cdl.await // make sure the execution of fiber has started
           } yield ()
         }.start
-        _ <- releaseInner.await.timeoutTo(2.seconds, IO(false must beTrue)) // release process has started
+        _ <- releaseInner
+          .await
+          .timeoutTo(2.seconds, IO(false must beTrue)) // release process has started
         released1 <- fiber.join.as(true).timeoutTo(200.millis, IO(false))
         _ <- fiberLatch.release
         released2 <- fiber.join.as(true).timeoutTo(200.millis, IO(false))

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -267,6 +267,10 @@ class DispatcherSpec extends BaseSpec {
 
           result <- resultR.get
           _ <- IO(result must beFalse)
+
+          secondLatch <- IO.deferred[Unit]
+          _ <- IO(runner.unsafeRunAndForget(secondLatch.complete(()).void))
+          _ <- secondLatch.get // if the dispatcher itself is dead, this will hang
         } yield ok
       }
     }

--- a/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
@@ -83,56 +83,59 @@ class SupervisorSpec extends BaseSpec {
       test must nonTerminate
     }
 
-    "await active fibers when supervisor with restarter exits with await = true" in ticked { implicit ticker =>
-      val test = constructor(true, Some(_ => true)) use { supervisor =>
-        supervisor.supervise(IO.never[Unit]).void
-      }
+    "await active fibers when supervisor with restarter exits with await = true" in ticked {
+      implicit ticker =>
+        val test = constructor(true, Some(_ => true)) use { supervisor =>
+          supervisor.supervise(IO.never[Unit]).void
+        }
 
-      test must nonTerminate
+        test must nonTerminate
     }
 
-    "await active fibers through a fiber when supervisor with restarter exits with await = true" in ticked { implicit ticker =>
-      val test = constructor(true, Some(_ => true)) use { supervisor =>
-        supervisor.supervise(IO.never[Unit]).void
-      }
+    "await active fibers through a fiber when supervisor with restarter exits with await = true" in ticked {
+      implicit ticker =>
+        val test = constructor(true, Some(_ => true)) use { supervisor =>
+          supervisor.supervise(IO.never[Unit]).void
+        }
 
-      test.start.flatMap(_.join).void must nonTerminate
+        test.start.flatMap(_.join).void must nonTerminate
     }
 
-    "stop restarting fibers when supervisor exits with await = true" in ticked { implicit ticker =>
-      val test = for {
-        counter <- IO.ref(0)
-        signal <- Semaphore[IO](1)
-        done <- IO.deferred[Unit]
+    "stop restarting fibers when supervisor exits with await = true" in ticked {
+      implicit ticker =>
+        val test = for {
+          counter <- IO.ref(0)
+          signal <- Semaphore[IO](1)
+          done <- IO.deferred[Unit]
 
-        fiber <- constructor(true, Some(_ => true)).use { supervisor =>
-          for {
-            _ <- signal.acquire
-            _ <- supervisor.supervise(signal.acquire >> counter.update(_ + 1))
+          fiber <- constructor(true, Some(_ => true)).use { supervisor =>
+            for {
+              _ <- signal.acquire
+              _ <- supervisor.supervise(signal.acquire >> counter.update(_ + 1))
 
-            _ <- IO.sleep(1.millis)
-            _ <- signal.release
-            _ <- IO.sleep(1.millis)
-            _ <- signal.release
-            _ <- IO.sleep(1.millis)
+              _ <- IO.sleep(1.millis)
+              _ <- signal.release
+              _ <- IO.sleep(1.millis)
+              _ <- signal.release
+              _ <- IO.sleep(1.millis)
 
-            _ <- done.complete(())
-          } yield ()
-        }.start
+              _ <- done.complete(())
+            } yield ()
+          }.start
 
-        _ <- done.get
-        completed1 <- fiber.join.as(true).timeoutTo(200.millis, IO.pure(false))
-        _ <- IO(completed1 must beFalse)
+          _ <- done.get
+          completed1 <- fiber.join.as(true).timeoutTo(200.millis, IO.pure(false))
+          _ <- IO(completed1 must beFalse)
 
-        _ <- signal.release
-        completed2 <- fiber.join.as(true).timeoutTo(200.millis, IO.pure(false))
-        _ <- IO(completed2 must beTrue)
+          _ <- signal.release
+          completed2 <- fiber.join.as(true).timeoutTo(200.millis, IO.pure(false))
+          _ <- IO(completed2 must beTrue)
 
-        count <- counter.get
-        _ <- IO(count mustEqual 3)
-      } yield ()
+          count <- counter.get
+          _ <- IO(count mustEqual 3)
+        } yield ()
 
-      test must completeAs(())
+        test must completeAs(())
     }
 
     "cancel awaited fibers when exiting with error" in ticked { implicit ticker =>


### PR DESCRIPTION
It's been so long I can't even remember what I did here, but it works! At least, thus say the unit tests.

---

**Edit** Okay so a longer explanation now that I've had some time to reflect. This fixes a few bugs, including some fundamentally squirrely things about the new `Dispatcher` modes. For example, if you `unsafeRunAndForget` on `F.canceled`, what would you expect to happen? In `parallel` this is fairly obvious: it's already on a forked fiber, that fiber dies, end of story. In `sequential` it becomes much more complex, and in the current implementation on **series/3.x**, it actually murders the whole dispatcher instance.

Additionally, the interactions between `await` and the parallel/sequential modes are not straightforward at all. I tried to spell things out really clearly in the tests (I recommend you start with the tests in review!) but I may have missed some things.

As you can probably see by the commit log (which I have left bare for all to peruse), this is where I got stuck for the past few months.