### PR TITLE
Add 'flatModify', 'flatModifyFull' and corresponding 'State' methods

### DIFF
--- a/tests/shared/src/test/scala/cats/effect/kernel/RefSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/RefSpec.scala
@@ -139,6 +139,43 @@ class RefSpec extends BaseSpec with DetectPlatform { outer =>
 
       op must completeAs(true)
     }
+
+    "flatModify - finalizer should be uncancelable" in ticked { implicit ticker =>
+      var passed = false
+      val op = for {
+        ref <- Ref[IO].of(0)
+        _ <- ref
+          .flatModify(_ => (1, IO.canceled >> IO { passed = true }))
+          .start
+          .flatMap(_.join)
+          .void
+        result <- ref.get
+      } yield result == 1
+
+      op must completeAs(true)
+      passed must beTrue
+    }
+
+    "flatModifyFull - finalizer should mask cancellation" in ticked { implicit ticker =>
+      var passed = false
+      var failed = false
+      val op = for {
+        ref <- Ref[IO].of(0)
+        _ <- ref
+          .flatModifyFull { (poll, _) =>
+            (1, poll(IO.canceled >> IO { failed = true }).onCancel(IO { passed = true }))
+          }
+          .start
+          .flatMap(_.join)
+          .void
+        result <- ref.get
+      } yield result == 1
+
+      op must completeAs(true)
+      passed must beTrue
+      failed must beFalse
+    }
+
   }
 
 }


### PR DESCRIPTION
My attempt at #3370.

I'm not exactly sure about `*Full` method signatures, it could also be `f: Poll[F] => A => (A, F[B])`. I've tried `f: A => (A, Poll[F] => F[B])` and `State[A, Poll[F] => F[B]]` but it does not plays well with type inference.