### PR TITLE
Even faster async mutex

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/MutexBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/MutexBenchmark.scala
@@ -51,10 +51,7 @@ class MutexBenchmark {
   var iterations: Int = _
 
   private def happyPathImpl(mutex: IO[Mutex[IO]]): Unit = {
-    mutex
-      .flatMap { m => m.lock.use_.replicateA_(fibers) }
-      .replicateA_(iterations)
-      .unsafeRunSync()
+    mutex.flatMap { m => m.lock.use_.replicateA_(fibers * iterations) }.unsafeRunSync()
   }
 
   @Benchmark

--- a/build.sbt
+++ b/build.sbt
@@ -906,11 +906,14 @@ lazy val std = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         "cats.effect.std.Queue#DroppingQueue.onOfferNoCapacity"),
       // introduced by #3346
       // private stuff
-      ProblemFilters.exclude[MissingClassProblem](
-        "cats.effect.std.Mutex$Impl"),
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Mutex$Impl"),
       // introduced by #3347
       // private stuff
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.AtomicCell$Impl")
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.AtomicCell$Impl"),
+      // introduced by #3409
+      // extracted UnsafeUnbounded private data structure
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$UnsafeUnbounded"),
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$UnsafeUnbounded$Cell")
     )
   )
   .jsSettings(

--- a/std/shared/src/main/scala/cats/effect/std/FailureSignal.scala
+++ b/std/shared/src/main/scala/cats/effect/std/FailureSignal.scala
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-package cats.effect
+package cats.effect.std
 
-package object std {
-
-  private[std] val FailureSignal: Throwable = new RuntimeException
-    with scala.util.control.NoStackTrace
-
-}
+private object FailureSignal extends RuntimeException with scala.util.control.NoStackTrace

--- a/std/shared/src/main/scala/cats/effect/std/Mutex.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Mutex.scala
@@ -21,7 +21,7 @@ package std
 import cats.effect.kernel._
 import cats.syntax.all._
 
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * A purely functional mutex.
@@ -84,9 +84,7 @@ object Mutex {
    * Creates a new `Mutex`. Like `apply` but initializes state using another effect constructor.
    */
   def in[F[_], G[_]](implicit F: Sync[F], G: Async[G]): F[Mutex[G]] =
-    F.delay(
-      new AtomicReference[LockCell]()
-    ).map(state => new AsyncImpl[G](state)(G))
+    F.delay(new AsyncImpl[G])
 
   private final class ConcurrentImpl[F[_]](sem: Semaphore[F]) extends Mutex[F] {
     override final val lock: Resource[F, Unit] =
@@ -96,87 +94,38 @@ object Mutex {
       new ConcurrentImpl(sem.mapK(f))
   }
 
-  private final class AsyncImpl[F[_]](state: AtomicReference[LockCell])(implicit F: Async[F])
-      extends Mutex[F] {
-    // Cancels a Fiber waiting for the Mutex.
-    private def cancel(thisCB: CB, thisCell: LockCell, previousCell: LockCell): F[Unit] =
+  private final class AsyncImpl[F[_]](implicit F: Async[F]) extends Mutex[F] {
+    private[this] val locked = new AtomicBoolean(false)
+    private[this] val waiters = new UnsafeUnbounded[Either[Throwable, Unit] => Unit]
+
+    private[this] val acquire: F[Unit] = F.asyncCheckAttempt { cb =>
       F.delay {
-        // If we are canceled.
-        // First, we check if the state still contains ourselves,
-        // if that is the case, we swap it with the previousCell.
-        // This ensures any consequent attempt to acquire the Mutex
-        // will register its callback on the appropriate cell.
-        // Additionally, that confirms there is no Fiber
-        // currently waiting for us.
-        if (!state.compareAndSet(thisCell, previousCell)) {
-          // Otherwise,
-          // it means we have a Fiber waiting for us.
-          // Thus, we need to tell the previous cell
-          // to awake that Fiber instead.
-          var nextCB = thisCell.get()
-          while (nextCB eq null) {
-            // There is a tiny fraction of time when
-            // the next cell has acquired ourselves,
-            // but hasn't registered itself yet.
-            // Thus, we spin loop until that happens
-            nextCB = thisCell.get()
-          }
-          if (!previousCell.compareAndSet(thisCB, nextCB)) {
-            // However, in case the previous cell had already completed,
-            // then the Mutex is free and we can awake our waiting fiber.
-            if (nextCB ne null) nextCB.apply(Either.unit)
-          }
-        }
-      }
-
-    // Awaits until the Mutex is free.
-    private def await(thisCell: LockCell): F[Unit] =
-      F.asyncCheckAttempt[Unit] { thisCB =>
-        F.delay {
-          val previousCell = state.getAndSet(thisCell)
-
-          if (previousCell eq null) {
-            // If the previous cell was null,
-            // then the Mutex is free.
+        if (locked.compareAndSet(false, true)) { // acquired
+          Either.unit
+        } else {
+          val cancel = waiters.put(cb)
+          if (locked.compareAndSet(false, true)) { // try again
+            cancel()
             Either.unit
           } else {
-            // Otherwise,
-            // we check again that the previous cell haven't been completed yet,
-            // if not we tell the previous cell to awake us when they finish.
-            if (!previousCell.compareAndSet(null, thisCB)) {
-              // If it was already completed,
-              // then the Mutex is free.
-              Either.unit
-            } else {
-              Left(Some(cancel(thisCB, thisCell, previousCell)))
-            }
+            Left(Some(F.delay(cancel())))
           }
         }
       }
+    }
 
-    // Acquires the Mutex.
-    private def acquire(poll: Poll[F]): F[LockCell] =
-      F.delay(new AtomicReference[CB]()).flatMap { thisCell =>
-        poll(await(thisCell).map(_ => thisCell))
+    private[this] val _release: F[Unit] = F.delay {
+      try { // pass the buck
+        waiters.take().apply(Either.unit)
+      } catch { // release
+        case FailureSignal => locked.set(false)
       }
+    }
 
-    // Releases the Mutex.
-    private def release(thisCell: LockCell): F[Unit] =
-      F.delay {
-        // If the state still contains our own cell,
-        // then it means nobody was waiting for the Mutex,
-        // and thus it can be put on a free state again.
-        if (!state.compareAndSet(thisCell, null)) {
-          // Otherwise,
-          // our cell is probably not empty,
-          // we must awake whatever Fiber is waiting for us.
-          val nextCB = thisCell.getAndSet(Sentinel)
-          if (nextCB ne null) nextCB.apply(Either.unit)
-        }
-      }
+    private[this] val release: Unit => F[Unit] = _ => _release
 
     override final val lock: Resource[F, Unit] =
-      Resource.makeFull[F, LockCell](acquire)(release).void
+      Resource.makeFull[F, Unit](poll => poll(acquire))(release)
 
     override def mapK[G[_]](f: F ~> G)(implicit G: MonadCancel[G, _]): Mutex[G] =
       new Mutex.TransformedMutex(this, f)
@@ -194,9 +143,4 @@ object Mutex {
       new Mutex.TransformedMutex(this, f)
   }
 
-  private type CB = Either[Throwable, Unit] => Unit
-
-  private final val Sentinel: CB = _ => ()
-
-  private type LockCell = AtomicReference[CB]
 }

--- a/std/shared/src/main/scala/cats/effect/std/Mutex.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Mutex.scala
@@ -99,6 +99,7 @@ object Mutex {
 
     private[this] val locked = new AtomicBoolean(false)
     private[this] val waiters = new UnsafeUnbounded[Either[Throwable, Boolean] => Unit]
+    private[this] val failureSignal = FailureSignal // prefetch
 
     private[this] val acquire: F[Unit] = F
       .asyncCheckAttempt[Boolean] { cb =>
@@ -127,14 +128,14 @@ object Mutex {
         while (waiter eq null) waiter = waiters.take()
         waiter(RightTrue) // pass the buck
       } catch { // no waiter found
-        case FailureSignal =>
+        case `failureSignal` =>
           locked.set(false) // release
           try {
             var waiter = waiters.take()
             while (waiter eq null) waiter = waiters.take()
             waiter(RightFalse) // waken any new waiters
           } catch {
-            case FailureSignal => // do nothing
+            case `failureSignal` => // do nothing
           }
       }
     }

--- a/std/shared/src/main/scala/cats/effect/std/Queue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Queue.scala
@@ -505,6 +505,8 @@ object Queue {
     private[this] val takers = new UnsafeUnbounded[Either[Throwable, Unit] => Unit]()
     private[this] val offerers = new UnsafeUnbounded[Either[Throwable, Unit] => Unit]()
 
+    private[this] val failureSignal = FailureSignal // prefetch
+
     // private[this] val takers = new ConcurrentLinkedQueue[AtomicReference[Either[Throwable, Unit] => Unit]]()
     // private[this] val offerers = new ConcurrentLinkedQueue[AtomicReference[Either[Throwable, Unit] => Unit]]()
 
@@ -520,7 +522,7 @@ object Queue {
             notifyOne(takers)
             F.unit
           } catch {
-            case FailureSignal =>
+            case `failureSignal` =>
               // capture whether or not we were successful in our retry
               var succeeded = false
 
@@ -555,7 +557,7 @@ object Queue {
                     // we're immediately complete, so no point in creating a finalizer
                     None
                   } catch {
-                    case FailureSignal =>
+                    case `failureSignal` =>
                       // our retry failed, meaning the queue is still full and we're listening, so suspend
                       // println(s"failed offer size = ${buffer.size()}")
                       Some(F.delay(clear()))
@@ -584,7 +586,7 @@ object Queue {
         notifyOne(takers)
         true
       } catch {
-        case FailureSignal =>
+        case `failureSignal` =>
           false
       }
     }
@@ -603,7 +605,7 @@ object Queue {
             notifyOne(offerers)
             F.pure(result)
           } catch {
-            case FailureSignal =>
+            case `failureSignal` =>
               // buffer was empty
               // capture the fact that our retry succeeded and the value we were able to take
               var received = false
@@ -639,7 +641,7 @@ object Queue {
                           // this is the thing that `async` doesn't allow us to do
                           G.unit
                         } catch {
-                          case FailureSignal =>
+                          case `failureSignal` =>
                             // println(s"failed take size = ${buffer.size()}")
                             // our retry failed, we're registered as a listener, so suspend
                             poll(get).onCancel(lift(F.delay(clear())))
@@ -671,7 +673,7 @@ object Queue {
         notifyOne(offerers)
         Some(back)
       } catch {
-        case FailureSignal =>
+        case `failureSignal` =>
           None
       }
     }
@@ -694,7 +696,7 @@ object Queue {
                 took = true
                 back
               } catch {
-                case FailureSignal => null
+                case `failureSignal` => null
               }
 
             if (took) {
@@ -745,7 +747,7 @@ object Queue {
           }
         } catch {
           // there are no takers, so don't notify anything
-          case FailureSignal => false
+          case `failureSignal` => false
         }
 
       if (retry) {
@@ -758,6 +760,7 @@ object Queue {
   private final class UnboundedAsyncQueue[F[_], A]()(implicit F: Async[F]) extends Queue[F, A] {
     private[this] val buffer = new UnsafeUnbounded[A]()
     private[this] val takers = new UnsafeUnbounded[Either[Throwable, Unit] => Unit]()
+    private[this] val failureSignal = FailureSignal // prefetch
 
     def offer(a: A): F[Unit] = F delay {
       buffer.put(a)
@@ -777,7 +780,7 @@ object Queue {
         // attempt to take from the buffer. if it's empty, this will raise an exception
         F.pure(buffer.take())
       } catch {
-        case FailureSignal =>
+        case `failureSignal` =>
           // buffer was empty
           // capture the fact that our retry succeeded and the value we were able to take
           var received = false
@@ -808,7 +811,7 @@ object Queue {
                 // don't bother with a finalizer since we're already complete
                 None
               } catch {
-                case FailureSignal =>
+                case `failureSignal` =>
                   // println(s"failed take size = ${buffer.size()}")
                   // our retry failed, we're registered as a listener, so suspend
                   Some(F.delay(clear()))
@@ -825,7 +828,7 @@ object Queue {
       try {
         Some(buffer.take())
       } catch {
-        case FailureSignal =>
+        case `failureSignal` =>
           None
       }
     }
@@ -852,7 +855,7 @@ object Queue {
           }
         } catch {
           // there are no takers, so don't notify anything
-          case FailureSignal => false
+          case `failureSignal` => false
         }
 
       if (retry) {
@@ -873,6 +876,8 @@ object Queue {
     private[this] val tail = new AtomicLong(0)
 
     private[this] val LookAheadStep = Math.max(2, Math.min(bound / 4, 4096)) // TODO tunable
+
+    private[this] val failureSignal = FailureSignal // prefetch
 
     0.until(bound).foreach(i => sequenceBuffer.set(i, i.toLong))
 
@@ -974,7 +979,7 @@ object Queue {
               back += take()
               true
             } catch {
-              case FailureSignal => false
+              case `failureSignal` => false
             }
 
           if (next) {

--- a/std/shared/src/main/scala/cats/effect/std/Queue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Queue.scala
@@ -26,7 +26,7 @@ import scala.annotation.tailrec
 import scala.collection.immutable.{Queue => ScalaQueue}
 import scala.collection.mutable.ListBuffer
 
-import java.util.concurrent.atomic.{AtomicLong, AtomicLongArray, AtomicReference}
+import java.util.concurrent.atomic.{AtomicLong, AtomicLongArray}
 
 /**
  * A purely functional, concurrent data structure which allows insertion and retrieval of
@@ -492,8 +492,6 @@ object Queue {
   }
 
   private val EitherUnit: Either[Nothing, Unit] = Right(())
-  private val FailureSignal: Throwable = new RuntimeException
-    with scala.util.control.NoStackTrace
 
   /*
    * Does not correctly handle bound = 0 because take waiters are async[Unit]
@@ -1037,97 +1035,6 @@ object Queue {
 
     private[this] def project(idx: Long): Int =
       ((idx & Int.MaxValue) % bound).toInt
-  }
-
-  final class UnsafeUnbounded[A] {
-    private[this] val first = new AtomicReference[Cell]
-    private[this] val last = new AtomicReference[Cell]
-
-    def size(): Int = {
-      var current = first.get()
-      var count = 0
-      while (current != null) {
-        count += 1
-        current = current.get()
-      }
-      count
-    }
-
-    def put(data: A): () => Unit = {
-      val cell = new Cell(data)
-
-      val prevLast = last.getAndSet(cell)
-
-      if (prevLast eq null)
-        first.set(cell)
-      else
-        prevLast.set(cell)
-
-      cell
-    }
-
-    @tailrec
-    def take(): A = {
-      val taken = first.get()
-      if (taken ne null) {
-        val next = taken.get()
-        if (first.compareAndSet(taken, next)) { // WINNING
-          if ((next eq null) && !last.compareAndSet(taken, null)) {
-            // we emptied the first, but someone put at the same time
-            // in this case, they might have seen taken in the last slot
-            // at which point they would *not* fix up the first pointer
-            // instead of fixing first, they would have written into taken
-            // so we fix first for them. but we might be ahead, so we loop
-            // on taken.get() to wait for them to make it not-null
-
-            var next2 = taken.get()
-            while (next2 eq null) {
-              next2 = taken.get()
-            }
-
-            first.set(next2)
-          }
-
-          val ret = taken.data()
-          taken() // Attempt to clear out data we've consumed
-          ret
-        } else {
-          take() // We lost, try again
-        }
-      } else {
-        if (last.get() ne null) {
-          take() // Waiting for prevLast.set(cell), so recurse
-        } else {
-          throw FailureSignal
-        }
-      }
-    }
-
-    def debug(): String = {
-      val f = first.get()
-
-      if (f == null) {
-        "[]"
-      } else {
-        f.debug()
-      }
-    }
-
-    private final class Cell(private[this] final var _data: A)
-        extends AtomicReference[Cell]
-        with (() => Unit) {
-
-      def data(): A = _data
-
-      final override def apply(): Unit = {
-        _data = null.asInstanceOf[A] // You want a lazySet here
-      }
-
-      def debug(): String = {
-        val tail = get()
-        s"${_data} -> ${if (tail == null) "[]" else tail.debug()}"
-      }
-    }
   }
 
   implicit def catsInvariantForQueue[F[_]: Functor]: Invariant[Queue[F, *]] =

--- a/std/shared/src/main/scala/cats/effect/std/UnsafeUnbounded.scala
+++ b/std/shared/src/main/scala/cats/effect/std/UnsafeUnbounded.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicReference
 private final class UnsafeUnbounded[A] {
   private[this] val first = new AtomicReference[Cell]
   private[this] val last = new AtomicReference[Cell]
-  private[this] val failureSignal = FailureSignal // prefetch
+  private[this] val FailureSignal = cats.effect.std.FailureSignal // prefetch
 
   def size(): Int = {
     var current = first.get()
@@ -80,7 +80,7 @@ private final class UnsafeUnbounded[A] {
       if (last.get() ne null) {
         take() // Waiting for prevLast.set(cell), so recurse
       } else {
-        throw failureSignal
+        throw FailureSignal
       }
     }
   }

--- a/std/shared/src/main/scala/cats/effect/std/UnsafeUnbounded.scala
+++ b/std/shared/src/main/scala/cats/effect/std/UnsafeUnbounded.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.std
+
+import scala.annotation.tailrec
+
+import java.util.concurrent.atomic.AtomicReference
+
+private final class UnsafeUnbounded[A] {
+  private[this] val first = new AtomicReference[Cell]
+  private[this] val last = new AtomicReference[Cell]
+
+  def size(): Int = {
+    var current = first.get()
+    var count = 0
+    while (current != null) {
+      count += 1
+      current = current.get()
+    }
+    count
+  }
+
+  def put(data: A): () => Unit = {
+    val cell = new Cell(data)
+
+    val prevLast = last.getAndSet(cell)
+
+    if (prevLast eq null)
+      first.set(cell)
+    else
+      prevLast.set(cell)
+
+    cell
+  }
+
+  @tailrec
+  def take(): A = {
+    val taken = first.get()
+    if (taken ne null) {
+      val next = taken.get()
+      if (first.compareAndSet(taken, next)) { // WINNING
+        if ((next eq null) && !last.compareAndSet(taken, null)) {
+          // we emptied the first, but someone put at the same time
+          // in this case, they might have seen taken in the last slot
+          // at which point they would *not* fix up the first pointer
+          // instead of fixing first, they would have written into taken
+          // so we fix first for them. but we might be ahead, so we loop
+          // on taken.get() to wait for them to make it not-null
+
+          var next2 = taken.get()
+          while (next2 eq null) {
+            next2 = taken.get()
+          }
+
+          first.set(next2)
+        }
+
+        val ret = taken.data()
+        taken() // Attempt to clear out data we've consumed
+        ret
+      } else {
+        take() // We lost, try again
+      }
+    } else {
+      if (last.get() ne null) {
+        take() // Waiting for prevLast.set(cell), so recurse
+      } else {
+        throw FailureSignal
+      }
+    }
+  }
+
+  def debug(): String = {
+    val f = first.get()
+
+    if (f == null) {
+      "[]"
+    } else {
+      f.debug()
+    }
+  }
+
+  private final class Cell(private[this] final var _data: A)
+      extends AtomicReference[Cell]
+      with (() => Unit) {
+
+    def data(): A = _data
+
+    final override def apply(): Unit = {
+      _data = null.asInstanceOf[A] // You want a lazySet here
+    }
+
+    def debug(): String = {
+      val tail = get()
+      s"${_data} -> ${if (tail == null) "[]" else tail.debug()}"
+    }
+  }
+}

--- a/std/shared/src/main/scala/cats/effect/std/UnsafeUnbounded.scala
+++ b/std/shared/src/main/scala/cats/effect/std/UnsafeUnbounded.scala
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicReference
 private final class UnsafeUnbounded[A] {
   private[this] val first = new AtomicReference[Cell]
   private[this] val last = new AtomicReference[Cell]
+  private[this] val failureSignal = FailureSignal // prefetch
 
   def size(): Int = {
     var current = first.get()
@@ -79,7 +80,7 @@ private final class UnsafeUnbounded[A] {
       if (last.get() ne null) {
         take() // Waiting for prevLast.set(cell), so recurse
       } else {
-        throw FailureSignal
+        throw failureSignal
       }
     }
   }

--- a/std/shared/src/main/scala/cats/effect/std/package.scala
+++ b/std/shared/src/main/scala/cats/effect/std/package.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020-2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+package object std {
+
+  private[std] val FailureSignal: Throwable = new RuntimeException
+    with scala.util.control.NoStackTrace
+
+}

--- a/tests/shared/src/test/scala/cats/effect/std/MutexSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/MutexSpec.scala
@@ -123,5 +123,9 @@ final class MutexSpec extends BaseSpec {
       }
       p must completeAs(())
     }
+
+    "not deadlock when highly contended" in real {
+      mutex.flatMap(_.lock.use_.parReplicateA_(10)).replicateA_(10000).as(true)
+    }
   }
 }

--- a/tests/shared/src/test/scala/cats/effect/std/MutexSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/MutexSpec.scala
@@ -110,5 +110,18 @@ final class MutexSpec extends BaseSpec {
 
       p must completeAs(true)
     }
+
+    "gracefully handle canceled waiters" in ticked { implicit ticker =>
+      val p = mutex.flatMap { m =>
+        m.lock.surround {
+          for {
+            f <- m.lock.useForever.start
+            _ <- IO.sleep(1.second)
+            _ <- f.cancel
+          } yield ()
+        }
+      }
+      p must completeAs(())
+    }
   }
 }

--- a/tests/shared/src/test/scala/cats/effect/std/UnsafeUnboundedSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/UnsafeUnboundedSpec.scala
@@ -20,7 +20,6 @@ package std
 import cats.syntax.all._
 
 class UnsafeUnboundedSpec extends BaseSpec {
-  import Queue.UnsafeUnbounded
 
   "unsafe unbounded queue" should {
     val length = 1000


### PR DESCRIPTION
This PR tries my idea from https://github.com/typelevel/cats-effect/pull/3346#issuecomment-1374040239 of re-using the `UnsafeUnbounded` datastructure from the async queue to implement the async mutex. /cc @BalmungSan 

#### this PR
```
[info] Benchmark                           (fibers)  (iterations)   Mode  Cnt    Score   Error  Units
[info] MutexBenchmark.cancellationAsync          10          1000  thrpt   20   15.434 ± 1.058  ops/s
[info] MutexBenchmark.cancellationAsync         100          1000  thrpt   20    3.203 ± 0.464  ops/s
[info] MutexBenchmark.happyPathAsync             10          1000  thrpt   20  145.271 ± 5.933  ops/s
[info] MutexBenchmark.happyPathAsync            100          1000  thrpt   20   13.297 ± 1.656  ops/s
[info] MutexBenchmark.highContentionAsync        10          1000  thrpt   20   22.955 ± 2.932  ops/s
[info] MutexBenchmark.highContentionAsync       100          1000  thrpt   20    2.953 ± 0.479  ops/s
```
#### series/3.x
```
[info] Benchmark                           (fibers)  (iterations)   Mode  Cnt    Score   Error  Units
[info] MutexBenchmark.cancellationAsync          10          1000  thrpt   20   14.627 ± 1.514  ops/s
[info] MutexBenchmark.cancellationAsync         100          1000  thrpt   20    3.234 ± 0.658  ops/s
[info] MutexBenchmark.happyPathAsync             10          1000  thrpt   20  124.522 ± 7.762  ops/s
[info] MutexBenchmark.happyPathAsync            100          1000  thrpt   20   11.987 ± 0.379  ops/s
[info] MutexBenchmark.highContentionAsync        10          1000  thrpt   20   16.659 ± 2.072  ops/s
[info] MutexBenchmark.highContentionAsync       100          1000  thrpt   20    2.131 ± 0.127  ops/s
```