### PR TITLE
ConcurrentAtomicCell

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -884,7 +884,11 @@ lazy val std = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "cats.effect.std.Queue#CircularBufferQueue.onOfferNoCapacity"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
-        "cats.effect.std.Queue#DroppingQueue.onOfferNoCapacity")
+        "cats.effect.std.Queue#DroppingQueue.onOfferNoCapacity"),
+      // introduced by #3347
+      // private stuff
+      ProblemFilters.exclude[MissingClassProblem](
+        "cats.effect.std.AtomicCell$Impl")
     )
   )
   .jsSettings(

--- a/std/shared/src/main/scala/cats/effect/std/AtomicCell.scala
+++ b/std/shared/src/main/scala/cats/effect/std/AtomicCell.scala
@@ -154,10 +154,10 @@ object AtomicCell {
       of(M.empty)(F)
   }
 
-  def async[F[_], A](init: A)(implicit F: Async[F]): F[AtomicCell[F, A]] =
+  private[effect] def async[F[_], A](init: A)(implicit F: Async[F]): F[AtomicCell[F, A]] =
     Mutex[F].map(mutex => new AsyncImpl(init, mutex))
 
-  def concurrent[F[_], A](init: A)(implicit F: Concurrent[F]): F[AtomicCell[F, A]] =
+  private[effect] def concurrent[F[_], A](init: A)(implicit F: Concurrent[F]): F[AtomicCell[F, A]] =
     (Ref.of[F, A](init), Mutex[F]).mapN { (ref, m) => new ConcurrentImpl(ref, m) }
 
   private final class ConcurrentImpl[F[_], A](

--- a/tests/shared/src/test/scala/cats/effect/std/AtomicCellSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/AtomicCellSpec.scala
@@ -20,80 +20,92 @@ package std
 
 import cats.syntax.all._
 
+import org.specs2.specification.core.Fragments
+
 import scala.concurrent.duration._
 
 final class AtomicCellSpec extends BaseSpec {
-  "AtomicCell" should {
-    "get and set successfully" in real {
-      val op = for {
-        cell <- AtomicCell[IO].of(0)
-        getAndSetResult <- cell.getAndSet(1)
-        getResult <- cell.get
-      } yield getAndSetResult == 0 && getResult == 1
+  "AsyncAtomicCell" should {
+    tests(AtomicCell.async)
+  }
 
-      op.mustEqual(true)
-    }
+  "ConcurrentAtomicCell" should {
+    tests(AtomicCell.concurrent)
+  }
 
-    "get and update successfully" in real {
-      val op = for {
-        cell <- AtomicCell[IO].of(0)
-        getAndUpdateResult <- cell.getAndUpdate(_ + 1)
-        getResult <- cell.get
-      } yield getAndUpdateResult == 0 && getResult == 1
+  def tests(factory: Int => IO[AtomicCell[IO, Int]]): Fragments = {
+    "AtomicCell" should {
+      "get and set successfully" in real {
+        val op = for {
+          cell <- factory(0)
+          getAndSetResult <- cell.getAndSet(1)
+          getResult <- cell.get
+        } yield getAndSetResult == 0 && getResult == 1
 
-      op.mustEqual(true)
-    }
-
-    "update and get successfully" in real {
-      val op = for {
-        cell <- AtomicCell[IO].of(0)
-        updateAndGetResult <- cell.updateAndGet(_ + 1)
-        getResult <- cell.get
-      } yield updateAndGetResult == 1 && getResult == 1
-
-      op.mustEqual(true)
-    }
-
-    "evalModify successfully" in ticked { implicit ticker =>
-      val op = AtomicCell[IO].of(0).flatMap { cell =>
-        cell.evalModify { x =>
-          val y = x + 1
-          IO.sleep(1.second).as((y, (x, y)))
-        } map {
-          case (oldValue, newValue) =>
-            oldValue == 0 && newValue == 1
-        }
+        op.mustEqual(true)
       }
 
-      op must completeAs(true)
-    }
+      "get and update successfully" in real {
+        val op = for {
+          cell <- factory(0)
+          getAndUpdateResult <- cell.getAndUpdate(_ + 1)
+          getResult <- cell.get
+        } yield getAndUpdateResult == 0 && getResult == 1
 
-    "evalUpdate should block and cancel should release" in ticked { implicit ticker =>
-      val op = for {
-        cell <- AtomicCell[IO].of(0)
-        b <- cell.evalUpdate(x => IO.never.as(x + 1)).start
-        _ <- IO.sleep(1.second)
-        f <- cell.update(_ + 3).start
-        _ <- IO.sleep(1.second)
-        _ <- f.cancel
-        _ <- IO.sleep(1.second)
-        _ <- b.cancel
-        _ <- IO.sleep(1.second)
-        _ <- cell.update(_ + 1)
-        r <- cell.get
-      } yield r == 1
+        op.mustEqual(true)
+      }
 
-      op must completeAs(true)
-    }
+      "update and get successfully" in real {
+        val op = for {
+          cell <- factory(0)
+          updateAndGetResult <- cell.updateAndGet(_ + 1)
+          getResult <- cell.get
+        } yield updateAndGetResult == 1 && getResult == 1
 
-    "evalModify should properly suspend read" in ticked { implicit ticker =>
-      val op = for {
-        cell <- AtomicCell[IO].of(0)
-        _ <- cell.update(_ + 1).replicateA_(2)
-        r <- cell.get
-      } yield r == 2
+        op.mustEqual(true)
+      }
 
-      op must completeAs(true)
+      "evalModify successfully" in ticked { implicit ticker =>
+        val op = factory(0).flatMap { cell =>
+          cell.evalModify { x =>
+            val y = x + 1
+            IO.sleep(1.second).as((y, (x, y)))
+          } map {
+            case (oldValue, newValue) =>
+              oldValue == 0 && newValue == 1
+          }
+        }
+
+        op must completeAs(true)
+      }
+
+      "evalUpdate should block and cancel should release" in ticked { implicit ticker =>
+        val op = for {
+          cell <- factory(0)
+          b <- cell.evalUpdate(x => IO.never.as(x + 1)).start
+          _ <- IO.sleep(1.second)
+          f <- cell.update(_ + 3).start
+          _ <- IO.sleep(1.second)
+          _ <- f.cancel
+          _ <- IO.sleep(1.second)
+          _ <- b.cancel
+          _ <- IO.sleep(1.second)
+          _ <- cell.update(_ + 1)
+          r <- cell.get
+        } yield r == 1
+
+        op must completeAs(true)
+      }
+
+      "evalModify should properly suspend read" in ticked { implicit ticker =>
+        val op = for {
+          cell <- factory(0)
+          _ <- cell.update(_ + 1).replicateA_(2)
+          r <- cell.get
+        } yield r == 2
+
+        op must completeAs(true)
+      }
     }
   }
 }

--- a/tests/shared/src/test/scala/cats/effect/std/AtomicCellSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/AtomicCellSpec.scala
@@ -25,10 +25,6 @@ import org.specs2.specification.core.Fragments
 import scala.concurrent.duration._
 
 final class AtomicCellSpec extends BaseSpec {
-  "AsyncAtomicCell" should {
-    tests(AtomicCell.async)
-  }
-
   "ConcurrentAtomicCell" should {
     tests(AtomicCell.concurrent)
   }


### PR DESCRIPTION
Adds a `Concurrent` based implementation of `AtomicCell` while leaving the current `Async` based one as a fallback.
In theory, the `Async` one should be more performant; especially if #3346 also improves the performance of `Mutex`.

However, it is not clear if such supposed improvement is worth the trickery did in this PR.
If not, we may just delete the `Async` implementation.