### PR TITLE
Fix NullPointerException in `RingBuffer#toList`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
@@ -37,14 +37,17 @@ private[effect] final class RingBuffer private (logSize: Int) {
    */
   def toList(): List[TracingEvent] = {
     var result = List.empty[TracingEvent]
-    val msk = mask
-    val idx = index
-    val start = math.max(idx - length, 0)
-    val end = idx
-    var i = start
-    while (i < end) {
-      result ::= buffer(i & msk)
-      i += 1
+    val buf = buffer
+    if (buf ne null) {
+      val msk = mask
+      val idx = index
+      val start = math.max(idx - length, 0)
+      val end = idx
+      var i = start
+      while (i < end) {
+        result ::= buf(i & msk)
+        i += 1
+      }
     }
     result
   }


### PR DESCRIPTION
I happened to come across this thing:
```
Exception in thread "Thread-13" javax.management.RuntimeMBeanException: java.lang.NullPointerException
	at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.rethrow(DefaultMBeanServerInterceptor.java:829)
	at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.rethrowMaybeMBeanException(DefaultMBeanServerInterceptor.java:842)
	at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.invoke(DefaultMBeanServerInterceptor.java:811)
	at java.management/com.sun.jmx.mbeanserver.JmxMBeanServer.invoke(JmxMBeanServer.java:801)
	at cats.effect.unsafe.TraceThread.run(TraceThread.scala:20)
Caused by: java.lang.NullPointerException
	at cats.effect.tracing.RingBuffer.toList(RingBuffer.scala:46)
	at cats.effect.tracing.Tracing$.getFrames(Tracing.scala:139)
	at cats.effect.tracing.Tracing$.prettyPrint(Tracing.scala:145)
	at cats.effect.IOFiber.prettyPrintTrace(IOFiber.scala:1552)
	at cats.effect.unsafe.FiberMonitorShared.fiberString(FiberMonitorShared.scala:28)
	at cats.effect.unsafe.FiberMonitorShared.$anonfun$printFibers$1(FiberMonitorShared.scala:37)
	at cats.effect.unsafe.FiberMonitorShared.$anonfun$printFibers$1$adapted(FiberMonitorShared.scala:35)
	at scala.collection.immutable.BitmapIndexedSetNode.foreach(HashSet.scala:937)
	at scala.collection.immutable.HashSet.foreach(HashSet.scala:944)
	at cats.effect.unsafe.FiberMonitorShared.printFibers(FiberMonitorShared.scala:35)
	at cats.effect.unsafe.FiberMonitor.$anonfun$liveFiberSnapshot$2(FiberMonitor.scala:125)
	at cats.effect.unsafe.FiberMonitor.$anonfun$liveFiberSnapshot$2$adapted(FiberMonitor.scala:91)
	at scala.Option.fold(Option.scala:263)
	at cats.effect.unsafe.FiberMonitor.liveFiberSnapshot(FiberMonitor.scala:91)
	at cats.effect.unsafe.metrics.LiveFiberSnapshotTrigger.liveFiberSnapshot(LiveFiberSnapshotTrigger.scala:33)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at sun.reflect.misc.Trampoline.invoke(MethodUtil.java:71)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at java.base/sun.reflect.misc.MethodUtil.invoke(MethodUtil.java:260)
	at java.management/com.sun.jmx.mbeanserver.StandardMBeanIntrospector.invokeM2(StandardMBeanIntrospector.java:112)
	at java.management/com.sun.jmx.mbeanserver.StandardMBeanIntrospector.invokeM2(StandardMBeanIntrospector.java:46)
	at java.management/com.sun.jmx.mbeanserver.MBeanIntrospector.invokeM(MBeanIntrospector.java:237)
	at java.management/com.sun.jmx.mbeanserver.PerInterface.invoke(PerInterface.java:138)
	at java.management/com.sun.jmx.mbeanserver.MBeanSupport.invoke(MBeanSupport.java:252)
	at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.invoke(DefaultMBeanServerInterceptor.java:809)
	... 2 more
```