### PR TITLE
Bypass `IO`-specialized `Deferred` for now

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1434,7 +1434,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
   def ref[A](a: A): IO[Ref[IO, A]] = IO(Ref.unsafe(a))
 
-  def deferred[A]: IO[Deferred[IO, A]] = IO(new IODeferred[A])
+  def deferred[A]: IO[Deferred[IO, A]] = IO(Deferred.unsafe)
 
   def bracketFull[A, B](acquire: Poll[IO] => IO[A])(use: A => IO[B])(
       release: (A, OutcomeIO[B]) => IO[Unit]): IO[B] =

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1585,7 +1585,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
     }
 
     "produce a specialized version of Deferred" in real {
-      IO.deferred[Unit].flatMap(d => IO(d must haveClass[IODeferred[_]]))
+      IO.deferred[Unit].flatMap(d => IO((d must haveClass[IODeferred[_]]).pendingUntilFixed))
     }
 
     platformSpecs


### PR DESCRIPTION
I have a fix for `CallbackStack` locally, but it needs more time to bake and the cost of a release is very low. Let's just get this out and then come back to it in the next increment.

Fixes #3359 