### PR TITLE
Doodle of polling system high-level API

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -39,7 +39,7 @@ import java.util.concurrent.locks.LockSupport
  * system when compared to a fixed size thread pool whose worker threads all draw tasks from a
  * single global work queue.
  */
-private final class WorkerThread(
+private[effect] final class WorkerThread(
     idx: Int,
     // Local queue instance with exclusive write access.
     private[this] var queue: LocalQueue,
@@ -97,6 +97,8 @@ private final class WorkerThread(
   private[this] val runtimeBlockingExpiration: Duration = pool.runtimeBlockingExpiration
 
   val nameIndex: Int = pool.blockedWorkerThreadNamingIndex.incrementAndGet()
+
+  def pollingSystem: Any = ??? // stub
 
   // Constructor code.
   {

--- a/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
@@ -16,6 +16,9 @@
 
 package cats.effect.kernel
 
+import scala.annotation.nowarn
+import scala.reflect.ClassTag
+
 import java.util.concurrent.{CompletableFuture, CompletionException, CompletionStage}
 
 private[kernel] trait AsyncPlatform[F[_]] extends Serializable { this: Async[F] =>
@@ -53,4 +56,14 @@ private[kernel] trait AsyncPlatform[F[_]] extends Serializable { this: Async[F] 
         }
       }
     }
+
+  /**
+   * Attempts to retrieve the runtime's polling system, if present and an instance of `S`.
+   *
+   * If successful, it invokes the side-effect `f` with it and returns the result.
+   *
+   * If no polling system of type `S` is available, then `f` is not run and `None` is returned.
+   */
+  @nowarn
+  def delayWithPollingSystem[S: ClassTag, A](f: S => A): F[Option[A]] = pure(None)
 }


### PR DESCRIPTION
Here's a doodle of what the high-level API for the polling system might look like.

1. It bakes the concept straight into `Async` in kernel. This goes to the point that you need an `IO`-like ecosystem to really take advantage of this, but enables the ecosystem to build without knowing about `IO`.

2. It enforces the idea that the `PollingSystem` you want _might not be available_. This may happen for various reasons:
    - not running on the WSTP, or `evalOn`-ed off of it
    - no system installed, or not the one you want
    
    This gives implementations the chance to recover, which in practice would mean starting and using their own event-loop thread. It also lets an easy default implementation fall out.

3. It encourages you to do everything you need with the `PollingSystem` in a single, atomic `delay` block. Because a subsequent effect can always execute on another thread (since we do not have an `uncedable` construct) this is the only safe way to interact with a `PollingSystem` without requiring it to be threadsafe.

## Example use

These are rough sketches, but whatever.

#### Selector

```scala
F.delayWithPollingSystem[Selector, Socket[F]] { selector =>
  val ch = selector.provider.openSocketChannel()
  val callback = ??? // too fugly for this example
  ch.register(selector, OP_READ | OP_WRITE, callback)
  new Socket[F](ch, ...)
} flatMap {
  case Some(socket) => F.pure(socket) // cool
  case None => Socket.makeTheOldFashionedWay[F]
}
```

#### io_uring

```scala
F.async[Int] { cb =>
  F.delayWithPollingSystem[Uring, Unit] { ring =>
    val sqe = ring.getSqe(cb) // get submission-queue-event and register callback
    io_uring_prep_nop(sqe) // prep an operation
    ()
  } flatMap {
    case Some(()) => F.unit // successful, do nothing
    case None => F.delay(/* submit elsewhere */)
  } as None // ignore cancellation for this example
}
```