### PR TITLE
Specialize `CallbackStack` on JS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -751,9 +751,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
           "cats.effect.tracing.TracingConstants.*"),
         // introduced by #3324, which specialized CallbackStack for JS
         // internal API change
-        ProblemFilters.exclude[MissingTypesProblem]("cats.effect.CallbackStack"),
-        ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.CallbackStack.push"),
-        ProblemFilters.exclude[IncompatibleMethTypeProblem]("cats.effect.CallbackStack.this")
+        ProblemFilters.exclude[IncompatibleTemplateDefProblem]("cats.effect.CallbackStack")
       )
     },
     mimaBinaryIssueFilters ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -598,7 +598,11 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.NonDaemonThreadLogger$"),
       // introduced by #3284
       // internal API change
-      ProblemFilters.exclude[IncompatibleMethTypeProblem]("cats.effect.CallbackStack.apply")
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("cats.effect.CallbackStack.apply"),
+      // introduced by #3324, which specialized CallbackStack for JS
+      // internal API change
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "cats.effect.CallbackStack.clearCurrent")
     ) ++ {
       if (tlIsScala3.value) {
         // Scala 3 specific exclusions
@@ -744,7 +748,12 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         ProblemFilters.exclude[Problem]("cats.effect.ArrayStack*"),
         // mystery filters that became required in 3.4.0
         ProblemFilters.exclude[DirectMissingMethodProblem](
-          "cats.effect.tracing.TracingConstants.*")
+          "cats.effect.tracing.TracingConstants.*"),
+        // introduced by #3324, which specialized CallbackStack for JS
+        // internal API change
+        ProblemFilters.exclude[MissingTypesProblem]("cats.effect.CallbackStack"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.CallbackStack.push"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("cats.effect.CallbackStack.this")
       )
     },
     mimaBinaryIssueFilters ++= {

--- a/core/js/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/js/src/main/scala/cats/effect/CallbackStack.scala
@@ -18,12 +18,14 @@ package cats.effect
 
 import scala.scalajs.js
 
-private final class CallbackStack[A](private val callbacks: js.Array[A => Unit])
+private trait CallbackStack[A] extends js.Object
+
+private final class CallbackStackOps[A](private val callbacks: js.Array[A => Unit])
     extends AnyVal {
 
   @inline def push(next: A => Unit): CallbackStack[A] = {
     callbacks.push(next)
-    this
+    callbacks.asInstanceOf[CallbackStack[A]]
   }
 
   @inline def unsafeSetCallback(cb: A => Unit): Unit = {
@@ -61,7 +63,10 @@ private final class CallbackStack[A](private val callbacks: js.Array[A => Unit])
 
 private object CallbackStack {
   @inline def apply[A](cb: A => Unit): CallbackStack[A] =
-    new CallbackStack(js.Array(cb))
+    js.Array(cb).asInstanceOf[CallbackStack[A]]
+
+  @inline implicit def ops[A](stack: CallbackStack[A]): CallbackStackOps[A] =
+    new CallbackStackOps(stack.asInstanceOf[js.Array[A => Unit]])
 
   type Handle = Int
 }

--- a/core/js/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/js/src/main/scala/cats/effect/CallbackStack.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import scala.scalajs.js
+
+private final class CallbackStack[A](private val callbacks: js.Array[A => Unit])
+    extends AnyVal {
+
+  @inline def push(next: A => Unit): CallbackStack[A] = {
+    callbacks.push(next)
+    this
+  }
+
+  @inline def unsafeSetCallback(cb: A => Unit): Unit = {
+    callbacks(callbacks.length - 1) = cb
+  }
+
+  /**
+   * Invokes *all* non-null callbacks in the queue, starting with the current one. Returns true
+   * iff *any* callbacks were invoked.
+   */
+  @inline def apply(oc: A, _invoked: Boolean): Boolean = {
+    var i = callbacks.length - 1
+    var invoked = _invoked
+    while (i >= 0) {
+      val cb = callbacks(i)
+      if (cb ne null) {
+        cb(oc)
+        invoked = true
+      }
+      i -= 1
+    }
+    invoked
+  }
+
+  /**
+   * Removes the current callback from the queue.
+   */
+  @inline def clearCurrent(handle: CallbackStack.Handle): Unit = callbacks(handle) = null
+
+  @inline def currentHandle(): CallbackStack.Handle = callbacks.length - 1
+
+  @inline def clear(): Unit =
+    callbacks.length = 0 // javascript is crazy!
+}
+
+private object CallbackStack {
+  @inline def apply[A](cb: A => Unit): CallbackStack[A] =
+    new CallbackStack(js.Array(cb))
+
+  type Handle = Int
+}

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -69,5 +69,19 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
   /**
    * Removes the current callback from the queue.
    */
-  def clearCurrent(): Unit = callback = null
+  def clearCurrent(handle: CallbackStack.Handle): Unit = {
+    val _ = handle
+    callback = null
+  }
+
+  def currentHandle(): CallbackStack.Handle = ()
+
+  def clear(): Unit = lazySet(null)
+}
+
+private object CallbackStack {
+  def apply[A](cb: A => Unit): CallbackStack[A] =
+    new CallbackStack(cb)
+
+  type Handle = Unit
 }

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -74,7 +74,7 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
     callback = null
   }
 
-  def currentHandle(): CallbackStack.Handle = ()
+  def currentHandle(): CallbackStack.Handle = 0
 
   def clear(): Unit = lazySet(null)
 }
@@ -83,5 +83,5 @@ private object CallbackStack {
   def apply[A](cb: A => Unit): CallbackStack[A] =
     new CallbackStack(cb)
 
-  type Handle = Unit
+  type Handle = Byte
 }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -171,7 +171,7 @@ private final class IOFiber[A](
     IO {
       val stack = registerListener(oc => cb(Right(oc)))
 
-      if (stack == null.asInstanceOf[CallbackStack[OutcomeIO[A]]])
+      if (stack eq null)
         None /* we were already invoked, so no `CallbackStack` needs to be managed */
       else {
         val handle = stack.currentHandle()
@@ -1131,13 +1131,13 @@ private final class IOFiber[A](
       if (outcome != null) {
         back.clearCurrent(back.currentHandle())
         listener(outcome) /* the implementation of async saves us from double-calls */
-        null.asInstanceOf[CallbackStack[OutcomeIO[A]]]
+        null
       } else {
         back
       }
     } else {
       listener(outcome)
-      null.asInstanceOf[CallbackStack[OutcomeIO[A]]]
+      null
     }
   }
 


### PR DESCRIPTION
It is now represented directly by a `js.Array[A]` via an `AnyVal` wrapper.

Still feels a bit ugly/hacky re `clearCurrent()` 😕 

Confirmed that there is no wrapping in `IODeferred` and `IOFiber`. 

<details>

```java
public final class IODeferred<A>
extends Deferred<IO, A> {
    public final AtomicReference<Object> cats$effect$IODeferred$$cell = new AtomicReference<Object>(IODeferred$.MODULE$.cats$effect$IODeferred$$Sentinel());
    public final Array<Function1<Right<Nothing$, A>, BoxedUnit>> cats$effect$IODeferred$$callbacks = CallbackStack$.MODULE$.apply(null);
```

```java
public final class IOFiber<A>
extends IOFiberPlatform<A>
implements Fiber<IO, Throwable, A>,
Runnable {
    private Map<IOLocal<?>, Object> localState;
    private ExecutionContext currentCtx;
    private final Array<Object> objectState;
    private final Array<IO<BoxedUnit>> finalizers;
    private final Array<Function1<Outcome<IO, Throwable, A>, BoxedUnit>> callbacks;
```

</details>