### PR TITLE
Corrected handling of self-cancelation within `timeout`

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -352,7 +352,7 @@ trait GenSpawn[F[_], E] extends MonadCancel[F, E] with Unique[F] {
             case Outcome.Succeeded(fa) => f.cancel *> fa.map(Left(_))
             case Outcome.Errored(ea) => f.cancel *> raiseError(ea)
             case Outcome.Canceled() =>
-              poll(f.join).onCancel(f.cancel).flatMap {
+              f.cancel *> f.join flatMap {
                 case Outcome.Succeeded(fb) => fb.map(Right(_))
                 case Outcome.Errored(eb) => raiseError(eb)
                 case Outcome.Canceled() => poll(canceled) *> never
@@ -363,7 +363,7 @@ trait GenSpawn[F[_], E] extends MonadCancel[F, E] with Unique[F] {
             case Outcome.Succeeded(fb) => f.cancel *> fb.map(Right(_))
             case Outcome.Errored(eb) => f.cancel *> raiseError(eb)
             case Outcome.Canceled() =>
-              poll(f.join).onCancel(f.cancel).flatMap {
+              f.cancel *> f.join flatMap {
                 case Outcome.Succeeded(fa) => fa.map(Left(_))
                 case Outcome.Errored(ea) => raiseError(ea)
                 case Outcome.Canceled() => poll(canceled) *> never

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenTemporal.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenTemporal.scala
@@ -152,9 +152,9 @@ trait GenTemporal[F[_], E] extends GenConcurrent[F, E] with Clock[F] {
     uncancelable { poll =>
       implicit val F: GenTemporal[F, E] = this
 
-      racePair(fa, sleep(duration)) flatMap {
+      poll(racePair(fa, sleep(duration))) flatMap {
         case Left((oc, f)) =>
-          poll(f.cancel *> oc.embedNever)
+          poll(f.cancel *> oc.embed(poll(F.canceled) *> F.never))
 
         case Right((f, _)) =>
           start(f.cancel) *> raiseError[A](ev(new TimeoutException(duration.toString)))

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -346,7 +346,7 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
             case Outcome.Errored(ea) =>
               F.raiseError[(Either[A, B], ExitCase => F[Unit])](ea).guarantee(cancelLoser(f))
             case Outcome.Canceled() =>
-              poll(f.join).onCancel(f.cancel).flatMap {
+              f.cancel *> f.join flatMap {
                 case Outcome.Succeeded(fb) =>
                   fb.map { case (b, fin) => (Either.right[A, B](b), fin) }
                 case Outcome.Errored(eb) =>
@@ -369,7 +369,7 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
             case Outcome.Errored(eb) =>
               F.raiseError[(Either[A, B], ExitCase => F[Unit])](eb).guarantee(cancelLoser(f))
             case Outcome.Canceled() =>
-              poll(f.join).onCancel(f.cancel).flatMap {
+              f.cancel *> f.join flatMap {
                 case Outcome.Succeeded(fa) =>
                   fa.map { case (a, fin) => (Either.left[A, B](a), fin) }
                 case Outcome.Errored(ea) =>

--- a/laws/shared/src/main/scala/cats/effect/laws/GenSpawnLaws.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenSpawnLaws.scala
@@ -33,10 +33,10 @@ trait GenSpawnLaws[F[_], E] extends MonadCancelLaws[F, E] with UniqueLaws[F] {
             case Outcome.Succeeded(fa) => F.productR(f.cancel)(F.map(fa)(Left(_)))
             case Outcome.Errored(ea) => F.productR(f.cancel)(F.raiseError(ea))
             case Outcome.Canceled() =>
-              F.flatMap(F.onCancel(poll(f.join), f.cancel)) {
+              F.flatMap(f.cancel *> f.join) {
                 case Outcome.Succeeded(fb) => F.map(fb)(Right(_))
                 case Outcome.Errored(eb) => F.raiseError(eb)
-                case Outcome.Canceled() => F.productR(F.canceled)(F.never)
+                case Outcome.Canceled() => F.productR(poll(F.canceled))(F.never)
               }
           }
         case Right((f, oc)) =>
@@ -44,10 +44,10 @@ trait GenSpawnLaws[F[_], E] extends MonadCancelLaws[F, E] with UniqueLaws[F] {
             case Outcome.Succeeded(fb) => F.productR(f.cancel)(F.map(fb)(Right(_)))
             case Outcome.Errored(eb) => F.productR(f.cancel)(F.raiseError(eb))
             case Outcome.Canceled() =>
-              F.flatMap(F.onCancel(poll(f.join), f.cancel)) {
+              F.flatMap(f.cancel *> f.join) {
                 case Outcome.Succeeded(fa) => F.map(fa)(Left(_))
                 case Outcome.Errored(ea) => F.raiseError(ea)
-                case Outcome.Canceled() => F.productR(F.canceled)(F.never)
+                case Outcome.Canceled() => F.productR(poll(F.canceled))(F.never)
               }
           }
       }
@@ -64,10 +64,10 @@ trait GenSpawnLaws[F[_], E] extends MonadCancelLaws[F, E] with UniqueLaws[F] {
             case Outcome.Succeeded(fa) => F.productR(f.cancel)(F.map(fa)(Left(_)))
             case Outcome.Errored(ea) => F.productR(f.cancel)(F.raiseError(ea))
             case Outcome.Canceled() =>
-              F.flatMap(F.onCancel(poll(f.join), f.cancel)) {
+              F.flatMap(f.cancel *> f.join) {
                 case Outcome.Succeeded(fb) => F.map(fb)(Right(_))
                 case Outcome.Errored(eb) => F.raiseError(eb)
-                case Outcome.Canceled() => F.productR(F.canceled)(F.never)
+                case Outcome.Canceled() => F.productR(poll(F.canceled))(F.never)
               }
           }
         case Right((f, oc)) =>
@@ -75,10 +75,10 @@ trait GenSpawnLaws[F[_], E] extends MonadCancelLaws[F, E] with UniqueLaws[F] {
             case Outcome.Succeeded(fb) => F.productR(f.cancel)(F.map(fb)(Right(_)))
             case Outcome.Errored(eb) => F.productR(f.cancel)(F.raiseError(eb))
             case Outcome.Canceled() =>
-              F.flatMap(F.onCancel(poll(f.join), f.cancel)) {
+              F.flatMap(f.cancel *> f.join) {
                 case Outcome.Succeeded(fa) => F.map(fa)(Left(_))
                 case Outcome.Errored(ea) => F.raiseError(ea)
-                case Outcome.Canceled() => F.productR(F.canceled)(F.never)
+                case Outcome.Canceled() => F.productR(poll(F.canceled))(F.never)
               }
           }
       }
@@ -87,25 +87,23 @@ trait GenSpawnLaws[F[_], E] extends MonadCancelLaws[F, E] with UniqueLaws[F] {
     F.race(F.never[A], fb) <-> results
   }
 
+  @deprecated("law is no longer applicable (or correct)", "3.5.0")
   def raceCanceledIdentityLeft[A](fa: F[A]) =
     F.race(F.canceled, fa.flatMap(F.pure(_)).handleErrorWith(F.raiseError(_))) <-> fa.map(
       _.asRight[Unit])
 
+  @deprecated("law is no longer applicable (or correct)", "3.5.0")
   def raceCanceledIdentityRight[A](fa: F[A]) =
     F.race(fa.flatMap(F.pure(_)).handleErrorWith(F.raiseError(_)), F.canceled) <-> fa.map(
       _.asLeft[Unit])
 
   def raceNeverNoncanceledIdentityLeft[A](fa: F[A]) =
-    F.race(F.never[Unit], fa.flatMap(F.pure(_)).handleErrorWith(F.raiseError(_))) <-> F
-      .onCancel(
-        fa.flatMap(r => F.pure(r.asRight[Unit])).handleErrorWith(F.raiseError(_)),
-        F.never)
+    F.race(F.never[Unit], fa.flatMap(F.pure(_)).handleErrorWith(F.raiseError(_))) <->
+      fa.flatMap(r => F.pure(r.asRight[Unit])).handleErrorWith(F.raiseError(_))
 
   def raceNeverNoncanceledIdentityRight[A](fa: F[A]) =
-    F.race(fa.flatMap(F.pure(_)).handleErrorWith(F.raiseError(_)), F.never[Unit]) <-> F
-      .onCancel(
-        fa.flatMap(r => F.pure(r.asLeft[Unit])).handleErrorWith(F.raiseError(_)),
-        F.never)
+    F.race(fa.flatMap(F.pure(_)).handleErrorWith(F.raiseError(_)), F.never[Unit]) <->
+      fa.flatMap(r => F.pure(r.asLeft[Unit])).handleErrorWith(F.raiseError(_))
 
   // I really like these laws, since they relate cede to timing, but they're definitely nondeterministic
   /*def raceLeftCedeYields[A](a: A) =

--- a/laws/shared/src/main/scala/cats/effect/laws/GenSpawnTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenSpawnTests.scala
@@ -107,8 +107,6 @@ trait GenSpawnTests[F[_], E] extends MonadCancelTests[F, E] with UniqueTests[F] 
         "race derives from racePair (left)" -> forAll(laws.raceDerivesFromRacePairLeft[A, B] _),
         "race derives from racePair (right)" -> forAll(
           laws.raceDerivesFromRacePairRight[A, B] _),
-        "race canceled identity (left)" -> forAll(laws.raceCanceledIdentityLeft[A] _),
-        "race canceled identity (right)" -> forAll(laws.raceCanceledIdentityRight[A] _),
         "race never non-canceled identity (left)" -> forAll(
           laws.raceNeverNoncanceledIdentityLeft[A] _),
         "race never non-canceled identity (right)" -> forAll(
@@ -197,8 +195,6 @@ trait GenSpawnTests[F[_], E] extends MonadCancelTests[F, E] with UniqueTests[F] 
         "race derives from racePair (left)" -> forAll(laws.raceDerivesFromRacePairLeft[A, B] _),
         "race derives from racePair (right)" -> forAll(
           laws.raceDerivesFromRacePairRight[A, B] _),
-        "race canceled identity (left)" -> forAll(laws.raceCanceledIdentityLeft[A] _),
-        "race canceled identity (right)" -> forAll(laws.raceCanceledIdentityRight[A] _),
         "race never non-canceled identity (left)" -> forAll(
           laws.raceNeverNoncanceledIdentityLeft[A] _),
         "race never non-canceled identity (right)" -> forAll(

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -18,7 +18,7 @@ package cats.effect
 
 import cats.effect.implicits._
 import cats.effect.laws.AsyncTests
-import cats.effect.testkit.TestContext
+import cats.effect.testkit.{TestContext, TestControl}
 import cats.kernel.laws.SerializableLaws.serializable
 import cats.kernel.laws.discipline.MonoidTests
 import cats.laws.discipline.{AlignTests, SemigroupKTests}
@@ -866,24 +866,24 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
             Outcome.canceled[IO, Throwable, Unit])
         }
 
-        "succeed if lhs cancels" in ticked { implicit ticker =>
-          IO.race(IO.canceled, IO.pure(1)) must completeAs(Right(1))
+        "cancel if lhs cancels and rhs succeeds" in ticked { implicit ticker =>
+          IO.race(IO.canceled, IO.sleep(1.milli) *> IO.pure(1)).void must selfCancel
         }
 
-        "succeed if rhs cancels" in ticked { implicit ticker =>
-          IO.race(IO.pure(1), IO.canceled) must completeAs(Left(1))
+        "cancel if rhs cancels and lhs succeeds" in ticked { implicit ticker =>
+          IO.race(IO.sleep(1.milli) *> IO.pure(1), IO.canceled).void must selfCancel
         }
 
-        "fail if lhs cancels and rhs fails" in ticked { implicit ticker =>
+        "cancel if lhs cancels and rhs fails" in ticked { implicit ticker =>
           case object TestException extends Throwable
-          IO.race(IO.canceled, IO.raiseError[Unit](TestException)).void must failAs(
-            TestException)
+          IO.race(IO.canceled, IO.sleep(1.milli) *> IO.raiseError[Unit](TestException))
+            .void must selfCancel
         }
 
-        "fail if rhs cancels and lhs fails" in ticked { implicit ticker =>
+        "cancel if rhs cancels and lhs fails" in ticked { implicit ticker =>
           case object TestException extends Throwable
-          IO.race(IO.raiseError[Unit](TestException), IO.canceled).void must failAs(
-            TestException)
+          IO.race(IO.sleep(1.milli) *> IO.raiseError[Unit](TestException), IO.canceled)
+            .void must selfCancel
         }
 
         "cancel both fibers" in ticked { implicit ticker =>
@@ -910,6 +910,42 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
               res must beRight(())
             }
           }
+        }
+
+        "immediately cancel when timing out canceled" in real {
+          val program = IO.canceled.timeout(2.seconds)
+
+          val test = TestControl.execute(program.start.flatMap(_.join)) flatMap { ctl =>
+            ctl.tickFor(1.second) *> ctl.results
+          }
+
+          test flatMap { results =>
+            IO {
+              results must beLike { case Some(Outcome.Succeeded(Outcome.Canceled())) => ok }
+            }
+          }
+        }
+
+        "immediately cancel when timing out and forgetting canceled" in real {
+          val program = IO.canceled.timeoutAndForget(2.seconds)
+          val test = TestControl.execute(program.start.flatMap(_.join)) flatMap { ctl =>
+            ctl.tickFor(1.second) *> ctl.results
+          }
+
+          test flatMap { results =>
+            IO {
+              results must beLike { case Some(Outcome.Succeeded(Outcome.Canceled())) => ok }
+            }
+          }
+        }
+
+        "timeout a suspended timeoutAndForget" in real {
+          val program = IO.never.timeoutAndForget(2.seconds).timeout(1.second)
+          val test = TestControl.execute(program.start.flatMap(_.join)) flatMap { ctl =>
+            ctl.tickFor(1.second) *> ctl.results
+          }
+
+          test.flatMap(results => IO(results must beSome))
         }
 
         "return the left when racing against never" in ticked { implicit ticker =>


### PR DESCRIPTION
This has to be targeted at 3.5.0 since it requires a law change. In particular, this adjusts the default race semantic such that `race(canceled, fa)` is now `canceled` rather than being equal to `fa`. I think this actually makes a lot more sense.

Fixes #3396 