### PR TITLE
fix #3501 flakey test

### DIFF
--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -359,7 +359,7 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
     "issue 3501: reject new tasks after release action is submitted as a task" in real {
       dispatcher.allocated.flatMap {
         case (runner, release) =>
-          IO(runner.unsafeRunAndForget(release)) *>
+          IO(runner.unsafeRunAndForget(IO.sleep(50.millis) *> release)) *>
             IO.sleep(100.millis) *>
             IO(runner.unsafeRunAndForget(IO(ko)) must throwAn[IllegalStateException])
       }


### PR DESCRIPTION
resolves #3501 for real this time!

With help from Arman, we figured out the problem I mentioned in my comment on the parent issue, where it looked like `unsafeToFutureCancelable` was failing before the release task was even enqueued. What's actually happening is that when the double check on `alive` fails, we try to cancel the task by submitting the cancellation to  _the dispatcher_ as a new task. It was the cancellation that was failing immediately because we'd already started the release process. 

Short term (this pr): adding a small sleep as part of the task before the release ensures that we finish the task and don't get caught trying to cancel with an already shut-down dispatcher. This should resolve the flake. 

Longer term: Arman and I have been chatting about a way to possibly change the enqueueing so that we don't need the double-check on alive. If we figure that out, then it would remove that race condition for good :)