### PR TITLE
Fix hang in `Dispatcher.sequential(await = true)` release

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -16,7 +16,7 @@
 
 package cats.effect.std
 
-import cats.effect.kernel.{Async, Outcome, Ref, Resource}
+import cats.effect.kernel.{Async, Outcome, Resource}
 import cats.syntax.all._
 
 import scala.annotation.tailrec
@@ -248,7 +248,7 @@ object Dispatcher {
 
       _ <- {
         def dispatcher(
-            doneR: Ref[F, Boolean],
+            doneR: AtomicBoolean,
             latch: AtomicReference[() => Unit],
             state: Array[AtomicReference[List[Registration]]]): F[Unit] = {
 
@@ -290,15 +290,18 @@ object Dispatcher {
           F.delay(latch.set(Noop)) *> // reset latch
             // if we're marked as done, yield immediately to give other fibers a chance to shut us down
             // we might loop on this a few times since we're marked as done before the supervisor is canceled
-            doneR.get.ifM(F.cede, step)
+            F.delay(doneR.get()).ifM(F.cede, step)
         }
 
         0.until(workers).toList traverse_ { n =>
-          Resource.eval(F.ref(false)) flatMap { doneR =>
+          Resource.eval(F.delay(new AtomicBoolean(false))) flatMap { doneR =>
             val latch = latches(n)
             val worker = dispatcher(doneR, latch, states(n))
             val release = F.delay(latch.getAndSet(Open)())
-            Resource.make(supervisor.supervise(worker))(_ => doneR.set(true) >> release)
+            Resource.make(supervisor.supervise(worker)) { _ =>
+              // published by release
+              F.delay(doneR.lazySet(true)) *> release
+            }
           }
         }
       }

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -23,7 +23,7 @@ import cats.syntax.all._
 
 import scala.concurrent.duration._
 
-class DispatcherSpec extends BaseSpec {
+class DispatcherSpec extends BaseSpec with DetectPlatform {
 
   override def executionTimeout = 30.seconds
 
@@ -34,6 +34,14 @@ class DispatcherSpec extends BaseSpec {
       sequential(D)
 
       awaitTermination(D)
+
+      "not hang" in real {
+        Dispatcher
+          .sequential[IO](await = true)
+          .use { dispatcher => IO(dispatcher.unsafeRunAndForget(IO.unit)) }
+          .replicateA(if (isJS || isNative) 1 else 10000)
+          .as(true)
+      }
     }
 
     "await = false" >> {

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -36,9 +36,7 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
       awaitTermination(D)
 
       "not hang" in real {
-        Dispatcher
-          .sequential[IO](await = true)
-          .use { dispatcher => IO(dispatcher.unsafeRunAndForget(IO.unit)) }
+        D.use(dispatcher => IO(dispatcher.unsafeRunAndForget(IO.unit)))
           .replicateA(if (isJS || isNative) 1 else 10000)
           .as(true)
       }


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/3363. Verified by running the reproducer for ~ 15 minutes without hanging.

First commit is the fix + test, second commit is an optimization.