### PR TITLE
Improve trace dumps of short-lived fibers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -729,7 +729,9 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
           "cats.effect.unsafe.PolyfillExecutionContext$"),
         ProblemFilters.exclude[MissingClassProblem]("cats.effect.unsafe.WorkerThread"),
         ProblemFilters.exclude[Problem]("cats.effect.IOFiberConstants.*"),
-        ProblemFilters.exclude[Problem]("cats.effect.SyncIOConstants.*")
+        ProblemFilters.exclude[Problem]("cats.effect.SyncIOConstants.*"),
+        // introduced by #3196. Changes in an internal API.
+        ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.unsafe.FiberAwareExecutionContext.liveFibers")
       )
     },
     mimaBinaryIssueFilters ++= {

--- a/core/js-native/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js-native/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -18,7 +18,6 @@ package cats.effect
 package unsafe
 
 import scala.concurrent.ExecutionContext
-import cats.effect.tracing.Tracing.FiberTrace
 
 // Can you imagine a thread pool on JS? Have fun trying to extend or instantiate
 // this class. Unfortunately, due to the explicit branching, this type leaks
@@ -29,8 +28,10 @@ private[effect] sealed abstract class WorkStealingThreadPool private ()
   def reportFailure(cause: Throwable): Unit
   private[effect] def reschedule(runnable: Runnable): Unit
   private[effect] def canExecuteBlockingCode(): Boolean
-  private[unsafe] def liveFiberTraces()
-  : (Map[Runnable, FiberTrace], Map[WorkerThread, (Thread.State, Option[(Runnable, FiberTrace)], Map[Runnable, FiberTrace])], Map[Runnable, FiberTrace])
+  private[unsafe] def liveTraces(): (
+      Map[Runnable, Trace],
+      Map[WorkerThread, (Thread.State, Option[(Runnable, Trace)], Map[Runnable, Trace])],
+      Map[Runnable, Trace])
 }
 
 private[unsafe] sealed abstract class WorkerThread private () extends Thread {

--- a/core/js-native/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js-native/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -18,6 +18,7 @@ package cats.effect
 package unsafe
 
 import scala.concurrent.ExecutionContext
+import cats.effect.tracing.Tracing.FiberTrace
 
 // Can you imagine a thread pool on JS? Have fun trying to extend or instantiate
 // this class. Unfortunately, due to the explicit branching, this type leaks
@@ -28,8 +29,8 @@ private[effect] sealed abstract class WorkStealingThreadPool private ()
   def reportFailure(cause: Throwable): Unit
   private[effect] def reschedule(runnable: Runnable): Unit
   private[effect] def canExecuteBlockingCode(): Boolean
-  private[unsafe] def liveFibers()
-      : (Set[Runnable], Map[WorkerThread, (Option[Runnable], Set[Runnable])], Set[Runnable])
+  private[unsafe] def liveFiberTraces()
+  : (Map[Runnable, FiberTrace], Map[WorkerThread, (Thread.State, Option[(Runnable, FiberTrace)], Map[Runnable, FiberTrace])], Map[Runnable, FiberTrace])
 }
 
 private[unsafe] sealed abstract class WorkerThread private () extends Thread {

--- a/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
@@ -23,7 +23,7 @@ import scala.concurrent.ExecutionContext
 private final class FiberAwareExecutionContext(ec: ExecutionContext) extends ExecutionContext {
 
   def liveTraces(): Map[IOFiber[_], Trace] =
-    fiberBag.iterator.map(f => f -> f.captureTrace()).toMap
+    fiberBag.iterator.filterNot(_.isDone).map(f => f -> f.captureTrace()).toMap
 
   private[this] val fiberBag = mutable.Set.empty[IOFiber[_]]
 

--- a/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
@@ -17,12 +17,15 @@
 package cats.effect
 package unsafe
 
+import cats.effect.tracing.Tracing.FiberTrace
+
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 
 private final class FiberAwareExecutionContext(ec: ExecutionContext) extends ExecutionContext {
 
-  def liveFibers(): Set[IOFiber[_]] = fiberBag.toSet
+  def liveFiberTraces(): Map[IOFiber[_], FiberTrace] =
+    fiberBag.iterator.map(f => f -> f.prettyPrintTrace()).toMap
 
   private[this] val fiberBag = mutable.Set.empty[IOFiber[_]]
 

--- a/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/FiberAwareExecutionContext.scala
@@ -17,15 +17,13 @@
 package cats.effect
 package unsafe
 
-import cats.effect.tracing.Tracing.FiberTrace
-
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 
 private final class FiberAwareExecutionContext(ec: ExecutionContext) extends ExecutionContext {
 
-  def liveFiberTraces(): Map[IOFiber[_], FiberTrace] =
-    fiberBag.iterator.map(f => f -> f.prettyPrintTrace()).toMap
+  def liveTraces(): Map[IOFiber[_], Trace] =
+    fiberBag.iterator.map(f => f -> f.captureTrace()).toMap
 
   private[this] val fiberBag = mutable.Set.empty[IOFiber[_]]
 

--- a/core/js/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -58,7 +58,8 @@ private final class ES2021FiberMonitor(
 
   def foreignTraces(): Map[IOFiber[_], Trace] = {
     val foreign = mutable.Map.empty[IOFiber[Any], Trace]
-    bag.forEach(fiber => foreign += (fiber.asInstanceOf[IOFiber[Any]] -> fiber.captureTrace()))
+    bag.forEach(fiber =>
+      if (!fiber.isDone) foreign += (fiber.asInstanceOf[IOFiber[Any]] -> fiber.captureTrace()))
     foreign.toMap
   }
 

--- a/core/js/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -17,8 +17,11 @@
 package cats.effect
 package unsafe
 
+import cats.effect.tracing.Tracing.FiberTrace
+
+import scala.collection.mutable
 import scala.concurrent.ExecutionContext
-import scala.scalajs.{js, LinkingInfo}
+import scala.scalajs.{LinkingInfo, js}
 
 private[effect] sealed abstract class FiberMonitor extends FiberMonitorShared {
 
@@ -55,19 +58,25 @@ private final class ES2021FiberMonitor(
   override def monitorSuspended(fiber: IOFiber[_]): WeakBag.Handle =
     bag.insert(fiber)
 
+  def foreignTraces(): Map[IOFiber[_], FiberTrace] = {
+    val foreign = mutable.Map.empty[IOFiber[Any], FiberTrace]
+    bag.forEach(fiber =>
+      foreign += (fiber.asInstanceOf[IOFiber[Any]] -> fiber.prettyPrintTrace()))
+    foreign.toMap
+  }
+
   def liveFiberSnapshot(print: String => Unit): Unit =
     Option(compute).foreach { compute =>
-      val queued = compute.liveFibers().filterNot(_.isDone)
-      val rawForeign = bag.toSet.filterNot(_.isDone)
+      val queued = compute.liveFiberTraces()
+      val rawForeign = foreignTraces()
 
       // We trust the sources of data in the following order, ordered from
       // most trustworthy to least trustworthy.
       // 1. Fibers from the macrotask executor
       // 2. Fibers from the foreign fallback weak GC map
 
-      val allForeign = rawForeign -- queued
-      val suspended = allForeign.filter(_.get())
-      val foreign = allForeign.filterNot(_.get())
+      val allForeign = rawForeign -- queued.keys
+      val (suspended, foreign) = allForeign.partition { case (f, _) => f.get() }
 
       printFibers(queued, "YIELDING")(print)
       printFibers(foreign, "YIELDING")(print)

--- a/core/jvm-native/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -199,7 +199,7 @@ private[effect] sealed class FiberMonitor(
       if (bag ne null) {
         val _ = bag.synchronizationPoint.get()
         bag.forEach {
-          case fiber: IOFiber[_] =>
+          case fiber: IOFiber[_] if !fiber.isDone =>
             foreign += (fiber.asInstanceOf[IOFiber[Any]] -> fiber.captureTrace())
           case _ => ()
         }

--- a/core/jvm-native/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/unsafe/FiberMonitor.scala
@@ -18,10 +18,10 @@ package cats.effect
 package unsafe
 
 import cats.effect.tracing.TracingConstants
+import cats.effect.tracing.Tracing.FiberTrace
 import cats.effect.unsafe.ref.WeakReference
 
 import scala.concurrent.ExecutionContext
-
 import java.util.concurrent.ConcurrentLinkedQueue
 
 /**
@@ -52,8 +52,8 @@ private[effect] sealed class FiberMonitor(
   private[this] final val Bags = FiberMonitor.Bags
   private[this] final val BagReferences = FiberMonitor.BagReferences
 
-  private[this] val justFibers: PartialFunction[Runnable, IOFiber[_]] = {
-    case fiber: IOFiber[_] => fiber
+  private[this] val justFibers: PartialFunction[(Runnable, FiberTrace), (IOFiber[_], FiberTrace)] = {
+    case (fiber: IOFiber[_], trace) => fiber -> trace
   }
 
   /**
@@ -109,15 +109,15 @@ private[effect] sealed class FiberMonitor(
         print(newline)
       } { compute =>
         val (rawExternal, workersMap, rawSuspended) = {
-          val (external, workers, suspended) = compute.liveFibers()
-          val externalFibers = external.collect(justFibers).filterNot(_.isDone)
-          val suspendedFibers = suspended.collect(justFibers).filterNot(_.isDone)
-          val workersMapping: Map[WorkerThread, (Option[IOFiber[_]], Set[IOFiber[_]])] =
+          val (external, workers, suspended) = compute.liveFiberTraces()
+          val externalFibers = external.collect(justFibers)
+          val suspendedFibers = suspended.collect(justFibers)
+          val workersMapping: Map[WorkerThread, (Thread.State, Option[(IOFiber[_], FiberTrace)], Map[IOFiber[_], FiberTrace])] =
             workers.map {
-              case (thread, (opt, set)) =>
+              case (thread, (state, opt, set)) =>
                 val filteredOpt = opt.collect(justFibers)
                 val filteredSet = set.collect(justFibers)
-                (thread, (filteredOpt, filteredSet))
+                (thread, (state, filteredOpt, filteredSet))
             }
 
           (externalFibers, workersMapping, suspendedFibers)
@@ -131,25 +131,25 @@ private[effect] sealed class FiberMonitor(
         // 3. Fibers from the foreign synchronized fallback weak GC maps
         // 4. Fibers from the suspended thread local GC maps
 
-        val localAndActive = workersMap.foldLeft(Set.empty[IOFiber[_]]) {
-          case (acc, (_, (active, local))) =>
-            (acc ++ local) ++ active.toSet.collect(justFibers)
+        val localAndActive = workersMap.foldLeft(Map.empty[IOFiber[_], FiberTrace]) {
+          case (acc, (_, (_, active, local))) =>
+            (acc ++ local) ++ active.collect(justFibers)
         }
-        val external = rawExternal -- localAndActive
-        val suspended = rawSuspended -- localAndActive -- external
-        val foreign = rawForeign -- localAndActive -- external -- suspended
+        val external = rawExternal -- localAndActive.keys
+        val suspended = rawSuspended -- localAndActive.keys -- external.keys
+        val foreign = rawForeign -- localAndActive.keys -- external.keys -- suspended.keys
 
         val workersStatuses = workersMap map {
-          case (worker, (active, local)) =>
-            val yielding = local.filterNot(_.isDone)
+          case (worker, (state, active, local)) =>
+            val yielding = local
 
             val status =
-              if (worker.getState() == Thread.State.RUNNABLE) "RUNNING" else "BLOCKED"
+              if (state == Thread.State.RUNNABLE) "RUNNING" else "BLOCKED"
 
             val workerString = s"$worker (#${worker.index}): ${yielding.size} enqueued"
 
             print(doubleNewline)
-            active.map(fiberString(_, status)).foreach(print(_))
+            active.map{ case (fiber, trace) => fiberString(fiber, trace, status)}.foreach(print(_))
             printFibers(yielding, "YIELDING")(print)
 
             workerString
@@ -187,14 +187,17 @@ private[effect] sealed class FiberMonitor(
    * @return
    *   a set of active fibers
    */
-  private[this] def foreignFibers(): Set[IOFiber[_]] = {
-    val foreign = Set.newBuilder[IOFiber[_]]
+  private[this] def foreignFibers(): Map[IOFiber[_], FiberTrace] = {
+    val foreign = Map.newBuilder[IOFiber[_], FiberTrace]
 
     BagReferences.iterator().forEachRemaining { bagRef =>
       val bag = bagRef.get()
       if (bag ne null) {
         val _ = bag.synchronizationPoint.get()
-        foreign ++= bag.toSet.collect(justFibers).filterNot(_.isDone)
+        bag.forEach{
+          case fiber: IOFiber[_] => foreign += (fiber.asInstanceOf[IOFiber[Any]] -> fiber.prettyPrintTrace())
+          case _ => ()
+        }
       }
     }
 

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -17,17 +17,18 @@
 package cats.effect
 package unsafe
 
+import cats.effect.tracing.Tracing.captureTrace
 import cats.effect.tracing.TracingConstants
 
 import scala.annotation.switch
+import scala.collection.mutable
 import scala.concurrent.{BlockContext, CanAwait}
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
+
 import java.util.concurrent.{ArrayBlockingQueue, ThreadLocalRandom}
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.LockSupport
-import scala.collection.mutable
-import cats.effect.tracing.Tracing.{FiberTrace, captureTrace}
 
 /**
  * Implementation of the worker thread at the heart of the [[WorkStealingThreadPool]].
@@ -218,8 +219,8 @@ private final class WorkerThread(
    * @return
    *   a set of suspended fibers tracked by this worker thread
    */
-  private[unsafe] def suspendedTraces(): Map[Runnable, FiberTrace] = {
-    val foreign = mutable.Map.empty[Runnable, FiberTrace]
+  private[unsafe] def suspendedTraces(): Map[Runnable, Trace] = {
+    val foreign = mutable.Map.empty[Runnable, Trace]
     fiberBag.forEach(r => foreign += (r -> captureTrace(r)))
     foreign.toMap
   }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -221,7 +221,7 @@ private final class WorkerThread(
    */
   private[unsafe] def suspendedTraces(): Map[Runnable, Trace] = {
     val foreign = mutable.Map.empty[Runnable, Trace]
-    fiberBag.forEach(r => foreign += (r -> captureTrace(r)))
+    fiberBag.forEach(r => foreign ++= captureTrace(r))
     foreign.toMap
   }
 

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1492,12 +1492,12 @@ private final class IOFiber[A](
   private[effect] def isDone: Boolean =
     resumeTag == DoneR
 
-  private[effect] def prettyPrintTrace(): String =
+  private[effect] def captureTrace(): Trace =
     if (tracingEvents ne null) {
       suspended.get()
-      Tracing.prettyPrint(tracingEvents)
+      Trace(tracingEvents)
     } else {
-      ""
+      Trace(RingBuffer.empty(1))
     }
 }
 

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -16,15 +16,13 @@
 
 package cats.effect.tracing
 
-import cats.effect.IOFiber
+import cats.effect.{IOFiber, Trace}
 
 import scala.collection.mutable.ArrayBuffer
 
 private[effect] object Tracing extends TracingPlatform {
 
   import TracingConstants._
-
-  type FiberTrace = String
 
   private[this] val TurnRight = "╰"
   // private[this] val InverseTurnRight = "╭"
@@ -145,8 +143,8 @@ private[effect] object Tracing extends TracingPlatform {
       .collect { case ev: TracingEvent.StackTrace => getOpAndCallSite(ev.getStackTrace) }
       .filter(_ ne null)
 
-  def prettyPrint(events: RingBuffer): String = {
-    val frames = getFrames(events)
+  def prettyPrint(trace: Trace): String = {
+    val frames = trace.toList
 
     frames
       .zipWithIndex
@@ -158,10 +156,10 @@ private[effect] object Tracing extends TracingPlatform {
       .mkString(System.lineSeparator())
   }
 
-  def captureTrace(runnable: Runnable): FiberTrace = {
+  def captureTrace(runnable: Runnable): Trace = {
     runnable match {
-      case f: IOFiber[_] => f.prettyPrintTrace()
-      case _ => ""
+      case f: IOFiber[_] => f.captureTrace()
+      case _ => Trace(RingBuffer.empty(1))
     }
   }
 }

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -16,11 +16,15 @@
 
 package cats.effect.tracing
 
+import cats.effect.IOFiber
+
 import scala.collection.mutable.ArrayBuffer
 
 private[effect] object Tracing extends TracingPlatform {
 
   import TracingConstants._
+
+  type FiberTrace = String
 
   private[this] val TurnRight = "╰"
   // private[this] val InverseTurnRight = "╭"
@@ -152,5 +156,12 @@ private[effect] object Tracing extends TracingPlatform {
           s" $junc $frame"
       }
       .mkString(System.lineSeparator())
+  }
+
+  def captureTrace(runnable: Runnable): FiberTrace = {
+    runnable match {
+      case f: IOFiber[_] => f.prettyPrintTrace()
+      case _ => ""
+    }
   }
 }

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -156,10 +156,11 @@ private[effect] object Tracing extends TracingPlatform {
       .mkString(System.lineSeparator())
   }
 
-  def captureTrace(runnable: Runnable): Trace = {
+  def captureTrace(runnable: Runnable): Option[(Runnable, Trace)] = {
     runnable match {
-      case f: IOFiber[_] => f.captureTrace()
-      case _ => Trace(RingBuffer.empty(1))
+      case f: IOFiber[_] if f.isDone => None
+      case f: IOFiber[_] => Some(runnable -> f.captureTrace())
+      case _ => Some(runnable -> Trace(RingBuffer.empty(1)))
     }
   }
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/FiberMonitorShared.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/FiberMonitorShared.scala
@@ -17,24 +17,24 @@
 package cats.effect.unsafe
 
 import cats.effect.IOFiber
+import cats.effect.tracing.Tracing.FiberTrace
 
 private[unsafe] abstract class FiberMonitorShared {
 
   protected val newline = System.lineSeparator()
   protected val doubleNewline = s"$newline $newline"
 
-  protected def fiberString(fiber: IOFiber[_], status: String): String = {
+  protected def fiberString(fiber: IOFiber[_], trace: FiberTrace, status: String): String = {
     val id = System.identityHashCode(fiber).toHexString
-    val trace = fiber.prettyPrintTrace()
     val prefixedTrace = if (trace.isEmpty) "" else newline + trace
     s"cats.effect.IOFiber@$id $status$prefixedTrace"
   }
 
-  protected def printFibers(fibers: Set[IOFiber[_]], status: String)(
+  protected def printFibers(fibers: Map[IOFiber[_], FiberTrace],  status: String)(
       print: String => Unit): Unit =
-    fibers foreach { fiber =>
+    fibers foreach { case (fiber, trace) =>
       print(doubleNewline)
-      print(fiberString(fiber, status))
+      print(fiberString(fiber, trace, status))
     }
 
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/FiberMonitorShared.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/FiberMonitorShared.scala
@@ -16,25 +16,26 @@
 
 package cats.effect.unsafe
 
-import cats.effect.IOFiber
-import cats.effect.tracing.Tracing.FiberTrace
+import cats.effect.{IOFiber, Trace}
+import cats.effect.tracing.Tracing
 
 private[unsafe] abstract class FiberMonitorShared {
 
   protected val newline = System.lineSeparator()
   protected val doubleNewline = s"$newline $newline"
 
-  protected def fiberString(fiber: IOFiber[_], trace: FiberTrace, status: String): String = {
+  protected def fiberString(fiber: IOFiber[_], trace: Trace, status: String): String = {
     val id = System.identityHashCode(fiber).toHexString
-    val prefixedTrace = if (trace.isEmpty) "" else newline + trace
+    val prefixedTrace = if (trace.toList.isEmpty) "" else newline + Tracing.prettyPrint(trace)
     s"cats.effect.IOFiber@$id $status$prefixedTrace"
   }
 
-  protected def printFibers(fibers: Map[IOFiber[_], FiberTrace],  status: String)(
+  protected def printFibers(fibers: Map[IOFiber[_], Trace], status: String)(
       print: String => Unit): Unit =
-    fibers foreach { case (fiber, trace) =>
-      print(doubleNewline)
-      print(fiberString(fiber, trace, status))
+    fibers foreach {
+      case (fiber, trace) =>
+        print(doubleNewline)
+        print(fiberString(fiber, trace, status))
     }
 
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/WeakBag.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/WeakBag.scala
@@ -19,7 +19,6 @@ package cats.effect.unsafe
 import cats.effect.unsafe.ref.{ReferenceQueue, WeakReference}
 
 import scala.annotation.tailrec
-import scala.collection.mutable
 
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -71,20 +70,17 @@ private final class WeakBag[A <: AnyRef] {
     }
   }
 
-  def toSet: Set[A] = {
-    val set = mutable.Set.empty[A]
+  def forEach(f: A => Unit): Unit = {
     var i = 0
     val sz = index
 
     while (i < sz) {
       val a = table(i).get()
       if (a ne null) {
-        set += a
+        f(a)
       }
       i += 1
     }
-
-    set.toSet
   }
 
   def size: Int = {

--- a/tests/jvm/src/test/scala/cats/effect/unsafe/FiberMonitorSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/FiberMonitorSpec.scala
@@ -44,6 +44,7 @@ class FiberMonitorSpec extends BaseSpec with TestInstances {
 
         _ <- cdl.release // allow further execution
         outcome <- fiber.join
+        _ <- IO.sleep(100.millis)
 
         _ <- IO(outcome must beEqualTo(Outcome.succeeded[IO, Throwable, Unit](IO.unit)))
         _ <- IO(fiber.toString must beMatching(completedPattern))


### PR DESCRIPTION
### Issue

The following application has roughly 1000 suspended fibers at any moment. When we do a fiber dump of that application, the number of dumped fibers is roughly as expected, but a large portion (20-50% on my machine, after warming up) of those fibers has no trace. 

```
package test

import cats.effect.std.Semaphore
import cats.effect.{IO, IOApp}

import scala.concurrent.duration.DurationInt

object Test9 extends IOApp.Simple {

  override def run: IO[Unit] = {
    Semaphore[IO](1000).flatMap { semaphore =>
      semaphore
        .acquire
        .flatMap(_ => IO.sleep(10.millisecond).flatMap(_ => semaphore.release).start)
        .foreverM
    }
  }

}
```

The process of collecting the fiber dump is
1. Make a list of all fibers 
2. Collect traces of the fibers
The problem is that that process takes 5-50ms, while the average life-span of the fibers is 10ms. There's a high chance that by the time we try to collect the trace, the fiber is already complete. There's a new fiber running in it's place, but that new fiber is not on our list.

### Solution
After collecting a reference to a fiber, collect the trace for it as early as possible.

### Measurements
Before (https://github.com/RafalSumislawski/cats-effect/tree/improve-trace-dumps-of-shortlived-fibers-34-repro-before):
```
fibersWithTraces / allFibers = ratio
1/1 = 100.0%
1/32 = 3.125%
73/371 = 19.67654986522911%
207/563 = 36.767317939609235%
221/806 = 27.419354838709676%
950/981 = 96.83995922528032%
451/876 = 51.48401826484018%
656/851 = 77.08578143360752%
386/936 = 41.23931623931624%
678/1001 = 67.73226773226773%
826/972 = 84.97942386831275%
673/901 = 74.69478357380689%
584/910 = 64.17582417582418%
514/671 = 76.60208643815201%
1001/1001 = 100.0%
897/924 = 97.07792207792208%
581/948 = 61.28691983122363%
546/626 = 87.22044728434504%
694/904 = 76.76991150442478%
703/845 = 83.19526627218934%
900/986 = 91.27789046653145%
1001/1001 = 100.0%
801/1001 = 80.01998001998003%
535/912 = 58.66228070175438%
```
After (https://github.com/RafalSumislawski/cats-effect/tree/improve-trace-dumps-of-shortlived-fibers-34-repro-after):
```
fibersWithTraces / allFibers = ratio
1/1 = 100.0%
1022/1022 = 100.0%
964/964 = 100.0%
952/952 = 100.0%
1001/1001 = 100.0%
1013/1016 = 99.70472440944881%
971/971 = 100.0%
979/979 = 100.0%
994/994 = 100.0%
995/995 = 100.0%
980/980 = 100.0%
1010/1010 = 100.0%
980/980 = 100.0%
1013/1013 = 100.0%
958/958 = 100.0%
1001/1001 = 100.0%
986/986 = 100.0%
1007/1007 = 100.0%
974/974 = 100.0%
1001/1001 = 100.0%
1021/1021 = 100.0%
999/1000 = 99.9%
960/961 = 99.89594172736733%
1001/1001 = 100.0%
1001/1001 = 100.0%
1001/1001 = 100.0%
1001/1001 = 100.0%
1045/1045 = 100.0%
1001/1001 = 100.0%
```

Because after these changes, the process o taking the snapshot is fast, and the slow String operations and printing are done later, not only the number of fibers with traces is improved, but also the total number o fibers is more accurate.

This PR supersedes #3185 
