### PR TITLE
update the ref example

### DIFF
--- a/docs/std/ref.md
+++ b/docs/std/ref.md
@@ -9,6 +9,7 @@ A concurrent mutable reference.
 abstract class Ref[F[_], A] {
   def get: F[A]
   def set(a: A): F[Unit]
+  def updateAndGet(f: A => A): F[A]
   def modify[B](f: A => (A, B)): F[B]
   // ... and more
 }
@@ -27,48 +28,57 @@ upon object reference equality.
 
 ### Concurrent Counter
 
-This is probably one of the most common uses of this concurrency primitive.
+This is probably one of the most common uses of this concurrency primitive. 
 
-The workers will concurrently run and modify the value of the Ref so this is one possible outcome showing “#worker » currentCount”:
-
-```
-#2 >> 0
-#1 >> 0
-#3 >> 0
-#1 >> 0
-#3 >> 2
-#2 >> 1
-```
+In this example, the workers will concurrently run and update the value of the `Ref`.
 
 ```scala mdoc:reset:silent
-import cats.effect.{IO, Sync, Ref}
+//> using scala "2.13.10"
+//> using jvm "temurin:11"
+//> using lib "org.typelevel::cats-effect:3.4.4"
+
+import cats.effect.{IO, IOApp, Sync}
+import cats.effect.kernel.Ref
 import cats.syntax.all._
 
-class Worker[F[_]](number: Int, ref: Ref[F, Int])(implicit F: Sync[F]) {
+class Worker[F[_]](id: Int, ref: Ref[F, Int])(implicit F: Sync[F]) {
 
-  private def putStrLn(value: String): F[Unit] = F.delay(println(value))
+  private def putStrLn(value: String): F[Unit] =
+    F.blocking(println(value))
 
   def start: F[Unit] =
     for {
       c1 <- ref.get
-      _  <- putStrLn(show"#$number >> $c1")
-      c2 <- ref.modify(x => (x + 1, x))
-      _  <- putStrLn(show"#$number >> $c2")
+      _  <- putStrLn(show"Worker #$id >> $c1")
+      c2 <- ref.updateAndGet(x => x + 1)
+      _  <- putStrLn(show"Worker #$id >> $c2")
     } yield ()
-
 }
 
-val program: IO[Unit] =
-  for {
-    ref <- Ref[IO].of(0)
-    w1  = new Worker[IO](1, ref)
-    w2  = new Worker[IO](2, ref)
-    w3  = new Worker[IO](3, ref)
-    _   <- List(
-             w1.start,
-             w2.start,
-             w3.start
-           ).parSequence.void
-  } yield ()
+object RefExample extends IOApp.Simple {
+
+  val run: IO[Unit] =
+    for {
+      ref <- Ref[IO].of(0)
+      w1 = new Worker[IO](1, ref)
+      w2 = new Worker[IO](2, ref)
+      w3 = new Worker[IO](3, ref)
+      _ <- List(
+        w1.start,
+        w2.start,
+        w3.start,
+      ).parSequence.void
+    } yield ()
+}
 ```
 
+This is one possible outcome showing “Worker #id » currentCount”:
+
+```
+Worker #1 >> 0
+Worker #3 >> 0
+Worker #2 >> 0
+Worker #2 >> 3
+Worker #1 >> 1
+Worker #3 >> 2
+```

--- a/docs/std/ref.md
+++ b/docs/std/ref.md
@@ -33,8 +33,6 @@ This is probably one of the most common uses of this concurrency primitive.
 In this example, the workers will concurrently run and update the value of the `Ref`.
 
 ```scala mdoc:reset:silent
-//> using scala "2.13.10"
-//> using jvm "temurin:11"
 //> using lib "org.typelevel::cats-effect:3.4.4"
 
 import cats.effect.{IO, IOApp, Sync}


### PR DESCRIPTION
While looking at `Ref` today I noticed the example was a bit dated. I've made the following changes:
- use scala-cli + `IOApp.Simple` for a complete runnable example
- minor updates to the example code
  - more obvious difference between worker ID and the ref count in
    `putStrLn`
  - switch to `updateAndGet` from modify, I think it's a bit more
    intuitive to see 0,0,0,1,2,3 in the output vs. 0,0,0,0,1,2
- add `updateAndGet` to class reference, since I'm using it in the example
- shift example output to below the code

~One concern is that the `using` statements in scala-cli are hardcoded to scala 2.13.10 and cats-effect 3.4.4. Ideally these would be set as mdoc variables, but I'm not sure where/how to go about doing that.~ Update: Dropped the scala/jvm usings, and the cats-effect version isn't adding much to the existing toil of an update (a future consideration though)