### PR TITLE
Don't shadow `println` in `IOFiber`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -77,7 +77,7 @@ private final class IOFiber[A](
   suspended: AtomicBoolean =>
 
   import IOFiber._
-  import IO._
+  import IO.{println => _, _}
   import IOFiberConstants._
   import TracingConstants._
 


### PR DESCRIPTION
Fool me once, shame on you;
Fool me twice, shame on me.
h/t @samspills 