### PR TITLE
Remove `IOLocal#scope`, revert #3214

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -906,8 +906,7 @@ lazy val std = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         "cats.effect.std.Queue#DroppingQueue.onOfferNoCapacity"),
       // introduced by #3347
       // private stuff
-      ProblemFilters.exclude[MissingClassProblem](
-        "cats.effect.std.AtomicCell$Impl")
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.AtomicCell$Impl")
     )
   )
   .jsSettings(

--- a/core/shared/src/main/scala/cats/effect/IOLocal.scala
+++ b/core/shared/src/main/scala/cats/effect/IOLocal.scala
@@ -17,7 +17,6 @@
 package cats.effect
 
 import cats.data.AndThen
-import cats.syntax.functor._
 
 /**
  * [[IOLocal]] provides a handy way of manipulating a context on different scopes.
@@ -190,28 +189,6 @@ sealed trait IOLocal[A] { self =>
    *   [[reset]]
    */
   def getAndReset: IO[A]
-
-  /**
-   * Creates a scope with the given value. The original value is restored upon the finalization
-   * of a resource. It means all changes made inside of the resource will not be propagated to
-   * the outside.
-   *
-   * @example
-   *
-   * {{{
-   *   for {
-   *     local <- IOLocal(42)
-   *     _     <- local.get // returns 42
-   *     _     <- local.scope(current => current + 1).surround(local.getAndSet(1)) // returns 43
-   *     _     <- local.get // returns 42, even though 1 was set inside of the resource
-   *   } yield ()
-   * }}}
-   *
-   * @param f
-   *   the function to make a new scope
-   */
-  final def scope(value: A): Resource[IO, Unit] =
-    Resource.make(getAndSet(value))(p => set(p)).void
 
   /**
    * Creates a lens to a value of some type `B` from current value and two functions: getter and

--- a/tests/shared/src/test/scala/cats/effect/IOLocalSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOLocalSpec.scala
@@ -17,8 +17,6 @@
 package cats
 package effect
 
-import cats.syntax.semigroup._
-
 import scala.annotation.tailrec
 
 class IOLocalSpec extends BaseSpec {
@@ -79,7 +77,7 @@ class IOLocalSpec extends BaseSpec {
     }
   }
 
-  private def ioLocalTests[A, B: Semigroup, C: Eq: Show](
+  private def ioLocalTests[A, B, C: Eq: Show](
       name: String,
       localF: A => IO[(IOLocal[B], IOLocal[C])]
   )(
@@ -158,18 +156,6 @@ class IOLocalSpec extends BaseSpec {
       }
 
       io must completeAs(checkA(initial))
-    }
-
-    "do not leak internal updates outside of a scope" in ticked { implicit ticker =>
-      val io = localF(initial).flatMap {
-        case (writer, reader) =>
-          for {
-            inside <- writer.scope(update).surround(reader.get <* writer.set(update |+| update))
-            outside <- reader.get
-          } yield (inside, outside)
-      }
-
-      io must completeAs((checkB(update), checkA(initial)))
     }
 
   }


### PR DESCRIPTION
Reverts #3214, with apologies to @iRevive. IIRC I even encouraged that PR, so my bad.

Basically, for `scope` to work correctly, the `acquire` and `release` effects must run on the same fiber. `Resource` cannot guarantee this, so IMO it's a leaky abstraction.  Furthermore Ross and I demonstrated various weird/surprising behaviors when mixed with other combinators starting from https://github.com/typelevel/cats-effect/pull/3360#issuecomment-1416883633.

So yeah, I feel very unsure about exposing an API like this now. If we want to offer "higher-level" APIs that can be used safely, my vote is for something like https://github.com/typelevel/cats-effect/issues/3385.