### PR TITLE
Increase sleep for `MainThreadReportFailure` test

### DIFF
--- a/tests/jvm/src/main/scala/catseffect/examplesplatform.scala
+++ b/tests/jvm/src/main/scala/catseffect/examplesplatform.scala
@@ -86,7 +86,7 @@ package examples {
 
     def run(args: List[String]): IO[ExitCode] =
       IO.raiseError(new Exception).startOn(MainThread) *>
-        IO.sleep(100.millis) *> IO(exitCode.get)
+        IO.sleep(1.second) *> IO(exitCode.get)
 
   }
 }


### PR DESCRIPTION
This is the test I added in https://github.com/typelevel/cats-effect/pull/3315. Suffice to say, it flaked. Annoying.