### PR TITLE
Fix Mutex memory leak

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Mutex.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Mutex.scala
@@ -65,9 +65,9 @@ object Mutex {
    */
   def apply[F[_]](implicit F: Concurrent[F]): F[Mutex[F]] =
     Ref
-      .of[F, ConcurrentImpl.LockQueue](
+      .of[F, ConcurrentImpl.LockQueueCell](
         // Initialize the state with an already completed cell.
-        ConcurrentImpl.Empty
+        ConcurrentImpl.EmptyCell
       )
       .map(state => new ConcurrentImpl[F](state))
 
@@ -76,21 +76,21 @@ object Mutex {
    */
   def in[F[_], G[_]](implicit F: Sync[F], G: Async[G]): F[Mutex[G]] =
     Ref
-      .in[F, G, ConcurrentImpl.LockQueue](
+      .in[F, G, ConcurrentImpl.LockQueueCell](
         // Initialize the state with an already completed cell.
-        ConcurrentImpl.Empty
+        ConcurrentImpl.EmptyCell
       )
       .map(state => new ConcurrentImpl[G](state))
 
   private final class ConcurrentImpl[F[_]](
-      state: Ref[F, ConcurrentImpl.LockQueue]
+      state: Ref[F, ConcurrentImpl.LockQueueCell]
   )(
       implicit F: Concurrent[F]
   ) extends Mutex[F] {
     // Awakes whoever is waiting for us with the next cell in the queue.
     private def awakeCell(
-        ourCell: ConcurrentImpl.Next[F],
-        nextCell: ConcurrentImpl.LockQueue
+        ourCell: ConcurrentImpl.WaitingCell[F],
+        nextCell: ConcurrentImpl.LockQueueCell
     ): F[Unit] =
       state.access.flatMap {
         // If the current last cell in the queue is our cell,
@@ -107,45 +107,47 @@ object Mutex {
 
     // Cancels a Fiber waiting for the Mutex.
     private def cancel(
-        ourCell: ConcurrentImpl.Next[F],
-        currentCell: ConcurrentImpl.LockQueue
+        ourCell: ConcurrentImpl.WaitingCell[F],
+        nextCell: ConcurrentImpl.LockQueueCell
     ): F[Unit] =
-      awakeCell(ourCell, nextCell = currentCell)
+      awakeCell(ourCell, nextCell)
 
     // Acquires the Mutex.
-    private def acquire(poll: Poll[F]): F[ConcurrentImpl.Next[F]] =
+    private def acquire(poll: Poll[F]): F[ConcurrentImpl.WaitingCell[F]] =
       ConcurrentImpl.LockQueueCell[F].flatMap { ourCell =>
         // Atomically get the last cell in the queue,
         // and put ourselves as the last one.
         state.getAndSet(ourCell).flatMap { lastCell =>
-          // Then we check what was the current cell is.
+          // Then we check what the next cell is.
           // There are two options:
-          //  + Empty: Signaling that the mutex is free.
-          //  + Next(cell): Which means there is someone ahead of us in the queue.
-          //    Thus, wait for that cell to complete; and check again.
+          //  + EmptyCell: Signaling that the mutex is free.
+          //  + WaitingCell: Which means there is someone ahead of us in the queue.
+          //    Thus, we wait for that cell to complete; and then check again.
           //
           // Only the waiting process is cancelable.
           // If we are cancelled while waiting,
-          // we then notify our waiter to wait for the cell ahead of us instead.
-          def loop(currentCell: ConcurrentImpl.LockQueue): F[ConcurrentImpl.Next[F]] =
-            if (currentCell eq ConcurrentImpl.Empty) F.pure(ourCell)
+          // we notify our waiter with the cell ahead of us.
+          def loop(
+              nextCell: ConcurrentImpl.LockQueueCell
+          ): F[ConcurrentImpl.WaitingCell[F]] =
+            if (nextCell eq ConcurrentImpl.EmptyCell) F.pure(ourCell)
             else {
               F.onCancel(
-                poll(currentCell.asInstanceOf[ConcurrentImpl.Next[F]].get),
-                cancel(ourCell, currentCell)
-              ).flatMap { nextCell => loop(currentCell = nextCell) }
+                poll(nextCell.asInstanceOf[ConcurrentImpl.WaitingCell[F]].get),
+                cancel(ourCell, nextCell)
+              ).flatMap(loop)
             }
 
-          loop(currentCell = lastCell)
+          loop(nextCell = lastCell)
         }
       }
 
     // Releases the Mutex.
-    private def release(ourCell: ConcurrentImpl.Next[F]): F[Unit] =
-      awakeCell(ourCell, nextCell = ConcurrentImpl.Empty)
+    private def release(ourCell: ConcurrentImpl.WaitingCell[F]): F[Unit] =
+      awakeCell(ourCell, nextCell = ConcurrentImpl.EmptyCell)
 
     override final val lock: Resource[F, Unit] =
-      Resource.makeFull[F, ConcurrentImpl.Next[F]](acquire)(release).void
+      Resource.makeFull[F, ConcurrentImpl.WaitingCell[F]](acquire)(release).void
 
     override def mapK[G[_]](f: F ~> G)(implicit G: MonadCancel[G, _]): Mutex[G] =
       new Mutex.TransformedMutex(this, f)
@@ -153,15 +155,15 @@ object Mutex {
 
   private object ConcurrentImpl {
     // Represents a queue of waiters for the mutex.
-    private[Mutex] final type LockQueue = AnyRef
+    private[Mutex] final type LockQueueCell = AnyRef
     // Represents the first cell of the queue.
-    private[Mutex] final type Empty = LockQueue
-    private[Mutex] final val Empty: Empty = null
-    // Represents a cell in the queue of waiters.
-    private[Mutex] final type Next[F[_]] = Deferred[F, LockQueue]
+    private[Mutex] final type EmptyCell = LockQueueCell
+    private[Mutex] final val EmptyCell: EmptyCell = null
+    // Represents a waiting cell in the queue.
+    private[Mutex] final type WaitingCell[F[_]] = Deferred[F, LockQueueCell]
 
-    private[Mutex] def LockQueueCell[F[_]](implicit F: Concurrent[F]): F[Next[F]] =
-      Deferred[F, LockQueue]
+    private[Mutex] def LockQueueCell[F[_]](implicit F: Concurrent[F]): F[WaitingCell[F]] =
+      Deferred[F, LockQueueCell]
   }
 
   private final class TransformedMutex[F[_], G[_]](


### PR DESCRIPTION
Previously, when we canceled the last waiter of the `Mutex`, then its cell would remain in memory until a new waiter would arrive; which was pointless since that waiter would immediately get the next cell on the queue.
Thus, we now first check if we are the last waiter, and if that is the case then we set the state as the next cell; allowing GC to free our cell. Note, we were already doing something very similar con `release`.

I also couldn't resist the need to rename a couple of things, hoping to make the implementation more readable; I did this in a separate commit.