### PR TITLE
Run Scalafix only on current platform in CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,17 +228,17 @@ jobs:
         run: sbt githubWorkflowCheck
 
       - name: Check that scalafix has been run on JVM
-        if: matrix.ci == 'ciJVM' && matrix.scala != '3.2.1' && matrix.os != 'windows-latest'
+        if: matrix.ci == 'ciJVM' && matrix.scala != '3.2.1' && matrix.os == 'ubuntu-latest'
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' 'rootJVM/scalafixAll --check'
 
       - name: Check that scalafix has been run on JS
-        if: matrix.ci == 'ciJS' && matrix.scala != '3.2.1' && matrix.os != 'windows-latest'
+        if: matrix.ci == 'ciJS' && matrix.scala != '3.2.1' && matrix.os == 'ubuntu-latest'
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' 'rootJS/scalafixAll --check'
 
       - name: Check that scalafix has been run on Native
-        if: matrix.ci == 'ciNative' && matrix.scala != '3.2.1' && matrix.os != 'windows-latest'
+        if: matrix.ci == 'ciNative' && matrix.scala != '3.2.1' && matrix.os == 'ubuntu-latest'
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' 'rootNative/scalafixAll --check'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,17 +228,17 @@ jobs:
         run: sbt githubWorkflowCheck
 
       - name: Check that scalafix has been run on JVM
-        if: matrix.ci == 'ciJVM' && matrix.scala != '3.2.1' && matrix.os == 'ubuntu-latest'
+        if: matrix.ci == 'ciJVM' && matrix.scala != '3.2.1' && matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' 'rootJVM/scalafixAll --check'
 
       - name: Check that scalafix has been run on JS
-        if: matrix.ci == 'ciJS' && matrix.scala != '3.2.1' && matrix.os == 'ubuntu-latest'
+        if: matrix.ci == 'ciJS' && matrix.scala != '3.2.1' && matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' 'rootJS/scalafixAll --check'
 
       - name: Check that scalafix has been run on Native
-        if: matrix.ci == 'ciNative' && matrix.scala != '3.2.1' && matrix.os == 'ubuntu-latest'
+        if: matrix.ci == 'ciNative' && matrix.scala != '3.2.1' && matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' 'rootNative/scalafixAll --check'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,10 +227,20 @@ jobs:
         shell: bash
         run: sbt githubWorkflowCheck
 
-      - name: Check that scalafix has been run
-        if: matrix.scala != '3.2.1' && matrix.os != 'windows-latest'
+      - name: Check that scalafix has been run on JVM
+        if: matrix.ci == 'ciJVM' && matrix.scala != '3.2.1' && matrix.os != 'windows-latest'
         shell: bash
-        run: sbt '++ ${{ matrix.scala }}' 'root/scalafixAll --check'
+        run: sbt '++ ${{ matrix.scala }}' 'rootJVM/scalafixAll --check'
+
+      - name: Check that scalafix has been run on JS
+        if: matrix.ci == 'ciJS' && matrix.scala != '3.2.1' && matrix.os != 'windows-latest'
+        shell: bash
+        run: sbt '++ ${{ matrix.scala }}' 'rootJS/scalafixAll --check'
+
+      - name: Check that scalafix has been run on Native
+        if: matrix.ci == 'ciNative' && matrix.scala != '3.2.1' && matrix.os != 'windows-latest'
+        shell: bash
+        run: sbt '++ ${{ matrix.scala }}' 'rootNative/scalafixAll --check'
 
       - shell: bash
         run: sbt '++ ${{ matrix.scala }}' '${{ matrix.ci }}'

--- a/build.sbt
+++ b/build.sbt
@@ -154,14 +154,15 @@ ThisBuild / githubWorkflowBuildPreamble ++= Seq(
   )
 )
 
-ThisBuild / githubWorkflowBuild := Seq(
+ThisBuild / githubWorkflowBuild := Seq("JVM", "JS", "Native").map { platform =>
   WorkflowStep.Sbt(
-    List("root/scalafixAll --check"),
-    name = Some("Check that scalafix has been run"),
+    List(s"root${platform}/scalafixAll --check"),
+    name = Some(s"Check that scalafix has been run on $platform"),
     cond = Some(
-      s"matrix.scala != '$Scala3' && matrix.os != 'windows-latest'"
+      s"matrix.ci == 'ci${platform}' && matrix.scala != '$Scala3' && matrix.os != 'windows-latest'"
     ) // windows has file lock issues due to shared sources
-  ),
+  )
+} ++ Seq(
   WorkflowStep.Sbt(List("${{ matrix.ci }}")),
   WorkflowStep.Sbt(
     List("docs/mdoc"),

--- a/build.sbt
+++ b/build.sbt
@@ -159,7 +159,7 @@ ThisBuild / githubWorkflowBuild := Seq("JVM", "JS", "Native").map { platform =>
     List(s"root${platform}/scalafixAll --check"),
     name = Some(s"Check that scalafix has been run on $platform"),
     cond = Some(
-      s"matrix.ci == 'ci${platform}' && matrix.scala != '$Scala3' && matrix.os == '$PrimaryOS'"
+      s"matrix.ci == 'ci${platform}' && matrix.scala != '$Scala3' && matrix.java == '${OldGuardJava.render}' && matrix.os == '$PrimaryOS'"
     ) // windows has file lock issues due to shared sources
   )
 } ++ Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -159,7 +159,7 @@ ThisBuild / githubWorkflowBuild := Seq("JVM", "JS", "Native").map { platform =>
     List(s"root${platform}/scalafixAll --check"),
     name = Some(s"Check that scalafix has been run on $platform"),
     cond = Some(
-      s"matrix.ci == 'ci${platform}' && matrix.scala != '$Scala3' && matrix.os != 'windows-latest'"
+      s"matrix.ci == 'ci${platform}' && matrix.scala != '$Scala3' && matrix.os == '$PrimaryOS'"
     ) // windows has file lock issues due to shared sources
   )
 } ++ Seq(


### PR DESCRIPTION
Currently every platform is compiling every other platform, to run a redundant scalafix check. It's also being run on the entire JDK/OS matrix which is very unnecessary. This was causing some jobs to take more than an hour to run and thus get timed out.

FTR: if we didn't completely override the generated steps, sbt-typelevel would do this automatically. Not just for scalafix, but also for scalafmt, MiMa (edit: although MiMa on JDK 17 did catch that dotty bug 🤔 ), scaladoc, anything else that really only needs to be run on one JDK and one OS.