### PR TITLE
Make `HotSwap` safe to concurrent access

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -915,7 +915,10 @@ lazy val std = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       // introduced by #3409
       // extracted UnsafeUnbounded private data structure
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$UnsafeUnbounded"),
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$UnsafeUnbounded$Cell")
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$UnsafeUnbounded$Cell"),
+      // introduced by #3480
+      // adds method to sealed Hotswap
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("cats.effect.std.Hotswap.get")
     )
   )
   .jsSettings(

--- a/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
@@ -64,10 +64,19 @@ sealed trait Hotswap[F[_], R] {
    * is not used thereafter. Failure to do so may result in an error on the _consumer_ side. In
    * any case, no resources will be leaked.
    *
+   * For safer access to the current resource see [[get]], which guarantees that it will not be
+   * released while it is being used.
+   *
    * If [[swap]] is called after the lifetime of the [[Hotswap]] is over, it will raise an
    * error, but will ensure that all resources are finalized before returning.
    */
   def swap(next: Resource[F, R]): F[R]
+
+  /**
+   * Gets the current resource, if it exists. The returned resource is guaranteed to be
+   * available for the duration of the returned resource.
+   */
+  def get: Resource[F, Option[R]]
 
   /**
    * Pops and runs the finalizer of the current resource, if it exists.
@@ -93,42 +102,64 @@ object Hotswap {
    * swapped during the lifetime of this [[Hotswap]].
    */
   def create[F[_], R](implicit F: Concurrent[F]): Resource[F, Hotswap[F, R]] = {
-    type State = Option[F[Unit]]
+    sealed abstract class State
+    case object Cleared extends State
+    case class Acquired(r: R, fin: F[Unit]) extends State
+    case object Finalized extends State
 
     def initialize: F[Ref[F, State]] =
-      F.ref(Some(F.pure(())))
+      F.ref(Cleared)
 
     def finalize(state: Ref[F, State]): F[Unit] =
-      state.getAndSet(None).flatMap {
-        case Some(finalizer) => finalizer
-        case None => raise("Hotswap already finalized")
+      state.getAndSet(Finalized).flatMap {
+        case Acquired(_, finalizer) => finalizer
+        case Cleared => F.unit
+        case Finalized => raise("Hotswap already finalized")
       }
 
     def raise(message: String): F[Unit] =
       F.raiseError[Unit](new RuntimeException(message))
 
-    Resource.make(initialize)(finalize).map { state =>
-      new Hotswap[F, R] {
+    Resource.eval(Mutex[F]).flatMap { mutex =>
+      Resource.make(initialize)(finalize).map { state =>
+        new Hotswap[F, R] {
 
-        override def swap(next: Resource[F, R]): F[R] =
-          F.uncancelable { poll =>
-            poll(next.allocated).flatMap {
-              case (r, finalizer) =>
-                swapFinalizer(finalizer).as(r)
+          override def swap(next: Resource[F, R]): F[R] =
+            mutex.lock.surround {
+              F.uncancelable { poll =>
+                poll(next.allocated).flatMap {
+                  case (r, fin) =>
+                    swapFinalizer(Acquired(r, fin)).as(r)
+                }
+              }
             }
-          }
 
-        override def clear: F[Unit] =
-          swapFinalizer(F.unit).uncancelable
+          override def get: Resource[F, Option[R]] =
+            mutex.lock.evalMap { _ =>
+              state.get.map {
+                case Acquired(r, _) => Some(r)
+                case _ => None
+              }
+            }
 
-        private def swapFinalizer(next: F[Unit]): F[Unit] =
-          state.modify {
-            case Some(previous) =>
-              Some(next) -> previous
-            case None =>
-              None -> (next *> raise("Cannot swap after finalization"))
-          }.flatten
+          override def clear: F[Unit] =
+            mutex.lock.surround(swapFinalizer(Cleared).uncancelable)
 
+          private def swapFinalizer(next: State): F[Unit] =
+            state.modify {
+              case Acquired(_, fin) =>
+                next -> fin
+              case Cleared =>
+                next -> F.unit
+              case Finalized =>
+                val fin = next match {
+                  case Acquired(_, fin) => fin
+                  case _ => F.unit
+                }
+                Finalized -> (fin *> raise("Cannot swap after finalization"))
+            }.flatten
+
+        }
       }
     }
   }

--- a/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
@@ -20,6 +20,8 @@ package std
 
 import cats.effect.kernel.Ref
 
+import scala.concurrent.duration._
+
 class HotswapSpec extends BaseSpec { outer =>
 
   sequential
@@ -74,6 +76,22 @@ class HotswapSpec extends BaseSpec { outer =>
           res must beEqualTo(List("open a", "close a", "open b", "close b"))
         }
       }
+    }
+
+    "not release current resource while it is in use" in ticked { implicit ticker =>
+      val r = Resource.make(IO.ref(true))(_.set(false))
+      val go = Hotswap.create[IO, Ref[IO, Boolean]].use { hs =>
+        hs.swap(r) *> (IO.sleep(1.second) *> hs.clear).background.surround {
+          hs.get.use {
+            case Some(ref) =>
+              val notReleased = ref.get.flatMap(b => IO(b must beTrue))
+              notReleased *> IO.sleep(2.seconds) *> notReleased.void
+            case None => IO(false must beTrue).void
+          }
+        }
+      }
+
+      go must completeAs(())
     }
   }
 

--- a/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
@@ -93,6 +93,17 @@ class HotswapSpec extends BaseSpec { outer =>
 
       go must completeAs(())
     }
+
+    "resource can be accessed concurrently" in ticked { implicit ticker =>
+      val go = Hotswap.create[IO, Unit].use { hs =>
+        hs.swap(Resource.unit) *>
+          hs.get.useForever.background.surround {
+            IO.sleep(1.second) *> hs.get.use_
+          }
+      }
+
+      go must completeAs(())
+    }
   }
 
 }


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/2050. Closes https://github.com/typelevel/cats-effect/issues/3473.

The current resource in `Hotswap` is now guarded by a mutex, which must be acquired to swap or clear it. A new method `get` also provides safe access to the current resource, by acquiring the mutex while it is in use.