### PR TITLE
Refactor `fromCompletableFuture` to use `cont`

### DIFF
--- a/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-package cats.effect.kernel
+package cats
+package effect.kernel
 
 import java.util.concurrent.{CompletableFuture, CompletionException, CompletionStage}
 
@@ -29,28 +30,36 @@ private[kernel] trait AsyncPlatform[F[_]] extends Serializable { this: Async[F] 
    * @param fut
    *   The `java.util.concurrent.CompletableFuture` to suspend in `F[_]`
    */
-  def fromCompletableFuture[A](fut: F[CompletableFuture[A]]): F[A] =
-    async[A] { cb =>
-      flatMap(fut) { cf =>
-        delay {
-          cf.handle[Unit] {
-            case (a, null) => cb(Right(a))
-            case (_, t) =>
-              cb(Left(t match {
-                case e: CompletionException if e.getCause ne null => e.getCause
-                case _ => t
-              }))
-          }
-
-          Some(
-            ifM(delay(cf.cancel(false)))(
-              unit,
-              async_[Unit] { cb =>
-                cf.handle[Unit]((_, _) => cb(Right(())))
-                ()
+  def fromCompletableFuture[A](fut: F[CompletableFuture[A]]): F[A] = flatMap(fut) { cf =>
+    cont {
+      new Cont[F, A, A] {
+        def apply[G[_]](
+            implicit
+            G: MonadCancelThrow[G]): (Either[Throwable, A] => Unit, G[A], F ~> G) => G[A] = {
+          (resume, get, lift) =>
+            G.uncancelable { poll =>
+              val go = delay {
+                cf.handle[Unit] {
+                  case (a, null) => resume(Right(a))
+                  case (_, t) =>
+                    resume(Left(t match {
+                      case e: CompletionException if e.getCause ne null => e.getCause
+                      case _ => t
+                    }))
+                }
               }
-            ))
+
+              val await = G.onCancel(
+                poll(get),
+                // if cannot cancel, fallback to get
+                G.ifM(lift(delay(cf.cancel(false))))(G.unit, G.void(get))
+              )
+
+              G.productR(lift(go))(await)
+            }
         }
       }
     }
+  }
+
 }


### PR DESCRIPTION
In the previous implementation, to ensure backpressure in the case that the `CompletableFuture` could not be canceled, a second callback was registered on it. By re-implementing via `cont` we can fallback to awaiting the already installed callback.