### PR TITLE
Fix issue with fibers not getting deregistered from monitoring...

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1368,7 +1368,7 @@ private final class IOFiber[A] private (
       }
 
     if (isStackTracing) {
-      // Remove the reference to the fiber monitor key
+      // Remove the reference to the fiber monitor handle
       objectState.pop().asInstanceOf[WeakBag.Handle].deregister()
     }
 
@@ -1469,8 +1469,8 @@ private final class IOFiber[A] private (
 
   private[this] def evalOnFailureK(t: Throwable): IO[Any] = {
     if (isStackTracing) {
-      // Remove the reference to the fiber monitor key
-      objectState.pop()
+      // Remove the reference to the fiber monitor handle
+      objectState.pop().asInstanceOf[WeakBag.Handle].deregister()
     }
     val ec = objectState.pop().asInstanceOf[ExecutionContext]
     currentCtx = ec


### PR DESCRIPTION
...if they failed in `evalOn`

### Reproduction of the issue:
```
import java.util.concurrent.Executors
import scala.concurrent.ExecutionContext
import scala.concurrent.duration.DurationInt

object Test8 extends IOApp.Simple {

  val ec2 = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor())

  override def run: IO[Unit] =
    IO.raiseError[Unit](new Exception())
      .evalOn(ec2)
      .attempt
      .flatMap(_ => IO.sleep(10000.seconds))

}
```
This program has exactly one fiber. But the `SuspendedFiberCount` (from `ComputePoolSampler`, available via JMX) reports value of 2. This is because that fiber is registered twice.

### Solution
This seems to be caused by a simple error in the implementation of fiber monitoring in `evalOnFailureK`. In two other scenarios a `objectState.pop().asInstanceOf[WeakBag.Handle].deregister()` is used, but here the code is just `objectState.pop()`. Calling `deregister` in the `evalOnFailureK` solves the problem.
