### PR TITLE
Introduce `raceOutcomeBoth`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -511,12 +511,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
     IO.race(this, that)
 
   def raceOutcome[B](that: IO[B]): IO[Either[OutcomeIO[A @uncheckedVariance], OutcomeIO[B]]] =
-    IO.uncancelable { _ =>
-      racePair(that).flatMap {
-        case Left((oc, f)) => f.cancel.as(Left(oc))
-        case Right((f, oc)) => f.cancel.as(Right(oc))
-      }
-    }
+    IO.asyncForIO.raceOutcome(this, that)
 
   def racePair[B](that: IO[B]): IO[Either[
     (OutcomeIO[A @uncheckedVariance], FiberIO[B]),

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -317,14 +317,14 @@ trait GenSpawn[F[_], E] extends MonadCancel[F, E] with Unique[F] {
         case Left((oca, f)) =>
           val joined =
             if (oca.isCanceled)
-              poll(f.join)
+              poll(f.join).onCancel(f.cancel)
             else
               f.cancel *> f.join
           joined.map(ocb => Left((oca, ocb)))
         case Right((f, ocb)) =>
           val joined =
             if (ocb.isCanceled)
-              poll(f.join)
+              poll(f.join).onCancel(f.cancel)
             else
               f.cancel *> f.join
           joined.map(oca => Right((oca, ocb)))

--- a/laws/shared/src/test/scala/cats/effect/laws/GenSpawnSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/GenSpawnSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package laws
+
+import cats.effect.kernel.Spawn
+import cats.effect.kernel.testkit.pure._
+import cats.syntax.all._
+
+import org.specs2.mutable.Specification
+
+class GenSpawnSpec extends Specification { outer =>
+
+  type F[A] = PureConc[Unit, A]
+  val F = Spawn[F]
+
+  "spawn" should {
+    "raceOutcome" should {
+      "not hang" in {
+        Eq[F[Unit]].eqv(F.raceOutcome(F.never, F.canceled).void, F.unit)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This allows us to generalize over `raceOutcome` and `race`. The motivation for this is to be able to handle the race condition where _both_ fibers succeed, even though the loser is canceled. More on that in a follow-up PR.

If this merges then I think I need to re-do https://github.com/typelevel/cats-effect/pull/3226 in terms of `raceOutcomeBoth` instead.