### PR TITLE
Make TimerSkipListIOSpec faster

### DIFF
--- a/tests/jvm/src/test/scala/cats/effect/unsafe/TimerSkipListIOSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/TimerSkipListIOSpec.scala
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 class TimerSkipListIOSpec extends BaseSpec {
 
-  final val N = 100000
+  final val N = 50000
   final val DELAY = 10000L // ns
 
   private def drainUntilDone(m: TimerSkipList, done: Ref[IO, Boolean]): IO[Unit] = {


### PR DESCRIPTION
I've seen this time out a few times in CI. I think it's just CI being slow, so this PR decreases the size of the tests.