### PR TITLE
Fix cancelation handling in `memoize`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -379,7 +379,8 @@ lazy val kernel = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       "org.specs2" %%% "specs2-core" % Specs2Version % Test
     ),
     mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.kernel.Ref$SyncRef")
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.kernel.Ref$SyncRef"),
+      ProblemFilters.exclude[Problem]("cats.effect.kernel.GenConcurrent#Memoize*")
     )
   )
   .jsSettings(

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -63,7 +63,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
 
                   fa.guaranteeCase {
                     case Outcome.Canceled() =>
-                      tryComplete(Finished(Right(never)))
+                      tryComplete(Finished(Right(productR(canceled)(never))))
                     case Outcome.Errored(err) =>
                       tryComplete(Finished(Left(err)))
                     case Outcome.Succeeded(fa) =>
@@ -73,7 +73,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
 
                 val eval = go.start.flatMap { fiber =>
                   deferredFiber.complete(fiber) *>
-                    poll(fiber.join.flatMap(_.embedNever))
+                    poll(fiber.join.flatMap(_.embed(productR(canceled)(never))))
                 }
 
                 Evaluating(deferredFiber, 1) -> eval

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -45,40 +45,65 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
     implicit val F: GenConcurrent[F, E] = this
 
     ref[Memoize[F, E, A]](Unevaluated()) map { state =>
-      def eval: F[A] =
-        deferred[Unit] flatMap { latch =>
+      // start running the effect, or subscribe if it already is
+      def evalOrSubscribe: F[A] =
+        deferred[Fiber[F, E, A]] flatMap { deferredFiber =>
           uncancelable { poll =>
             state.modify {
               case Unevaluated() =>
-                val go =
-                  poll(fa).guaranteeCase { outcome =>
-                    val stateAction = outcome match {
-                      case Outcome.Canceled() =>
-                        state.set(Unevaluated())
-                      case Outcome.Errored(err) =>
-                        state.set(Finished(Left(err)))
-                      case Outcome.Succeeded(fa) =>
-                        state.set(Finished(Right(fa)))
-                    }
-                    stateAction <* latch.complete(())
+                // run the effect, and if this fiber is still relevant set its result
+                val go = {
+                  def tryComplete(result: Memoize[F, E, A]): F[Unit] = state.update {
+                    case Evaluating(fiber, _) if fiber eq deferredFiber =>
+                      // we are the blessed fiber of this memo
+                      result
+                    case other => // our outcome is no longer relevant
+                      other
                   }
 
-                Evaluating(latch.get) -> go
+                  fa.guaranteeCase {
+                    case Outcome.Canceled() =>
+                      tryComplete(Finished(Right(never)))
+                    case Outcome.Errored(err) =>
+                      tryComplete(Finished(Left(err)))
+                    case Outcome.Succeeded(fa) =>
+                      tryComplete(Finished(Right(fa)))
+                  }
+                }
 
-              case other =>
-                other -> poll(get)
+                val eval = go.start.flatMap { fiber =>
+                  deferredFiber.complete(fiber) *>
+                    poll(fiber.join.flatMap(_.embedNever))
+                }
+
+                Evaluating(deferredFiber, 1) -> eval
+
+              case Evaluating(fiber, subscribers) =>
+                Evaluating(fiber, subscribers + 1) ->
+                  poll(fiber.get.flatMap(_.join).flatMap(_.embedNever))
+                    .onCancel(unsubscribe(fiber))
+
+              case finished @ Finished(result) =>
+                finished -> fromEither(result).flatten
             }.flatten
           }
         }
 
-      def get: F[A] =
-        state.get flatMap {
-          case Unevaluated() => eval
-          case Evaluating(await) => await *> get
-          case Finished(efa) => fromEither(efa).flatten
-        }
+      def unsubscribe(expected: Deferred[F, Fiber[F, E, A]]): F[Unit] =
+        state.modify {
+          case Evaluating(fiber, subscribers) if fiber eq expected =>
+            if (subscribers == 1) // we are the last subscriber to this fiber
+              Unevaluated() -> fiber.get.flatMap(_.cancel)
+            else
+              Evaluating(fiber, subscribers - 1) -> unit
+          case other =>
+            other -> unit
+        }.flatten
 
-      get
+      state.get.flatMap {
+        case Finished(result) => fromEither(result).flatten
+        case _ => evalOrSubscribe
+      }
     }
   }
 
@@ -143,7 +168,10 @@ object GenConcurrent {
   private sealed abstract class Memoize[F[_], E, A]
   private object Memoize {
     final case class Unevaluated[F[_], E, A]() extends Memoize[F, E, A]
-    final case class Evaluating[F[_], E, A](await: F[Unit]) extends Memoize[F, E, A]
+    final case class Evaluating[F[_], E, A](
+        fiber: Deferred[F, Fiber[F, E, A]],
+        subscribers: Long
+    ) extends Memoize[F, E, A]
     final case class Finished[F[_], E, A](result: Either[E, F[A]]) extends Memoize[F, E, A]
   }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -74,13 +74,14 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
                 val eval = go.start.flatMap { fiber =>
                   deferredFiber.complete(fiber) *>
                     poll(fiber.join.flatMap(_.embed(productR(canceled)(never))))
+                      .onCancel(unsubscribe(deferredFiber))
                 }
 
                 Evaluating(deferredFiber, 1) -> eval
 
               case Evaluating(fiber, subscribers) =>
                 Evaluating(fiber, subscribers + 1) ->
-                  poll(fiber.get.flatMap(_.join).flatMap(_.embedNever))
+                  poll(fiber.get.flatMap(_.join).flatMap(_.embed(productR(canceled)(never))))
                     .onCancel(unsubscribe(fiber))
 
               case finished @ Finished(result) =>

--- a/tests/shared/src/test/scala/cats/effect/MemoizeSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/MemoizeSpec.scala
@@ -100,6 +100,12 @@ class MemoizeSpec extends BaseSpec with Discipline {
       forAll { (fa: IO[Int]) => lowerK(Concurrent[F].memoize(liftK(fa)).flatten) eqv fa }
     }
 
+    "Concurrent.memoize uncancelable canceled and then flatten is identity" in ticked {
+      implicit ticker =>
+        val fa = Concurrent[F].uncancelable(_ => Concurrent[F].canceled)
+        lowerK(Concurrent[F].memoize(fa).flatten) eqv lowerK(fa)
+    }
+
     "Memoized effects can be canceled when there are no other active subscribers (1)" in ticked {
       implicit ticker =>
         val op = for {

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -1165,7 +1165,7 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
           def releasedMustBe(i: Int) = released.get.map(_ must be_==(i)).void
 
           r.memoize.use { memo =>
-            memo.timeoutTo(1.second, Resource.unit).use_
+            memo.timeoutTo(1.second, Resource.unit[IO]).use_
           } *> acquiredMustBe(1) *> releasedMustBe(1)
         }.void must completeAs(())
       }


### PR DESCRIPTION
In the old implementation, the first fiber to access the memo would take responsibility for evaluating the effect, and all other fibers would subscribe to its result. However, this meant that if this fiber got canceled, so would the effect evaluation, even if there are active subscribers.

In this new implementation, the first fiber to access the memo setups a background fiber to evaluate the effect. Then, all active subscribers take responsibility for it.

Fixes https://github.com/typelevel/cats-effect/issues/3348.