### PR TITLE
Dispatcher error reporting

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -312,7 +312,7 @@ object Dispatcher {
 
           val action = fe
             .flatMap(e => F.delay(promise.success(e)))
-            .onError { case t => F.delay(promise.failure(t)) }
+            .handleErrorWith(t => F.delay(promise.failure(t)))
             .void
 
           val cancelState = new AtomicReference[CancelState](CancelInit)

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -52,11 +52,6 @@ trait Dispatcher[F[_]] extends DispatcherPlatform[F] {
   def unsafeToFutureCancelable[A](fa: F[A]): (Future[A], () => Future[Unit])
 
   /**
-   * Submits an effect to be executed with fire-and-forget semantics.
-   */
-  def unsafeRunAndForget[A](fa: F[A]): Unit
-
-  /**
    * Submits an effect to be executed, returning a `Future` that holds the result of its
    * evaluation.
    */
@@ -69,6 +64,16 @@ trait Dispatcher[F[_]] extends DispatcherPlatform[F] {
    */
   def unsafeRunCancelable[A](fa: F[A]): () => Future[Unit] =
     unsafeToFutureCancelable(fa)._2
+
+  /**
+   * Submits an effect to be executed with fire-and-forget semantics.
+   */
+  def unsafeRunAndForget[A](fa: F[A]): Unit = {
+    unsafeRunAsync(fa) {
+      case Left(t) => t.printStackTrace()
+      case Right(_) => ()
+    }
+  }
 
   // package-private because it's just an internal utility which supports specific implementations
   // anyone who needs this type of thing should use unsafeToFuture and then onComplete
@@ -304,15 +309,6 @@ object Dispatcher {
       }
     } yield {
       new Dispatcher[F] {
-        def unsafeRunAndForget[A](fa: F[A]): Unit = {
-          unsafeToFutureCancelable(fa)
-            ._1
-            .onComplete {
-              case Success(_) => ()
-              case Failure(t) => t.printStackTrace()
-            }(ec)
-        }
-
         def unsafeToFutureCancelable[E](fe: F[E]): (Future[E], () => Future[Unit]) = {
           val promise = Promise[E]()
 

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -309,6 +309,13 @@ object Dispatcher {
       }
     } yield {
       new Dispatcher[F] {
+        override def unsafeRunAndForget[A](fa: F[A]): Unit = {
+          unsafeRunAsync(fa) {
+            case Left(t) => ec.reportFailure(t)
+            case Right(_) => ()
+          }
+        }
+
         def unsafeToFutureCancelable[E](fe: F[E]): (Future[E], () => Future[Unit]) = {
           val promise = Promise[E]()
 

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -275,7 +275,7 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
       } yield errorReporter
 
       test
-        .use(t => IO.fromFuture(IO(t.future)).timeout(1.second).handleError(_ => false))
+        .use(t => IO.fromFuture(IO(t.future)).timeoutTo(1.second, IO.pure(false)))
         .flatMap(t => IO(t mustEqual true))
     }
 

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -21,6 +21,7 @@ import cats.effect.kernel.Deferred
 import cats.effect.testkit.TestControl
 import cats.syntax.all._
 
+import scala.concurrent.{ExecutionContext, Promise}
 import scala.concurrent.duration._
 
 class DispatcherSpec extends BaseSpec with DetectPlatform {
@@ -255,6 +256,47 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
           runner.unsafeRunAndForget(IO(ko)) must throwAn[IllegalStateException]
         }
       }
+    }
+
+    "report exception if raised during unsafeRunAndForget" in real {
+      def ec2(ec1: ExecutionContext, er: Promise[Boolean]) = new ExecutionContext {
+        def reportFailure(t: Throwable) = er.success(true)
+        def execute(r: Runnable) = ec1.execute(r)
+      }
+
+      val test = for {
+        ec <- Resource.eval(IO.executionContext)
+        errorReporter <- Resource.eval(IO(Promise[Boolean]()))
+        customEc = ec2(ec, errorReporter)
+        _ <- dispatcher
+          .evalOn(customEc)
+          .flatMap(runner =>
+            Resource.eval(IO(runner.unsafeRunAndForget(IO.raiseError(new Exception("boom"))))))
+        reported <- Resource.eval(IO.fromFuture(IO(errorReporter.future)))
+      } yield reported
+
+      test.use(t => IO(t mustEqual true))
+    }
+
+    "do not treat exception in unsafeRunToFuture as unhandled" in real {
+      import scala.concurrent.TimeoutException
+      def ec2(ec1: ExecutionContext, er: Promise[Boolean]) = new ExecutionContext {
+        def reportFailure(t: Throwable) = er.failure(t)
+        def execute(r: Runnable) = ec1.execute(r)
+      }
+
+      val test = for {
+        ec <- Resource.eval(IO.executionContext)
+        errorReporter <- Resource.eval(IO(Promise[Boolean]()))
+        customEc = ec2(ec, errorReporter)
+        _ <- dispatcher
+          .evalOn(customEc)
+          .flatMap(runner =>
+            Resource.eval(IO(runner.unsafeToFuture(IO.raiseError(new Exception("boom"))))))
+        reported <- Resource.eval(IO.fromFuture(IO(errorReporter.future)))
+      } yield reported
+
+      test.use(t => IO(t).mustFailWith[TimeoutException])
     }
 
     "respect self-cancelation" in real {


### PR DESCRIPTION
This is my attempt to resolve #3131 

My investigation (with Arman's help <3) branched out to two different problems:
1. The original issue about unwanted stack traces being logged when using `Dispatcher#unsafeToFuture`, in the parallel case. Exceptions are currently being reraised in the IO, via `onError`, and triggering the fiber unhandled error reporting. 
2. While investigating that, we realized that sequential dispatchers would have the opposite issue: because all exceptions are being handled with a [`handleError` in the fork](https://github.com/typelevel/cats-effect/blob/series/3.x/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala#L214), you wouldn't know about an exception in the case of `Dispatcher#unsafeRunAndForget` 

This PR attempts to resolve both. Respectively:
1. 66857f4b069faa533e7f607353d80c01406c924f replaces `onError` with `handleErrorWith`
~2. b21e122dd8a74250b143c794e3e3a3c0ea0ecd6e moves the `unsafeRunAndForget` definition into the apply, so we can print the stack trace if the future completes with an exception.~ 
2. e844c59ac8b0eec8ef39d14adc7c612ed6ca7136 redefines `unsafeRunAndForget` using `unsafeRunAsync` + callback to print a stack trace 

I haven't figured out how to test this yet so I'm still working on that, but also looking for feedback on the 2nd solution. I'm not sure if its okay to just move things around like that 😅 

Edit: hahaha, I guess I got my answer about just moving things around
```
java.lang.RuntimeException: Failed binary compatibility check against org.typelevel:cats-effect-std_2.13:3.3.11
```