### PR TITLE
Fix `CallbackStack` leak, restore specialized `IODeferred`

### DIFF
--- a/core/js/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/js/src/main/scala/cats/effect/CallbackStack.scala
@@ -57,6 +57,8 @@ private final class CallbackStackOps[A](private val callbacks: js.Array[A => Uni
 
   @inline def clear(): Unit =
     callbacks.length = 0 // javascript is crazy!
+
+  @inline def pack(bound: Int): Int = bound
 }
 
 private object CallbackStack {

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -80,35 +80,40 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
 
   /**
    * It is intended that `bound` be tracked externally and incremented on each clear(). Whenever
-   * pack is called, the number of empty cells removed from the stack is produced. It is expected
-   * that this value should be subtracted from `bound` for the subsequent pack/clear calls. It is
-   * permissible to pack on every clear() for simplicity, though it may be more reasonable to delay
-   * pack() calls until bound exceeds some reasonable threshold.
+   * pack is called, the number of empty cells removed from the stack is produced. It is
+   * expected that this value should be subtracted from `bound` for the subsequent pack/clear
+   * calls. It is permissible to pack on every clear() for simplicity, though it may be more
+   * reasonable to delay pack() calls until bound exceeds some reasonable threshold.
    *
-   * The observation here is that it is cheapest to remove empty cells from the front of the list,
-   * but very expensive to remove them from the back of the list, and so we can be relatively
-   * aggressive about the former and conservative about the latter. In a "pack on every clear"
-   * protocol, the best possible case is if we're always clearing at the very front of the list.
-   * In this scenario, pack is always O(1). Conversely, the worst possible scenario is when we're
-   * clearing at the *end* of the list. In this case, we won't actually remove any cells until
-   * exactly half the list is emptied (thus, the number of empty cells is equal to the number of
-   * full cells). In this case, the final pack is O(n), while the accumulated wasted packs (which
-   * will fail to remove any items) will total to O((n / 2)^2). Thus, in the worst case, we would
-   * need O((n / 2)^2 + n) operations to clear out the waste, where the waste would be accumulated
-   * by n / 2 total clears, meaning that the marginal cost added to clear is O(n/2 + 2), which is
-   * to say, O(n).
+   * The observation here is that it is cheapest to remove empty cells from the front of the
+   * list, but very expensive to remove them from the back of the list, and so we can be
+   * relatively aggressive about the former and conservative about the latter. In a "pack on
+   * every clear" protocol, the best possible case is if we're always clearing at the very front
+   * of the list. In this scenario, pack is always O(1). Conversely, the worst possible scenario
+   * is when we're clearing at the *end* of the list. In this case, we won't actually remove any
+   * cells until exactly half the list is emptied (thus, the number of empty cells is equal to
+   * the number of full cells). In this case, the final pack is O(n), while the accumulated
+   * wasted packs (which will fail to remove any items) will total to O((n / 2)^2). Thus, in the
+   * worst case, we would need O((n / 2)^2 + n) operations to clear out the waste, where the
+   * waste would be accumulated by n / 2 total clears, meaning that the marginal cost added to
+   * clear is O(n/2 + 2), which is to say, O(n).
    *
    * In order to reduce this to a sub-linear cost, we need to pack less frequently, with higher
-   * bounds, as the number of outstanding clears increases. Thus, rather than packing on each clear,
-   * we should pack on the even log clears (1, 2, 4, 8, etc). For cases where most of the churn is
-   * at the head of the list, this remains essentially O(1) and clears frequently. For cases where
-   * the churn is buried deeper in the list, it becomes O(log n) per clear (amortized). This still
-   * biases the optimizations towards the head of the list, but ensures that packing will still
-   * inevitably reach all of the garbage cells.
+   * bounds, as the number of outstanding clears increases. Thus, rather than packing on each
+   * clear, we should pack on the even log clears (1, 2, 4, 8, etc). For cases where most of the
+   * churn is at the head of the list, this remains essentially O(1) and clears frequently. For
+   * cases where the churn is buried deeper in the list, it becomes O(log n) per clear
+   * (amortized). This still biases the optimizations towards the head of the list, but ensures
+   * that packing will still inevitably reach all of the garbage cells.
    */
-  def pack(bound: Int): Int =
+  def pack(bound: Int): Int = {
     // the first cell is always retained
-    get().packInternal(bound, 0, this)
+    val got = get()
+    if (got ne null)
+      got.packInternal(bound, 0, this)
+    else
+      0
+  }
 
   @tailrec
   private def packInternal(bound: Int, removed: Int, parent: CallbackStack[A]): Int = {

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -77,6 +77,70 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
   def currentHandle(): CallbackStack.Handle = 0
 
   def clear(): Unit = lazySet(null)
+
+  /**
+   * It is intended that `bound` be tracked externally and incremented on each clear(). Whenever
+   * pack is called, the number of empty cells removed from the stack is produced. It is expected
+   * that this value should be subtracted from `bound` for the subsequent pack/clear calls. It is
+   * permissible to pack on every clear() for simplicity, though it may be more reasonable to delay
+   * pack() calls until bound exceeds some reasonable threshold.
+   *
+   * The observation here is that it is cheapest to remove empty cells from the front of the list,
+   * but very expensive to remove them from the back of the list, and so we can be relatively
+   * aggressive about the former and conservative about the latter. In a "pack on every clear"
+   * protocol, the best possible case is if we're always clearing at the very front of the list.
+   * In this scenario, pack is always O(1). Conversely, the worst possible scenario is when we're
+   * clearing at the *end* of the list. In this case, we won't actually remove any cells until
+   * exactly half the list is emptied (thus, the number of empty cells is equal to the number of
+   * full cells). In this case, the final pack is O(n), while the accumulated wasted packs (which
+   * will fail to remove any items) will total to O((n / 2)^2). Thus, in the worst case, we would
+   * need O((n / 2)^2 + n) operations to clear out the waste, where the waste would be accumulated
+   * by n / 2 total clears, meaning that the marginal cost added to clear is O(n/2 + 2), which is
+   * to say, O(n).
+   *
+   * In order to reduce this to a sub-linear cost, we need to pack less frequently, with higher
+   * bounds, as the number of outstanding clears increases. Thus, rather than packing on each clear,
+   * we should pack on the even log clears (1, 2, 4, 8, etc). For cases where most of the churn is
+   * at the head of the list, this remains essentially O(1) and clears frequently. For cases where
+   * the churn is buried deeper in the list, it becomes O(log n) per clear (amortized). This still
+   * biases the optimizations towards the head of the list, but ensures that packing will still
+   * inevitably reach all of the garbage cells.
+   */
+  def pack(bound: Int): Int =
+    // the first cell is always retained
+    get().packInternal(bound, 0, this)
+
+  @tailrec
+  private def packInternal(bound: Int, removed: Int, parent: CallbackStack[A]): Int = {
+    if (callback == null) {
+      val child = get()
+
+      // doing this cas here ultimately deoptimizes contiguous empty chunks
+      if (!parent.compareAndSet(this, child)) {
+        // if we're contending with another pack(), just bail and let them continue
+        removed
+      } else {
+        if (child == null) {
+          // bottomed out
+          removed
+        } else {
+          // note this can cause the bound to go negative, which is fine
+          child.packInternal(bound - 1, removed + 1, parent)
+        }
+      }
+    } else {
+      val child = get()
+      if (child == null) {
+        // bottomed out
+        removed
+      } else {
+        if (bound > 0)
+          child.packInternal(bound - 1, removed, this)
+        else
+          removed
+      }
+    }
+  }
 }
 
 private object CallbackStack {

--- a/tests/shared/src/test/scala/cats/effect/kernel/DeferredSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/DeferredSpec.scala
@@ -190,8 +190,7 @@ class DeferredSpec extends BaseSpec { outer =>
         d <- deferredU
 
         range = 0.until(512)
-        fibers <- range.toVector.traverse(_ => d.get.start)
-        _ <- IO.sleep(1.millis)
+        fibers <- range.toVector.traverse(_ => d.get.start <* IO.sleep(1.millis))
 
         // these are mostly randomly chosen
         // the consecutive runs are significant, but only loosely so

--- a/tests/shared/src/test/scala/cats/effect/kernel/DeferredSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/DeferredSpec.scala
@@ -171,13 +171,18 @@ class DeferredSpec extends BaseSpec { outer =>
     }
 
     "handle lots of canceled gets" in real {
-      List(10, 100, 1000).traverse_ { n =>
-        deferredU.flatMap { d =>
-          (d.get.background.surround(IO.cede).replicateA_(n) *> d.complete(())).background.surround {
-            d.get.as(1).parReplicateA(n).map(_.sum must be_==(n))
-          }
-        }.replicateA_(100)
-      }.as(true)
+      List(10, 100, 1000)
+        .traverse_ { n =>
+          deferredU
+            .flatMap { d =>
+              (d.get.background.surround(IO.cede).replicateA_(n) *> d
+                .complete(())).background.surround {
+                d.get.as(1).parReplicateA(n).map(_.sum must be_==(n))
+              }
+            }
+            .replicateA_(100)
+        }
+        .as(true)
     }
 
   }


### PR DESCRIPTION
Closes https://github.com/typelevel/cats-effect/issues/3366.

### This PR
```
[info] Benchmark                   (count)   Mode  Cnt     Score    Error  Units
[info] DeferredBenchmark.cancel         10  thrpt   20    38.933 ±  0.777  ops/s
[info] DeferredBenchmark.cancel        100  thrpt   20     5.323 ±  0.401  ops/s
[info] DeferredBenchmark.cancel       1000  thrpt   20     0.395 ±  0.028  ops/s
[info] DeferredBenchmark.complete       10  thrpt   20    35.443 ±  4.403  ops/s
[info] DeferredBenchmark.complete      100  thrpt   20    10.200 ±  2.016  ops/s
[info] DeferredBenchmark.complete     1000  thrpt   20     1.687 ±  0.058  ops/s
[info] DeferredBenchmark.get            10  thrpt   20  1880.096 ± 12.066  ops/s
[info] DeferredBenchmark.get           100  thrpt   20   277.012 ±  2.158  ops/s
[info] DeferredBenchmark.get          1000  thrpt   20    28.974 ±  0.091  ops/s
```

### 3.4.x
```
[info] Benchmark                   (count)   Mode  Cnt    Score    Error  Units
[info] DeferredBenchmark.cancel         10  thrpt   20   42.868 ±  1.431  ops/s
[info] DeferredBenchmark.cancel        100  thrpt   20    4.399 ±  0.254  ops/s
[info] DeferredBenchmark.cancel       1000  thrpt   20    0.361 ±  0.025  ops/s
[info] DeferredBenchmark.complete       10  thrpt   20   25.492 ±  2.345  ops/s
[info] DeferredBenchmark.complete      100  thrpt   20    8.211 ±  1.625  ops/s
[info] DeferredBenchmark.complete     1000  thrpt   20    1.216 ±  0.271  ops/s
[info] DeferredBenchmark.get            10  thrpt   20  906.738 ± 83.481  ops/s
[info] DeferredBenchmark.get           100  thrpt   20  166.403 ±  4.774  ops/s
[info] DeferredBenchmark.get          1000  thrpt   20   19.388 ±  1.687  ops/s
```
