### PR TITLE
Feature test for `clearTimeout`

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
@@ -44,7 +44,7 @@ private[unsafe] abstract class SchedulerCompanionPlatform { this: Scheduler.type
       },
       () => ())
 
-  private[this] val nowMicrosImpl: () => Long = {
+  private[this] val nowMicrosImpl: js.Function0[Long] = {
     def test(performance: Performance) = {
       // take it for a spin
       !(performance.timeOrigin + performance.now()).isNaN
@@ -64,7 +64,7 @@ private[unsafe] abstract class SchedulerCompanionPlatform { this: Scheduler.type
           .filter(test)
       }.toOption.flatMap(_.toOption)
 
-    browsers.orElse(nodeJS).map { performance => () =>
+    browsers.orElse(nodeJS).map[js.Function0[Long]] { performance => () =>
       ((performance.timeOrigin + performance.now()) * 1000).toLong
     } getOrElse { () => System.currentTimeMillis() * 1000 }
   }

--- a/tests/js/src/test/scala/cats/effect/unsafe/SchedulerSpec.scala
+++ b/tests/js/src/test/scala/cats/effect/unsafe/SchedulerSpec.scala
@@ -19,6 +19,8 @@ package unsafe
 
 import scala.concurrent.duration._
 
+import java.util.concurrent.atomic.AtomicBoolean
+
 class SchedulerSpec extends BaseSpec {
 
   "Default scheduler" should {
@@ -41,6 +43,17 @@ class SchedulerSpec extends BaseSpec {
         case (realTime, currentTime) =>
           (realTime.toMillis - currentTime) should be_<=(1L)
       }
+    }
+    "cancel" in real {
+      val scheduler = IORuntime.global.scheduler
+      for {
+        ref <- IO(new AtomicBoolean(true))
+        cancel <- IO(scheduler.sleep(200.millis, () => ref.set(false)))
+        _ <- IO.sleep(100.millis)
+        _ <- IO(cancel.run())
+        _ <- IO.sleep(200.millis)
+        didItCancel <- IO(ref.get())
+      } yield didItCancel
     }
   }
 


### PR DESCRIPTION
It turns out that raw V8 doesn't implement `clearTimeout`. So we add a feature-test for this, and no-op timer cancelation if it's missing. This is annoying and a memory leak, but at least it doesn't break `IO` semantics since cancelation is also implemented at that layer. And it's better than crashing.

FTR V8 standalone is not a very practical runtime, but it does expose several diagnostics (similar to JVM `-XX:+UnlockDiagnosticVMOptions`), so it's useful to be able to run a basic Cats Effect application in it without crashing.