### PR TITLE
debugging notes

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -510,17 +510,21 @@ private[effect] final class WorkStealingThreadPool(
    *   the runnable to be executed
    */
   override def execute(runnable: Runnable): Unit = {
+    println(s"SRP WSTP: inside execute")
     val pool = this
     val thread = Thread.currentThread()
 
     if (thread.isInstanceOf[WorkerThread]) {
       val worker = thread.asInstanceOf[WorkerThread]
       if (worker.isOwnedBy(pool)) {
+        println(s"SRP WSTP: schedule if worker owned by pool")
         worker.schedule(runnable)
       } else {
+        println(s"SRP WSTP: schedule external 1")
         scheduleExternal(runnable)
       }
     } else {
+      println(s"SRP WSTP: schedule external 2 ${thread.getName()}")
       scheduleExternal(runnable)
     }
   }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -938,7 +938,10 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    * should never be totally silent.
    */
   def unsafeRunAndForget()(implicit runtime: unsafe.IORuntime): Unit = {
-    val _ = unsafeRunFiber((), _ => (), _ => ())
+    println(
+      s"SRP unsafeRunAndForget: report unhandled errors? ${runtime.config.reportUnhandledFiberErrors}")
+    val _ =
+      unsafeRunFiber((), _ => (), _ => ())
     ()
   }
 
@@ -1014,6 +1017,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
             canceled
           },
           { t =>
+            println(s"SRP unsafeRunFiber: inside failure outcome")
             runtime.fiberErrorCbs.remove(failure)
             failure(t)
           },

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -113,6 +113,7 @@ private final class IOFiber[A](
 
   override def run(): Unit = {
     // insert a read barrier after every async boundary
+    println("SRP fiber run")
     readBarrier()
     (resumeTag: @switch) match {
       case 0 => execR()
@@ -1015,12 +1016,14 @@ private final class IOFiber[A](
    */
   private[this] def done(oc: OutcomeIO[A]): Unit = {
     // println(s"<$name> invoking done($oc); callback = ${callback.get()}")
+    println("SRP fiber done")
     _join = IO.pure(oc)
     _cancel = IO.unit
 
     outcome = oc
 
     try {
+      println(s"SRP outcome stack: ${oc}")
       if (!callbacks(oc, false) && runtime.config.reportUnhandledFiberErrors) {
         oc match {
           case Outcome.Errored(e) => currentCtx.reportFailure(e)


### PR DESCRIPTION
- #3468 
## Running
I've been testing with scala 3. I've been running this by:
- changing the version in build.sbt to `3.5-sam-SNAPSHOT`
- in sbt change the scala version to 3.2.2
- running `rootJVM/publishLocal` 
- using scala-cli to run Arman's example from the issue
```scala
//> using scala "3.2.2"
//> using lib "org.typelevel::cats-effect::3.5-sam-SNAPSHOT"

import cats.effect.*
import cats.effect.unsafe.implicits.*

@main def main =
  IO.raiseError(new RuntimeException).unsafeRunAndForget()
  Thread.sleep(1000)
```

## Notes
- added printlns all over the place
- tried to use them to follow my way down the worker thread
  - inside `run` on worker thread we end up in case 3: worker looking for work in external queue
    - in case 3 we find an element, which is a single runnable (vs. array of runnable)
    - the runnable is an IOFiber, and WT calls `fiber.run()`
- however the `try fiber.run()` DOES NOT cause me to see the println that I put in the fiber.run method
- also don't see anything coming out of fiber `done` method