### PR TITLE
Fix 'Dispatcher' deprecaton annotation 'message' and 'since'

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -96,9 +96,9 @@ object Dispatcher {
   private[this] val Completed: Either[Throwable, Unit] = Right(())
 
   @deprecated(
-    since = "3.4.0",
     message =
-      "use '.parallel' or '.sequential' instead; the former corresponds to the current semantics of '.apply'")
+      "use '.parallel' or '.sequential' instead; the former corresponds to the current semantics of '.apply'",
+    since = "3.4.0")
   def apply[F[_]: Async]: Resource[F, Dispatcher[F]] = parallel[F](await = false)
 
   /**

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -96,8 +96,9 @@ object Dispatcher {
   private[this] val Completed: Either[Throwable, Unit] = Right(())
 
   @deprecated(
-    "3.4.0",
-    "use parallel or sequential instead; the former corresponds to the current semantics of this method")
+    since = "3.4.0",
+    message =
+      "use '.parallel' or '.sequential' instead; the former corresponds to the current semantics of '.apply'")
   def apply[F[_]: Async]: Resource[F, Dispatcher[F]] = parallel[F](await = false)
 
   /**


### PR DESCRIPTION
Currently `Dispatcher.apply` deprecation annotation have it's fields swapped, leading to not so readable errors:

```console
method apply in object Dispatcher is deprecated (since use parallel or sequential instead; the former corresponds to the current semantics of this method): 3.4.0
```