### PR TITLE
Added MPSC `Queue` benchmarks

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/QueueBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/QueueBenchmark.scala
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.MINUTES)
 class QueueBenchmark {
 
-  @Param(Array("100000"))
+  @Param(Array("65533"))
   var size: Int = _
 
   @Benchmark
@@ -60,6 +60,13 @@ class QueueBenchmark {
     Queue
       .boundedForConcurrent[IO, Unit](size / 8)
       .flatMap(enqueueDequeueContended(_))
+      .unsafeRunSync()
+
+  @Benchmark
+  def boundedConcurrentEnqueueDequeueContendedSingleConsumer(): Unit =
+    Queue
+      .boundedForConcurrent[IO, Unit](size / 8)
+      .flatMap(enqueueDequeueContendedSingleConsumer(_))
       .unsafeRunSync()
 
   @Benchmark
@@ -137,5 +144,17 @@ class QueueBenchmark {
     val takers = par(q.take, size / 4)
 
     offerers &> takers
+  }
+
+  private[this] def enqueueDequeueContendedSingleConsumer(q: Queue[IO, Unit]): IO[Unit] = {
+    def par(action: IO[Unit], num: Int): IO[Unit] =
+      if (num <= 10)
+        action
+      else
+        par(action, num / 2) &> par(action, num / 2)
+
+    val offerers = par(q.offer(()), size / 4)
+
+    offerers &> q.take.replicateA_(size / 4)
   }
 }

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/QueueBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/QueueBenchmark.scala
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.MINUTES)
 class QueueBenchmark {
 
-  @Param(Array("32768"))    // must be a power of 2
+  @Param(Array("32768")) // must be a power of 2
   var size: Int = _
 
   @Benchmark

--- a/build.sbt
+++ b/build.sbt
@@ -726,7 +726,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         ProblemFilters.exclude[Problem]("cats.effect.IOFiberConstants.*"),
         ProblemFilters.exclude[Problem]("cats.effect.SyncIOConstants.*"),
         // introduced by #3196. Changes in an internal API.
-        ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.unsafe.FiberAwareExecutionContext.liveFibers")
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "cats.effect.unsafe.FiberAwareExecutionContext.liveFibers")
       )
     },
     mimaBinaryIssueFilters ++= {

--- a/std/shared/src/main/scala/cats/effect/std/Queue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Queue.scala
@@ -74,8 +74,8 @@ object Queue {
   def bounded[F[_], A](capacity: Int)(implicit F: GenConcurrent[F, _]): F[Queue[F, A]] = {
     assertNonNegative(capacity)
 
-    // async queue can't handle capacity == 1 and allocates eagerly
-    if (1 < capacity && capacity < Short.MaxValue) {
+    // async queue can't handle capacity == 1 and allocates eagerly, so cap at 64k
+    if (1 < capacity && capacity < Short.MaxValue.toInt * 2) {
       F match {
         case f0: Async[F] =>
           boundedForAsync[F, A](capacity)(f0)


### PR DESCRIPTION
Verifies that fs2's `Channel` is mostly bounded by the `Ref` state and not by any latent optimizations.