### PR TITLE
fixing up additional dispatcher flakey tests

### DIFF
--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -325,8 +325,8 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
       }
     }
 
-    "reject new tasks while shutting down" in real {
-      (IO.ref(false), IO.ref(false)).flatMapN { (resultR, rogueResultR) =>
+    "reject new tasks while shutting down" in ticked { implicit ticker =>
+      val results = (IO.ref(false), IO.ref(false)).flatMapN { (resultR, rogueResultR) =>
         dispatcher
           .allocated
           .flatMap {
@@ -347,9 +347,10 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
                 _ <- IO(result must beTrue)
                 _ <- IO(rogueResult must beFalse)
                 _ <- IO(rogueSubmitResult must beLeft)
-              } yield ok
+              } yield ()
           }
       }
+      results must completeAs(())
     }
   }
 

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -325,8 +325,8 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
       }
     }
 
-    "reject new tasks while shutting down" in ticked { implicit ticker =>
-      val results = (IO.ref(false), IO.ref(false)).flatMapN { (resultR, rogueResultR) =>
+    "reject new tasks while shutting down" in real {
+      (IO.ref(false), IO.ref(false)).flatMapN { (resultR, rogueResultR) =>
         dispatcher
           .allocated
           .flatMap {
@@ -347,10 +347,9 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
                 _ <- IO(result must beTrue)
                 _ <- IO(rogueResult must beFalse)
                 _ <- IO(rogueSubmitResult must beLeft)
-              } yield ()
+              } yield ok
           }
       }
-      results must completeAs(())
     }
   }
 


### PR DESCRIPTION
resolves #3312 

- fixed the flaky `reject new tasks while shutting down` test by approaching the test case in a slightly different way, see my comment for more details
- the other test mentioned in #3312, `wait for the completion of the active fibers` appears to no longer be flaky?
  - I refactored the test lightly to add a `.replicateA(1000)` and then ran that a few times and it did not flake
  - I ran the test on each version of CE, in reverse, and I can't replicate a flake until 3.4.4
    - I don't see anything in the [release notes for 3.4.5](https://github.com/typelevel/cats-effect/releases/tag/v3.4.5) that would have obviously affected this particular flake (and I saw it flake in March but maybe I can't remember, maybe I was accidentally on an old branch?)

@armanbilge have you seen the `wait for the completion of the active fibers` test flake anywhere lately?