### PR TITLE
Implement redeem and redeemWith without attempt

### DIFF
--- a/core/js-native/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js-native/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -32,6 +32,7 @@ private object IOFiberConstants {
   final val UncancelableK = 7
   final val UnmaskK = 8
   final val AttemptK = 9
+  final val RedeemWithK = 10
 
   // resume ids
   final val ExecR = 0

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -32,6 +32,7 @@ final class IOFiberConstants {
   static final byte UncancelableK = 7;
   static final byte UnmaskK = 8;
   static final byte AttemptK = 9;
+  static final byte RedeemWithK = 10;
 
   // resume ids
   static final byte ExecR = 0;

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1927,7 +1927,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
   private[effect] final case class RedeemWith[E, +A](
       ioe: IO[E],
       recover: Throwable => IO[A],
-      map: E => IO[A])
+      bind: E => IO[A])
       extends IO[A] {
     def tag = 24
   }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -974,7 +974,7 @@ private final class IOFiber[A](
           val cur = cur0.asInstanceOf[RedeemWith[Any, Any]]
           val ioe = cur.ioe
 
-          objectState.push(cur.map)
+          objectState.push(cur.bind)
           objectState.push(cur.recover)
           conts = ByteStack.push(conts, RedeemWithK)
 
@@ -1202,9 +1202,9 @@ private final class IOFiber[A](
 
       case 10 => // redeemWithK
         objectState.pop()
-        val map = objectState.pop().asInstanceOf[Any => IO[Any]]
+        val bind = objectState.pop().asInstanceOf[Any => IO[Any]]
 
-        try map(result)
+        try bind(result)
         catch {
           case NonFatal(t) =>
             failed(t, depth + 1)


### PR DESCRIPTION
Attempts #3148 

The benchmarks show mixed results with only the happy path being worse:
```
Before:
Benchmark                        (size)   Mode  Cnt     Score     Error  Units
RedeemWithBenchmark.errorRaised   10000  thrpt   10  2416.151 ±  56.584  ops/s
RedeemWithBenchmark.happyPath     10000  thrpt   10  3278.920 ± 157.717  ops/s
RedeemBenchmark.errorRaised       10000  thrpt   10  1432.012 ±  10.972  ops/s
RedeemBenchmark.happyPath         10000  thrpt   10  2099.513 ±   4.591  ops/s

After:
Benchmark                        (size)   Mode  Cnt     Score    Error  Units
RedeemWithBenchmark.errorRaised   10000  thrpt   20  3315.182 ±  16.192  ops/s
RedeemWithBenchmark.happyPath     10000  thrpt   20  4765.599 ±  91.358  ops/s
RedeemBenchmark.errorRaised       10000  thrpt   10  1639.106 ±  19.014  ops/s
RedeemBenchmark.happyPath         10000  thrpt   10  1785.519 ±  11.161  ops/s
```