### PR TITLE
Try to fix #3568

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -220,8 +220,10 @@ private[effect] final class WorkStealingThreadPool(
    *   the current time as returned by `System.nanoTime`
    * @param random
    *   the `ThreadLocalRandom` of the current thread
+   * @return
+   *   whether stealing was successful
    */
-  private[unsafe] def stealTimers(now: Long, random: ThreadLocalRandom): Unit = {
+  private[unsafe] def stealTimers(now: Long, random: ThreadLocalRandom): Boolean = {
     val from = random.nextInt(threadCount)
     var i = 0
     while (i < threadCount) {
@@ -245,11 +247,13 @@ private[effect] final class WorkStealingThreadPool(
       if (invoked) {
         // we did some work, don't
         // check other threads
-        return
+        return true
       } else {
         i += 1
       }
     }
+
+    false
   }
 
   /**

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -596,8 +596,7 @@ private final class WorkerThread(
 
         case 2 =>
           // First try to steal some expired timers:
-          pool.stealTimers(System.nanoTime(), rnd)
-          if (queue.nonEmpty()) {
+          if (pool.stealTimers(System.nanoTime(), rnd)) {
             // some stolen timer created new work for us
             pool.transitionWorkerFromSearching(rnd)
             state = 4

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -597,40 +597,46 @@ private final class WorkerThread(
         case 2 =>
           // First try to steal some expired timers:
           pool.stealTimers(System.nanoTime(), rnd)
-          // Try stealing fibers from other worker threads.
-          val fiber = pool.stealFromOtherWorkerThread(index, rnd, self)
-          if (fiber ne null) {
-            // Successful steal. Announce that the current thread is no longer
-            // looking for work.
+          if (queue.nonEmpty()) {
+            // some stolen timer created new work for us
             pool.transitionWorkerFromSearching(rnd)
-            // Run the stolen fiber.
-            try fiber.run()
-            catch {
-              case t if NonFatal(t) => pool.reportFailure(t)
-              case t: Throwable => IOFiber.onFatalFailure(t)
-            }
-            // Transition to executing fibers from the local queue.
             state = 4
           } else {
-            // Stealing attempt is unsuccessful. Park.
-            // Set the worker thread parked signal.
-            if (isStackTracing) {
-              _active = null
-            }
+            // Try stealing fibers from other worker threads.
+            val fiber = pool.stealFromOtherWorkerThread(index, rnd, self)
+            if (fiber ne null) {
+              // Successful steal. Announce that the current thread is no longer
+              // looking for work.
+              pool.transitionWorkerFromSearching(rnd)
+              // Run the stolen fiber.
+              try fiber.run()
+              catch {
+                case t if NonFatal(t) => pool.reportFailure(t)
+                case t: Throwable => IOFiber.onFatalFailure(t)
+              }
+              // Transition to executing fibers from the local queue.
+              state = 4
+            } else {
+              // Stealing attempt is unsuccessful. Park.
+              // Set the worker thread parked signal.
+              if (isStackTracing) {
+                _active = null
+              }
 
-            parked.lazySet(true)
-            // Announce that the worker thread which was searching for work is now
-            // parking. This checks if the parking worker thread was the last
-            // actively searching thread.
-            if (pool.transitionWorkerToParkedWhenSearching()) {
-              // If this was indeed the last actively searching thread, do another
-              // global check of the pool. Other threads might be busy with their
-              // local queues or new work might have arrived on the external
-              // queue. Another thread might be able to help.
-              pool.notifyIfWorkPending(rnd)
+              parked.lazySet(true)
+              // Announce that the worker thread which was searching for work is now
+              // parking. This checks if the parking worker thread was the last
+              // actively searching thread.
+              if (pool.transitionWorkerToParkedWhenSearching()) {
+                // If this was indeed the last actively searching thread, do another
+                // global check of the pool. Other threads might be busy with their
+                // local queues or new work might have arrived on the external
+                // queue. Another thread might be able to help.
+                pool.notifyIfWorkPending(rnd)
+              }
+              // Park the thread.
+              state = park()
             }
-            // Park the thread.
-            state = park()
           }
 
         case 3 =>


### PR DESCRIPTION
I was able to reproduce #3568 locally by changing the test:
```scala
        "use fallback" in real {
          val loop = IO.cede.foreverM

          val op = loop.timeoutTo(5.millis, IO.pure(true))

          op.flatMap { res =>
            IO {
              res must beTrue
            }
          }.replicateA(16384).as(ok)
        }
```
And forcing the WSTP to 2 threads (`-XX:ActiveProcessorCount=2`), and of course increasing the test timeout.

I think what happens is this: one of the threads is working very hard on `IO.cede.foreverM`, its local queue is always empty (`cedeBypass`), and it never steals (it always has its own work). I think the timer which should win the race originally was at this thread.

The other thread doesn't have anything to do, so after a while it steals (and calls) the timer. This adds a task to its local queue. However, it goes on, and tries to steal from the other local queue (it can't, see above), then tries to go to sleep. This is of course incorrect (it tries to park with a non-empty local queue). However, before actually parking, it calls `pool.notifyIfWorkPending(rnd)`, which (correctly) detects, that there is some work (in its own local queue). So it won't actually park, but go to state 3, but the external queue is empty, go to 2, trying to steal, it can't, so tries to park again, and again...

(This park-notify self-loop probably can only happen with 2 threads, if there is at least a 3rd one, that will be notified after a few tries, and will steal the task from the local queue. Probably this is why this seemingly only happens in CI.)

(When reproducing the bug, I've seen in a threaddump one thread with an empty local queue and no timers, executing `cede`. And the other, with a non-empty local queue being in state 2. External queue empty.)

The fix is simply to re-check the local queue after stealing timers. If it's non-empty, go to 4, and do the work. (I recommend reviewing with "ignore whitespace", as there is a big block of code indented.)

After the fix, I'm not able to reproduce the bug locally any more. (We'll see in CI...)