### PR TITLE
Expand docs for Ref flatModify methods, and use them when appropriate

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -48,50 +48,48 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
       // start running the effect, or subscribe if it already is
       def evalOrSubscribe: F[A] =
         deferred[Fiber[F, E, A]] flatMap { deferredFiber =>
-          uncancelable { poll =>
-            state.modify {
-              case Unevaluated() =>
-                // run the effect, and if this fiber is still relevant set its result
-                val go = {
-                  def tryComplete(result: Memoize[F, E, A]): F[Unit] = state.update {
-                    case Evaluating(fiber, _) if fiber eq deferredFiber =>
-                      // we are the blessed fiber of this memo
-                      result
-                    case other => // our outcome is no longer relevant
-                      other
+          state.flatModifyFull {
+            case (poll, Unevaluated()) =>
+              // run the effect, and if this fiber is still relevant set its result
+              val go = {
+                def tryComplete(result: Memoize[F, E, A]): F[Unit] = state.update {
+                  case Evaluating(fiber, _) if fiber eq deferredFiber =>
+                    // we are the blessed fiber of this memo
+                    result
+                  case other => // our outcome is no longer relevant
+                    other
+                }
+
+                fa
+                  // hack around functor law breakage
+                  .flatMap(F.pure(_))
+                  .handleErrorWith(F.raiseError(_))
+                  // end hack
+                  .guaranteeCase {
+                    case Outcome.Canceled() =>
+                      tryComplete(Finished(Right(productR(canceled)(never))))
+                    case Outcome.Errored(err) =>
+                      tryComplete(Finished(Left(err)))
+                    case Outcome.Succeeded(fa) =>
+                      tryComplete(Finished(Right(fa)))
                   }
+              }
 
-                  fa
-                    // hack around functor law breakage
-                    .flatMap(F.pure(_))
-                    .handleErrorWith(F.raiseError(_))
-                    // end hack
-                    .guaranteeCase {
-                      case Outcome.Canceled() =>
-                        tryComplete(Finished(Right(productR(canceled)(never))))
-                      case Outcome.Errored(err) =>
-                        tryComplete(Finished(Left(err)))
-                      case Outcome.Succeeded(fa) =>
-                        tryComplete(Finished(Right(fa)))
-                    }
-                }
+              val eval = go.start.flatMap { fiber =>
+                deferredFiber.complete(fiber) *>
+                  poll(fiber.join.flatMap(_.embed(productR(canceled)(never))))
+                    .onCancel(unsubscribe(deferredFiber))
+              }
 
-                val eval = go.start.flatMap { fiber =>
-                  deferredFiber.complete(fiber) *>
-                    poll(fiber.join.flatMap(_.embed(productR(canceled)(never))))
-                      .onCancel(unsubscribe(deferredFiber))
-                }
+              Evaluating(deferredFiber, 1) -> eval
 
-                Evaluating(deferredFiber, 1) -> eval
+            case (poll, Evaluating(fiber, subscribers)) =>
+              Evaluating(fiber, subscribers + 1) ->
+                poll(fiber.get.flatMap(_.join).flatMap(_.embed(productR(canceled)(never))))
+                  .onCancel(unsubscribe(fiber))
 
-              case Evaluating(fiber, subscribers) =>
-                Evaluating(fiber, subscribers + 1) ->
-                  poll(fiber.get.flatMap(_.join).flatMap(_.embed(productR(canceled)(never))))
-                    .onCancel(unsubscribe(fiber))
-
-              case finished @ Finished(result) =>
-                finished -> fromEither(result).flatten
-            }.flatten
+            case (_, finished @ Finished(result)) =>
+              finished -> fromEither(result).flatten
           }
         }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
@@ -102,8 +102,14 @@ abstract class Ref[F[_], A] extends RefSource[F, A] with RefSink[F, A] {
   /**
    * Like [[modify]] but schedules resulting effect right after modification.
    *
-   * Both modification and finalizer are uncancelable, if you need cancellation mechanic in
-   * finalizer please see [[flatModifyFull]].
+   * Useful for implementing effectful transition of a state machine, in which an effect is
+   * performed based on current state and the state must be updated to reflect that this effect
+   * will be performed.
+   *
+   * Both modification and finalizer are within a single uncancelable region, to prevent
+   * canceled finalizers from leaving the Ref's value permanently out of sync with effects
+   * actually performed. if you need cancellation mechanic in finalizer please see
+   * [[flatModifyFull]].
    *
    * @see
    *   [[modify]]

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
@@ -122,8 +122,11 @@ abstract class Ref[F[_], A] extends RefSource[F, A] with RefSink[F, A] {
   /**
    * Like [[modify]] but schedules resulting effect right after modification.
    *
-   * Unlike [[flatModify]] finalizer cancellation could be masked via supplied `Poll`.
+   * Unlike [[flatModify]] finalizer cancellation could be unmasked via supplied `Poll`.
    * Modification itself is still uncancelable.
+   *
+   * When used as part of a state machine, cancelable regions should usually have an `onCancel`
+   * finalizer to update the state to reflect that the effect will not be performed.
    *
    * @see
    *   [[modify]]

--- a/std/shared/src/main/scala/cats/effect/std/CountDownLatch.scala
+++ b/std/shared/src/main/scala/cats/effect/std/CountDownLatch.scala
@@ -69,12 +69,10 @@ object CountDownLatch {
       extends CountDownLatch[F] {
 
     override def release: F[Unit] =
-      F.uncancelable { _ =>
-        state.modify {
-          case Awaiting(n, signal) =>
-            if (n > 1) (Awaiting(n - 1, signal), F.unit) else (Done(), signal.complete(()).void)
-          case d @ Done() => (d, F.unit)
-        }.flatten
+      state.flatModify {
+        case Awaiting(n, signal) =>
+          if (n > 1) (Awaiting(n - 1, signal), F.unit) else (Done(), signal.complete(()).void)
+        case d @ Done() => (d, F.unit)
       }
 
     override def await: F[Unit] =

--- a/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
+++ b/std/shared/src/main/scala/cats/effect/std/CyclicBarrier.scala
@@ -66,26 +66,24 @@ object CyclicBarrier {
       new CyclicBarrier[F] {
         val await: F[Unit] =
           F.deferred[Unit].flatMap { gate =>
-            F.uncancelable { poll =>
-              state.modify {
-                case State(awaiting, epoch, unblock) =>
-                  val awaitingNow = awaiting - 1
+            state.flatModifyFull {
+              case (poll, State(awaiting, epoch, unblock)) =>
+                val awaitingNow = awaiting - 1
 
-                  if (awaitingNow == 0)
-                    State(capacity, epoch + 1, gate) -> unblock.complete(()).void
-                  else {
-                    val newState = State(awaitingNow, epoch, unblock)
-                    // reincrement count if this await gets canceled,
-                    // but only if the barrier hasn't reset in the meantime
-                    val cleanup = state.update { s =>
-                      if (s.epoch == epoch) s.copy(awaiting = s.awaiting + 1)
-                      else s
-                    }
-
-                    newState -> poll(unblock.get).onCancel(cleanup)
+                if (awaitingNow == 0)
+                  State(capacity, epoch + 1, gate) -> unblock.complete(()).void
+                else {
+                  val newState = State(awaitingNow, epoch, unblock)
+                  // reincrement count if this await gets canceled,
+                  // but only if the barrier hasn't reset in the meantime
+                  val cleanup = state.update { s =>
+                    if (s.epoch == epoch) s.copy(awaiting = s.awaiting + 1)
+                    else s
                   }
 
-              }.flatten
+                  newState -> poll(unblock.get).onCancel(cleanup)
+                }
+
             }
           }
       }

--- a/std/shared/src/main/scala/cats/effect/std/Dequeue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dequeue.scala
@@ -184,20 +184,17 @@ object Dequeue {
       }
 
     private def _tryOffer(update: BankersQueue[A] => BankersQueue[A]) =
-      state
-        .modify {
-          case State(queue, size, takers, offerers) if takers.nonEmpty =>
-            val (taker, rest) = takers.dequeue
-            State(update(queue), size, rest, offerers) -> taker.complete(()).as(true)
+      state.flatModify {
+        case State(queue, size, takers, offerers) if takers.nonEmpty =>
+          val (taker, rest) = takers.dequeue
+          State(update(queue), size, rest, offerers) -> taker.complete(()).as(true)
 
-          case State(queue, size, takers, offerers) if size < capacity =>
-            State(update(queue), size + 1, takers, offerers) -> F.pure(true)
+        case State(queue, size, takers, offerers) if size < capacity =>
+          State(update(queue), size + 1, takers, offerers) -> F.pure(true)
 
-          case s =>
-            s -> F.pure(false)
-        }
-        .flatten
-        .uncancelable
+        case s =>
+          s -> F.pure(false)
+      }
 
     private def _take(dequeue: BankersQueue[A] => (BankersQueue[A], Option[A])): F[A] =
       F uncancelable { poll =>
@@ -254,22 +251,19 @@ object Dequeue {
 
     private def _tryTake(
         dequeue: BankersQueue[A] => (BankersQueue[A], Option[A])): F[Option[A]] =
-      state
-        .modify {
-          case State(queue, size, takers, offerers) if queue.nonEmpty && offerers.isEmpty =>
-            val (rest, ma) = dequeue(queue)
-            State(rest, size - 1, takers, offerers) -> F.pure(ma)
+      state.flatModify {
+        case State(queue, size, takers, offerers) if queue.nonEmpty && offerers.isEmpty =>
+          val (rest, ma) = dequeue(queue)
+          State(rest, size - 1, takers, offerers) -> F.pure(ma)
 
-          case State(queue, size, takers, offerers) if queue.nonEmpty =>
-            val (rest, ma) = dequeue(queue)
-            val (release, tail) = offerers.dequeue
-            State(rest, size - 1, takers, tail) -> release.complete(()).as(ma)
+        case State(queue, size, takers, offerers) if queue.nonEmpty =>
+          val (rest, ma) = dequeue(queue)
+          val (release, tail) = offerers.dequeue
+          State(rest, size - 1, takers, tail) -> release.complete(()).as(ma)
 
-          case s =>
-            s -> F.pure(none[A])
-        }
-        .flatten
-        .uncancelable
+        case s =>
+          s -> F.pure(none[A])
+      }
 
     override def size: F[Int] = state.get.map(_.size)
   }

--- a/std/shared/src/main/scala/cats/effect/std/PQueue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/PQueue.scala
@@ -105,19 +105,16 @@ object PQueue {
       }
 
     def tryOffer(a: A): F[Boolean] =
-      ref
-        .modify {
-          case State(heap, size, takers, offerers) if takers.nonEmpty =>
-            val (taker, rest) = takers.dequeue
-            State(heap.insert(a), size + 1, rest, offerers) -> taker.complete(()).as(true)
+      ref.flatModify {
+        case State(heap, size, takers, offerers) if takers.nonEmpty =>
+          val (taker, rest) = takers.dequeue
+          State(heap.insert(a), size + 1, rest, offerers) -> taker.complete(()).as(true)
 
-          case State(heap, size, takers, offerers) if size < capacity =>
-            State(heap.insert(a), size + 1, takers, offerers) -> F.pure(true)
+        case State(heap, size, takers, offerers) if size < capacity =>
+          State(heap.insert(a), size + 1, takers, offerers) -> F.pure(true)
 
-          case s => s -> F.pure(false)
-        }
-        .flatten
-        .uncancelable
+        case s => s -> F.pure(false)
+      }
 
     val take: F[A] =
       F.uncancelable { poll =>
@@ -159,22 +156,19 @@ object PQueue {
       }
 
     val tryTake: F[Option[A]] =
-      ref
-        .modify {
-          case State(heap, size, takers, offerers) if heap.nonEmpty && offerers.isEmpty =>
-            val (rest, a) = heap.take
-            State(rest, size - 1, takers, offerers) -> F.pure(a.some)
+      ref.flatModify {
+        case State(heap, size, takers, offerers) if heap.nonEmpty && offerers.isEmpty =>
+          val (rest, a) = heap.take
+          State(rest, size - 1, takers, offerers) -> F.pure(a.some)
 
-          case State(heap, size, takers, offerers) if heap.nonEmpty =>
-            val (rest, a) = heap.take
-            val (release, tail) = offerers.dequeue
-            State(rest, size - 1, takers, tail) -> release.complete(()).as(a.some)
+        case State(heap, size, takers, offerers) if heap.nonEmpty =>
+          val (rest, a) = heap.take
+          val (release, tail) = offerers.dequeue
+          State(rest, size - 1, takers, tail) -> release.complete(()).as(a.some)
 
-          case s =>
-            s -> F.pure(none[A])
-        }
-        .flatten
-        .uncancelable
+        case s =>
+          s -> F.pure(none[A])
+      }
 
     def size: F[Int] =
       ref.get.map(_.size)


### PR DESCRIPTION
There's a lot of indentation changes, so easiest to review with "hide whitespace" enabled.