### PR TITLE
Fixed example code for CPU starvation checking in documentation.

### DIFF
--- a/docs/core/starvation-and-tuning.md
+++ b/docs/core/starvation-and-tuning.md
@@ -49,20 +49,20 @@ Before diving into how we can correct issues with CPU starvation, it is worth un
 ```scala mdoc:silent
 import scala.concurrent.duration._
 
-val Threshold = 0.1d
+val starvationThreshold = 0.1.seconds
+val sleepInterval       = 1.second
 
 val tick: IO[Unit] =
   // grab a time offset from when we started
   IO.monotonic flatMap { start =>
     // sleep for some long interval, then measure when we woke up
-    // get the difference (this will always be a bit more than 1.second)
-    IO.sleep(1.second) *> IO.monotonic.map(_ - start) flatMap { delta =>
-      // the delta here is the amount of *lag* in the scheduler
-      // specifically, the time between requesting CPU access and actually getting it
-      IO.println("starvation detected").whenA(delta > 1.second * Threshold)
+    // get the difference (this will always be a bit more than the interval we slept for)
+    IO.sleep(sleepInterval) *> IO.monotonic.map(_ - start) flatMap { delta =>
+      // the delta here is the sum of the sleep interval and the amount of *lag* in the scheduler
+      // specifically, the lag is the time between requesting CPU access and actually getting it
+      IO.println("starvation detected").whenA(delta - sleepInterval > starvationThreshold)
     }
   }
-
 // add an initial delay
 // run the check infinitely, forked to a separate fiber
 val checker: IO[Unit] = (IO.sleep(1.second) *> tick.foreverM).start.void


### PR DESCRIPTION
**What**
Fixed a bug in the example code that shows how CPU starvation checking can be implemented.

**Why**
To ensure the documentation is correct.

**Details**
The existing code will always conclude CPU starvation has occurred and print out a warning message because the `delta` value is assumed to be "the time between requesting CPU access and actually getting it" but it is actually the **sum** of the sleep interval and "the time between requesting CPU access and actually getting it". 