### PR TITLE
report failures during unsafeRunAndForget

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -865,7 +865,17 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    * should never be totally silent.
    */
   def unsafeRunAndForget()(implicit runtime: unsafe.IORuntime): Unit = {
-    val _ = unsafeRunFiber((), _ => (), _ => ())
+    val _ = unsafeRunFiber(
+      (),
+      t => {
+        if (NonFatal(t) && runtime.config.reportUnhandledFiberErrors) {
+          runtime.compute.reportFailure(t)
+        } else {
+          // fatal failure
+          t.printStackTrace()
+        }
+      },
+      _ => ())
     ()
   }
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -868,11 +868,10 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
     val _ = unsafeRunFiber(
       (),
       t => {
-        if (NonFatal(t) && runtime.config.reportUnhandledFiberErrors) {
-          runtime.compute.reportFailure(t)
-        } else {
-          t.printStackTrace()
-        }
+        if (NonFatal(t)) {
+          if (runtime.config.reportUnhandledFiberErrors)
+            runtime.compute.reportFailure(t)
+        } else { t.printStackTrace() }
       },
       _ => ())
     ()

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -871,7 +871,6 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
         if (NonFatal(t) && runtime.config.reportUnhandledFiberErrors) {
           runtime.compute.reportFailure(t)
         } else {
-          // fatal failure
           t.printStackTrace()
         }
       },

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1346,7 +1346,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         test.flatMap(_ => IO(canceled)) must completeAs(true)
       }
 
-      "handle errors raised during unsafeRunAndForget" in ticked { implicit ticker =>
+      "report errors raised during unsafeRunAndForget" in ticked { implicit ticker =>
         import cats.effect.unsafe.IORuntime
         import scala.concurrent.Promise
         val test = for {

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -320,7 +320,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
             .builder()
             .setCompute(ec2(ec, errorReporter), () => ())
             .build()
-          _ = IO.raiseError(new RuntimeException).unsafeRunAndForget()(customRuntime)
+          _ <- IO(IO.raiseError(new RuntimeException).unsafeRunAndForget()(customRuntime))
           reported <- IO.fromFuture(IO(errorReporter.future))
         } yield reported
         test must completeAs(true)


### PR DESCRIPTION
We noticed in #3468 that errors were being swallowed by `unsafeRunAndForget()`. After exploring, I found that there is a callback invoked for the fiber in this case, which causes it to bypass the error reporting in `IOFiber.done`:
https://github.com/typelevel/cats-effect/blob/a9eac6cf8685a43bb45db2d4ce35a387a7ec8c52/core/shared/src/main/scala/cats/effect/IOFiber.scala#L1024

This PR updates `unsafeRunAndForget` to report non-fatal errors, if the runtime is configured to do so, and also prints the stack trace of fatal errors.

resolves #3468 