### PR TITLE
Add flush to print functions in std.Console

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/ConsoleCrossPlatform.scala
+++ b/std/shared/src/main/scala/cats/effect/std/ConsoleCrossPlatform.scala
@@ -239,12 +239,18 @@ private[std] abstract class ConsoleCompanionCrossPlatform {
 
     def print[A](a: A)(implicit S: Show[A] = Show.fromToString[A]): F[Unit] = {
       val text = a.show
-      F.blocking(System.out.print(text))
+      F.blocking {
+        System.out.print(text)
+        System.out.flush()
+      }
     }
 
     def println[A](a: A)(implicit S: Show[A] = Show.fromToString[A]): F[Unit] = {
       val text = a.show
-      F.blocking(System.out.println(text))
+      F.blocking {
+        System.out.println(text)
+        System.out.flush()
+      }
     }
 
     def error[A](a: A)(implicit S: Show[A] = Show.fromToString[A]): F[Unit] = {


### PR DESCRIPTION
This time picked off from the right branch!

From discord:

>  I think we should probably just add it on each call. That's kind of what people intuitively expect anyway. If someone wants more control over buffering, they should use Fs2. Console is meant for quick-and-dirty things
