### PR TITLE
Fix propagation of `ExitCase` in `Resource#{both,combineK}`

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -251,9 +251,9 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
    * _each_ of the two resources, nested finalizers are run in the usual reverse order of
    * acquisition.
    *
-   * The same [[ExitCase]] is propagated to every finalizer. If both resources acquired
-   * successfully, the [[ExitCase]] is determined by the outcome of [[use]]. Otherwise, it is
-   * determined by which resource failed or canceled first during acquisition.
+   * The same [[Resource.ExitCase]] is propagated to every finalizer. If both resources acquired
+   * successfully, the [[Resource.ExitCase]] is determined by the outcome of [[use]]. Otherwise,
+   * it is determined by which resource failed or canceled first during acquisition.
    *
    * Note that `Resource` also comes with a `cats.Parallel` instance that offers more convenient
    * access to the same functionality as `both`, for example via `parMapN`:

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -251,6 +251,10 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
    * _each_ of the two resources, nested finalizers are run in the usual reverse order of
    * acquisition.
    *
+   * The same [[ExitCase]] is propagated to every finalizer. If both resources acquired
+   * successfully, the [[ExitCase]] is determined by the outcome of [[use]]. Otherwise, it is
+   * determined by which resource failed or canceled first during acquisition.
+   *
    * Note that `Resource` also comes with a `cats.Parallel` instance that offers more convenient
    * access to the same functionality as `both`, for example via `parMapN`:
    *

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -154,7 +154,7 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
 
   private[effect] def fold[B](
       onOutput: A => F[B],
-      onRelease: F[Unit] => F[Unit]
+      onRelease: (ExitCase => F[Unit], ExitCase) => F[Unit]
   )(implicit F: MonadCancel[F, Throwable]): F[B] = {
     sealed trait Stack[AA]
     case object Nil extends Stack[A]
@@ -178,7 +178,7 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
               }
           } {
             case ((_, release), outcome) =>
-              onRelease(release(ExitCase.fromOutcome(outcome)))
+              onRelease(release, ExitCase.fromOutcome(outcome))
           }
         case Bind(source, fs) =>
           loop(source, Frame(fs, stack))
@@ -204,7 +204,7 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
    *   the result of applying [F] to
    */
   def use[B](f: A => F[B])(implicit F: MonadCancel[F, Throwable]): F[B] =
-    fold(f, identity)
+    fold(f, _.apply(_))
 
   /**
    * For a resource that allocates an action (type `F[B]`), allocate that action, run it and
@@ -281,19 +281,31 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
   def both[B](
       that: Resource[F, B]
   )(implicit F: Concurrent[F]): Resource[F, (A, B)] = {
-    type Update = (F[Unit] => F[Unit]) => F[Unit]
+    type Finalizer = Resource.ExitCase => F[Unit]
+    type Update = (Finalizer => Finalizer) => F[Unit]
 
     def allocate[C](r: Resource[F, C], storeFinalizer: Update): F[C] =
-      r.fold(_.pure[F], release => storeFinalizer(F.guarantee(_, release)))
+      r.fold(
+        _.pure[F],
+        (release, _) => storeFinalizer(fin => ec => F.unit >> fin(ec).guarantee(release(ec)))
+      )
 
-    val bothFinalizers = F.ref(F.unit -> F.unit)
+    val noop: Finalizer = _ => F.unit
+    val bothFinalizers = F.ref((noop, noop))
 
-    Resource.make(bothFinalizers)(_.get.flatMap(_.parTupled).void).evalMap { store =>
-      val thisStore: Update = f => store.update(_.bimap(f, identity))
-      val thatStore: Update = f => store.update(_.bimap(identity, f))
+    Resource
+      .makeCase(bothFinalizers) { (finalizers, ec) =>
+        finalizers.get.flatMap {
+          case (thisFin, thatFin) =>
+            F.void(F.both(thisFin(ec), thatFin(ec)))
+        }
+      }
+      .evalMap { store =>
+        val thisStore: Update = f => store.update(_.bimap(f, identity))
+        val thatStore: Update = f => store.update(_.bimap(identity, f))
 
-      (allocate(this, thisStore), allocate(that, thatStore)).parTupled
-    }
+        F.both(allocate(this, thisStore), allocate(that, thatStore))
+      }
   }
 
   /**
@@ -661,12 +673,19 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
       implicit F: MonadCancel[F, Throwable],
       K: SemigroupK[F],
       G: Ref.Make[F]): Resource[F, B] =
-    Resource.make(Ref[F].of(F.unit))(_.get.flatten).evalMap { finalizers =>
-      def allocate(r: Resource[F, B]): F[B] =
-        r.fold(_.pure[F], (release: F[Unit]) => finalizers.update(_.guarantee(release)))
+    Resource
+      .makeCase(Ref[F].of((_: Resource.ExitCase) => F.unit))((fin, ec) =>
+        fin.get.flatMap(_(ec)))
+      .evalMap { finalizers =>
+        def allocate(r: Resource[F, B]): F[B] =
+          r.fold(
+            _.pure[F],
+            (release, _) =>
+              finalizers.update(fin => ec => F.unit >> fin(ec).guarantee(release(ec)))
+          )
 
-      K.combineK(allocate(this), allocate(that))
-    }
+        K.combineK(allocate(this), allocate(that))
+      }
 
 }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -280,21 +280,72 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
    */
   def both[B](
       that: Resource[F, B]
-  )(implicit F: Concurrent[F]): Resource[F, (A, B)] = {
-    type Update = (F[Unit] => F[Unit]) => F[Unit]
+  )(implicit F: Concurrent[F]): Resource[F, (A, B)] =
+    Resource
+      .makeCaseFull[F, ((A, ExitCase => F[Unit]), (B, ExitCase => F[Unit]))] {
+        (poll: Poll[F]) =>
+          poll(F.racePair(this.allocatedCase, that.allocatedCase)).flatMap {
+            case Left((oc, f)) =>
+              def cancelRight(ec: ExitCase): F[Unit] =
+                f.cancel *> f.join.flatMap(_.fold(F.unit, _ => F.unit, _.flatMap(_._2(ec))))
 
-    def allocate[C](r: Resource[F, C], storeFinalizer: Update): F[C] =
-      r.fold(_.pure[F], release => storeFinalizer(F.guarantee(_, release)))
+              oc match {
+                case Outcome.Succeeded(fa) =>
+                  poll(f.join)
+                    .onCancel(
+                      F.void(
+                        F.both(
+                          fa.flatMap(_._2(ExitCase.Canceled)),
+                          cancelRight(ExitCase.Canceled)
+                        )
+                      )
+                    )
+                    .flatMap {
+                      case Outcome.Succeeded(fb) => F.product(fa, fb)
+                      case Outcome.Errored(ex) =>
+                        fa.flatMap(_._2(ExitCase.Errored(ex))) *> F.raiseError(ex)
+                      case Outcome.Canceled() =>
+                        fa.flatMap(_._2(ExitCase.Canceled)) *> F.canceled *> poll(F.never)
+                    }
+                case Outcome.Errored(ex) =>
+                  cancelRight(ExitCase.Errored(ex)) *> F.raiseError(ex)
+                case Outcome.Canceled() =>
+                  cancelRight(ExitCase.Canceled) *> F.canceled *> poll(F.never)
+              }
+            case Right((f, oc)) =>
+              def cancelLeft(ec: ExitCase): F[Unit] =
+                f.cancel *> f.join.flatMap(_.fold(F.unit, _ => F.unit, _.flatMap(_._2(ec))))
 
-    val bothFinalizers = F.ref(F.unit -> F.unit)
+              oc match {
+                case Outcome.Succeeded(fb) =>
+                  poll(f.join)
+                    .onCancel(
+                      F.void(
+                        F.both(
+                          fb.flatMap(_._2(ExitCase.Canceled)),
+                          cancelLeft(ExitCase.Canceled)
+                        )
+                      )
+                    )
+                    .flatMap {
+                      case Outcome.Succeeded(fa) => F.product(fa, fb)
+                      case Outcome.Errored(ex) =>
+                        fb.flatMap(_._2(ExitCase.Errored(ex))) *> F.raiseError(ex)
+                      case Outcome.Canceled() =>
+                        fb.flatMap(_._2(ExitCase.Canceled)) *> F.canceled *> poll(F.never)
+                    }
+                case Outcome.Errored(ex) =>
+                  cancelLeft(ExitCase.Errored(ex)) *> F.raiseError(ex)
+                case Outcome.Canceled() =>
+                  cancelLeft(ExitCase.Canceled) *> F.canceled *> poll(F.never)
+              }
 
-    Resource.make(bothFinalizers)(_.get.flatMap(_.parTupled).void).evalMap { store =>
-      val thisStore: Update = f => store.update(_.bimap(f, identity))
-      val thatStore: Update = f => store.update(_.bimap(identity, f))
-
-      (allocate(this, thisStore), allocate(that, thatStore)).parTupled
-    }
-  }
+          }
+      } {
+        case (((_, releaseLeft), (_, releaseRight)), ec) =>
+          F.void(F.both(releaseLeft(ec), releaseRight(ec)))
+      }
+      .map { case ((a, _), (b, _)) => (a, b) }
 
   /**
    * Races the evaluation of two resource allocations and returns the result of the winner,

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -599,7 +599,7 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
         rightReleased must beTrue
       }
 
-      "passes along the exit case" in {
+      "propagate the exit case" in {
         import Resource.ExitCase
 
         "use succesfully, test left" >> ticked { implicit ticker =>
@@ -721,7 +721,7 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
         }
       }
 
-      "passes along the exit case" in {
+      "propagate the exit case" in {
         import Resource.ExitCase
 
         "use succesfully, test left" >> ticked { implicit ticker =>

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -599,24 +599,24 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
         rightReleased must beTrue
       }
 
-      "passes along the exit case" in ticked { implicit ticker =>
+      "passes along the exit case" in {
         import Resource.ExitCase
 
-        { // use successfully, test left
+        "use succesfully, test left" >> ticked { implicit ticker =>
           var got: ExitCase = null
           val r = Resource.onFinalizeCase(ec => IO { got = ec })
           r.both(Resource.unit).use(_ => IO.unit) must completeAs(())
           got mustEqual ExitCase.Succeeded
         }
 
-        { // use successfully, test right
+        "use successfully, test right" >> ticked { implicit ticker =>
           var got: ExitCase = null
           val r = Resource.onFinalizeCase(ec => IO { got = ec })
           Resource.unit.both(r).use(_ => IO.unit) must completeAs(())
           got mustEqual ExitCase.Succeeded
         }
 
-        { // use errored, test left
+        "use errored, test left" >> ticked { implicit ticker =>
           var got: ExitCase = null
           val ex = new Exception
           val r = Resource.onFinalizeCase(ec => IO { got = ec })
@@ -624,7 +624,7 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
           got mustEqual ExitCase.Errored(ex)
         }
 
-        { // use errored, test right
+        "use errored, test right" >> ticked { implicit ticker =>
           var got: ExitCase = null
           val ex = new Exception
           val r = Resource.onFinalizeCase(ec => IO { got = ec })
@@ -632,7 +632,7 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
           got mustEqual ExitCase.Errored(ex)
         }
 
-        { // right errored, test left
+        "right errored, test left" >> ticked { implicit ticker =>
           var got: ExitCase = null
           val ex = new Exception
           val r = Resource.onFinalizeCase(ec => IO { got = ec })
@@ -640,7 +640,7 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
           got mustEqual ExitCase.Errored(ex)
         }
 
-        { // left errored, test right
+        "left errored, test right" >> ticked { implicit ticker =>
           var got: ExitCase = null
           val ex = new Exception
           val r = Resource.onFinalizeCase(ec => IO { got = ec })
@@ -648,28 +648,28 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
           got mustEqual ExitCase.Errored(ex)
         }
 
-        { // use canceled, test left
+        "use canceled, test left" >> ticked { implicit ticker =>
           var got: ExitCase = null
           val r = Resource.onFinalizeCase(ec => IO { got = ec })
           r.both(Resource.unit).use(_ => IO.canceled) must selfCancel
           got mustEqual ExitCase.Canceled
         }
 
-        { // use canceled, test right
+        "use canceled, test right" >> ticked { implicit ticker =>
           var got: ExitCase = null
           val r = Resource.onFinalizeCase(ec => IO { got = ec })
           Resource.unit.both(r).use(_ => IO.canceled) must selfCancel
           got mustEqual ExitCase.Canceled
         }
 
-        { // right canceled, test left
+        "right canceled, test left" >> ticked { implicit ticker =>
           var got: ExitCase = null
           val r = Resource.onFinalizeCase(ec => IO { got = ec })
           r.both(Resource.eval(IO.sleep(1.second) *> IO.canceled)).use_ must selfCancel
           got mustEqual ExitCase.Canceled
         }
 
-        { // left canceled, test right
+        "left canceled, test right" >> ticked { implicit ticker =>
           var got: ExitCase = null
           val r = Resource.onFinalizeCase(ec => IO { got = ec })
           Resource.eval(IO.sleep(1.second) *> IO.canceled).both(r).use_ must selfCancel


### PR DESCRIPTION
Noticed this while looking into https://github.com/typelevel/cats-effect/pull/3227. `ExitCase`s were not being propagated at all to the finalizers.