### PR TITLE
Suspend `cell` read in `AtomicCell#evalModify`

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/AtomicCell.scala
+++ b/std/shared/src/main/scala/cats/effect/std/AtomicCell.scala
@@ -168,7 +168,7 @@ object AtomicCell {
 
     override def evalModify[B](f: A => F[(A, B)]): F[B] =
       mutex.lock.surround {
-        f(cell).flatMap {
+        F.delay(cell).flatMap(f).flatMap {
           case (a, b) =>
             F.delay {
               cell = a

--- a/tests/shared/src/test/scala/cats/effect/std/AtomicCellSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/AtomicCellSpec.scala
@@ -85,5 +85,15 @@ final class AtomicCellSpec extends BaseSpec {
 
       op must completeAs(true)
     }
+
+    "evalModify should properly suspend read" in ticked { implicit ticker =>
+      val op = for {
+        cell <- AtomicCell[IO].of(0)
+        _ <- cell.update(_ + 1).replicateA_(2)
+        r <- cell.get
+      } yield r == 2
+
+      op must completeAs(true)
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/3279