### PR TITLE
Record CPU starvation metrics

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOApp.scala
+++ b/core/js/src/main/scala/cats/effect/IOApp.scala
@@ -16,7 +16,7 @@
 
 package cats.effect
 
-import cats.effect.metrics.CpuStarvationMetrics
+import cats.effect.metrics.JsCpuStarvationMetrics
 import cats.effect.tracing.TracingConstants._
 
 import scala.concurrent.CancellationException
@@ -233,7 +233,7 @@ trait IOApp {
     val fiber = Spawn[IO]
       .raceOutcome[ExitCode, Nothing](
         CpuStarvationCheck
-          .run(runtimeConfig, CpuStarvationMetrics.noOp)
+          .run(runtimeConfig, JsCpuStarvationMetrics())
           .background
           .surround(run(argList)),
         keepAlive)

--- a/core/js/src/main/scala/cats/effect/IOApp.scala
+++ b/core/js/src/main/scala/cats/effect/IOApp.scala
@@ -16,11 +16,12 @@
 
 package cats.effect
 
+import cats.effect.metrics.CpuStarvationMetrics
 import cats.effect.tracing.TracingConstants._
 
 import scala.concurrent.CancellationException
 import scala.concurrent.duration._
-import scala.scalajs.{js, LinkingInfo}
+import scala.scalajs.{LinkingInfo, js}
 import scala.util.Try
 
 /**
@@ -231,7 +232,10 @@ trait IOApp {
     var cancelCode = 1 // So this can be updated by external cancellation
     val fiber = Spawn[IO]
       .raceOutcome[ExitCode, Nothing](
-        CpuStarvationCheck.run(runtimeConfig).background.surround(run(argList)),
+        CpuStarvationCheck
+          .run(runtimeConfig, CpuStarvationMetrics.noOp)
+          .background
+          .surround(run(argList)),
         keepAlive)
       .flatMap {
         case Left(Outcome.Canceled()) =>

--- a/core/js/src/main/scala/cats/effect/IOApp.scala
+++ b/core/js/src/main/scala/cats/effect/IOApp.scala
@@ -21,7 +21,7 @@ import cats.effect.tracing.TracingConstants._
 
 import scala.concurrent.CancellationException
 import scala.concurrent.duration._
-import scala.scalajs.{LinkingInfo, js}
+import scala.scalajs.{js, LinkingInfo}
 import scala.util.Try
 
 /**

--- a/core/js/src/main/scala/cats/effect/metrics/JsCpuStarvationMetrics.scala
+++ b/core/js/src/main/scala/cats/effect/metrics/JsCpuStarvationMetrics.scala
@@ -26,6 +26,6 @@ private[effect] class JsCpuStarvationMetrics extends CpuStarvationMetrics {
   override def recordClockDrift(drift: FiniteDuration): IO[Unit] = IO.unit
 }
 
-private [effect] object JsCpuStarvationMetrics {
+private[effect] object JsCpuStarvationMetrics {
   private[effect] def apply(): CpuStarvationMetrics = new JsCpuStarvationMetrics
 }

--- a/core/js/src/main/scala/cats/effect/metrics/JsCpuStarvationMetrics.scala
+++ b/core/js/src/main/scala/cats/effect/metrics/JsCpuStarvationMetrics.scala
@@ -20,8 +20,12 @@ import cats.effect.IO
 
 import scala.concurrent.duration.FiniteDuration
 
-private[effect] trait CpuStarvationMetrics {
-  def incCpuStarvationCount: IO[Unit]
+private[effect] class JsCpuStarvationMetrics extends CpuStarvationMetrics {
+  override def incCpuStarvationCount: IO[Unit] = IO.unit
 
-  def recordClockDrift(drift: FiniteDuration): IO[Unit]
+  override def recordClockDrift(drift: FiniteDuration): IO[Unit] = IO.unit
+}
+
+private [effect] object JsCpuStarvationMetrics {
+  private[effect] def apply(): CpuStarvationMetrics = new JsCpuStarvationMetrics
 }

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -17,6 +17,7 @@
 package cats.effect
 
 import cats.effect.std.Console
+import cats.effect.metrics.JvmCpuStarvationMetrics
 import cats.effect.tracing.TracingConstants._
 import cats.syntax.all._
 
@@ -367,9 +368,10 @@ trait IOApp {
     val ioa = run(args.toList)
 
     val fiber =
-      CpuStarvationCheck
-        .run(runtimeConfig)
-        .background
+      JvmCpuStarvationMetrics()
+        .flatMap { cpuStarvationMetrics =>
+          CpuStarvationCheck.run(runtimeConfig, cpuStarvationMetrics).background
+        }
         .surround(ioa)
         .unsafeRunFiber(
           {

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -16,8 +16,8 @@
 
 package cats.effect
 
-import cats.effect.std.Console
 import cats.effect.metrics.JvmCpuStarvationMetrics
+import cats.effect.std.Console
 import cats.effect.tracing.TracingConstants._
 import cats.syntax.all._
 

--- a/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbean.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbean.scala
@@ -1,0 +1,23 @@
+package cats.effect.metrics
+
+/**
+ * An MBean interfaces for monitoring when CPU starvation occurs.
+ */
+private[metrics] trait CpuStarvationMbean {
+
+  /**
+   * Returns the number of times CPU starvation has occurred.
+   *
+   * @return
+   *   count of the number of times CPU starvation has occurred.
+   */
+  def getCpuStarvationCount(): Long
+
+  /**
+   * Tracks the maximum clock seen during runtime.
+   *
+   * @return
+   *   the current maximum clock drift observed in milliseconds.
+   */
+  def getMaxClockDriftMs(): Long
+}

--- a/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbean.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbean.scala
@@ -20,4 +20,12 @@ private[metrics] trait CpuStarvationMbean {
    *   the current maximum clock drift observed in milliseconds.
    */
   def getMaxClockDriftMs(): Long
+
+  /**
+   * Tracks the current clock drift.
+   *
+   * @return
+   *   the current clock drift in milliseconds.
+   */
+  def getCurrentClockDriftMs(): Long
 }

--- a/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbean.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbean.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cats.effect.metrics
 
 /**

--- a/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbeanImpl.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbeanImpl.scala
@@ -16,11 +16,11 @@
 
 package cats.effect.metrics
 
-import java.util.concurrent.atomic.AtomicLong
-
 import cats.effect.IO
 
 import scala.concurrent.duration.FiniteDuration
+
+import java.util.concurrent.atomic.AtomicLong
 
 private[metrics] class CpuStarvationMbeanImpl private (
     counter: AtomicLong,

--- a/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbeanImpl.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbeanImpl.scala
@@ -1,0 +1,29 @@
+package cats.effect.metrics
+
+import java.util.concurrent.atomic.AtomicLong
+
+import cats.effect.IO
+
+import scala.concurrent.duration.FiniteDuration
+
+private[metrics] class CpuStarvationMbeanImpl private (
+    counter: AtomicLong,
+    maxClockDrift: AtomicLong)
+    extends CpuStarvationMbean {
+  override def getCpuStarvationCount(): Long = counter.get()
+
+  override def getMaxClockDriftMs(): Long = maxClockDrift.get()
+
+  def incStarvationCount: IO[Unit] = IO.delay(counter.incrementAndGet()).void
+
+  def recordDrift(drift: FiniteDuration): IO[Unit] =
+    IO.delay(maxClockDrift.updateAndGet(_.max(drift.toMillis))).void
+
+}
+
+object CpuStarvationMbeanImpl {
+  private[metrics] def apply(): IO[CpuStarvationMbeanImpl] = for {
+    counter <- IO.delay(new AtomicLong(0))
+    maxClockDrift <- IO.delay(new AtomicLong(0))
+  } yield new CpuStarvationMbeanImpl(counter, maxClockDrift)
+}

--- a/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbeanImpl.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbeanImpl.scala
@@ -39,7 +39,7 @@ private[metrics] class CpuStarvationMbeanImpl private (
     val driftMs = drift.toMillis
 
     val maxDrift =
-      if (driftMs > 0) IO.delay(maxClockDrift.updateAndGet(_.max(driftMs))).void
+      if (driftMs > 0) IO.delay(maxClockDrift.updateAndGet(math.max(_, driftMs))).void
       else IO.unit
 
     IO.delay(currentClockDrift.set(driftMs)) >> maxDrift

--- a/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbeanImpl.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbeanImpl.scala
@@ -47,7 +47,7 @@ private[metrics] class CpuStarvationMbeanImpl private (
 
 }
 
-object CpuStarvationMbeanImpl {
+private[metrics] object CpuStarvationMbeanImpl {
   private[metrics] def apply(): IO[CpuStarvationMbeanImpl] = for {
     counter <- IO.delay(new AtomicLong(0))
     currentClockDrift <- IO.delay(new AtomicLong(0))

--- a/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbeanImpl.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbeanImpl.scala
@@ -8,22 +8,33 @@ import scala.concurrent.duration.FiniteDuration
 
 private[metrics] class CpuStarvationMbeanImpl private (
     counter: AtomicLong,
+    currentClockDrift: AtomicLong,
     maxClockDrift: AtomicLong)
     extends CpuStarvationMbean {
   override def getCpuStarvationCount(): Long = counter.get()
 
   override def getMaxClockDriftMs(): Long = maxClockDrift.get()
 
+  override def getCurrentClockDriftMs(): Long = currentClockDrift.get()
+
   def incStarvationCount: IO[Unit] = IO.delay(counter.incrementAndGet()).void
 
-  def recordDrift(drift: FiniteDuration): IO[Unit] =
-    IO.delay(maxClockDrift.updateAndGet(_.max(drift.toMillis))).void
+  def recordDrift(drift: FiniteDuration): IO[Unit] = {
+    lazy val driftMs = drift.toMillis
+
+    val maxDrift =
+      if (driftMs > 0) IO.delay(maxClockDrift.updateAndGet(_.max(drift.toMillis))).void
+      else IO.unit
+
+    IO.delay(currentClockDrift.set(driftMs)) >> maxDrift
+  }
 
 }
 
 object CpuStarvationMbeanImpl {
   private[metrics] def apply(): IO[CpuStarvationMbeanImpl] = for {
     counter <- IO.delay(new AtomicLong(0))
+    currentClockDrift <- IO.delay(new AtomicLong(0))
     maxClockDrift <- IO.delay(new AtomicLong(0))
-  } yield new CpuStarvationMbeanImpl(counter, maxClockDrift)
+  } yield new CpuStarvationMbeanImpl(counter, currentClockDrift, maxClockDrift)
 }

--- a/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbeanImpl.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbeanImpl.scala
@@ -39,7 +39,7 @@ private[metrics] class CpuStarvationMbeanImpl private (
     lazy val driftMs = drift.toMillis
 
     val maxDrift =
-      if (driftMs > 0) IO.delay(maxClockDrift.updateAndGet(_.max(drift.toMillis))).void
+      if (driftMs > 0) IO.delay(maxClockDrift.updateAndGet(_.max(driftMs))).void
       else IO.unit
 
     IO.delay(currentClockDrift.set(driftMs)) >> maxDrift

--- a/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbeanImpl.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbeanImpl.scala
@@ -36,7 +36,7 @@ private[metrics] class CpuStarvationMbeanImpl private (
   def incStarvationCount: IO[Unit] = IO.delay(counter.incrementAndGet()).void
 
   def recordDrift(drift: FiniteDuration): IO[Unit] = {
-    lazy val driftMs = drift.toMillis
+    val driftMs = drift.toMillis
 
     val maxDrift =
       if (driftMs > 0) IO.delay(maxClockDrift.updateAndGet(_.max(driftMs))).void

--- a/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbeanImpl.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/CpuStarvationMbeanImpl.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cats.effect.metrics
 
 import java.util.concurrent.atomic.AtomicLong

--- a/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
@@ -46,7 +46,7 @@ private[effect] object JvmCpuStarvationMetrics {
        |""".stripMargin
   }
 
-  private [this] class NoOpCpuStarvationMetrics extends CpuStarvationMetrics {
+  private[this] class NoOpCpuStarvationMetrics extends CpuStarvationMetrics {
     override def incCpuStarvationCount: IO[Unit] = IO.unit
 
     override def recordClockDrift(drift: FiniteDuration): IO[Unit] = IO.unit

--- a/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
@@ -33,7 +33,7 @@ private[effect] class JvmCpuStarvationMetrics private (mbean: CpuStarvationMbean
   override def recordClockDrift(drift: FiniteDuration): IO[Unit] = mbean.recordDrift(drift)
 }
 
-object JvmCpuStarvationMetrics {
+private[effect] object JvmCpuStarvationMetrics {
   private[this] val mBeanObjectName = new ObjectName("cats.effect.metrics:type=CpuStarvation")
 
   private[this] def warning(th: Throwable) = {

--- a/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cats.effect.metrics
 
 import java.io.{PrintWriter, StringWriter}

--- a/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
@@ -1,0 +1,48 @@
+package cats.effect.metrics
+
+import java.io.{PrintWriter, StringWriter}
+import java.lang.management.ManagementFactory
+
+import cats.effect.std.Console
+import cats.effect.{IO, Resource}
+import javax.management.{MBeanServer, ObjectName}
+
+import scala.concurrent.duration.FiniteDuration
+
+private[effect] class JvmCpuStarvationMetrics private (mbean: CpuStarvationMbeanImpl)
+    extends CpuStarvationMetrics {
+  override def incCpuStarvationCount: IO[Unit] = mbean.incStarvationCount
+
+  override def recordClockDrift(drift: FiniteDuration): IO[Unit] = mbean.recordDrift(drift)
+}
+
+object JvmCpuStarvationMetrics {
+  private[this] val mBeanObjectName = new ObjectName("cats.effect.metrics:type=CpuStarvation")
+
+  private[this] def warning(th: Throwable) = {
+    val exceptionWriter = new StringWriter()
+    th.printStackTrace(new PrintWriter(exceptionWriter))
+
+    s"""[WARNING] Failed to register cats-effect CPU starvation MBean, proceeding with
+       |no-operation versions. You will not see MBean metrics for CPU starvation.
+       |Exception follows: \n ${exceptionWriter.toString}
+       |""".stripMargin
+  }
+
+  private[effect] def apply(): Resource[IO, CpuStarvationMetrics] = {
+    val acquire: IO[(MBeanServer, JvmCpuStarvationMetrics)] = for {
+      mBeanServer <- IO.delay(ManagementFactory.getPlatformMBeanServer)
+      mBean <- CpuStarvationMbeanImpl()
+      _ <- IO.blocking(mBeanServer.registerMBean(mBean, mBeanObjectName))
+    } yield (mBeanServer, new JvmCpuStarvationMetrics(mBean))
+
+    Resource
+      .make(acquire) {
+        case (mbeanServer, _) => IO.blocking(mbeanServer.unregisterMBean(mBeanObjectName))
+      }
+      .map(_._2)
+      .handleErrorWith[CpuStarvationMetrics, Throwable] { th =>
+        Resource.eval(Console[IO].errorln(warning(th))).map(_ => CpuStarvationMetrics.noOp)
+      }
+  }
+}

--- a/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
@@ -16,14 +16,15 @@
 
 package cats.effect.metrics
 
+import cats.effect.{IO, Resource}
+import cats.effect.std.Console
+
+import scala.concurrent.duration.FiniteDuration
+
 import java.io.{PrintWriter, StringWriter}
 import java.lang.management.ManagementFactory
 
-import cats.effect.std.Console
-import cats.effect.{IO, Resource}
 import javax.management.{MBeanServer, ObjectName}
-
-import scala.concurrent.duration.FiniteDuration
 
 private[effect] class JvmCpuStarvationMetrics private (mbean: CpuStarvationMbeanImpl)
     extends CpuStarvationMetrics {

--- a/core/native/src/main/scala/cats/effect/IOApp.scala
+++ b/core/native/src/main/scala/cats/effect/IOApp.scala
@@ -16,6 +16,8 @@
 
 package cats.effect
 
+import cats.effect.metrics.CpuStarvationMetrics
+
 import scala.concurrent.CancellationException
 import scala.concurrent.duration._
 
@@ -217,7 +219,10 @@ trait IOApp {
 
     Spawn[IO]
       .raceOutcome[ExitCode, Nothing](
-        CpuStarvationCheck.run(runtimeConfig).background.surround(run(args.toList)),
+        CpuStarvationCheck
+          .run(runtimeConfig, CpuStarvationMetrics.noOp)
+          .background
+          .surround(run(args.toList)),
         keepAlive)
       .flatMap {
         case Left(Outcome.Canceled()) =>

--- a/core/native/src/main/scala/cats/effect/IOApp.scala
+++ b/core/native/src/main/scala/cats/effect/IOApp.scala
@@ -16,7 +16,7 @@
 
 package cats.effect
 
-import cats.effect.metrics.CpuStarvationMetrics
+import cats.effect.metrics.NativeCpuStarvationMetrics
 
 import scala.concurrent.CancellationException
 import scala.concurrent.duration._
@@ -220,7 +220,7 @@ trait IOApp {
     Spawn[IO]
       .raceOutcome[ExitCode, Nothing](
         CpuStarvationCheck
-          .run(runtimeConfig, CpuStarvationMetrics.noOp)
+          .run(runtimeConfig, NativeCpuStarvationMetrics())
           .background
           .surround(run(args.toList)),
         keepAlive)

--- a/core/native/src/main/scala/cats/effect/metrics/NativeCpuStarvationMetrics.scala
+++ b/core/native/src/main/scala/cats/effect/metrics/NativeCpuStarvationMetrics.scala
@@ -20,8 +20,12 @@ import cats.effect.IO
 
 import scala.concurrent.duration.FiniteDuration
 
-private[effect] trait CpuStarvationMetrics {
-  def incCpuStarvationCount: IO[Unit]
+private[effect] class NativeCpuStarvationMetrics extends CpuStarvationMetrics {
+  override def incCpuStarvationCount: IO[Unit] = IO.unit
 
-  def recordClockDrift(drift: FiniteDuration): IO[Unit]
+  override def recordClockDrift(drift: FiniteDuration): IO[Unit] = IO.unit
+}
+
+private [effect] object NativeCpuStarvationMetrics {
+  private[effect] def apply(): CpuStarvationMetrics = new NativeCpuStarvationMetrics
 }

--- a/core/native/src/main/scala/cats/effect/metrics/NativeCpuStarvationMetrics.scala
+++ b/core/native/src/main/scala/cats/effect/metrics/NativeCpuStarvationMetrics.scala
@@ -26,6 +26,6 @@ private[effect] class NativeCpuStarvationMetrics extends CpuStarvationMetrics {
   override def recordClockDrift(drift: FiniteDuration): IO[Unit] = IO.unit
 }
 
-private [effect] object NativeCpuStarvationMetrics {
+private[effect] object NativeCpuStarvationMetrics {
   private[effect] def apply(): CpuStarvationMetrics = new NativeCpuStarvationMetrics
 }

--- a/core/shared/src/main/scala/cats/effect/CpuStarvationCheck.scala
+++ b/core/shared/src/main/scala/cats/effect/CpuStarvationCheck.scala
@@ -29,9 +29,10 @@ private[effect] object CpuStarvationCheck {
     def go(initial: FiniteDuration): IO[Nothing] =
       IO.sleep(runtimeConfig.cpuStarvationCheckInterval) >> IO.monotonic.flatMap { now =>
         val delta = now - initial
-        (Console[IO].errorln(warning) >> metrics.incCpuStarvationCount >> metrics
-          .recordClockDrift(delta - runtimeConfig.cpuStarvationCheckInterval)).whenA(delta >=
-          runtimeConfig.cpuStarvationCheckInterval * (1 + runtimeConfig.cpuStarvationCheckThreshold)) >>
+
+        metrics.recordClockDrift(delta - runtimeConfig.cpuStarvationCheckInterval) >>
+          (Console[IO].errorln(warning) >> metrics.incCpuStarvationCount).whenA(delta >=
+            runtimeConfig.cpuStarvationCheckInterval * (1 + runtimeConfig.cpuStarvationCheckThreshold)) >>
           go(now)
       }
 

--- a/core/shared/src/main/scala/cats/effect/metrics/CpuStarvationMetrics.scala
+++ b/core/shared/src/main/scala/cats/effect/metrics/CpuStarvationMetrics.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cats.effect.metrics
 
 import cats.effect.IO

--- a/core/shared/src/main/scala/cats/effect/metrics/CpuStarvationMetrics.scala
+++ b/core/shared/src/main/scala/cats/effect/metrics/CpuStarvationMetrics.scala
@@ -1,0 +1,19 @@
+package cats.effect.metrics
+
+import cats.effect.IO
+
+import scala.concurrent.duration.FiniteDuration
+
+private[effect] trait CpuStarvationMetrics {
+  def incCpuStarvationCount: IO[Unit]
+
+  def recordClockDrift(drift: FiniteDuration): IO[Unit]
+}
+
+object CpuStarvationMetrics {
+  private[effect] def noOp: CpuStarvationMetrics = new CpuStarvationMetrics {
+    override def incCpuStarvationCount: IO[Unit] = IO.unit
+
+    override def recordClockDrift(drift: FiniteDuration): IO[Unit] = IO.unit
+  }
+}


### PR DESCRIPTION
Builds on the work by @TimWSpence that adds CPU starvation detection, adding an MBean in the JVM with metrics on how many times starvation has been detected, the maximum clock drift and the current clock drift.