### PR TITLE
dispatcher releasing itself rejects new tasks

### DIFF
--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -346,10 +346,9 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
                   result <- resultR.get
                   rogueResult <- rogueResultR.get
                   _ <- IO(result must beTrue)
-                  _ <- IO(rogueResult match {
-                    // if the rogue task is not completed then we _must_ have failed to submit it
-                    case false => rogueSubmitResult must beLeft
-                    case true => rogueSubmitResult must beRight
+                  _ <- IO(if (rogueResult == false) {
+                    // if the rogue task is not completed then we must have failed to submit it
+                    rogueSubmitResult must beLeft
                   })
                 } yield ok
             }

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -356,6 +356,15 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
         }
         .replicateA(5)
     }
+
+    "issue 3501: reject new tasks after release action is submitted as a task" in real {
+      dispatcher.allocated.flatMap {
+        case (runner, release) =>
+          IO(runner.unsafeRunAndForget(release)) *>
+            IO.sleep(100.millis) *>
+            IO(runner.unsafeRunAndForget(IO(ko)) must throwAn[IllegalStateException])
+      }
+    }
   }
 
   private def awaitTermination(dispatcher: Resource[IO, Dispatcher[IO]]) = {


### PR DESCRIPTION
resolves #3501 

- adds a test to confirm that an illegal state exception is raised when attempting to submit tasks to a dispatcher after we've already submitted its own release action as a task
- confirmed that if I move the `alive` release in `Dispatcher` from line 315 up to 245, this test fails for sequential dispatchers
- I replicated the test 1000 times and it passed so I think 100 milliseconds is enough time for the parallel case and this won't be flaky. 

(I wasn't sure about release plans so I branched off of 3.x? This is just a test so not super important for releasing but let me know if I should switch the branch)