### PR TITLE
Dispatcher: set `alive` to false when done

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -303,8 +303,7 @@ object Dispatcher {
             val worker = dispatcher(doneR, latch, states(n))
             val release = F.delay(latch.getAndSet(Open)())
             Resource.make(supervisor.supervise(worker)) { _ =>
-              // published by release
-              F.delay(doneR.lazySet(true)) *> step(states(n), F.unit) *> release
+              F.delay(doneR.set(true)) *> step(states(n), F.unit) *> release
             }
           }
         }

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -303,7 +303,9 @@ object Dispatcher {
             val worker = dispatcher(doneR, latch, states(n))
             val release = F.delay(latch.getAndSet(Open)())
             Resource.make(supervisor.supervise(worker)) { _ =>
-              F.delay(doneR.set(true)) *> step(states(n), F.unit) *> release
+              F.delay(doneR.set(true)) *> F.delay(alive.set(false)) *> step(
+                states(n),
+                F.unit) *> release
             }
           }
         }

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -310,6 +310,15 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
       }
     }
 
+    "issue #3506: await unsafeRunAndForget" in real {
+      for {
+        resultR <- IO.ref(false)
+        _ <- dispatcher.use { runner => IO(runner.unsafeRunAndForget(resultR.set(true))) }
+        result <- resultR.get
+        _ <- IO(result must beTrue)
+      } yield ok
+    }
+
     "cancel active fibers when an error is produced" in real {
       case object TestException extends RuntimeException
 

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -289,7 +289,7 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
                 IO.sleep(1.second).uncancelable.guarantee(resultR.set(true)))) *>
                 IO.sleep(100.millis) *>
                 release.both(
-                  IO.sleep(100.millis) *>
+                  IO.sleep(500.nanos) *>
                     IO(runner.unsafeRunAndForget(rogueResultR.set(true))).attempt
                 )
           }

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -310,13 +310,13 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
       }
     }
 
-    "issue #3506: await unsafeRunAndForget" in real {
-      for {
+    "issue #3506: await unsafeRunAndForget" in ticked { implicit ticker =>
+      val result = for {
         resultR <- IO.ref(false)
         _ <- dispatcher.use { runner => IO(runner.unsafeRunAndForget(resultR.set(true))) }
         result <- resultR.get
-        _ <- IO(result must beTrue)
-      } yield ok
+      } yield result
+      result must completeAs(true)
     }
 
     "cancel active fibers when an error is produced" in real {


### PR DESCRIPTION
I branched off of #3510, with the intention to try to keep the alive work separate from the `step` work, but ultimately it might make sense to merge together. 

The differences to #3510 are in the last 3 commits:
- 27c55c344dde191396d67f60476a794d96c332c8 initial test
    - failing for sequential dispatchers b/c `rogueSubmitResult` is Right
    - was passing for parallel dispatchers though
- 804fdb90b043fd480d80594396178984f4a197c6 test with reduced sleep
    - failing for parallel dispatchers, sometimes b/c `rogueSubmitResult` is Right, sometimes because the task actually gets done (a done task fails the test, but if the task finished then we're not actually in the failure situation we're concerned about. So this is still flaky, just a different kind of flaky)
    - Edit: I wrote a better explanation of the test situation and the impact of changing the sleep period:
        - wait long enough before submitting the task: the dispatcher is not alive and the task isn't submitted at all
        - wait not at all: the dispatcher is alive and kicking and the task is submitted and completed
        - wait a goldilocks period of 500-900ish nanos: the task can be submitted but not completed
    - The problem is that the first two cases _are_ reasonable behaviours and fine. The third case can currently happen, and that's the problematic behaviour.
- 24d1bdb035cba91ae4860294e28b45b0b69e5389 set alive to false as part of the worker shutdown
    - setting this before we do the final loop through `step` so we can be sure that no new tasks are added 
    - the test passes


I'm concerned that I don't understand the potential implications of the fix. It makes sense to me for a sequential dispatcher, but for a parallel dispatcher one worker will toggle `alive` for the whole dispatcher. It doesn't seem like a single worker _should_ release on its own but I'm still a bit anxious about bringing this shared dispatcher scope into the worker loop?

### update
After chatting with Arman:
- 090aad0e765177cdc036f75b823ff8ffcaf17a52 instead of having workers handle the `alive` setting, I moved the `alive` resource so that it is the very last thing in the for comprehension. This way when closing the dispatcher, the very first thing that happens is that `alive` is set to false, even before we've set workers to done and run their final `step` call. 