### PR TITLE
New `AsyncMutex` implementation

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/MutexBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/MutexBenchmark.scala
@@ -56,12 +56,7 @@ class MutexBenchmark {
 
   @Benchmark
   def happyPathConcurrent(): Unit = {
-    happyPathImpl(mutex = Mutex.concurrent)
-  }
-
-  @Benchmark
-  def happyPathAsync(): Unit = {
-    happyPathImpl(mutex = Mutex.async)
+    happyPathImpl(mutex = Mutex.apply)
   }
 
   private def highContentionImpl(mutex: IO[Mutex[IO]]): Unit = {
@@ -73,12 +68,7 @@ class MutexBenchmark {
 
   @Benchmark
   def highContentionConcurrent(): Unit = {
-    highContentionImpl(mutex = Mutex.concurrent)
-  }
-
-  @Benchmark
-  def highContentionAsync(): Unit = {
-    highContentionImpl(mutex = Mutex.async)
+    highContentionImpl(mutex = Mutex.apply)
   }
 
   private def cancellationImpl(mutex: IO[Mutex[IO]]): Unit = {
@@ -94,11 +84,6 @@ class MutexBenchmark {
 
   @Benchmark
   def cancellationConcurrent(): Unit = {
-    cancellationImpl(mutex = Mutex.concurrent)
-  }
-
-  @Benchmark
-  def cancellationAsync(): Unit = {
-    cancellationImpl(mutex = Mutex.async)
+    cancellationImpl(mutex = Mutex.apply)
   }
 }

--- a/std/shared/src/main/scala/cats/effect/std/AtomicCell.scala
+++ b/std/shared/src/main/scala/cats/effect/std/AtomicCell.scala
@@ -154,11 +154,11 @@ object AtomicCell {
   }
 
   private[effect] def async[F[_], A](init: A)(implicit F: Async[F]): F[AtomicCell[F, A]] =
-    Mutex.async[F].map(mutex => new AsyncImpl(init, mutex))
+    Mutex.apply[F].map(mutex => new AsyncImpl(init, mutex))
 
   private[effect] def concurrent[F[_], A](init: A)(
       implicit F: Concurrent[F]): F[AtomicCell[F, A]] =
-    (Ref.of[F, A](init), Mutex.concurrent[F]).mapN { (ref, m) => new ConcurrentImpl(ref, m) }
+    (Ref.of[F, A](init), Mutex.apply[F]).mapN { (ref, m) => new ConcurrentImpl(ref, m) }
 
   private final class ConcurrentImpl[F[_], A](
       ref: Ref[F, A],

--- a/std/shared/src/main/scala/cats/effect/std/Mutex.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Mutex.scala
@@ -21,8 +21,6 @@ package std
 import cats.effect.kernel._
 import cats.syntax.all._
 
-import java.util.concurrent.atomic.AtomicReference
-
 /**
  * A purely functional mutex.
  *
@@ -84,9 +82,7 @@ object Mutex {
    * Creates a new `Mutex`. Like `apply` but initializes state using another effect constructor.
    */
   def in[F[_], G[_]](implicit F: Sync[F], G: Async[G]): F[Mutex[G]] =
-    F.delay(
-      new AtomicReference[AsyncImpl.LockCell]()
-    ).map(state => new AsyncImpl[G](state)(G))
+    Ref.in[F, G, AsyncImpl.LockChain](AsyncImpl.Empty).map(state => new AsyncImpl[G](state))
 
   private final class ConcurrentImpl[F[_]](sem: Semaphore[F]) extends Mutex[F] {
     override final val lock: Resource[F, Unit] =
@@ -97,114 +93,38 @@ object Mutex {
   }
 
   private final class AsyncImpl[F[_]](
-      state: AtomicReference[AsyncImpl.LockCell]
+      state: Ref[F, AsyncImpl.LockChain]
   )(
       implicit F: Async[F]
   ) extends Mutex[F] {
-    // Cancels a Fiber waiting for the Mutex.
-    private def cancel(
-        thisCB: AsyncImpl.CB,
-        thisCell: AsyncImpl.LockCell,
-        previousCell: AsyncImpl.LockCell
-    ): F[Unit] =
-      F.delay {
-        // If we are canceled.
-        // First, we check if the state still contains ourselves,
-        // if that is the case, we swap it with the previousCell.
-        // This ensures any consequent attempt to acquire the Mutex
-        // will register its callback on the appropriate cell.
-        // Additionally, that confirms there is no Fiber
-        // currently waiting for us.
-        if (!state.compareAndSet(thisCell, previousCell)) {
-          // Otherwise,
-          // it means we have a Fiber waiting for us.
-          // Thus, we need to tell the previous cell
-          // to awake that Fiber instead.
+    override final val lock: Resource[F, Unit] =
+      Resource
+        .makeFull[F, Deferred[F, AsyncImpl.LockChain]] { poll =>
+          Deferred[F, AsyncImpl.LockChain].flatMap { lock =>
+            def loop(chain: AsyncImpl.LockChain): F[Deferred[F, AsyncImpl.LockChain]] =
+              chain match {
+                case AsyncImpl.Cons(otherLock) =>
+                  otherLock.asInstanceOf[Deferred[F, AsyncImpl.LockChain]].get.flatMap(loop)
 
-          // There is a tiny fraction of time when
-          // the next cell has acquired ourselves,
-          // but hasn't registered itself yet.
-          // Thus, we spin loop until that happens.
-          var nextCB = thisCell.get()
-          while (nextCB eq null) {
-            nextCB = thisCell.get()
-          }
+                case AsyncImpl.Empty =>
+                  F.pure(lock)
+              }
 
-          // Before telling previous to awake the next Fiber,
-          // We will set our cell in the terminal state (Sentinel),
-          // to signal that we are already completed.
-          // However, before doing that, we need to ensure our next callback,
-          // has not been concurrently modified.
-          while (!thisCell.compareAndSet(nextCB, AsyncImpl.Sentinel)) {
-            nextCB = thisCell.get()
-          }
-
-          // We are ready to tell the previous cell to awake the next Fiber in the chain.
-          if (!previousCell.compareAndSet(thisCB, nextCB)) {
-            // But, in case the previous cell had already completed,
-            // then the Mutex is free and we can awake our waiting Fiber.
-            if (nextCB ne null) nextCB.apply(Either.unit)
-          }
-        }
-      }
-
-    // Awaits until the Mutex is free.
-    private def await(thisCell: AsyncImpl.LockCell): F[Unit] =
-      F.asyncCheckAttempt[Unit] { thisCB =>
-        F.delay {
-          val previousCell = state.getAndSet(thisCell)
-
-          if (previousCell eq null) {
-            // If the previous cell was null,
-            // then the Mutex is free.
-            Either.unit
-          } else {
-            // Otherwise,
-            // we check again that the previous cell haven't been completed yet,
-            // if not we tell the previous cell to awake us when they finish.
-            if (!previousCell.compareAndSet(null, thisCB)) {
-              // If it was already completed,
-              // then the Mutex is free.
-              Either.unit
-            } else {
-              Left(Some(cancel(thisCB, thisCell, previousCell)))
+            state.getAndSet(AsyncImpl.Cons[F](lock)).flatMap { chain =>
+              F.onCancel(poll(loop(chain)), lock.complete(chain).void)
             }
           }
-        }
-      }
-
-    // Acquires the Mutex.
-    private def acquire(poll: Poll[F]): F[AsyncImpl.LockCell] =
-      F.delay(new AtomicReference[AsyncImpl.CB]()).flatMap { thisCell =>
-        poll(await(thisCell).map(_ => thisCell))
-      }
-
-    // Releases the Mutex.
-    private def release(thisCell: AsyncImpl.LockCell): F[Unit] =
-      F.delay {
-        // If the state still contains our own cell,
-        // then it means nobody was waiting for the Mutex,
-        // and thus it can be put on a free state again.
-        if (!state.compareAndSet(thisCell, null)) {
-          // Otherwise,
-          // our cell is probably not empty,
-          // we must awake whatever Fiber is waiting for us.
-          val nextCB = thisCell.getAndSet(AsyncImpl.Sentinel)
-          if (nextCB ne null) nextCB.apply(Either.unit)
-        }
-      }
-
-    override final val lock: Resource[F, Unit] =
-      Resource.makeFull[F, AsyncImpl.LockCell](acquire)(release).void
+        } { lock => lock.complete(AsyncImpl.Empty).void }
+        .void
 
     override def mapK[G[_]](f: F ~> G)(implicit G: MonadCancel[G, _]): Mutex[G] =
       new Mutex.TransformedMutex(this, f)
   }
 
   object AsyncImpl {
-    private[Mutex] type CB = Either[Throwable, Unit] => Unit
-    private[Mutex] final val Sentinel: CB = _ => ()
-    private[Mutex] type LockCell = AtomicReference[CB]
+    private[Mutex] sealed abstract class LockChain
+    private[Mutex] final case class Cons[F[_]](df: Deferred[F, LockChain]) extends LockChain
+    private[Mutex] case object Empty extends LockChain
   }
 
   private final class TransformedMutex[F[_], G[_]](

--- a/std/shared/src/main/scala/cats/effect/std/Mutex.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Mutex.scala
@@ -166,7 +166,7 @@ object Mutex {
               // In case they cancel their wait, we reset our sate to null.
               // Race condition with our own cancel or complete,
               // in that case they have priority.
-              Left(Some(F.delay(this.compareAndSet(cb, null))))
+              Left(Some(F.delay { this.compareAndSet(cb, null); () }))
             } else {
               // If we are not in null, then we can only be on completed.
               // Which means the mutex is free.

--- a/tests/shared/src/test/scala/cats/effect/std/MutexSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/MutexSpec.scala
@@ -163,7 +163,7 @@ final class MutexSpec extends BaseSpec with DetectPlatform {
           _ <- f4.join
         } yield ()
 
-        task.replicateA_(if (isJS || isNative) 5 else 3000)
+        task.replicateA_(if (isJS || isNative) 5 else 1000)
       }
 
       t.timeoutTo(executionTimeout - 1.second, IO(ko)) mustEqual (())

--- a/tests/shared/src/test/scala/cats/effect/std/MutexSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/MutexSpec.scala
@@ -30,11 +30,7 @@ final class MutexSpec extends BaseSpec with DetectPlatform {
   final override def executionTimeout = 2.minutes
 
   "ConcurrentMutex" should {
-    tests(Mutex.concurrent[IO])
-  }
-
-  "AsyncMutex" should {
-    tests(Mutex.async[IO])
+    tests(Mutex.apply[IO])
   }
 
   "Mutex with dual constructors" should {

--- a/tests/shared/src/test/scala/cats/effect/std/MutexSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/MutexSpec.scala
@@ -151,7 +151,8 @@ final class MutexSpec extends BaseSpec with DetectPlatform {
     "handle multiple concurrent cancels during release" in real {
       val t = mutex.flatMap { m =>
         val task = for {
-          (_, f1Release) <- m.lock.allocated
+          f1 <- m.lock.allocated
+          (_, f1Release) = f1
           f2 <- m.lock.use_.start
           _ <- IO.sleep(5.millis)
           f3 <- m.lock.use_.start
@@ -166,6 +167,31 @@ final class MutexSpec extends BaseSpec with DetectPlatform {
       }
 
       t.timeoutTo(executionTimeout - 1.second, IO(ko)) mustEqual (())
+    }
+
+    "preserve waiters order (fifo) on a non-race cancellation" in ticked { implicit ticker =>
+      val numbers = List.range(1, 10)
+      val p = mutex.flatMap { m =>
+        IO.ref(List.empty[Int]).flatMap { ref =>
+          for {
+            f1 <- m.lock.allocated
+            (_, f1Release) = f1
+            f2 <- m.lock.use_.start
+            _ <- IO.sleep(1.millis)
+            t <- numbers.parTraverse_ { i =>
+              IO.sleep(i.millis) >>
+                m.lock.surround(ref.update(acc => i :: acc))
+            }.start
+            _ <- IO.sleep(100.millis)
+            _ <- f2.cancel
+            _ <- f1Release
+            _ <- t.join
+            r <- ref.get
+          } yield r.reverse
+        }
+      }
+
+      p must completeAs(numbers)
     }
   }
 }


### PR DESCRIPTION
I was half-following the recent discussions about the `Mutex` issue and on an internal conversation with Arman, we both concluded that the **current** version of `AsyncMutex` was hard to follow, whereas the two **previous** versions were "easier" _(it still requires a lot of comments and some mental force but still it is more straightforward IMHO)_. There is also the point that the **previous** versions always preserved fairness _(FIFO semantics)_, contrary to **current**.

Thus, considering that the main rationale for the implementation change was performance _(especially on the happy path)_ I was curious and decided to re-run the benchmarks. Since the version Arman introduced on #3409 was heavily modified, I expected some changes.

---

For clarification, during the lifetime of this PR, we have had the following versions:
+ **current** is the version currently on _main_ `series/3.x`
+ **previous** is the final version presented on #3346 _(this version has been discarded since a new test shows it has a serious bug which would allow multiple acquires of the `Mutex`)_
+ **deferred** is the original version presented on #3346 _(this version only requires `Concurrent` so it can also replace **semaphore** implementation)_
+ **new** is the final version presented on this PR _(it is based on **deferred** but taking advantage of `Async`)_

---

Right now we _(Arman & Luis)_ propose to use either **deferred** or **new**, since both pass all the current tests _(including the FIFO order one)_ as well as being easier to understand _(in our humble opinion)_.

---

## Benchmark results

### Current

| Benchmark | (fibers) | (iterations) | Mode | Cnt | Score | Error | Units |
| - | - | - | - | - | - | - | - |
| MutexBenchmark.happyPathAsync      |  10 | 1000 | thrpt | 20 | 219.723 | ± 0.334 | ops/s |
| MutexBenchmark.happyPathAsync      |  50 | 1000 | thrpt | 20 |  44.040 | ± 0.563 | ops/s |
| MutexBenchmark.happyPathAsync      | 100 | 1000 | thrpt | 20 |  22.485 | ± 0.152 | ops/s |
| - | - | - | - | - | - | - | - |
| MutexBenchmark.highContentionAsync |  10 | 1000 | thrpt | 20 |  31.041 | ± 1.161 | ops/s |
| MutexBenchmark.highContentionAsync |  50 | 1000 | thrpt | 20 |   9.442 | ± 0.129 | ops/s |
| MutexBenchmark.highContentionAsync | 100 | 1000 | thrpt | 20 |   5.477 | ± 0.131 | ops/s |
| - | - | - | - | - | - | - | - |
| MutexBenchmark.cancellationAsync   |  10 | 1000 | thrpt | 20 |  21.953 | ± 0.809 | ops/s |
| MutexBenchmark.cancellationAsync   |  50 | 1000 | thrpt | 20 |   7.899 | ± 0.202 | ops/s |
| MutexBenchmark.cancellationAsync   | 100 | 1000 | thrpt | 20 |   4.844 | ± 0.034 | ops/s |

### Previous / Deferred

| Benchmark | (fibers) | (iterations) | Mode | Cnt | Score | Error | Units |
| - | - | - | - | - | - | - | - |
| MutexBenchmark.happyPathAsync      |  10 | 1000 | thrpt | 20 | 213.143 | ± 1.696 | ops/s |
| MutexBenchmark.happyPathAsync      |  50 | 1000 | thrpt | 20 |  44.325 | ± 0.215 | ops/s |
| MutexBenchmark.happyPathAsync      | 100 | 1000 | thrpt | 20 |  22.191 | ± 0.215 | ops/s |
| - | - | - | - | - | - | - | - |
| MutexBenchmark.highContentionAsync |  10 | 1000 | thrpt | 20 |  34.244 | ± 1.025 | ops/s |
| MutexBenchmark.highContentionAsync |  50 | 1000 | thrpt | 20 |   8.179 | ± 0.230 | ops/s |
| MutexBenchmark.highContentionAsync | 100 | 1000 | thrpt | 20 |   4.424 | ± 0.028 | ops/s |
| - | - | - | - | - | - | - | - |
| MutexBenchmark.cancellationAsync   |  10 | 1000 | thrpt | 20 |  22.864 | ± 0.901 | ops/s |
| MutexBenchmark.cancellationAsync   |  50 | 1000 | thrpt | 20 |   7.927 | ± 0.066 | ops/s |
| MutexBenchmark.cancellationAsync   | 100 | 1000 | thrpt | 20 |   4.895 | ± 0.045 | ops/s |

### New

| Benchmark | (fibers) | (iterations) | Mode | Cnt | Score | Error | Units |
| - | - | - | - | - | - | - | - |
| MutexBenchmark.happyPathAsync      |  10 | 1000 | thrpt | 20 | 183.778 | ± 0.156 | ops/s |
| MutexBenchmark.happyPathAsync      |  50 | 1000 | thrpt | 20 |  37.519 | ± 0.046 | ops/s |
| MutexBenchmark.happyPathAsync      | 100 | 1000 | thrpt | 20 |  18.778 | ± 0.121 | ops/s |
| - | - | - | - | - | - | - | - |
| MutexBenchmark.highContentionAsync |  10 | 1000 | thrpt | 20 |  32.455 | ± 1.579 | ops/s |
| MutexBenchmark.highContentionAsync |  50 | 1000 | thrpt | 20 |   8.192 | ± 0.276 | ops/s |
| MutexBenchmark.highContentionAsync | 100 | 1000 | thrpt | 20 |   4.486 | ± 0.075 | ops/s |
| - | - | - | - | - | - | - | - |
| MutexBenchmark.cancellationAsync   |  10 | 1000 | thrpt | 20 |  24.626 | ± 1.514 | ops/s |
| MutexBenchmark.cancellationAsync   |  50 | 1000 | thrpt | 20 |   8.150 | ± 0.073 | ops/s |
| MutexBenchmark.cancellationAsync   | 100 | 1000 | thrpt | 20 |   5.046 | ± 0.089 | ops/s |

---

For context, here are the results of the **semaphore** implementation for all runs.

### Current

```
[info] MutexBenchmark.happyPathConcurrent             10          1000  thrpt   20  198.903 ± 0.638  ops/s
[info] MutexBenchmark.happyPathConcurrent             50          1000  thrpt   20   40.689 ± 0.348  ops/s
[info] MutexBenchmark.happyPathConcurrent            100          1000  thrpt   20   20.214 ± 0.116  ops/s
[info] MutexBenchmark.highContentionConcurrent        10          1000  thrpt   20   31.392 ± 1.198  ops/s
[info] MutexBenchmark.highContentionConcurrent        50          1000  thrpt   20    7.466 ± 0.156  ops/s
[info] MutexBenchmark.highContentionConcurrent       100          1000  thrpt   20    4.014 ± 0.067  ops/s
[info] MutexBenchmark.cancellationConcurrent          10          1000  thrpt   20   21.554 ± 0.651  ops/s
[info] MutexBenchmark.cancellationConcurrent          50          1000  thrpt   20    7.455 ± 0.049  ops/s
[info] MutexBenchmark.cancellationConcurrent         100          1000  thrpt   20    3.619 ± 0.056  ops/s
```

### Previous / Deferred

```
[info] MutexBenchmark.happyPathConcurrent             10          1000  thrpt   20  198.903 ± 0.638  ops/s
[info] MutexBenchmark.happyPathConcurrent             50          1000  thrpt   20   40.689 ± 0.348  ops/s
[info] MutexBenchmark.happyPathConcurrent            100          1000  thrpt   20   20.214 ± 0.116  ops/s
[info] MutexBenchmark.highContentionConcurrent        10          1000  thrpt   20   31.392 ± 1.198  ops/s
[info] MutexBenchmark.highContentionConcurrent        50          1000  thrpt   20    7.466 ± 0.156  ops/s
[info] MutexBenchmark.highContentionConcurrent       100          1000  thrpt   20    4.014 ± 0.067  ops/s
[info] MutexBenchmark.cancellationConcurrent          10          1000  thrpt   20   21.554 ± 0.651  ops/s
[info] MutexBenchmark.cancellationConcurrent          50          1000  thrpt   20    7.455 ± 0.049  ops/s
[info] MutexBenchmark.cancellationConcurrent         100          1000  thrpt   20    3.619 ± 0.056  ops/s
```

### New

```
[info] MutexBenchmark.happyPathConcurrent             10          1000  thrpt   20  199.503 ± 0.725  ops/s
[info] MutexBenchmark.happyPathConcurrent             50          1000  thrpt   20   40.464 ± 0.115  ops/s
[info] MutexBenchmark.happyPathConcurrent            100          1000  thrpt   20   20.236 ± 0.263  ops/s
[info] MutexBenchmark.highContentionConcurrent        10          1000  thrpt   20   32.125 ± 1.281  ops/s
[info] MutexBenchmark.highContentionConcurrent        50          1000  thrpt   20    7.467 ± 0.117  ops/s
[info] MutexBenchmark.highContentionConcurrent       100          1000  thrpt   20    3.934 ± 0.026  ops/s
[info] MutexBenchmark.cancellationConcurrent          10          1000  thrpt   20   21.359 ± 0.838  ops/s
[info] MutexBenchmark.cancellationConcurrent          50          1000  thrpt   20    7.438 ± 0.102  ops/s
[info] MutexBenchmark.cancellationConcurrent         100          1000  thrpt   20    3.432 ± 0.017  ops/s
```

---

> Lies, Damn Lies, and Benchmarks