### PR TITLE
Optimized `ArrayStack` for JS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -726,7 +726,10 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         ProblemFilters.exclude[Problem]("cats.effect.IOFiberConstants.*"),
         ProblemFilters.exclude[Problem]("cats.effect.SyncIOConstants.*"),
         // introduced by #3196. Changes in an internal API.
-        ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.unsafe.FiberAwareExecutionContext.liveFibers")
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "cats.effect.unsafe.FiberAwareExecutionContext.liveFibers"),
+        // introduced by #3222. Optimized ArrayStack internal API
+        ProblemFilters.exclude[Problem]("cats.effect.ArrayStack*")
       )
     },
     mimaBinaryIssueFilters ++= {

--- a/core/js/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/js/src/main/scala/cats/effect/ArrayStack.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import scala.scalajs.js
+
+private final class ArrayStack[A <: AnyRef](val buffer: js.Array[A]) extends AnyVal {
+
+  @inline def init(bound: Int): Unit = {
+    val _ = bound
+    ()
+  }
+
+  @inline def push(a: A): Unit = {
+    buffer.push(a)
+    ()
+  }
+
+  @inline def pop(): A = {
+    buffer.pop()
+  }
+
+  @inline def peek(): A = buffer(buffer.length - 1)
+
+  @inline def isEmpty(): Boolean = buffer.length == 0
+
+  // to allow for external iteration
+  @inline def unsafeBuffer(): js.Array[A] = buffer
+  @inline def unsafeIndex(): Int = buffer.length
+
+  @inline def invalidate(): Unit = {
+    buffer.length = 0 // javascript is crazy!
+  }
+
+}
+
+private object ArrayStack {
+
+  @inline def apply[A <: AnyRef](size: Int): ArrayStack[A] = {
+    val _ = size
+    apply()
+  }
+
+  @inline def apply[A <: AnyRef](): ArrayStack[A] = {
+    new ArrayStack(new js.Array[A])
+  }
+
+}

--- a/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
@@ -83,4 +83,3 @@ private object ArrayStack {
   def apply[A <: AnyRef](size: Int): ArrayStack[A] = new ArrayStack(size)
 
 }
-

--- a/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
@@ -75,3 +75,12 @@ private final class ArrayStack[A <: AnyRef](
       buffer = buffer2
     }
 }
+
+private object ArrayStack {
+
+  def apply[A <: AnyRef](): ArrayStack[A] = new ArrayStack()
+
+  def apply[A <: AnyRef](size: Int): ArrayStack[A] = new ArrayStack(size)
+
+}
+

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -83,8 +83,8 @@ private final class IOFiber[A](
 
   private[this] var localState: IOLocalState = initState
   private[this] var currentCtx: ExecutionContext = startEC
-  private[this] val objectState: ArrayStack[AnyRef] = new ArrayStack()
-  private[this] val finalizers: ArrayStack[IO[Unit]] = new ArrayStack()
+  private[this] val objectState: ArrayStack[AnyRef] = ArrayStack()
+  private[this] val finalizers: ArrayStack[IO[Unit]] = ArrayStack()
   private[this] val callbacks: CallbackStack[A] = new CallbackStack(cb)
   private[this] var resumeTag: Byte = ExecR
   private[this] var resumeIO: AnyRef = startIO

--- a/core/shared/src/main/scala/cats/effect/SyncIO.scala
+++ b/core/shared/src/main/scala/cats/effect/SyncIO.scala
@@ -224,7 +224,7 @@ sealed abstract class SyncIO[+A] private () extends Serializable {
     import SyncIOConstants._
 
     var conts = ByteStack.create(8)
-    val objectState = new ArrayStack[AnyRef](16)
+    val objectState = ArrayStack[AnyRef](16)
 
     conts = ByteStack.push(conts, RunTerminusK)
 


### PR DESCRIPTION
On Scala.js `Array` is implemented in terms of `js.Array` which already has a stack-like API. So by directly using that for our `ArrayStack` we remove at least a few layers of indirection 😅 

I manually checked the bytecode to verify that the `ArrayStack` allocation is completely elided and the `js.Array` is used directly. This itself is a win.

Wish we had benchmarking 😕 