### PR TITLE
Release loser eagerly in `Resource.race`

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -310,7 +310,7 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
             .flatMap(
               _.fold(
                 F.unit,
-                F.raiseError[Unit](_),
+                _ => F.unit,
                 _.flatMap(_._2.apply(ExitCase.Canceled))
               )
             )

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1337,6 +1337,9 @@ abstract private[effect] class ResourceConcurrent[F[_]]
   override def both[A, B](fa: Resource[F, A], fb: Resource[F, B]): Resource[F, (A, B)] =
     fa.both(fb)
 
+  override def race[A, B](fa: Resource[F, A], fb: Resource[F, B]): Resource[F, Either[A, B]] =
+    fa.race(fb)
+
   override def memoize[A](fa: Resource[F, A]): Resource[F, Resource[F, A]] = {
     Resource.eval(F.ref(false)).flatMap { allocated =>
       val fa2 = F.uncancelable(poll => poll(fa.allocatedCase) <* allocated.set(true))

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -328,7 +328,7 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
                 }
               }
             case Outcome.Errored(ea) =>
-              cancelLoser(f) *> F.raiseError[(Either[A, B], ExitCase => F[Unit])](ea)
+              F.raiseError[(Either[A, B], ExitCase => F[Unit])](ea).guarantee(cancelLoser(f))
             case Outcome.Canceled() =>
               poll(f.join).onCancel(f.cancel).flatMap {
                 case Outcome.Succeeded(fb) =>
@@ -351,7 +351,7 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
                 }
               }
             case Outcome.Errored(eb) =>
-              cancelLoser(f) *> F.raiseError[(Either[A, B], ExitCase => F[Unit])](eb)
+              F.raiseError[(Either[A, B], ExitCase => F[Unit])](eb).guarantee(cancelLoser(f))
             case Outcome.Canceled() =>
               poll(f.join).onCancel(f.cancel).flatMap {
                 case Outcome.Succeeded(fa) =>

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -833,8 +833,8 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
           val left = Resource.make(IO.unit)(_ => loser.complete(Left[Unit, Unit](())).void)
           val right = Resource.make(IO.unit)(_ => loser.complete(Right[Unit, Unit](())).void)
           Resource.race(left, right).use {
-            case Left(()) => loser.tryGet.map(_ must beSome(beRight[Unit])).void
-            case Right(()) => loser.tryGet.map(_ must beSome(beLeft[Unit])).void
+            case Left(()) => loser.get.map(_ must beRight[Unit]).void
+            case Right(()) => loser.get.map(_ must beLeft[Unit]).void
           }
         }
 


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/3111