### PR TITLE
Fix deregistration of fiber from monitoring when IOCont.Get gets cancelled

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -772,7 +772,8 @@ private final class IOFiber[A] private (
                 state.handle.deregister()
                 ()
               })
-              conts = ByteStack.push(conts, OnCancelK) // remove the above finalizer if the Get completes without getting cancelled
+              // remove the above finalizer if the Get completes without getting cancelled
+              conts = ByteStack.push(conts, OnCancelK)
             }
 
             /*


### PR DESCRIPTION
### The Problem
The problem appears in variety of scenarios where `async` operation gets cancelled. The simplest (in terms of internal complexity, not amount of code) reproduction example is:
```
package cats.effect

import java.util.concurrent.atomic.AtomicInteger
import scala.concurrent.duration.DurationInt

object Test7_minimised extends IOApp.Simple {

  val i1 = new AtomicInteger(0)

  override def run: IO[Unit] =
    IO.never[Unit]
      .start
      .flatMap { f =>
        while (i1.incrementAndGet() < 300000000) {} // Keep this fiber busy for some time so that f can progress to IOCont.Get before we cancel it
        f.cancel
      } >>
      IO.sleep(1000.seconds)

}
```
Once that program reaches the IO.sleep, it has exactly one suspended fiber. But `SuspendedFiberCount` (from `ComputePoolSampler`, available via JMX ) is reported as `2`. The fiber `f` executing the `never` (which is an `async` / `IOCont`) is registered as a suspended fiber (this happens while interpreting `IOCont.Get`), and when it gets cancelled it isn't deregistered (the successful/failed execution paths deregister it correctly).

### Solution
The solution is to register a finaliser that will deregister the fiber gets cancelled while suspended on Get, and removing that finaliser if the fiber resumes without cancellation. The implementation is inspired by a similar solution here: https://github.com/typelevel/cats-effect/blob/series/3.3.x/core/shared/src/main/scala/cats/effect/IOFiber.scala#L748

### For curious
Here's a branch with additional logging showing the process: https://github.com/RafalSumislawski/cats-effect/tree/fiber-monitoring-investigation
And examples that reproduce (not guaranteed) the issue: https://github.com/RafalSumislawski/cats-effect/blob/fiber-monitoring-investigation/core/jvm/src/main/scala/cats/effect/Test7.scala . I started from "this thing happens when sending a request with http4s-blaze" and it took only ~15h :sweat_smile:  to reduce it down to a reliable reproduction with just 2 fibers.