### PR TITLE
Fix sbt invocation in JVM example app test

### DIFF
--- a/example/test-jvm.sh
+++ b/example/test-jvm.sh
@@ -26,10 +26,8 @@ await-output() {
 
 cd $(dirname $0)/..
 
-launcher=~/.sbt/launchers/$(cat project/build.properties | sed s/sbt.version=//)/sbt-launch.jar
-
 echo -e "\e[32mRunning sbt...\e[0m"
-java -jar $launcher ++$1 exampleJVM/run &> >(tee $output) &
+sbt ++$1 exampleJVM/run &> >(tee $output) &
 
 await-output started
 echo -e "\e[32mKilling sbt\e[0m"


### PR DESCRIPTION
The old invocation was getting us this.
```
Run example/test-jvm.sh 2.13.8
  example/test-jvm.sh 2.13.8
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    GITHUB_TOKEN: ***
    JAVA_HOME: /opt/hostedtoolcache/Java_jdkfile_jdk/11/x64
    JAVA_HOME_11_X64: /opt/hostedtoolcache/Java_jdkfile_jdk/11/x64
Running sbt...
Error: Unable to access jarfile /home/runner/.sbt/launchers/1.7.1/sbt-launch.jar
Killing sbt
```