### PR TITLE
More detailed warning for starvation checker

### DIFF
--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -200,7 +200,7 @@ class IOAppSpec extends Specification {
           h.awaitStatus()
           val err = h.stderr()
           err must not(contain("[WARNING] Failed to register Cats Effect CPU"))
-          err must contain("[WARNING] Your CPU is probably starving")
+          err must contain("[WARNING] Your app's responsiveness")
         }
 
         "custom runtime installed as global" in {


### PR DESCRIPTION
The warning is now prefixed with:
> Your app's responsiveness to a new asynchronous event (such as a new connection, an upstream response, or a timer) was in excess of $threshold.

I think this will help with understanding what this warning actually _means_.