### PR TITLE
Simplify ContState

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -604,7 +604,11 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       // introduced by #3324, which specialized CallbackStack for JS
       // internal API change
       ProblemFilters.exclude[DirectMissingMethodProblem](
-        "cats.effect.CallbackStack.clearCurrent")
+        "cats.effect.CallbackStack.clearCurrent"),
+      // #3393, ContState is a private class:
+      ProblemFilters.exclude[MissingTypesProblem]("cats.effect.ContState"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.ContState.result"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.ContState.result_="),
     ) ++ {
       if (tlIsScala3.value) {
         // Scala 3 specific exclusions

--- a/build.sbt
+++ b/build.sbt
@@ -609,6 +609,11 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       ProblemFilters.exclude[MissingTypesProblem]("cats.effect.ContState"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.ContState.result"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.ContState.result_="),
+      // #3393, IOFiberConstants is a (package) private class/object:
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IOFiberConstants.ContStateInitial"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IOFiberConstants.ContStateWaiting"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IOFiberConstants.ContStateWinner"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IOFiberConstants.ContStateResult"),
     ) ++ {
       if (tlIsScala3.value) {
         // Scala 3 specific exclusions

--- a/core/js-native/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js-native/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -44,10 +44,4 @@ private object IOFiberConstants {
   final val AutoCedeR = 7
   final val ExecuteRunnableR = 8
   final val DoneR = 9
-
-  // unused, but remains here for bincompat:
-  final val ContStateInitial = 0
-  final val ContStateWaiting = 1
-  final val ContStateWinner = 2
-  final val ContStateResult = 3
 }

--- a/core/js-native/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js-native/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -44,10 +44,4 @@ private object IOFiberConstants {
   final val AutoCedeR = 7
   final val ExecuteRunnableR = 8
   final val DoneR = 9
-
-  // ContState tags
-  final val ContStateInitial = 0
-  final val ContStateWaiting = 1
-  final val ContStateWinner = 2
-  final val ContStateResult = 3
 }

--- a/core/js-native/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js-native/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -44,4 +44,10 @@ private object IOFiberConstants {
   final val AutoCedeR = 7
   final val ExecuteRunnableR = 8
   final val DoneR = 9
+
+  // unused, but remains here for bincompat:
+  final val ContStateInitial = 0
+  final val ContStateWaiting = 1
+  final val ContStateWinner = 2
+  final val ContStateResult = 3
 }

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -44,4 +44,10 @@ final class IOFiberConstants {
   static final byte AutoCedeR = 7;
   static final byte ExecuteRunnableR = 8;
   static final byte DoneR = 9;
+
+  // unused, but remains here for bincompat:
+  static final int ContStateInitial = 0;
+  static final int ContStateWaiting = 1;
+  static final int ContStateWinner = 2;
+  static final int ContStateResult = 3;
 }

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -44,10 +44,4 @@ final class IOFiberConstants {
   static final byte AutoCedeR = 7;
   static final byte ExecuteRunnableR = 8;
   static final byte DoneR = 9;
-
-  // unused, but remains here for bincompat:
-  static final int ContStateInitial = 0;
-  static final int ContStateWaiting = 1;
-  static final int ContStateWinner = 2;
-  static final int ContStateResult = 3;
 }

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -44,10 +44,4 @@ final class IOFiberConstants {
   static final byte AutoCedeR = 7;
   static final byte ExecuteRunnableR = 8;
   static final byte DoneR = 9;
-
-  // ContState tags
-  static final int ContStateInitial = 0;
-  static final int ContStateWaiting = 1;
-  static final int ContStateWinner = 2;
-  static final int ContStateResult = 3;
 }

--- a/core/shared/src/main/scala/cats/effect/ContState.scala
+++ b/core/shared/src/main/scala/cats/effect/ContState.scala
@@ -42,7 +42,7 @@ private final class ContState(var wasFinalizing: Boolean)
   var handle: WeakBag.Handle = _
 }
 
-private final object ContState {
+private object ContState {
 
   /**
    * This is a sentinel, signifying a "waiting" state of `ContState`; only its identity is

--- a/core/shared/src/main/scala/cats/effect/ContState.scala
+++ b/core/shared/src/main/scala/cats/effect/ContState.scala
@@ -18,11 +18,37 @@ package cats.effect
 
 import cats.effect.unsafe.WeakBag
 
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
-// `result` is published by a volatile store on the atomic integer extended by this class.
-// `wasFinalizing` and `handle` are published in terms of the `suspended` atomic variable in `IOFiber`
-private final class ContState(var wasFinalizing: Boolean) extends AtomicInteger(0) {
-  var result: Either[Throwable, Any] = _
+/**
+ * Possible states (held in the `AtomicReference`):
+ *   - "initial": `get() == null`
+ *   - "waiting": `get() == waiting` (sentinel)
+ *   - "result": `get()` is the result from the callback
+ *
+ * Note: A `null` result is forbidden, so "initial" is always different from "result". Also,
+ * `waitingSentinel` is private, so that can also be differentiated from a result (by object
+ * identity).
+ *
+ * `wasFinalizing` and `handle` are published in terms of the `suspended` atomic variable in
+ * `IOFiber`
+ */
+private final class ContState(var wasFinalizing: Boolean)
+    extends AtomicReference[Either[Throwable, Any]] {
+
+  val waiting: Either[Throwable, Any] =
+    ContState.waitingSentinel // this is just a reference to the sentinel
+
   var handle: WeakBag.Handle = _
+}
+
+private final object ContState {
+
+  /**
+   * This is a sentinel, signifying a "waiting" state of `ContState`; only its identity is
+   * important. It must be private (so that no user code can access it), and it mustn't be used
+   * for any other purpose.
+   */
+  private val waitingSentinel: Either[Throwable, Any] =
+    new Right(null)
 }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -588,8 +588,8 @@ private final class IOFiber[A](
            * `asyncContinue`.
            *
            * If `get` wins, it gets the result from the `state`
-           * `AtomicRef` and it continues, while the callback just
-           * terminates (`stateLoop`, when `tag == 3`)
+           * `AtomicReference` and it continues, while the callback just
+           * terminates (`stateLoop`, when `(tag ne null) && (tag ne waiting)`)
            *
            * The two sides communicate with each other through
            * `state` to know who should take over, and through
@@ -677,32 +677,32 @@ private final class IOFiber[A](
                */
             }
 
+            val waiting = state.waiting
+
             /*
              * CAS loop to update the Cont state machine:
-             * 0 - Initial
-             * 1 - (Get) Waiting
-             * 2 - (Cb) Result
+             * null - initial
+             * waiting - (Get) waiting
+             * anything else - (Cb) result
              *
-             * If state is Initial or Waiting, update the state,
+             * If state is "initial" or "waiting", update the state,
              * and then if `get` has been flatMapped somewhere already
              * and is waiting for a result (i.e. it has suspended),
              * acquire runloop to continue.
              *
              * If not, `cb` arrived first, so it just sets the result and die off.
              *
-             * If `state` is `Result`, the callback has been already invoked, so no-op.
-             * (guards from double calls)
+             * If `state` is "result", the callback has been already invoked, so no-op
+             * (guards from double calls).
              */
             @tailrec
             def stateLoop(): Unit = {
               val tag = state.get()
-              if (tag <= ContStateWaiting) {
-                if (!state.compareAndSet(tag, ContStateWinner)) stateLoop()
-                else {
-                  state.result = result
-                  // The winner has to publish the result.
-                  state.set(ContStateResult)
-                  if (tag == ContStateWaiting) {
+              if ((tag eq null) || (tag eq waiting)) {
+                if (!state.compareAndSet(tag, result)) {
+                  stateLoop()
+                } else {
+                  if (tag eq waiting) {
                     /*
                      * `get` has been sequenced and is waiting
                      * reacquire runloop to continue
@@ -729,20 +729,20 @@ private final class IOFiber[A](
 
           /*
            * If get gets canceled but the result hasn't been computed yet,
-           * restore the state to Initial to ensure a subsequent `Get` in
+           * restore the state to "initial" (null) to ensure a subsequent `Get` in
            * a finalizer still works with the same logic.
            */
           val fin = IO {
-            state.compareAndSet(ContStateWaiting, ContStateInitial)
+            state.compareAndSet(state.waiting, null)
             ()
           }
           finalizers.push(fin)
           conts = ByteStack.push(conts, OnCancelK)
 
-          if (state.compareAndSet(ContStateInitial, ContStateWaiting)) {
+          if (state.compareAndSet(null, state.waiting)) {
             /*
-             * `state` was Initial, so `get` has arrived before the callback,
-             * it needs to set the state to `Waiting` and suspend: `cb` will
+             * `state` was "initial" (null), so `get` has arrived before the callback,
+             * it needs to set the state to "waiting" and suspend: `cb` will
              * resume with the result once that's ready
              */
 
@@ -796,30 +796,27 @@ private final class IOFiber[A](
             }
           } else {
             /*
-             * state was no longer Initial, so the callback has already been invoked
-             * and the state is Result.
-             * We leave the Result state unmodified so that `get` is idempotent.
+             * State was no longer "initial" (null), as the CAS above failed; so the
+             * callback has already been invoked and the state is "result".
+             * We leave the "result" state unmodified so that `get` is idempotent.
              *
-             * Note that it's impossible for `state` to be `Waiting` here:
+             * Note that it's impossible for `state` to be "waiting" here:
              * - `cont` doesn't allow concurrent calls to `get`, so there can't be
-             *    another `get` in `Waiting` when we execute this.
+             *    another `get` in "waiting" when we execute this.
              *
              * - If a previous `get` happened before this code, and we are in a `flatMap`
              *   or `handleErrorWith`, it means the callback has completed once
              *   (unblocking the first `get` and letting us execute), and the state is still
-             *   `Result`
+             *   "result".
              *
              * - If a previous `get` has been canceled and we are being called within an
              *  `onCancel` of that `get`, the finalizer installed on the `Get` node by `Cont`
-             *   has restored the state to `Initial` before the execution of this method,
+             *   has restored the state to "initial" before the execution of this method,
              *   which would have been caught by the previous branch unless the `cb` has
-             *   completed and the state is `Result`
+             *   completed and the state is "result"
              */
 
-            // Wait for the winner to publish the result.
-            while (state.get() != ContStateResult) ()
-
-            val result = state.result
+            val result = state.get()
 
             if (!shouldFinalize()) {
               /* we weren't canceled, so resume the runloop */


### PR DESCRIPTION
##### This is the commit message:

Instead of having 4 separate states (initial, waiting, winner and result) now we only have 3: initial, waiting and result. Instead of an `AtomicInteger` storing tags, now we use an `AtomicReference` for the result, and 2 sentinels: `null` for "initial", and a private object for "waiting".

This allows us to publish the result with a single CAS (instead of a CAS and a volatile write). We can also get rid of the spinning in `Get` (since we don't have to wait for the transition between "winner" and "result").

There should be no observable change in behavior (except maybe a small performance improvement).

##### Other comments:

I'm not sure about this, but I already did the work, so here it is.

What I think is good: somewhat simpler code; no spinning  in `Get`.

But the "waiting" sentinel is not exactly pretty...

##### Performance:

I've run 2 seemingly relevant benchmarks in `AsyncBenchmark`, here are the results. The difference is really small (like 1.5%), so I'm not sure if it's real. But if it's real, then it's slightly faster :-)

```
1263a9017 (series/3.4.x):

[info] Benchmark                  (size)   Mode  Cnt      Score     Error  Units
[info] AsyncBenchmark.async          100  thrpt   25  47030.178 ± 252.288  ops/s
[info] AsyncBenchmark.cancelable     100  thrpt   25  42272.219 ± 174.570  ops/s


f8c656413 (this PR):

[info] Benchmark                  (size)   Mode  Cnt      Score     Error  Units
[info] AsyncBenchmark.async          100  thrpt   25  47769.803 ± 236.728  ops/s
[info] AsyncBenchmark.cancelable     100  thrpt   25  42964.563 ± 122.446  ops/s
```
