### PR TITLE
Protect timers against Long overflow

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/SleepCallback.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SleepCallback.scala
@@ -75,5 +75,5 @@ private object SleepCallback {
   }
 
   implicit val sleepCallbackReverseOrdering: Ordering[SleepCallback] =
-    Ordering.fromLessThan(_.triggerTime > _.triggerTime)
+    Ordering.fromLessThan(_.triggerTime - _.triggerTime > 0)
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -401,7 +401,7 @@ private final class WorkerThread(
         while (cont) {
           val head = sleepers.head()
 
-          if (head.triggerTime <= now) {
+          if (head.triggerTime - now <= 0) {
             if (head.get()) {
               head.callback(RightUnit)
             }


### PR DESCRIPTION
The `System.nanoTime` docs say this:

> To compare two nanoTime values ... one should use `t1 - t0 < 0`, not `t1 < t0`, because of the possibility of numerical overflow.