### PR TITLE
Avoid spurious wake-up in `Concurrent` queues at capacity

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Queue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Queue.scala
@@ -240,8 +240,14 @@ object Queue {
 
             case State(queue, size, takers, offerers) if queue.nonEmpty =>
               val (a, rest) = queue.dequeue
-              val (release, tail) = offerers.dequeue
-              State(rest, size - 1, takers, tail) -> release.complete(()).as(a)
+
+              // if we haven't made enough space for a new offerer, don't disturb the water
+              if (size - 1 < capacity) {
+                val (release, tail) = offerers.dequeue
+                State(rest, size - 1, takers, tail) -> release.complete(()).as(a)
+              } else {
+                State(rest, size - 1, takers, offerers) -> F.pure(a)
+              }
 
             case State(queue, size, takers, offerers) =>
               /*


### PR DESCRIPTION
I accidentally PRed this into series/3.x instead of series/3.4.x.