### PR TITLE
Fix corking when writing large strings to stdout/stderr on Node.js

### DIFF
--- a/tests/js/src/test/scala/cats/effect/std/ConsoleJSSpec.scala
+++ b/tests/js/src/test/scala/cats/effect/std/ConsoleJSSpec.scala
@@ -23,6 +23,9 @@ class ConsoleJSSpec extends BaseSpec {
     "work in any JS environment" in real {
       Console[IO].println("printing") *> Console[IO].errorln("erroring") *> IO(true)
     }
+    "println should not hang for large strings" in real {
+      Console[IO].println("foo" * 10000).as(true)
+    }
   }
 
 }


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/3423.

As mentioned in the issue, the bug was that corking forces buffering, which in turn prevents draining, so there was no `'drain'` event being emitted. Corking is used here to buffer the first write until we follow-up with the `write("\n")`, to minimize syscalls.

This fix is to uncork _before_ waiting on the `'drain'` callback ... not after 😅 

While revisiting this code, I also fixed a couple other issues related to corking. Namely, between corking/uncorking there should not be any `cede`s (e.g. due to concurrent `println(...)`) so it should happen in an atomic `delay` block. And the uncork should be in a `finally` block.