### PR TITLE
Handle if async callback receives null

### DIFF
--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -514,10 +514,11 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
           latch <- Deferred[IO, Unit]
           fib <- IO.async[Int] { cb => cbp.complete(cb) *> latch.get.as(None) }.start
           cb <- cbp.get
-          (_, r) <- IO.both(
+          _r <- IO.both(
             latch.complete(()) *> IO.sleep(0.1.second) *> IO(cb(null)),
             fib.joinWithNever.attempt
           )
+          (_, r) = _r
           _ <- IO(r must beLeft(beAnInstanceOf[NullPointerException]))
         } yield ok
       }

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -319,12 +319,12 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         ioa must completeAs(44)
       }
 
-      "result in an null if lifting a pure null value" in ticked { implicit ticker =>
+      "result in a null if lifting a pure null value" in ticked { implicit ticker =>
         // convoluted in order to avoid scalac warnings
         IO.pure(null).map(_.asInstanceOf[Any]).map(_ == null) must completeAs(true)
       }
 
-      "result in an NPE if delaying a null value" in ticked { implicit ticker =>
+      "result in a null if delaying a null value" in ticked { implicit ticker =>
         IO(null).map(_.asInstanceOf[Any]).map(_ == null) must completeAs(true)
         IO.delay(null).map(_.asInstanceOf[Any]).map(_ == null) must completeAs(true)
       }
@@ -334,7 +334,6 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
           .attempt
           .map(_.left.toOption.get.isInstanceOf[NullPointerException]) must completeAs(true)
       }
-
     }
 
     "fibers" should {
@@ -475,6 +474,52 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         } yield value
 
         test.attempt.flatMap { n => IO(n mustEqual Right(42)) }
+      }
+
+      "calling async callback with null during registration (ticked)" in ticked {
+        implicit ticker =>
+          IO.async[Int] { cb => IO(cb(null)).as(None) }
+            .map(_ + 1)
+            .attempt
+            .map(_.left.toOption.get.isInstanceOf[NullPointerException]) must completeAs(true)
+      }
+
+      "calling async callback with null after registration (ticked)" in ticked {
+        implicit ticker =>
+          val test = for {
+            cbp <- Deferred[IO, Either[Throwable, Int] => Unit]
+            fib <- IO.async[Int] { cb => cbp.complete(cb).as(None) }.start
+            _ <- IO(ticker.ctx.tickAll())
+            cb <- cbp.get
+            _ <- IO(ticker.ctx.tickAll())
+            _ <- IO(cb(null))
+            e <- fib.joinWithNever.attempt
+          } yield e.left.toOption.get.isInstanceOf[NullPointerException]
+
+          test must completeAs(true)
+      }
+
+      "calling async callback with null during registration (real)" in real {
+        IO.async[Int] { cb => IO(cb(null)).as(None) }
+          .map(_ + 1)
+          .attempt
+          .map(_.left.toOption.get.isInstanceOf[NullPointerException])
+          .flatMap { r => IO(r must beTrue) }
+      }
+
+      "calling async callback with null after registration (real)" in real {
+        val test = for {
+          cbp <- Deferred[IO, Either[Throwable, Int] => Unit]
+          latch <- Deferred[IO, Unit]
+          fib <- IO.async[Int] { cb => cbp.complete(cb) *> latch.get.as(None) }.start
+          cb <- cbp.get
+          r <- IO.both(
+            latch.complete(()) *> IO.sleep(0.1.second) *> IO(cb(null)),
+            fib.joinWithNever.attempt
+          )
+        } yield r._2.left.toOption.get.isInstanceOf[NullPointerException]
+
+        test.flatMap { r => IO(r must beTrue) }
       }
 
       "complete a fiber with Canceled under finalizer on poll" in ticked { implicit ticker =>


### PR DESCRIPTION
If an async callback is called with `null`, instead of hanging, behave as if it was called with `Left(new NullPointerException)`.

This is a change in behavior. But I would be surprised, if anybody would prefer the current behavior.

See also #1178.