### PR TITLE
Encourage alternatives to `IOApp` for browser apps

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOApp.scala
+++ b/core/js/src/main/scala/cats/effect/IOApp.scala
@@ -127,6 +127,12 @@ import scala.util.Try
  * number of compute worker threads to "make room" for the I/O workers, such that they all sum
  * to the number of physical threads exposed by the kernel.
  *
+ * @note
+ *   While [[IOApp]] works perfectly fine for browser applications, in practice it brings little
+ *   value over calling [[IO.unsafeRunAndForget]]. You can use your UI framework's preferred API
+ *   for defining your application's entrypoint. On the other hand, Node.js applications must
+ *   use [[IOApp]] to behave correctly.
+ *
  * @see
  *   [[IO]]
  * @see


### PR DESCRIPTION
While `IOApp` can be used to make a browser application, in practice it brings little value over `unsafeRunAndForget()`.

Various caveats of using `IOApp` in the browser:
- there is no need for a "keep alive" fiber
- there are no command line args and no exit codes
- there are no signals to setup for cancellation/fiber dumps
- indeed, there is [no reliable notion of life cycle](https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event#usage_notes) at all
- it interacts poorly with hot module reloading
  https://github.com/typelevel/cats-effect/issues/1959
- starvation checking might be annoying[^1]
  https://github.com/typelevel/cats-effect/issues/3321

Furthermore, web frameworks such as Calico or Tyrian generally offer a dedicated API for defining the application entrypoint.

[^1]: although I still think it's valuable