### PR TITLE
Fix NullPointerException during fiber dump

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1540,7 +1540,7 @@ private final class IOFiber[A] private (
   }
 
   private[effect] def prettyPrintTrace(): String =
-    if (isStackTracing) {
+    if (tracingEvents ne null) {
       suspended.get()
       Tracing.prettyPrint(tracingEvents)
     } else {


### PR DESCRIPTION
Fiber dumps fail with a `NullPointerException` whenever there's a task executing on the compute pool, that was submitted via the `ExecutionContext#execute`.

```
Exception in thread "SIGUSR1 handler" java.lang.NullPointerException: Cannot invoke "cats.effect.tracing.RingBuffer.toList()" because "events" is null
	at cats.effect.tracing.Tracing$.getFrames(Tracing.scala:139)
	at cats.effect.tracing.Tracing$.prettyPrint(Tracing.scala:145)
	at cats.effect.IOFiber.prettyPrintTrace(IOFiber.scala:1545)
	at cats.effect.unsafe.FiberMonitorShared.fiberString(FiberMonitorShared.scala:28)
	at cats.effect.unsafe.FiberMonitor.$anonfun$liveFiberSnapshot$5(FiberMonitor.scala:118)
	at scala.Option.map(Option.scala:242)
	at cats.effect.unsafe.FiberMonitor.$anonfun$liveFiberSnapshot$4(FiberMonitor.scala:118)
	at scala.collection.StrictOptimizedIterableOps.map(StrictOptimizedIterableOps.scala:100)
	at scala.collection.StrictOptimizedIterableOps.map$(StrictOptimizedIterableOps.scala:87)
	at scala.collection.immutable.HashMap.map(HashMap.scala:39)
	at cats.effect.unsafe.FiberMonitor.$anonfun$liveFiberSnapshot$2(FiberMonitor.scala:110)
	at cats.effect.unsafe.FiberMonitor.$anonfun$liveFiberSnapshot$2$adapted(FiberMonitor.scala:91)
	at scala.Option.fold(Option.scala:263)
	at cats.effect.unsafe.FiberMonitor.liveFiberSnapshot(FiberMonitor.scala:91)
	at cats.effect.IOApp.$anonfun$main$8(IOApp.scala:260)
	at cats.effect.Signal.lambda$invocationHandlerFromConsumer$0(Signal.java:105)
	at jdk.proxy2/jdk.proxy2.$Proxy3.handle(Unknown Source)
	at jdk.unsupported/sun.misc.Signal$InternalMiscHandler.handle(Signal.java:198)
	at java.base/jdk.internal.misc.Signal$1.run(Signal.java:219)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

The issue can be reproduced with:
```
import cats.effect.{IO, IOApp}

import scala.concurrent.ExecutionContext

object Test2 extends IOApp.Simple {

  override def run: IO[Unit] =
    IO(runtime.compute.execute(new Run(runtime.compute))) >> IO.never

}

class Run(ec: ExecutionContext) extends Runnable {
  override def run(): Unit = {
    Vector.fill(1000000)(())
    ec.execute(this)
  }
}
```

With the changes introduced in this PR, the same application outputs this (when a fiber dump is triggered):
```
cats.effect.IOFiber@c5ba33a RUNNING
 

 

 

 

 

 

 

 

 

 

 
cats.effect.IOFiber@644a7d13 WAITING
 ├ <clinit> @ io.sumislawski.http4sbenchmark.seriess_1_0.Test2$.run(Test2.scala:10)
 ├ apply @ io.sumislawski.http4sbenchmark.seriess_1_0.Test2$.run(Test2.scala:10)
 ├ >> @ io.sumislawski.http4sbenchmark.seriess_1_0.Test2$.run(Test2.scala:10)
 ╰ run$ @ io.sumislawski.http4sbenchmark.seriess_1_0.Test2$.run(Test2.scala:7)
 
Thread[io-compute-7,5,main] (#6): 0 enqueued
Thread[io-compute-1,5,main] (#0): 0 enqueued
Thread[io-compute-6,5,main] (#5): 0 enqueued
Thread[io-compute-2,5,main] (#1): 0 enqueued
Thread[io-compute-12,5,main] (#11): 0 enqueued
Thread[io-compute-4,5,main] (#3): 0 enqueued
Thread[io-compute-9,5,main] (#8): 0 enqueued
Thread[io-compute-11,5,main] (#10): 0 enqueued
Thread[io-compute-10,5,main] (#9): 0 enqueued
Thread[io-compute-8,5,main] (#7): 0 enqueued
Thread[io-compute-5,5,main] (#4): 0 enqueued
Thread[io-compute-3,5,main] (#2): 0 enqueued
 
Global: enqueued 0, foreign 0, waiting 1
```