### PR TITLE
Move the mbean initialization out of blocking and into delay

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
@@ -56,7 +56,6 @@ private[effect] object JvmCpuStarvationMetrics {
     val acquire: IO[(MBeanServer, JvmCpuStarvationMetrics)] = for {
       mBeanServer <- IO.delay(ManagementFactory.getPlatformMBeanServer)
       mBean <- CpuStarvation()
-      _ <- IO.blocking(mBeanServer.registerMBean(mBean, mBeanObjectName))
       // To allow user-defined program to use the compute pool from the beginning,
       // here we use `IO.delay` rather than `IO.blocking`.
       _ <- IO.delay(mBeanServer.registerMBean(mBean, mBeanObjectName))

--- a/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
@@ -57,6 +57,8 @@ private[effect] object JvmCpuStarvationMetrics {
       mBeanServer <- IO.delay(ManagementFactory.getPlatformMBeanServer)
       mBean <- CpuStarvation()
       _ <- IO.blocking(mBeanServer.registerMBean(mBean, mBeanObjectName))
+      // To allow user-defined program to use the compute pool from the beginning,
+      // here we use `IO.delay` rather than `IO.blocking`.
       _ <- IO.delay(mBeanServer.registerMBean(mBean, mBeanObjectName))
     } yield (mBeanServer, new JvmCpuStarvationMetrics(mBean))
 

--- a/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
@@ -57,6 +57,7 @@ private[effect] object JvmCpuStarvationMetrics {
       mBeanServer <- IO.delay(ManagementFactory.getPlatformMBeanServer)
       mBean <- CpuStarvation()
       _ <- IO.blocking(mBeanServer.registerMBean(mBean, mBeanObjectName))
+      _ <- IO.delay(mBeanServer.registerMBean(mBean, mBeanObjectName))
     } yield (mBeanServer, new JvmCpuStarvationMetrics(mBean))
 
     Resource


### PR DESCRIPTION
Fix #3316.

This PR moves the mbean initialization out of `IO.blocking` and into `IO.delay`, to allow user-defined program can use the compute pool from the beginning.

This is my first PR so give me a hint if I missed something :)