### PR TITLE
Fix worker thread name index

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -98,7 +98,7 @@ private final class WorkerThread(
   private val indexTransfer: LinkedTransferQueue[Integer] = new LinkedTransferQueue()
   private[this] val runtimeBlockingExpiration: Duration = pool.runtimeBlockingExpiration
 
-  val nameIndex: Int = pool.blockedWorkerThreadNamingIndex.incrementAndGet()
+  val nameIndex: Int = pool.blockedWorkerThreadNamingIndex.getAndIncrement()
 
   // Constructor code.
   {

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -668,6 +668,9 @@ private final class WorkerThread(
         val idx = index
         val clone =
           new WorkerThread(idx, queue, parked, external, fiberBag, pool)
+        // Make sure the clone gets our old name:
+        val clonePrefix = pool.threadPrefix
+        clone.setName(s"$clonePrefix-$idx")
         pool.replaceWorker(idx, clone)
         pool.blockedWorkerThreadCounter.incrementAndGet()
         clone.start()

--- a/tests/jvm/src/test/scala/cats/effect/unsafe/WorkerThreadNameSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/WorkerThreadNameSpec.scala
@@ -54,6 +54,7 @@ class WorkerThreadNameSpec extends BaseSpec with TestInstances {
   "WorkerThread" should {
     "rename itself when entering and exiting blocking region" in real {
       for {
+        _ <- IO.cede
         computeThread <- threadInfo
         (computeThreadName, _) = computeThread
         blockerThread <- IO.blocking(threadInfo).flatten
@@ -65,6 +66,8 @@ class WorkerThreadNameSpec extends BaseSpec with TestInstances {
       } yield {
         // Start with the regular prefix
         computeThreadName must startWith("io-compute")
+        // correct WSTP index (threadCount is 1, so the only possible index is 0)
+        computeThreadName must endWith("-0")
         // Check that entering a blocking region changes the name
         blockerThreadName must startWith("io-blocker")
         // Check that the same thread is renamed again when it is readded to the compute pool
@@ -75,6 +78,8 @@ class WorkerThreadNameSpec extends BaseSpec with TestInstances {
           "blocker thread not found after reset")
         resetBlockerThread must beSome((_: String).startsWith("io-compute"))
           .setMessage("blocker thread name was not reset")
+        resetBlockerThread must beSome((_: String).endsWith("-0"))
+          .setMessage("blocker thread index was not correct")
       }
     }
   }


### PR DESCRIPTION
Strangely, the _initial_ name of the `WorkerThreads` is one higher than their (zero-based) index in the WSTP (i.e., `io-compute-1`, `io-compute-2`, ... instead of `io-compute-0`, `io-compute-1`, ...). After a worker is converted to a blocker, and then returns to the WSTP, its name will have the _correct_ index (i.e., zero-based). Confusingly, this can cause two worker threads to have the _same_ name. E.g., originally `io-compute-2` (with index `1`) becomes `io-compute-1`, but there could be _another_ `io-compute-1` (with index `0`).

This PR fixes this inconsistency.