### PR TITLE
`AtomicCell#get` should not semantically block

### DIFF
--- a/docs/std/atomic-cell.md
+++ b/docs/std/atomic-cell.md
@@ -22,15 +22,15 @@ abstract class AtomicCell[F[_], A] {
 
 ## Using `AtomicCell`
 
-The `AtomicCell` can be treated as a combination of `Semaphore` and `Ref`:
+The `AtomicCell` can be treated as a combination of `Mutex` and `Ref`:
 ```scala mdoc:reset:silent
 import cats.effect.{IO, Ref}
-import cats.effect.std.Semaphore
+import cats.effect.std.Mutex
 
 trait State
-class Service(sem: Semaphore[IO], ref: Ref[IO, State]) {
+class Service(mtx: Mutex[IO], ref: Ref[IO, State]) {
   def modify(f: State => IO[State]): IO[Unit] = 
-    sem.permit.surround {
+    mtx.lock.surround {
       for {
         current <- ref.get
         next <- f(current)

--- a/docs/std/atomic-cell.md
+++ b/docs/std/atomic-cell.md
@@ -6,7 +6,7 @@ title: Atomic Cell
 A synchronized, concurrent, mutable reference.
 
 Provides safe concurrent access and modification of its contents, by ensuring only one fiber
-can operate on them at the time. Thus, **all** operations may semantically block the
+can operate on them at the time. Thus, all operations except `get` may semantically block the
 calling fiber.
 
 ```scala mdoc:silent

--- a/std/shared/src/main/scala/cats/effect/std/AtomicCell.scala
+++ b/std/shared/src/main/scala/cats/effect/std/AtomicCell.scala
@@ -166,8 +166,7 @@ object AtomicCell {
   )(
       implicit F: Concurrent[F]
   ) extends AtomicCell[F, A] {
-    override def get: F[A] =
-      mutex.lock.surround(ref.get)
+    override def get: F[A] = ref.get
 
     override def set(a: A): F[Unit] =
       mutex.lock.surround(ref.set(a))
@@ -199,13 +198,11 @@ object AtomicCell {
   )(
       implicit F: Async[F]
   ) extends AtomicCell[F, A] {
-    private var cell: A = init
+    @volatile private var cell: A = init
 
     override def get: F[A] =
-      mutex.lock.surround {
-        F.delay {
-          cell
-        }
+      F.delay {
+        cell
       }
 
     override def set(a: A): F[Unit] =

--- a/std/shared/src/main/scala/cats/effect/std/AtomicCell.scala
+++ b/std/shared/src/main/scala/cats/effect/std/AtomicCell.scala
@@ -25,7 +25,7 @@ import cats.syntax.all._
  * A synchronized, concurrent, mutable reference.
  *
  * Provides safe concurrent access and modification of its contents, by ensuring only one fiber
- * can operate on them at the time. Thus, '''all''' operations may semantically block the
+ * can operate on them at the time. Thus, all operations except `get` may semantically block the
  * calling fiber.
  *
  * {{{

--- a/tests/shared/src/test/scala/cats/effect/std/AtomicCellSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/AtomicCellSpec.scala
@@ -111,7 +111,7 @@ final class AtomicCellSpec extends BaseSpec {
         val op = for {
           cell <- factory(0)
           gate <- IO.deferred[Unit]
-          _ <- (gate.complete(()) *> cell.evalModify(_ => IO.never)).start
+          _ <- cell.evalModify(_ => gate.complete(()) *> IO.never).start
           _ <- gate.get
           r <- cell.get
         } yield r == 0

--- a/tests/shared/src/test/scala/cats/effect/std/AtomicCellSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/AtomicCellSpec.scala
@@ -106,6 +106,18 @@ final class AtomicCellSpec extends BaseSpec {
 
         op must completeAs(true)
       }
+
+      "get should not block during concurrent modification" in ticked { implicit ticker =>
+        val op = for {
+          cell <- factory(0)
+          gate <- IO.deferred[Unit]
+          _ <- (gate.complete(()) *> cell.evalModify(_ => IO.never)).start
+          _ <- gate.get
+          r <- cell.get
+        } yield r == 0
+
+        op must completeAs(true)
+      }
     }
   }
 }


### PR DESCRIPTION
At least, I don't see why it should. It seems to me that the primary concern is that `get` shouldn't see inconsistent state, otherwise it doesn't matter if someone happens to be modifying/updating the cell at that moment. Also there's no reason that concurrent `get`s should have to take turns acquiring the mutex; they can all just read.

cc @BalmungSan 