### PR TITLE
Add `Async#blockingCancelable`

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -169,19 +169,22 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
    *   context
    */
   def blockingCancelable[A](cancel: F[Unit])(thunk: => A): F[A] =
-    flatMap2(deferred[Unit], delay(new AtomicBoolean(false))) { (gate, completed) =>
-      map(
-        race(
-          productR(gate.get)( // ensure cancelation fiber started before blocking
-            blocking(
-              try thunk
-              finally completed.set(true)
-            )),
-          onCancel(
-            productR(gate.complete(()))(never[A]),
-            ifM(delay(completed.get()))(unit, cancel)
-          )
-        ))(_.merge)
+    flatMap3(deferred[Unit], delay(new AtomicBoolean(false)), delay(new AtomicBoolean(false))) {
+      (gate, started, completed) =>
+        map(
+          race(
+            productR(gate.get)( // ensure cancelation fiber started before blocking
+              blocking {
+                started.set(true)
+                try thunk
+                finally completed.set(true)
+              }),
+            onCancel(
+              productR(gate.complete(()))(never[A]),
+              // only cancel if blocking has started and has not completed
+              ifM(delay(started.get() && !completed.get()))(cancel, unit)
+            )
+          ))(_.merge)
     }
 
   /**

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -25,8 +25,7 @@ import scala.annotation.{nowarn, tailrec}
 import scala.concurrent.{ExecutionContext, Future}
 
 import java.util.concurrent.Executor
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
 /**
  * A typeclass that encodes the notion of suspending asynchronous side effects in the `F[_]`

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -172,7 +172,10 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
     flatMap(delay(new AtomicBoolean(false))) { completed =>
       map(
         race(
-          guarantee(blocking(thunk), delay(completed.set(true))),
+          blocking(
+            try thunk
+            finally completed.set(true)
+          ),
           onCancel(never[A], ifM(delay(completed.get()))(unit, cancel))
         ))(_.merge)
     }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Sync.scala
@@ -66,7 +66,8 @@ trait Sync[F[_]] extends MonadCancel[F, Throwable] with Clock[F] with Unique[F] 
    * execution of the blocking operation to a separate threadpool to avoid blocking on the main
    * execution context. See the thread-model documentation for more information on why this is
    * necessary. Note that the created effect will be uncancelable; if you need cancelation then
-   * you should use [[Sync.interruptible]] or [[Sync.interruptibleMany]].
+   * you should use [[Async.blockingCancelable]], [[Sync.interruptible]], or
+   * [[Sync.interruptibleMany]].
    *
    * {{{
    * Sync[F].blocking(scala.io.Source.fromFile("path").mkString)

--- a/tests/jvm/src/test/scala/cats/effect/kernel/AsyncPlatformSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/kernel/AsyncPlatformSpec.scala
@@ -69,4 +69,23 @@ class AsyncPlatformSpec extends BaseSpec {
         .map(_.forall(identity(_)))
     }
   }
+
+  "blockingCancelable" should {
+    "externally cancel a blocking op" in real {
+      IO(new Object)
+        .flatMap { blocker =>
+          Async[IO].blockingCancelable(IO {
+            blocker.synchronized {
+              blocker.notify()
+            }
+          }) {
+            blocker.synchronized {
+              blocker.wait()
+            }
+          }
+        }
+        .timeoutTo(1.second, IO.unit)
+        .as(ok)
+    }
+  }
 }


### PR DESCRIPTION
This is a common idiom I am encountering with JDK I/O APIs: the operation is not _interruptible_, but it is possible to "cancel" it by closing the underlying resource. While this is not the "ideal" form of cancelation, it is much better than a completely uncancelable op that hangs your program (and indefinitely squats a thread). Besides, usually when you are canceling it you are about to close the resource _anyway_.

I've encoded this as an `Async#blockingCancelable` combinator. The logic is non-trivial, and requires concurrent state to ensure that the cancelation fiber is in place before starting the blocking op, and that cancelation happens only when in the blocking region. This is important since cancelation is presumed to be destructive (i.e. closing a resource), so it should be performed only conservatively.