### PR TITLE
Fix typo in `Resource` docs

### DIFF
--- a/docs/std/resource.md
+++ b/docs/std/resource.md
@@ -60,7 +60,7 @@ abstract class Resource[F, A] {
 Our concat example then becomes:
 
 ```scala
-def file(name: String): Resource[IO, File] = Resource.make(openFile(name)))(file => close(file))
+def file(name: String): Resource[IO, File] = Resource.make(openFile(name))(file => close(file))
 
 val concat: IO[Unit] =
   (


### PR DESCRIPTION
I noticed an extra parentheses in this code snippet so I thought it wouldn't be hard to PR its removal