### PR TITLE
Fixed issues in the timer handling state machine integration

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -327,21 +327,41 @@ private final class WorkerThread(
       }
     }
 
-    def parkUntilNextSleeper(): Unit = {
-      if (!isInterrupted()) {
+    // returns true if timed out, false if unparked
+    def parkUntilNextSleeper(): Boolean = {
+      while (!done.get()) {
         val now = System.nanoTime()
         val head = sleepersQueue.head()
         val nanos = head.triggerTime - now
+
+        // System.err.println(s"parking for $nanos nanos")
         LockSupport.parkNanos(pool, nanos)
 
-        if (parked.getAndSet(false)) {
-          pool.doneSleeping()
+        if (isInterrupted()) {
+          pool.shutdown()
+        } else {
+          if (parked.get()) {
+            // we were either awakened spuriously, or we timed out
+
+            if (head.triggerTime - System.nanoTime() <= 0) {
+              // we timed out
+              if (parked.getAndSet(false)) {
+                pool.doneSleeping()
+              }
+
+              return true
+            }
+          } else {
+            // we were awakened
+            return false
+          }
         }
       }
+
+      false
     }
 
     while (!done.get()) {
-
       if (blocking) {
         // The worker thread was blocked before. It is no longer part of the
         // core pool and needs to be cached.
@@ -393,25 +413,6 @@ private final class WorkerThread(
       }
 
       val sleepers = sleepersQueue
-
-      if (sleepers.nonEmpty) {
-        val now = System.nanoTime()
-
-        var cont = true
-        while (cont) {
-          val head = sleepers.head()
-
-          if (head.triggerTime - now <= 0) {
-            if (head.get()) {
-              head.callback(RightUnit)
-            }
-            sleepers.popHead()
-            cont = sleepers.nonEmpty
-          } else {
-            cont = false
-          }
-        }
-      }
 
       ((state & ExternalQueueTicksMask): @switch) match {
         case 0 =>
@@ -534,13 +535,20 @@ private final class WorkerThread(
               // Park the thread.
               if (sleepers.isEmpty) {
                 parkLoop()
-              } else {
-                parkUntilNextSleeper()
-              }
 
-              // After the worker thread has been unparked, look for work in the
-              // external queue.
-              state = 3
+                // After the worker thread has been unparked, look for work in the
+                // external queue.
+                state = 3
+              } else {
+                if (parkUntilNextSleeper()) {
+                  // we made it to the end of our sleeping, so go straight to local queue stuff
+                  pool.transitionWorkerFromSearching(rnd)
+                  state = 4
+                } else {
+                  // we were interrupted, look for more work in the external queue
+                  state = 3
+                }
+              }
             }
           }
 
@@ -580,13 +588,20 @@ private final class WorkerThread(
             // Park the thread.
             if (sleepers.isEmpty) {
               parkLoop()
-            } else {
-              parkUntilNextSleeper()
-            }
 
-            // After the worker thread has been unparked, look for work in the
-            // external queue.
-            state = 3
+              // After the worker thread has been unparked, look for work in the
+              // external queue.
+              state = 3
+            } else {
+              if (parkUntilNextSleeper()) {
+                // we made it to the end of our sleeping, so go straight to local queue stuff
+                pool.transitionWorkerFromSearching(rnd)
+                state = 4
+              } else {
+                // we were interrupted, look for more work in the external queue
+                state = 3
+              }
+            }
           }
 
         case 3 =>
@@ -643,6 +658,26 @@ private final class WorkerThread(
           }
 
         case _ =>
+          if (sleepers.nonEmpty) {
+            val now = System.nanoTime()
+
+            var cont = true
+            while (cont) {
+              val head = sleepers.head()
+
+              if (head.triggerTime - now <= 0) {
+                if (head.get()) {
+                  // System.err.println(s"dequeued with state = $state; sleepers = $sleepers")
+                  head.callback(RightUnit)
+                }
+                sleepers.popHead()
+                cont = sleepers.nonEmpty
+              } else {
+                cont = false
+              }
+            }
+          }
+
           // Check the queue bypass reference before dequeueing from the local
           // queue.
           val fiber = if (cedeBypass eq null) {

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -348,6 +348,7 @@ trait IOPlatformSpecification { self: BaseSpec with ScalaCheck =>
         implicit val runtime: IORuntime = IORuntime.builder().setCompute(pool, shutdown).build()
 
         try {
+          // longer sleep all-but guarantees this timer is fired *after* the worker is parked
           val test = IO.sleep(500.millis) *> IO.pure(true)
           test.unsafeRunTimed(5.seconds) must beSome(true)
         } finally {
@@ -362,6 +363,7 @@ trait IOPlatformSpecification { self: BaseSpec with ScalaCheck =>
         implicit val runtime: IORuntime = IORuntime.builder().setCompute(pool, shutdown).build()
 
         try {
+          // shorter sleep makes it more likely this timer fires *before* the worker is parked
           val test = IO.sleep(1.milli) *> IO.pure(true)
           test.unsafeRunTimed(1.second) must beSome(true)
         } finally {


### PR DESCRIPTION
This may fix @armanbilge's Fs2 issue. The essence here is the fact that `parkUntilNextSleeper` breaks an implicit assumption in the state machine, which is that the local queue cannot get *new* work items while the thread is parked. This is totally reasonable, but the timers stuff breaks this since new local work can come from timers expiring. The solution is to detect that some timer expired and then reroute directly to local work handling. In the rare case where the worker is awakened by external work *and* a timer expires simultaneously, the timer takes precedence, but the worker will eventually loop back around to state `0` which should poll externally or steal.