### PR TITLE
WIP: Improve trace dumps of short-lived fibers

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
@@ -17,12 +17,15 @@
 package cats.effect
 package unsafe
 
+import cats.effect.tracing.Tracing.FiberTrace
+
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 
 private final class FiberAwareExecutionContext(ec: ExecutionContext) extends ExecutionContext {
 
-  def liveFibers(): Set[IOFiber[_]] = fiberBag.toSet
+  def liveFiberTraces(): Map[IOFiber[_], FiberTrace] =
+    fiberBag.iterator.map(f => f -> f.prettyPrintTrace()).toMap
 
   private[this] val fiberBag = mutable.Set.empty[IOFiber[_]]
 

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -22,6 +22,8 @@ private[effect] object Tracing extends TracingPlatform {
 
   import TracingConstants._
 
+  type FiberTrace = String
+
   private[this] val TurnRight = "╰"
   // private[this] val InverseTurnRight = "╭"
   private[this] val Junction = "├"

--- a/core/shared/src/main/scala/cats/effect/unsafe/FiberMonitorShared.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/FiberMonitorShared.scala
@@ -23,18 +23,17 @@ private[unsafe] abstract class FiberMonitorShared {
   protected val newline = System.lineSeparator()
   protected val doubleNewline = s"$newline $newline"
 
-  protected def fiberString(fiber: IOFiber[_], status: String): String = {
+  protected def fiberString(fiber: IOFiber[_], trace: String, status: String): String = {
     val id = System.identityHashCode(fiber).toHexString
-    val trace = fiber.prettyPrintTrace()
     val prefixedTrace = if (trace.isEmpty) "" else newline + trace
     s"cats.effect.IOFiber@$id $status$prefixedTrace"
   }
 
-  protected def printFibers(fibers: Set[IOFiber[_]], status: String)(
+  protected def printFibers(fibers: Map[IOFiber[_], String], status: String)(
       print: String => Unit): Unit =
-    fibers foreach { fiber =>
-      print(doubleNewline)
-      print(fiberString(fiber, status))
+    fibers foreach {
+      case (fiber, trace) =>
+        print(doubleNewline)
+        print(fiberString(fiber, trace, status))
     }
-
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/WeakBag.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/WeakBag.scala
@@ -19,7 +19,6 @@ package cats.effect.unsafe
 import cats.effect.unsafe.ref.{ReferenceQueue, WeakReference}
 
 import scala.annotation.tailrec
-import scala.collection.mutable
 
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -71,20 +70,17 @@ private final class WeakBag[A <: AnyRef] {
     }
   }
 
-  def toSet: Set[A] = {
-    val set = mutable.Set.empty[A]
+  def forEach(f: A => Unit): Unit = {
     var i = 0
     val sz = index
 
     while (i < sz) {
       val a = table(i).get()
       if (a ne null) {
-        set += a
+        f(a)
       }
       i += 1
     }
-
-    set.toSet
   }
 
   def size: Int = {


### PR DESCRIPTION
### Issue

The following application has roughly 1000 suspended fibers at any moment. When we do a fiber dump of that application, the number of dumped fibers is roughly as expected, but a large portion (20-50% on my machine, after warming up) of those fibers has no trace. 

```
package test

import cats.effect.std.Semaphore
import cats.effect.{IO, IOApp}

import scala.concurrent.duration.DurationInt

object Test9 extends IOApp.Simple {

  override def run: IO[Unit] = {
    Semaphore[IO](1000).flatMap { semaphore =>
      semaphore
        .acquire
        .flatMap(_ => IO.sleep(10.millisecond).flatMap(_ => semaphore.release).start)
        .foreverM
    }
  }

}
```

The process of collecting the fiber dump is
1. Make a list of all fibers 
2. Collect traces of the fibers
The problem is that that process takes 5-50ms, while the average life-span of the fibers is 10ms. There's a high chance that by the time we try to collect the trace, the fiber is already complete. There's a new fiber running in it's place, but that new fiber is not on our list.

### Solution
After collecting a reference to a fiber, collect the trace for it as early as possible.

### Measurements
Before (https://github.com/RafalSumislawski/cats-effect/tree/improve-trace-dumps-of-shortlived-fibers-repro-before):
```
fibersWithTraces / allFibers = ratio
1/1 = 100.0%
57/989 = 5.763397371081901%
201/977 = 20.573183213920164%
592/1001 = 59.14085914085914%
533/1013 = 52.61599210266535%
910/1002 = 90.81836327345309%
806/1001 = 80.51948051948052%
436/980 = 44.48979591836735%
890/1007 = 88.38133068520358%
595/994 = 59.859154929577464%
749/997 = 75.12537612838516%
867/1001 = 86.61338661338661%
838/982 = 85.33604887983707%
690/997 = 69.20762286860582%
964/1001 = 96.3036963036963%
571/1013 = 56.36722606120434%
717/988 = 72.57085020242916%
845/1001 = 84.41558441558442%
802/1001 = 80.11988011988012%
757/1002 = 75.54890219560878%
1001/1001 = 100.0%
981/1001 = 98.001998001998%
813/1001 = 81.21878121878122%
704/997 = 70.61183550651955%
772/1011 = 76.36003956478734%
821/995 = 82.51256281407035%
777/999 = 77.77777777777777%
893/996 = 89.65863453815261%
832/1019 = 81.648675171737%
724/966 = 74.94824016563147%
740/998 = 74.14829659318637%
833/1001 = 83.21678321678321%
917/1001 = 91.60839160839161%
842/1001 = 84.11588411588411%
529/988 = 53.54251012145749%
687/1018 = 67.4852652259332%
887/1013 = 87.56169792694965%
950/1001 = 94.9050949050949%
869/998 = 87.07414829659318%
978/1001 = 97.7022977022977%
```
After (https://github.com/RafalSumislawski/cats-effect/tree/improve-trace-dumps-of-shortlived-fibers-repro):
```
1/1 = 100.0%
1106/1106 = 100.0%
1002/1002 = 100.0%
977/977 = 100.0%
1008/1008 = 100.0%
1006/1006 = 100.0%
996/996 = 100.0%
999/999 = 100.0%
871/872 = 99.88532110091744%
1009/1013 = 99.6051332675222%
1008/1008 = 100.0%
1035/1035 = 100.0%
997/997 = 100.0%
1036/1036 = 100.0%
956/956 = 100.0%
998/998 = 100.0%
998/998 = 100.0%
1002/1002 = 100.0%
999/999 = 100.0%
976/976 = 100.0%
1014/1014 = 100.0%
981/981 = 100.0%
1006/1006 = 100.0%
1001/1001 = 100.0%
990/990 = 100.0%
1001/1001 = 100.0%
1013/1013 = 100.0%
1002/1002 = 100.0%
958/959 = 99.89572471324296%
954/954 = 100.0%
1001/1001 = 100.0%
```
