### PR TITLE
POC: plugging the `cancelable` leak

### DIFF
--- a/core/js-native/src/main/scala/cats/effect/IOFiberConstants.scala
+++ b/core/js-native/src/main/scala/cats/effect/IOFiberConstants.scala
@@ -32,6 +32,7 @@ private object IOFiberConstants {
   final val UncancelableK = 7
   final val UnmaskK = 8
   final val AttemptK = 9
+  final val CancelableK = 10
 
   // resume ids
   final val ExecR = 0

--- a/core/js/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/js/src/main/scala/cats/effect/ArrayStack.scala
@@ -38,7 +38,7 @@ private final class ArrayStack[A <: AnyRef](val buffer: js.Array[A]) extends Any
 
   @inline def peekOrNull(): A = {
     val i = buffer.length - 1
-    if (i < buffer.length)
+    if (0 <= i && i < buffer.length)
       buffer(i)
     else
       null.asInstanceOf[A]

--- a/core/js/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/js/src/main/scala/cats/effect/ArrayStack.scala
@@ -36,6 +36,14 @@ private final class ArrayStack[A <: AnyRef](val buffer: js.Array[A]) extends Any
 
   @inline def peek(): A = buffer(buffer.length - 1)
 
+  @inline def peekOrNull(): A = {
+    val i = buffer.length - 1
+    if (i < buffer.length)
+      buffer(i)
+    else
+      null.asInstanceOf[A]
+  }
+
   @inline def isEmpty(): Boolean = buffer.length == 0
 
   // to allow for external iteration

--- a/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
@@ -46,6 +46,16 @@ private final class ArrayStack[A <: AnyRef](
 
   def peek(): A = buffer(index - 1).asInstanceOf[A]
 
+  def peekOrNull(): A = {
+    // local copies
+    val i = index - 1
+    val buffer = this.buffer
+    if (0 <= i && i < buffer.length)
+      buffer(i).asInstanceOf[A]
+    else
+      null.asInstanceOf[A]
+  }
+
   def isEmpty(): Boolean = index <= 0
 
   // to allow for external iteration

--- a/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
+++ b/core/jvm/src/main/java/cats/effect/IOFiberConstants.java
@@ -32,6 +32,7 @@ final class IOFiberConstants {
   static final byte UncancelableK = 7;
   static final byte UnmaskK = 8;
   static final byte AttemptK = 9;
+  static final byte CancelableK = 10;
 
   // resume ids
   static final byte ExecR = 0;

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1835,6 +1835,9 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
     def sleep(time: FiniteDuration): IO[Unit] =
       IO.sleep(time)
 
+    override def cancelable[A](ioa: IO[A], fin: IO[Unit]): IO[A] =
+      IO.Cancelable(ioa, fin)
+
     def canceled: IO[Unit] =
       IO.canceled
 
@@ -2082,6 +2085,10 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
   private[effect] case object IOTrace extends IO[Trace] {
     def tag = 23
+  }
+
+  private[effect] final case class Cancelable[+A](ioa: IO[A], cancel: IO[Unit]) extends IO[A] {
+    def tag = 24
   }
 
   // INTERNAL, only created by the runloop itself as the terminal state of several operations

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -85,6 +85,7 @@ private final class IOFiber[A](
   private[this] var currentCtx: ExecutionContext = startEC
   private[this] val objectState: ArrayStack[AnyRef] = ArrayStack()
   private[this] val finalizers: ArrayStack[IO[Unit]] = ArrayStack()
+  private[this] val cancelers: ArrayStack[IO[Unit]] = ArrayStack()
   private[this] val callbacks: CallbackStack[OutcomeIO[A]] = CallbackStack(cb)
   private[this] var resumeTag: Byte = ExecR
   private[this] var resumeIO: AnyRef = startIO
@@ -134,6 +135,11 @@ private final class IOFiber[A](
   private[this] var _cancel: IO[Unit] = IO uncancelable { _ =>
     canceled = true
 
+    def externalCancel = {
+      val c = cancelers.peekOrNull()
+      if (c eq null) IO.unit else c
+    }
+
     // println(s"${name}: attempting cancelation")
 
     /* check to see if the target fiber is suspended */
@@ -144,7 +150,7 @@ private final class IOFiber[A](
         // println(s"<$name> running cancelation (finalizers.length = ${finalizers.unsafeIndex()})")
 
         /* if we have async finalizers, runLoop may return early */
-        IO.async_[Unit] { fin =>
+        externalCancel *> IO.async_[Unit] { fin =>
           // println(s"${name}: canceller started at ${Thread.currentThread().getName} + ${suspended.get()}")
           val ec = currentCtx
           resumeTag = AsyncContinueCanceledWithFinalizerR
@@ -157,12 +163,12 @@ private final class IOFiber[A](
          * it was doing  and cancel itself
          */
         suspend() /* allow someone else to take the runloop */
-        join.void
+        externalCancel *> join.void
       }
     } else {
       // println(s"${name}: had to join")
       /* it's already being run somewhere; await the finalizers */
-      join.void
+      externalCancel *> join.void
     }
   }
 
@@ -992,6 +998,14 @@ private final class IOFiber[A](
 
         case 23 =>
           runLoop(succeeded(Trace(tracingEvents), 0), nextCancelation, nextAutoCede)
+
+        case 24 =>
+          val cur = cur0.asInstanceOf[Cancelable[Any]]
+
+          cancelers.push(EvalOn(cur.cancel, currentCtx))
+
+          conts = ByteStack.push(conts, CancelableK)
+          runLoop(cur.ioa, nextCancelation, nextAutoCede)
       }
     }
   }
@@ -1213,6 +1227,10 @@ private final class IOFiber[A](
 
       case 9 => // attemptK
         succeeded(Right(result), depth)
+
+      case 10 => // cancelableSuccessK
+        cancelers.pop()
+        succeeded(result, depth + 1)
     }
 
   private[this] def failed(error: Throwable, depth: Int): IO[Any] = {
@@ -1275,6 +1293,10 @@ private final class IOFiber[A](
         failed(error, depth + 1)
 
       case 9 => succeeded(Left(error), depth) // attemptK
+
+      case 10 => // CancelableFailureK
+        cancelers.pop()
+        failed(error, depth + 1)
     }
   }
 

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1060,6 +1060,7 @@ private final class IOFiber[A](
     conts = null
     objectState.invalidate()
     finalizers.invalidate()
+    cancelers.invalidate()
     currentCtx = null
 
     if (isStackTracing) {
@@ -1363,6 +1364,7 @@ private final class IOFiber[A](
 
       objectState.init(16)
       finalizers.init(16)
+      cancelers.init(1)
 
       val io = resumeIO.asInstanceOf[IO[Any]]
       resumeIO = null

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -18,6 +18,7 @@ package cats.effect
 
 import cats.effect.implicits._
 import cats.effect.laws.AsyncTests
+import cats.effect.std.CountDownLatch
 import cats.effect.testkit.{TestContext, TestControl}
 import cats.kernel.laws.SerializableLaws.serializable
 import cats.kernel.laws.discipline.MonoidTests
@@ -828,15 +829,15 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
 
       "racePair" should {
         "not leak" in ticked { implicit ticker =>
-          IO.deferred[Unit].flatMap { gate =>
+          CountDownLatch[IO](2).flatMap { latch =>
             val test = IO.racePair(
-              (gate.complete(()) *> IO.sleep(1.second)).uncancelable,
-              IO.sleep(2.seconds).uncancelable
+              (latch.release *> IO.sleep(1.second)).uncancelable,
+              (latch.release *> IO.sleep(2.seconds)).uncancelable
             )
 
             test
               .start
-              .flatMap(f => gate.get *> f.cancel *> f.join)
+              .flatMap(f => latch.await *> f.cancel *> f.join)
               .flatMap(_.embedError)
               .map(_.isLeft)
           } must completeAs(true)


### PR DESCRIPTION
Implements a proof-of-concept for my proposal in https://github.com/typelevel/cats-effect/issues/3474#issuecomment-1459309054.

To re-iterate:
1. `IO.Cancelable[+A](ioa: IO[A], cancel: IO[Unit])` is now a primitive operation
2. When you enter a `Cancelable`, it exposes its `cancel` operation as part of the `fiber.cancel`.
3. By leaning into `uncancelable` semantics, this guarantees that the final result of `ioa` (be it success, error, or cancellation) will always be propagated.

As such, it plugs the leak.