### PR TITLE
Relax constraints for `Monad[Resource]` and `Monoid[Resource]`

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1218,22 +1218,34 @@ private[effect] trait ResourceHOInstances5 {
 
 abstract private[effect] class ResourceFOInstances0 extends ResourceFOInstances1 {
   implicit def catsEffectMonoidForResource[F[_], A](
-      implicit F0: Monad[F],
-      A0: Monoid[A]): Monoid[Resource[F, A]] =
+      implicit A0: Monoid[A]): Monoid[Resource[F, A]] =
     new ResourceMonoid[F, A] {
       def A = A0
-      def F = F0
     }
+
+  @deprecated("Use overload without monad constraint", "3.4.0")
+  def catsEffectMonoidForResource[F[_], A](
+      F0: Monad[F],
+      A0: Monoid[A]): Monoid[Resource[F, A]] = {
+    val _ = F0
+    catsEffectMonoidForResource(A0)
+  }
 }
 
 abstract private[effect] class ResourceFOInstances1 {
   implicit def catsEffectSemigroupForResource[F[_], A](
-      implicit F0: Monad[F],
-      A0: Semigroup[A]): ResourceSemigroup[F, A] =
+      implicit A0: Semigroup[A]): ResourceSemigroup[F, A] =
     new ResourceSemigroup[F, A] {
       def A = A0
-      def F = F0
     }
+
+  @deprecated("Use overload without monad constraint", "3.4.0")
+  def catsEffectSemigroupForResource[F[_], A](
+      F0: Monad[F],
+      A0: Semigroup[A]): ResourceSemigroup[F, A] = {
+    val _ = F0
+    catsEffectSemigroupForResource[F, A](A0)
+  }
 }
 
 abstract private[effect] class ResourceMonadCancel[F[_]]
@@ -1394,7 +1406,6 @@ abstract private[effect] class ResourceMonoid[F[_], A]
 }
 
 abstract private[effect] class ResourceSemigroup[F[_], A] extends Semigroup[Resource[F, A]] {
-  implicit protected def F: Monad[F]
   implicit protected def A: Semigroup[A]
 
   def combine(rx: Resource[F, A], ry: Resource[F, A]): Resource[F, A] =

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1206,10 +1206,14 @@ private[effect] trait ResourceHOInstances4 extends ResourceHOInstances5 {
 }
 
 private[effect] trait ResourceHOInstances5 {
-  implicit def catsEffectMonadForResource[F[_]](implicit F0: Monad[F]): Monad[Resource[F, *]] =
-    new ResourceMonad[F] {
-      def F = F0
-    }
+  implicit def catsEffectMonadForResource[F[_]]: Monad[Resource[F, *]] =
+    new ResourceMonad[F]
+
+  @deprecated("Use overload without constraint", "3.4.0")
+  def catsEffectMonadForResource[F[_]](F: Monad[F]): Monad[Resource[F, *]] = {
+    val _ = F
+    catsEffectMonadForResource[F]
+  }
 }
 
 abstract private[effect] class ResourceFOInstances0 extends ResourceFOInstances1 {
@@ -1370,11 +1374,9 @@ abstract private[effect] class ResourceMonadError[F[_], E]
     Resource.raiseError[F, A, E](e)
 }
 
-abstract private[effect] class ResourceMonad[F[_]]
+private[effect] class ResourceMonad[F[_]]
     extends Monad[Resource[F, *]]
     with StackSafeMonad[Resource[F, *]] {
-
-  implicit protected def F: Monad[F]
 
   def pure[A](a: A): Resource[F, A] =
     Resource.pure(a)


### PR DESCRIPTION
Going to try and squeak this into 3.4.0 😇 