### PR TITLE
Use Node.js 18 in CI, bump setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,11 +207,11 @@ jobs:
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
-      - name: Setup NodeJS v16 LTS
+      - name: Setup NodeJS v18 LTS
         if: matrix.ci == 'ciJS'
-        uses: actions/setup-node@v2.4.0
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install jsdom and source-map-support
         if: matrix.ci == 'ciJS'

--- a/build.sbt
+++ b/build.sbt
@@ -137,9 +137,9 @@ ThisBuild / githubWorkflowOSes := Seq(PrimaryOS, Windows, MacOS)
 
 ThisBuild / githubWorkflowBuildPreamble ++= Seq(
   WorkflowStep.Use(
-    UseRef.Public("actions", "setup-node", "v2.4.0"),
-    name = Some("Setup NodeJS v16 LTS"),
-    params = Map("node-version" -> "16"),
+    UseRef.Public("actions", "setup-node", "v3"),
+    name = Some("Setup NodeJS v18 LTS"),
+    params = Map("node-version" -> "18"),
     cond = Some("matrix.ci == 'ciJS'")
   ),
   WorkflowStep.Run(


### PR DESCRIPTION
It's the LTS and it's officially supported by AWS Lambda.
https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/