### PR TITLE
Dispatcher: check for outstanding actions before release

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -303,8 +303,7 @@ object Dispatcher {
             val worker = dispatcher(doneR, latch, states(n))
             val release = F.delay(latch.getAndSet(Open)())
             Resource.make(supervisor.supervise(worker)) { _ =>
-              // published by release
-              F.delay(doneR.lazySet(true)) *> step(states(n), F.unit) *> release
+              F.delay(doneR.set(true)) *> step(states(n), F.unit) *> release
             }
           }
         }

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -303,7 +303,9 @@ object Dispatcher {
             val worker = dispatcher(doneR, latch, states(n))
             val release = F.delay(latch.getAndSet(Open)())
             Resource.make(supervisor.supervise(worker)) { _ =>
-              F.delay(doneR.set(true)) *> step(states(n), F.unit) *> release
+              F.delay(doneR.set(true)) *> F.delay(alive.set(false)) *> step(
+                states(n),
+                F.unit) *> release
             }
           }
         }

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -310,6 +310,15 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
       }
     }
 
+    "issue #3506: await unsafeRunAndForget" in real {
+      for {
+        resultR <- IO.ref(false)
+        _ <- dispatcher.use { runner => IO(runner.unsafeRunAndForget(resultR.set(true))) }
+        result <- resultR.get
+        _ <- IO(result must beTrue)
+      } yield ok
+    }
+
     "cancel active fibers when an error is produced" in real {
       case object TestException extends RuntimeException
 

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -289,7 +289,7 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
                 IO.sleep(1.second).uncancelable.guarantee(resultR.set(true)))) *>
                 IO.sleep(100.millis) *>
                 release.both(
-                  IO.sleep(100.millis) *>
+                  IO.sleep(500.nanos) *>
                     IO(runner.unsafeRunAndForget(rogueResultR.set(true))).attempt
                 )
           }

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -310,13 +310,13 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
       }
     }
 
-    "issue #3506: await unsafeRunAndForget" in real {
-      for {
+    "issue #3506: await unsafeRunAndForget" in ticked { implicit ticker =>
+      val result = for {
         resultR <- IO.ref(false)
         _ <- dispatcher.use { runner => IO(runner.unsafeRunAndForget(resultR.set(true))) }
         result <- resultR.get
-        _ <- IO(result must beTrue)
-      } yield ok
+      } yield result
+      result must completeAs(true)
     }
 
     "cancel active fibers when an error is produced" in real {


### PR DESCRIPTION
resolves #3506

c0ed15a88eaff0c1d1073551e9cdf74693578030 adds a test demonstrating that a `Dispatcher`, with `await=true`, will finish without completing the effect (thus failing the test) 

Ultimately this is caused by the dispatcher finalizer running and releasing, even though there may have been new actions enqueued since the worker last checked. 

Paired with @djspiewak and came to the solution in 0b6eaa446e352573f8f64acb8a3d3137d0b951b8 in which we can now call `step` one last time, after the dispatcher is done but before releasing, so that those last-minute actions are forked appropriately. With this change the new test passes 🎉 