### PR TITLE
Enabled configurability of unhandled fiber exceptions

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
@@ -48,11 +48,17 @@ private[unsafe] abstract class IORuntimeConfigCompanionPlatform { this: IORuntim
       .flatMap(x => Try(Duration(x)).toOption)
       .getOrElse(DefaultShutdownHookTimeout)
 
+    val reportUnhandledFiberErrors = process
+      .env("CATS_EFFECT_REPORT_UNHANDLED_FIBER_ERRORS")
+      .flatMap(x => Try(x.toBoolean).toOption)
+      .getOrElse(DefaultReportUnhandledFiberErrors)
+
     apply(
       cancelationCheckThreshold,
       autoYieldThreshold,
       enhancedExceptions,
       traceBufferSize,
-      shutdownHookTimeout)
+      shutdownHookTimeout,
+      reportUnhandledFiberErrors)
   }
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
@@ -44,11 +44,16 @@ private[unsafe] abstract class IORuntimeConfigCompanionPlatform { this: IORuntim
         .map(Duration(_))
         .getOrElse(DefaultShutdownHookTimeout)
 
+    val reportUnhandledFiberErrors =
+      Try(System.getProperty("cats.effect.report.unhandledFiberErrors").toBoolean)
+        .getOrElse(DefaultReportUnhandledFiberErrors)
+
     apply(
       cancelationCheckThreshold,
       autoYieldThreshold,
       enhancedExceptions,
       traceBufferSize,
-      shutdownHookTimeout)
+      shutdownHookTimeout,
+      reportUnhandledFiberErrors)
   }
 }

--- a/core/native/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/IORuntimeConfigCompanionPlatform.scala
@@ -45,11 +45,17 @@ private[unsafe] abstract class IORuntimeConfigCompanionPlatform { this: IORuntim
       .flatMap(x => Try(Duration(x)).toOption)
       .getOrElse(DefaultShutdownHookTimeout)
 
+    val reportUnhandledFiberErrors =
+      Option(System.getenv("CATS_EFFECT_REPORT_UNHANDLED_FIBER_ERRORS"))
+        .flatMap(x => Try(x.toBoolean).toOption)
+        .getOrElse(DefaultReportUnhandledFiberErrors)
+
     apply(
       cancelationCheckThreshold,
       autoYieldThreshold,
       enhancedExceptions,
       traceBufferSize,
-      shutdownHookTimeout)
+      shutdownHookTimeout,
+      reportUnhandledFiberErrors)
   }
 }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -999,7 +999,7 @@ private final class IOFiber[A](
     outcome = oc
 
     try {
-      if (!callbacks(oc, false)) {
+      if (!callbacks(oc, false) && runtime.config.reportUnhandledFiberErrors) {
         oc match {
           case Outcome.Errored(e) => currentCtx.reportFailure(e)
           case _ => ()

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntimeConfig.scala
@@ -24,7 +24,8 @@ final case class IORuntimeConfig private (
     val autoYieldThreshold: Int,
     val enhancedExceptions: Boolean,
     val traceBufferSize: Int,
-    val shutdownHookTimeout: Duration) {
+    val shutdownHookTimeout: Duration,
+    val reportUnhandledFiberErrors: Boolean) {
 
   private[unsafe] def this(cancelationCheckThreshold: Int, autoYieldThreshold: Int) =
     this(
@@ -32,7 +33,8 @@ final case class IORuntimeConfig private (
       autoYieldThreshold,
       IORuntimeConfig.DefaultEnhancedExceptions,
       IORuntimeConfig.DefaultTraceBufferSize,
-      IORuntimeConfig.DefaultShutdownHookTimeout
+      IORuntimeConfig.DefaultShutdownHookTimeout,
+      IORuntimeConfig.DefaultReportUnhandledFiberErrors
     )
 
   def copy(
@@ -40,13 +42,29 @@ final case class IORuntimeConfig private (
       autoYieldThreshold: Int = this.autoYieldThreshold,
       enhancedExceptions: Boolean = this.enhancedExceptions,
       traceBufferSize: Int = this.traceBufferSize,
-      shutdownHookTimeout: Duration = this.shutdownHookTimeout): IORuntimeConfig =
+      shutdownHookTimeout: Duration = this.shutdownHookTimeout,
+      reportUnhandledFiberErrors: Boolean = this.reportUnhandledFiberErrors): IORuntimeConfig =
     new IORuntimeConfig(
       cancelationCheckThreshold,
       autoYieldThreshold,
       enhancedExceptions,
       traceBufferSize,
-      shutdownHookTimeout)
+      shutdownHookTimeout,
+      reportUnhandledFiberErrors)
+
+  private[unsafe] def copy(
+      cancelationCheckThreshold: Int,
+      autoYieldThreshold: Int,
+      enhancedExceptions: Boolean,
+      traceBufferSize: Int,
+      shutdownHookTimeout: Duration): IORuntimeConfig =
+    new IORuntimeConfig(
+      cancelationCheckThreshold,
+      autoYieldThreshold,
+      enhancedExceptions,
+      traceBufferSize,
+      shutdownHookTimeout,
+      IORuntimeConfig.DefaultReportUnhandledFiberErrors)
 
   // shims for binary compat
   private[unsafe] def this(
@@ -59,7 +77,24 @@ final case class IORuntimeConfig private (
       autoYieldThreshold,
       enhancedExceptions,
       traceBufferSize,
-      IORuntimeConfig.DefaultShutdownHookTimeout)
+      IORuntimeConfig.DefaultShutdownHookTimeout,
+      IORuntimeConfig.DefaultReportUnhandledFiberErrors
+    )
+
+  // shims for binary compat
+  private[unsafe] def this(
+      cancelationCheckThreshold: Int,
+      autoYieldThreshold: Int,
+      enhancedExceptions: Boolean,
+      traceBufferSize: Int,
+      shutdownHookTimeout: Duration) =
+    this(
+      cancelationCheckThreshold,
+      autoYieldThreshold,
+      enhancedExceptions,
+      traceBufferSize,
+      shutdownHookTimeout,
+      IORuntimeConfig.DefaultReportUnhandledFiberErrors)
 
   private[unsafe] def copy(
       cancelationCheckThreshold: Int,
@@ -71,7 +106,8 @@ final case class IORuntimeConfig private (
       autoYieldThreshold,
       enhancedExceptions,
       traceBufferSize,
-      shutdownHookTimeout)
+      shutdownHookTimeout,
+      reportUnhandledFiberErrors)
 
   private[unsafe] def copy(
       cancelationCheckThreshold: Int,
@@ -81,7 +117,8 @@ final case class IORuntimeConfig private (
       autoYieldThreshold,
       enhancedExceptions,
       traceBufferSize,
-      shutdownHookTimeout)
+      shutdownHookTimeout,
+      reportUnhandledFiberErrors)
 
   private[effect] val traceBufferLogSize: Int =
     Math.round(Math.log(traceBufferSize.toDouble) / Math.log(2)).toInt
@@ -93,6 +130,7 @@ object IORuntimeConfig extends IORuntimeConfigCompanionPlatform {
   private[unsafe] def DefaultEnhancedExceptions = true
   private[unsafe] def DefaultTraceBufferSize = 16
   private[unsafe] def DefaultShutdownHookTimeout = Duration.Inf
+  private[unsafe] def DefaultReportUnhandledFiberErrors = true
 
   def apply(): IORuntimeConfig = Default
 
@@ -121,14 +159,30 @@ object IORuntimeConfig extends IORuntimeConfigCompanionPlatform {
       autoYieldThreshold: Int,
       enhancedExceptions: Boolean,
       traceBufferSize: Int,
-      shutdownHookTimeout: Duration): IORuntimeConfig = {
+      shutdownHookTimeout: Duration): IORuntimeConfig =
+    apply(
+      cancelationCheckThreshold,
+      autoYieldThreshold,
+      enhancedExceptions,
+      traceBufferSize,
+      shutdownHookTimeout,
+      DefaultReportUnhandledFiberErrors)
+
+  def apply(
+      cancelationCheckThreshold: Int,
+      autoYieldThreshold: Int,
+      enhancedExceptions: Boolean,
+      traceBufferSize: Int,
+      shutdownHookTimeout: Duration,
+      reportUnhandledFiberErrors: Boolean): IORuntimeConfig = {
     if (autoYieldThreshold % cancelationCheckThreshold == 0)
       new IORuntimeConfig(
         cancelationCheckThreshold,
         autoYieldThreshold,
         enhancedExceptions,
         1 << Math.round(Math.log(traceBufferSize.toDouble) / Math.log(2)).toInt,
-        shutdownHookTimeout
+        shutdownHookTimeout,
+        reportUnhandledFiberErrors
       )
     else
       throw new AssertionError(


### PR DESCRIPTION
Fixes #3151

Hopefully this should make the Fs2 build a bit nicer. I'm still defaulting the reporting to `true` since it's definitely good hygiene to avoid provoking the reporter in most cases, but having a global kill switch should help for situations where people are aggressively error shifting using `Deferred`.