### PR TITLE
forward raceOutcome to correct implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -618,7 +618,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         "cats.effect.IOFiberConstants.ContStateWinner"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "cats.effect.IOFiberConstants.ContStateResult"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.IOFiberConstants.ExecuteRunnableR"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "cats.effect.IOFiberConstants.ExecuteRunnableR")
     ) ++ {
       if (tlIsScala3.value) {
         // Scala 3 specific exclusions
@@ -900,7 +901,8 @@ lazy val std = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "cats.effect.std.Queue#DroppingQueue.onOfferNoCapacity"),
       // #3524, private class
-      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.std.MapRef#ConcurrentHashMapImpl.keys"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "cats.effect.std.MapRef#ConcurrentHashMapImpl.keys")
     )
   )
   .jsSettings(

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -507,12 +507,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
     IO.race(this, that)
 
   def raceOutcome[B](that: IO[B]): IO[Either[OutcomeIO[A @uncheckedVariance], OutcomeIO[B]]] =
-    IO.uncancelable { _ =>
-      racePair(that).flatMap {
-        case Left((oc, f)) => f.cancel.as(Left(oc))
-        case Right((f, oc)) => f.cancel.as(Right(oc))
-      }
-    }
+    IO.asyncForIO.raceOutcome(this, that)
 
   def racePair[B](that: IO[B]): IO[Either[
     (OutcomeIO[A @uncheckedVariance], FiberIO[B]),

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -670,6 +670,22 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         }
       }
 
+      "raceOutcome" should {
+        "cancel both fibers" in ticked { implicit ticker =>
+          (for {
+            l <- Ref.of[IO, Boolean](false)
+            r <- Ref.of[IO, Boolean](false)
+            fiber <-
+              IO.never[Int].onCancel(l.set(true)).raceOutcome(IO.never[Int].onCancel(r.set(true))).start
+            _ <- IO(ticker.ctx.tick())
+            _ <- fiber.cancel
+            _ <- IO(ticker.ctx.tick())
+            l2 <- l.get
+            r2 <- r.get
+          } yield l2 -> r2) must completeAs(true -> true)
+        }
+      }
+
       "race" should {
         "succeed with faster side" in ticked { implicit ticker =>
           IO.race(IO.sleep(10.minutes) >> IO.pure(1), IO.pure(2)) must completeAs(Right(2))

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -676,7 +676,10 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
             l <- Ref.of[IO, Boolean](false)
             r <- Ref.of[IO, Boolean](false)
             fiber <-
-              IO.never[Int].onCancel(l.set(true)).raceOutcome(IO.never[Int].onCancel(r.set(true))).start
+              IO.never[Int]
+                .onCancel(l.set(true))
+                .raceOutcome(IO.never[Int].onCancel(r.set(true)))
+                .start
             _ <- IO(ticker.ctx.tick())
             _ <- fiber.cancel
             _ <- IO(ticker.ctx.tick())


### PR DESCRIPTION
And test that raceOutcome can now be canceled.