### PR TITLE
Try using a field for `IO#tag`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -620,7 +620,13 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         "cats.effect.IOFiberConstants.ContStateResult"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("cats.effect.IOLocal.scope"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
-        "cats.effect.IOFiberConstants.ContStateResult")
+        "cats.effect.IOFiberConstants.ContStateResult"),
+      // introduced by #3471
+      // make `IO#tag` a field
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IO#IOCont#Get.tag"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "cats.effect.IO#Uncancelable#UnmaskRunLoop.tag")
     ) ++ {
       if (tlIsScala3.value) {
         // Scala 3 specific exclusions

--- a/core/js/src/main/scala/cats/effect/IOPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOPlatform.scala
@@ -19,7 +19,7 @@ package cats.effect
 import scala.concurrent.Future
 import scala.scalajs.js.{|, Function1, JavaScriptException, Promise, Thenable}
 
-abstract private[effect] class IOPlatform[+A] { self: IO[A] =>
+abstract private[effect] class IOPlatform[+A](private[effect] val tag: Byte) { self: IO[A] =>
 
   /**
    * Evaluates the effect and produces the result in a JavaScript `Promise`.

--- a/core/jvm/src/main/java/cats/effect/IOTag.java
+++ b/core/jvm/src/main/java/cats/effect/IOTag.java
@@ -18,6 +18,7 @@ package cats.effect;
 
 abstract class IOTag {
   final byte tag;
+
   protected IOTag(byte tag) {
     this.tag = tag;
   }

--- a/core/jvm/src/main/java/cats/effect/IOTag.java
+++ b/core/jvm/src/main/java/cats/effect/IOTag.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020-2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect;
+
+abstract class IOTag {
+  final byte tag;
+  protected IOTag(byte tag) {
+    this.tag = tag;
+  }
+}

--- a/core/jvm/src/main/java/cats/effect/IOTag.java
+++ b/core/jvm/src/main/java/cats/effect/IOTag.java
@@ -16,7 +16,10 @@
 
 package cats.effect;
 
-abstract class IOTag {
+import java.io.Serializable;
+
+@SuppressWarnings("serial")
+abstract class IOTag implements Serializable {
   final byte tag;
 
   protected IOTag(byte tag) {

--- a/core/jvm/src/main/scala/cats/effect/IOPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOPlatform.scala
@@ -22,7 +22,7 @@ import scala.concurrent.duration._
 
 import java.util.concurrent.{ArrayBlockingQueue, CompletableFuture, TimeUnit}
 
-abstract private[effect] class IOPlatform[+A](tag: Byte) extends IOTag(tag) {
+abstract private[effect] class IOPlatform[+A](tag: Byte) extends IOTag(tag) with Serializable {
   self: IO[A] =>
 
   /**

--- a/core/jvm/src/main/scala/cats/effect/IOPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOPlatform.scala
@@ -22,7 +22,8 @@ import scala.concurrent.duration._
 
 import java.util.concurrent.{ArrayBlockingQueue, CompletableFuture, TimeUnit}
 
-abstract private[effect] class IOPlatform[+A] extends Serializable { self: IO[A] =>
+abstract private[effect] class IOPlatform[+A](tag: Byte) extends IOTag(tag) with Serializable {
+  self: IO[A] =>
 
   /**
    * Produces the result by running the encapsulated effects as impure side effects.

--- a/core/jvm/src/main/scala/cats/effect/IOPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOPlatform.scala
@@ -22,7 +22,7 @@ import scala.concurrent.duration._
 
 import java.util.concurrent.{ArrayBlockingQueue, CompletableFuture, TimeUnit}
 
-abstract private[effect] class IOPlatform[+A](tag: Byte) extends IOTag(tag) with Serializable {
+abstract private[effect] class IOPlatform[+A](tag: Byte) extends IOTag(tag) {
   self: IO[A] =>
 
   /**

--- a/core/native/src/main/scala/cats/effect/IOPlatform.scala
+++ b/core/native/src/main/scala/cats/effect/IOPlatform.scala
@@ -16,4 +16,4 @@
 
 package cats.effect
 
-abstract private[effect] class IOPlatform[+A]
+abstract private[effect] class IOPlatform[+A](private[effect] val tag: Byte)

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -107,9 +107,9 @@ import java.util.concurrent.Executor
  * @see
  *   [[IOApp]] for the preferred way of executing whole programs wrapped in `IO`
  */
-sealed abstract class IO[+A] private () extends IOPlatform[A] {
+sealed abstract class IO[+A] private (tag: Byte) extends IOPlatform[A](tag) {
 
-  private[effect] def tag: Byte
+  // private[effect] def tag: Byte
 
   /**
    * Like [[*>]], but keeps the result of the source.
@@ -1962,131 +1962,106 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
   // implementations
 
-  private[effect] final case class Pure[+A](value: A) extends IO[A] {
-    def tag = 0
+  private[effect] final case class Pure[+A](value: A) extends IO[A](0) {
     override def toString: String = s"IO($value)"
   }
 
-  private[effect] final case class Error(t: Throwable) extends IO[Nothing] {
-    def tag = 1
+  private[effect] final case class Error(t: Throwable) extends IO[Nothing](1) {
   }
 
   private[effect] final case class Delay[+A](thunk: () => A, event: TracingEvent)
-      extends IO[A] {
-    def tag = 2
+      extends IO[A](2) {
   }
 
-  private[effect] case object RealTime extends IO[FiniteDuration] {
-    def tag = 3
+  private[effect] case object RealTime extends IO[FiniteDuration](3) {
   }
 
-  private[effect] case object Monotonic extends IO[FiniteDuration] {
-    def tag = 4
+  private[effect] case object Monotonic extends IO[FiniteDuration](4) {
   }
 
-  private[effect] case object ReadEC extends IO[ExecutionContext] {
-    def tag = 5
+  private[effect] case object ReadEC extends IO[ExecutionContext](5) {
   }
 
   private[effect] final case class Map[E, +A](ioe: IO[E], f: E => A, event: TracingEvent)
-      extends IO[A] {
-    def tag = 6
+      extends IO[A](6) {
   }
 
   private[effect] final case class FlatMap[E, +A](
       ioe: IO[E],
       f: E => IO[A],
       event: TracingEvent)
-      extends IO[A] {
-    def tag = 7
+      extends IO[A](7) {
   }
 
-  private[effect] final case class Attempt[+A](ioa: IO[A]) extends IO[Either[Throwable, A]] {
-    def tag = 8
+  private[effect] final case class Attempt[+A](ioa: IO[A]) extends IO[Either[Throwable, A]](8) {
   }
 
   private[effect] final case class HandleErrorWith[+A](
       ioa: IO[A],
       f: Throwable => IO[A],
       event: TracingEvent)
-      extends IO[A] {
-    def tag = 9
+      extends IO[A](9) {
   }
 
-  private[effect] case object Canceled extends IO[Unit] {
-    def tag = 10
+  private[effect] case object Canceled extends IO[Unit](10) {
   }
 
-  private[effect] final case class OnCancel[+A](ioa: IO[A], fin: IO[Unit]) extends IO[A] {
-    def tag = 11
+  private[effect] final case class OnCancel[+A](ioa: IO[A], fin: IO[Unit]) extends IO[A](11) {
   }
 
   private[effect] final case class Uncancelable[+A](
       body: Poll[IO] => IO[A],
       event: TracingEvent)
-      extends IO[A] {
-    def tag = 12
+      extends IO[A](12) {
   }
   private[effect] object Uncancelable {
     // INTERNAL, it's only created by the runloop itself during the execution of `Uncancelable`
-    final case class UnmaskRunLoop[+A](ioa: IO[A], id: Int, self: IOFiber[_]) extends IO[A] {
-      def tag = 13
+    final case class UnmaskRunLoop[+A](ioa: IO[A], id: Int, self: IOFiber[_]) extends IO[A](13) {
     }
   }
 
   // Low level construction that powers `async`
   private[effect] final case class IOCont[K, R](body: Cont[IO, K, R], event: TracingEvent)
-      extends IO[R] {
-    def tag = 14
+      extends IO[R](14) {
   }
   private[effect] object IOCont {
     // INTERNAL, it's only created by the runloop itself during the execution of `IOCont`
-    final case class Get[A](state: ContState) extends IO[A] {
-      def tag = 15
+    final case class Get[A](state: ContState) extends IO[A](15) {
     }
   }
 
-  private[effect] case object Cede extends IO[Unit] {
-    def tag = 16
+  private[effect] case object Cede extends IO[Unit](16) {
   }
 
-  private[effect] final case class Start[A](ioa: IO[A]) extends IO[FiberIO[A]] {
-    def tag = 17
+  private[effect] final case class Start[A](ioa: IO[A]) extends IO[FiberIO[A]](17) {
   }
 
   private[effect] final case class RacePair[A, B](ioa: IO[A], iob: IO[B])
-      extends IO[Either[(OutcomeIO[A], FiberIO[B]), (FiberIO[A], OutcomeIO[B])]] {
-    def tag = 18
+      extends IO[Either[(OutcomeIO[A], FiberIO[B]), (FiberIO[A], OutcomeIO[B])]](18) {
   }
 
-  private[effect] final case class Sleep(delay: FiniteDuration) extends IO[Unit] {
-    def tag = 19
+  private[effect] final case class Sleep(delay: FiniteDuration) extends IO[Unit](19) {
   }
 
-  private[effect] final case class EvalOn[+A](ioa: IO[A], ec: ExecutionContext) extends IO[A] {
-    def tag = 20
+  private[effect] final case class EvalOn[+A](ioa: IO[A], ec: ExecutionContext) extends IO[A](20) {
   }
 
   private[effect] final case class Blocking[+A](
       hint: Sync.Type,
       thunk: () => A,
       event: TracingEvent)
-      extends IO[A] {
-    def tag = 21
+      extends IO[A](21) {
   }
 
   private[effect] final case class Local[+A](f: IOLocalState => (IOLocalState, A))
-      extends IO[A] {
-    def tag = 22
+      extends IO[A](22) {
   }
 
-  private[effect] case object IOTrace extends IO[Trace] {
-    def tag = 23
+  private[effect] case object IOTrace extends IO[Trace](23) {
   }
 
   // INTERNAL, only created by the runloop itself as the terminal state of several operations
-  private[effect] case object EndFiber extends IO[Nothing] {
-    def tag = -1
+  private[effect] case object EndFiber extends IO[Nothing](-1) {
   }
 
 }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1966,103 +1966,80 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     override def toString: String = s"IO($value)"
   }
 
-  private[effect] final case class Error(t: Throwable) extends IO[Nothing](1) {
-  }
+  private[effect] final case class Error(t: Throwable) extends IO[Nothing](1)
 
   private[effect] final case class Delay[+A](thunk: () => A, event: TracingEvent)
-      extends IO[A](2) {
-  }
+      extends IO[A](2)
 
-  private[effect] case object RealTime extends IO[FiniteDuration](3) {
-  }
+  private[effect] case object RealTime extends IO[FiniteDuration](3)
 
-  private[effect] case object Monotonic extends IO[FiniteDuration](4) {
-  }
+  private[effect] case object Monotonic extends IO[FiniteDuration](4)
 
-  private[effect] case object ReadEC extends IO[ExecutionContext](5) {
-  }
+  private[effect] case object ReadEC extends IO[ExecutionContext](5)
 
   private[effect] final case class Map[E, +A](ioe: IO[E], f: E => A, event: TracingEvent)
-      extends IO[A](6) {
-  }
+      extends IO[A](6)
 
   private[effect] final case class FlatMap[E, +A](
       ioe: IO[E],
       f: E => IO[A],
       event: TracingEvent)
-      extends IO[A](7) {
-  }
+      extends IO[A](7)
 
-  private[effect] final case class Attempt[+A](ioa: IO[A]) extends IO[Either[Throwable, A]](8) {
-  }
+  private[effect] final case class Attempt[+A](ioa: IO[A]) extends IO[Either[Throwable, A]](8)
 
   private[effect] final case class HandleErrorWith[+A](
       ioa: IO[A],
       f: Throwable => IO[A],
       event: TracingEvent)
-      extends IO[A](9) {
-  }
+      extends IO[A](9)
 
-  private[effect] case object Canceled extends IO[Unit](10) {
-  }
+  private[effect] case object Canceled extends IO[Unit](10)
 
-  private[effect] final case class OnCancel[+A](ioa: IO[A], fin: IO[Unit]) extends IO[A](11) {
-  }
+  private[effect] final case class OnCancel[+A](ioa: IO[A], fin: IO[Unit]) extends IO[A](11)
 
   private[effect] final case class Uncancelable[+A](
       body: Poll[IO] => IO[A],
       event: TracingEvent)
-      extends IO[A](12) {
-  }
+      extends IO[A](12) {}
   private[effect] object Uncancelable {
     // INTERNAL, it's only created by the runloop itself during the execution of `Uncancelable`
-    final case class UnmaskRunLoop[+A](ioa: IO[A], id: Int, self: IOFiber[_]) extends IO[A](13) {
-    }
+    final case class UnmaskRunLoop[+A](ioa: IO[A], id: Int, self: IOFiber[_]) extends IO[A](13)
   }
 
   // Low level construction that powers `async`
   private[effect] final case class IOCont[K, R](body: Cont[IO, K, R], event: TracingEvent)
-      extends IO[R](14) {
-  }
+      extends IO[R](14)
   private[effect] object IOCont {
     // INTERNAL, it's only created by the runloop itself during the execution of `IOCont`
-    final case class Get[A](state: ContState) extends IO[A](15) {
-    }
+    final case class Get[A](state: ContState) extends IO[A](15)
   }
 
-  private[effect] case object Cede extends IO[Unit](16) {
-  }
+  private[effect] case object Cede extends IO[Unit](16)
 
-  private[effect] final case class Start[A](ioa: IO[A]) extends IO[FiberIO[A]](17) {
-  }
+  private[effect] final case class Start[A](ioa: IO[A]) extends IO[FiberIO[A]](17)
 
   private[effect] final case class RacePair[A, B](ioa: IO[A], iob: IO[B])
-      extends IO[Either[(OutcomeIO[A], FiberIO[B]), (FiberIO[A], OutcomeIO[B])]](18) {
-  }
+      extends IO[Either[(OutcomeIO[A], FiberIO[B]), (FiberIO[A], OutcomeIO[B])]](18)
 
-  private[effect] final case class Sleep(delay: FiniteDuration) extends IO[Unit](19) {
-  }
+  private[effect] final case class Sleep(delay: FiniteDuration) extends IO[Unit](19)
 
-  private[effect] final case class EvalOn[+A](ioa: IO[A], ec: ExecutionContext) extends IO[A](20) {
-  }
+  private[effect] final case class EvalOn[+A](ioa: IO[A], ec: ExecutionContext)
+      extends IO[A](20)
 
   private[effect] final case class Blocking[+A](
       hint: Sync.Type,
       thunk: () => A,
       event: TracingEvent)
-      extends IO[A](21) {
-  }
+      extends IO[A](21)
 
   private[effect] final case class Local[+A](f: IOLocalState => (IOLocalState, A))
-      extends IO[A](22) {
-  }
+      extends IO[A](22)
 
-  private[effect] case object IOTrace extends IO[Trace](23) {
-  }
+  private[effect] case object IOTrace extends IO[Trace](23)
 
   // INTERNAL, only created by the runloop itself as the terminal state of several operations
-  private[effect] case object EndFiber extends IO[Nothing](-1) {
-  }
+  private[effect] case object EndFiber extends IO[Nothing](-1)
 
 }
 


### PR DESCRIPTION
All the talk about unsafe shenanigans when I thought we may as well try the obvious thing: `final byte tag;`.

(De-)compiles down to this in the runloop:
```java
byte by = cur0.tag;
switch (by) {
```

Threw a couple of benchmarks at it, seems to be a win? `delay` came out a bit weird.

#### This PR
```
Benchmark                (size)   Mode  Cnt     Score    Error  Units
DeepBindBenchmark.async           10000  thrpt   20  1270.544 ±   8.526  ops/s
DeepBindBenchmark.delay           10000  thrpt   20  3699.730 ± 215.698  ops/s
DeepBindBenchmark.pure            10000  thrpt   20  4707.829 ± 181.234  ops/s
RedeemWithBenchmark.errorRaised   10000  thrpt   20  1147.630 ±   6.235  ops/s
RedeemWithBenchmark.happyPath     10000  thrpt   20  1693.848 ±  13.185  ops/s
```

#### series/3.x
```
Benchmark                (size)   Mode  Cnt     Score    Error  Units
DeepBindBenchmark.async           10000  thrpt   20  1076.945 ± 67.990  ops/s
DeepBindBenchmark.delay           10000  thrpt   20  3819.385 ± 37.620  ops/s
DeepBindBenchmark.pure            10000  thrpt   20  4346.132 ± 60.918  ops/s
RedeemWithBenchmark.errorRaised   10000  thrpt   20  1071.057 ± 13.123  ops/s
RedeemWithBenchmark.happyPath     10000  thrpt   20  1604.361 ±  9.081  ops/s
```