### PR TITLE
Fix `fromCompletableFuture` cancelation leak

### DIFF
--- a/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
@@ -32,33 +32,37 @@ private[kernel] trait AsyncPlatform[F[_]] extends Serializable { this: Async[F] 
    */
   def fromCompletableFuture[A](fut: F[CompletableFuture[A]]): F[A] = uncancelable { poll =>
     flatMap(poll(fut)) { cf =>
-      cont {
-        new Cont[F, A, A] {
-          def apply[G[_]](implicit G: MonadCancelThrow[G])
-              : (Either[Throwable, A] => Unit, G[A], F ~> G) => G[A] = { (resume, get, lift) =>
-            G.uncancelable { poll =>
-              val go = delay {
-                cf.handle[Unit] {
-                  case (a, null) => resume(Right(a))
-                  case (_, t) =>
-                    resume(Left(t match {
-                      case e: CompletionException if e.getCause ne null => e.getCause
-                      case _ => t
-                    }))
+      onCancel(
+        poll(cont {
+          new Cont[F, A, A] {
+            def apply[G[_]](implicit G: MonadCancelThrow[G])
+                : (Either[Throwable, A] => Unit, G[A], F ~> G) => G[A] = {
+              (resume, get, lift) =>
+                G.uncancelable { poll =>
+                  val go = delay {
+                    cf.handle[Unit] {
+                      case (a, null) => resume(Right(a))
+                      case (_, t) =>
+                        resume(Left(t match {
+                          case e: CompletionException if e.getCause ne null => e.getCause
+                          case _ => t
+                        }))
+                    }
+                  }
+
+                  val await = G.onCancel(
+                    poll(get),
+                    // if cannot cancel, fallback to get
+                    G.ifM(lift(delay(cf.cancel(false))))(G.unit, G.void(get))
+                  )
+
+                  G.productR(lift(go))(await)
                 }
-              }
-
-              val await = G.onCancel(
-                poll(get),
-                // if cannot cancel, fallback to get
-                G.ifM(lift(delay(cf.cancel(false))))(G.unit, G.void(get))
-              )
-
-              G.productR(lift(go))(await)
             }
           }
-        }
-      }
+        }),
+        void(delay(cf.cancel(false)))
+      )
     }
   }
 

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -17,7 +17,6 @@
 package cats.effect
 
 import cats.effect.std.{Random, Semaphore}
-import cats.effect.unsafe.WorkStealingThreadPool
 import cats.syntax.all._
 
 import org.scalacheck.Prop.forAll


### PR DESCRIPTION
Previously we could observe cancelation on the `flatMap` boundary before we register the finalizer.