### PR TITLE
Add `fromFutureCancelable` and friends

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -43,8 +43,14 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
   def fromThenable[A](iot: IO[Thenable[A]]): IO[A] =
     asyncForIO.fromThenable(iot)
 
+  def fromThenableCancelable[A](iot: IO[(Thenable[A], IO[Unit])]): IO[A] =
+    asyncForIO.fromThenableCancelable(iot)
+
   def fromPromise[A](iop: IO[Promise[A]]): IO[A] =
     asyncForIO.fromPromise(iop)
+
+  def fromPromiseCancelable[A](iop: IO[(Promise[A], IO[Unit])]): IO[A] =
+    asyncForIO.fromPromiseCancelable(iop)
 
   def realTimeDate: IO[js.Date] = asyncForIO.realTimeDate
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1486,10 +1486,16 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
    * }}}
    *
    * @see
-   *   [[IO#unsafeToFuture]]
+   *   [[IO#unsafeToFuture]], [[fromFutureCancelable]]
    */
   def fromFuture[A](fut: IO[Future[A]]): IO[A] =
     asyncForIO.fromFuture(fut)
+
+  /**
+   * Like [[fromFuture]], but is cancelable via the provided finalizer.
+   */
+  def fromFutureCancelable[A](fut: IO[(Future[A], IO[Unit])]): IO[A] =
+    asyncForIO.fromFutureCancelable(fut)
 
   /**
    * Run two IO tasks concurrently, and return the first to finish, either in success or error.

--- a/kernel/js/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
+++ b/kernel/js/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
@@ -22,24 +22,36 @@ private[kernel] trait AsyncPlatform[F[_]] { this: Async[F] =>
 
   def fromPromise[A](iop: F[Promise[A]]): F[A] = fromThenable(widen(iop))
 
+  def fromPromiseCancelable[A](iop: F[(Promise[A], F[Unit])]): F[A] =
+    fromThenableCancelable(widen(iop))
+
   def fromThenable[A](iot: F[Thenable[A]]): F[A] =
     flatMap(iot) { t =>
       async_[A] { cb =>
-        val onFulfilled: Function1[A, Unit | Thenable[Unit]] =
-          (v: A) => cb(Right(v)): Unit | Thenable[Unit]
-
-        val onRejected: Function1[Any, Unit | Thenable[Unit]] = { (a: Any) =>
-          val e = a match {
-            case th: Throwable => th
-            case _ => JavaScriptException(a)
-          }
-
-          cb(Left(e)): Unit | Thenable[Unit]
-        }
-
-        t.`then`[Unit](onFulfilled, defined(onRejected))
-
+        t.`then`[Unit](mkOnFulfilled(cb), defined(mkOnRejected(cb)))
         ()
       }
     }
+
+  def fromThenableCancelable[A](iot: F[(Thenable[A], F[Unit])]): F[A] =
+    flatMap(iot) {
+      case (t, fin) =>
+        async[A] { cb =>
+          as(delay(t.`then`[Unit](mkOnFulfilled(cb), defined(mkOnRejected(cb)))), Some(fin))
+        }
+    }
+
+  @inline private[this] def mkOnFulfilled[A](
+      cb: Either[Throwable, A] => Unit): Function1[A, Unit | Thenable[Unit]] =
+    (v: A) => cb(Right(v)): Unit | Thenable[Unit]
+
+  @inline private[this] def mkOnRejected[A](
+      cb: Either[Throwable, A] => Unit): Function1[Any, Unit | Thenable[Unit]] = { (a: Any) =>
+    val e = a match {
+      case th: Throwable => th
+      case _ => JavaScriptException(a)
+    }
+
+    cb(Left(e)): Unit | Thenable[Unit]
+  }
 }

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1416,6 +1416,16 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         }
       }
 
+      "round trip cancelable through s.c.Future" in ticked { implicit ticker =>
+        forAll { (ioa: IO[Int]) =>
+          ioa eqv IO.fromFutureCancelable(
+            IO(ioa.unsafeToFutureCancelable()).map {
+              case (fut, fin) => (fut, IO.fromFuture(IO(fin())))
+            }
+          )
+        }
+      }
+
       "canceled through s.c.Future is errored" in ticked { implicit ticker =>
         val test =
           IO.fromFuture(IO(IO.canceled.as(-1).unsafeToFuture())).handleError(_ => 42)

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -28,7 +28,7 @@ import cats.syntax.all._
 import org.scalacheck.Prop
 import org.typelevel.discipline.specs2.mutable.Discipline
 
-import scala.concurrent.{ExecutionContext, TimeoutException}
+import scala.concurrent.{CancellationException, ExecutionContext, TimeoutException}
 import scala.concurrent.duration._
 
 import Prop.forAll
@@ -1418,11 +1418,13 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
 
       "round trip cancelable through s.c.Future" in ticked { implicit ticker =>
         forAll { (ioa: IO[Int]) =>
-          ioa eqv IO.fromFutureCancelable(
-            IO(ioa.unsafeToFutureCancelable()).map {
-              case (fut, fin) => (fut, IO.fromFuture(IO(fin())))
-            }
-          )
+          ioa eqv IO
+            .fromFutureCancelable(
+              IO(ioa.unsafeToFutureCancelable()).map {
+                case (fut, fin) => (fut, IO.fromFuture(IO(fin())))
+              }
+            )
+            .recoverWith { case _: CancellationException => IO.canceled *> IO.never[Int] }
         }
       }
 


### PR DESCRIPTION
This is a follow-up to:
- https://github.com/typelevel/cats-effect/pull/3205

I was working on http4s-dom and encountered roughly this:

```scala
F.fromPromise(F.delay(Fetch.fetch(...))).onCancel(F.delay(abortController.abort()))
```

The problem is that `fromPromise` is implemented via `async_` which will be uncancelable under the new semantics. Without a `fromPromiseCancelable` variant I'd have to re-implement the conversion logic or run it on another fiber, so here we are.

Along these lines I also added `fromFutureCancelable`. I did not add a variant for `CompletableFuture` because its API natively supports cancelation (go Java! :trollface:). As a plus side, these methods offer an escape hatch for anyone who is bitten by the new semantics.

The method names and signatures feel a bit unergonomic so definitely open to bikeshed. I didn't try too hard to share implementations since it would also be messy.