### PR TITLE
Avoid spurious wake-up in `Concurrent` queues at capacity

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Queue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Queue.scala
@@ -240,8 +240,14 @@ object Queue {
 
             case State(queue, size, takers, offerers) if queue.nonEmpty =>
               val (a, rest) = queue.dequeue
-              val (release, tail) = offerers.dequeue
-              State(rest, size - 1, takers, tail) -> release.complete(()).as(a)
+
+              // if we haven't made enough space for a new offerer, don't disturb the water
+              if (size - 1 < capacity) {
+                val (release, tail) = offerers.dequeue
+                State(rest, size - 1, takers, tail) -> release.complete(()).as(a)
+              } else {
+                State(rest, size - 1, takers, offerers) -> F.pure(a)
+              }
 
             case State(queue, size, takers, offerers) =>
               /*


### PR DESCRIPTION
Prior to this fix, we would wake up the next offerer every time we `take` if there are any `offerers`. However, in the special case of `synchronous`, this is *not* the right semantic since we haven't actually brought the queue under capacity, meaning that the offerer in question will just go back to sleep… at the end of the queue. Now we simply check to see whether it's even meaningful to wake up the offerer, and if it isn't, we just… don't.