### PR TITLE
Parallel map2 optimization

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/instances/GenSpawnInstances.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/instances/GenSpawnInstances.scala
@@ -51,7 +51,8 @@ trait GenSpawnInstances {
 
       final override def map2[A, B, Z](fa: ParallelF[F, A], fb: ParallelF[F, B])(
           f: (A, B) => Z): ParallelF[F, Z] = {
-        ParallelF(F.both(ParallelF.value(fa), ParallelF.value(fb)).map { case (a, b) => f(a, b) })
+        ParallelF(
+          F.both(ParallelF.value(fa), ParallelF.value(fb)).map { case (a, b) => f(a, b) })
       }
 
       final override def ap[A, B](ff: ParallelF[F, A => B])(

--- a/kernel/shared/src/main/scala/cats/effect/kernel/instances/GenSpawnInstances.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/instances/GenSpawnInstances.scala
@@ -18,7 +18,7 @@ package cats.effect.kernel.instances
 
 import cats.{~>, Align, Applicative, CommutativeApplicative, Functor, Monad, Parallel}
 import cats.data.Ior
-import cats.effect.kernel.{GenSpawn, ParallelF}
+import cats.effect.kernel.{GenSpawn, Outcome, ParallelF}
 import cats.implicits._
 
 trait GenSpawnInstances {
@@ -52,8 +52,41 @@ trait GenSpawnInstances {
       final override def map2[A, B, Z](fa: ParallelF[F, A], fb: ParallelF[F, B])(
           f: (A, B) => Z): ParallelF[F, Z] = {
         ParallelF(
-          F.both(ParallelF.value(fa), ParallelF.value(fb)).map { case (a, b) => f(a, b) })
+          F.uncancelable { poll =>
+            F.start(ParallelF.value(fa)).flatMap { fia =>
+              F.start(F.guaranteeCase(ParallelF.value(fb)) {
+                case Outcome.Succeeded(_) => F.unit
+                case _ => fia.cancel
+              }).flatMap { fib =>
+                F.onCancel(poll(fia.join), bothUnit(fia.cancel, fib.cancel)).flatMap {
+                  case Outcome.Succeeded(fa) =>
+                    F.onCancel(poll(fib.join), fib.cancel).flatMap {
+                      case Outcome.Succeeded(fb) =>
+                        F.map2(fa, fb)(f)
+                      case Outcome.Errored(e) =>
+                        F.raiseError(e)
+                      case Outcome.Canceled() =>
+                        poll(F.canceled *> F.never)
+                    }
+                  case Outcome.Errored(e) =>
+                    fib.cancel *> F.raiseError(e)
+                  case Outcome.Canceled() =>
+                    fib.cancel *> poll(fib.join).flatMap {
+                      case Outcome.Errored(e) =>
+                        F.raiseError(e)
+                      case _ =>
+                        poll(F.canceled *> F.never)
+                    }
+                }
+              }
+            }
+          }
+        )
       }
+
+      // assumed to be uncancelable
+      private[this] final def bothUnit(a: F[Unit], b: F[Unit]): F[Unit] =
+        F.start(a).flatMap { fib => F.guarantee(b, fib.join.void) }
 
       final override def ap[A, B](ff: ParallelF[F, A => B])(
           fa: ParallelF[F, A]): ParallelF[F, B] =

--- a/laws/shared/src/test/scala/cats/effect/laws/PureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/PureConcSpec.scala
@@ -43,10 +43,11 @@ class PureConcSpec extends Specification with Discipline with BaseSpec {
     type F[A] = PureConc[Int, A]
     val F = GenConcurrent[F]
 
+    // fails probably due to issue #3430
     "short-circuit on error" in {
       pure.run((F.never[Unit], F.raiseError[Unit](42)).parTupled) mustEqual Outcome.Errored(42)
       pure.run((F.raiseError[Unit](42), F.never[Unit]).parTupled) mustEqual Outcome.Errored(42)
-    }
+    }.pendingUntilFixed
 
     "short-circuit on canceled" in {
       pure.run((F.never[Unit], F.canceled).parTupled.start.flatMap(_.join)) mustEqual Outcome
@@ -55,6 +56,7 @@ class PureConcSpec extends Specification with Discipline with BaseSpec {
         .Succeeded(Some(Outcome.canceled[F, Nothing, Unit]))
     }
 
+    // fails probably due to issue #3430
     "not run forever on chained product" in {
       import cats.effect.kernel.Par.ParallelF
 
@@ -65,7 +67,7 @@ class PureConcSpec extends Specification with Discipline with BaseSpec {
         ParallelF.value(
           ParallelF(fa).product(ParallelF(fb)).product(ParallelF(fc)))) mustEqual Outcome
         .Errored(42)
-    }
+    }.pendingUntilFixed
 
     "ignore unmasking in finalizers" in {
       val fa = F.uncancelable { poll => F.onCancel(poll(F.unit), poll(F.unit)) }

--- a/laws/shared/src/test/scala/cats/effect/laws/PureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/PureConcSpec.scala
@@ -43,11 +43,10 @@ class PureConcSpec extends Specification with Discipline with BaseSpec {
     type F[A] = PureConc[Int, A]
     val F = GenConcurrent[F]
 
-    // fails probably due to issue #3430
     "short-circuit on error" in {
       pure.run((F.never[Unit], F.raiseError[Unit](42)).parTupled) mustEqual Outcome.Errored(42)
       pure.run((F.raiseError[Unit](42), F.never[Unit]).parTupled) mustEqual Outcome.Errored(42)
-    }.pendingUntilFixed
+    }
 
     "short-circuit on canceled" in {
       pure.run((F.never[Unit], F.canceled).parTupled.start.flatMap(_.join)) mustEqual Outcome
@@ -56,7 +55,6 @@ class PureConcSpec extends Specification with Discipline with BaseSpec {
         .Succeeded(Some(Outcome.canceled[F, Nothing, Unit]))
     }
 
-    // fails probably due to issue #3430
     "not run forever on chained product" in {
       import cats.effect.kernel.Par.ParallelF
 
@@ -67,7 +65,7 @@ class PureConcSpec extends Specification with Discipline with BaseSpec {
         ParallelF.value(
           ParallelF(fa).product(ParallelF(fb)).product(ParallelF(fc)))) mustEqual Outcome
         .Errored(42)
-    }.pendingUntilFixed
+    }
 
     "ignore unmasking in finalizers" in {
       val fa = F.uncancelable { poll => F.onCancel(poll(F.unit), poll(F.unit)) }

--- a/laws/shared/src/test/scala/cats/effect/laws/PureConcSpec.scala
+++ b/laws/shared/src/test/scala/cats/effect/laws/PureConcSpec.scala
@@ -48,6 +48,13 @@ class PureConcSpec extends Specification with Discipline with BaseSpec {
       pure.run((F.raiseError[Unit](42), F.never[Unit]).parTupled) mustEqual Outcome.Errored(42)
     }
 
+    "short-circuit on canceled" in {
+      pure.run((F.never[Unit], F.canceled).parTupled.start.flatMap(_.join)) mustEqual Outcome
+        .Succeeded(Some(Outcome.canceled[F, Nothing, Unit]))
+      pure.run((F.canceled, F.never[Unit]).parTupled.start.flatMap(_.join)) mustEqual Outcome
+        .Succeeded(Some(Outcome.canceled[F, Nothing, Unit]))
+    }
+
     "not run forever on chained product" in {
       import cats.effect.kernel.Par.ParallelF
 

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1335,6 +1335,19 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
 
         tsk must completeAs(42)
       }
+
+      "not run forever on chained product" in ticked { implicit ticker =>
+        import cats.effect.kernel.Par.ParallelF
+
+        case object TestException extends RuntimeException
+
+        val fa: IO[String] = IO.pure("a")
+        val fb: IO[String] = IO.pure("b")
+        val fc: IO[Unit] = IO.raiseError[Unit](TestException)
+        val tsk =
+          ParallelF.value(ParallelF(fa).product(ParallelF(fb)).product(ParallelF(fc))).void
+        tsk must failAs(TestException)
+      }
     }
 
     "miscellaneous" should {

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1273,6 +1273,17 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         (IO.raiseError[Unit](TestException), IO.never[Unit]).parTupled.void must failAs(
           TestException)
       }
+
+      "short-circuit on canceled" in ticked { implicit ticker =>
+        (IO.never[Unit], IO.canceled)
+          .parTupled
+          .start
+          .flatMap(_.join.map(_.isCanceled)) must completeAs(true)
+        (IO.canceled, IO.never[Unit])
+          .parTupled
+          .start
+          .flatMap(_.join.map(_.isCanceled)) must completeAs(true)
+      }
     }
 
     "miscellaneous" should {


### PR DESCRIPTION
#### Context:
The "old" parallel `map2` used `both`; #2159 optimized it to avoid tuples, but that implementation was incorrect; #2239 fixed it by starting 2 extra fibers.

#### What is this:

- Wrote some extra tests to detect possible changes in behavior.
- In [9e9d015](https://github.com/typelevel/cats-effect/pull/3428/commits/9e9d015514fbb482bdebe17aab3a68f1c7a95f93) restored the "old" implementation with `both` (as allocating a few tuples might be cheaper than starting 2 extra fibers).
- In [2c4bc68](https://github.com/typelevel/cats-effect/pull/3428/commits/2c4bc684daca18b77239194196dcabd58e40a95f) created a new implementation, which avoids tuples and starting extra fibers too. Its unclear, if this actually helps (benchmark results pending).