### PR TITLE
Backport `fromFutureCancelable` and friends to 2.4.x

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOCompanionPlatform.scala
@@ -43,8 +43,14 @@ private[effect] abstract class IOCompanionPlatform { this: IO.type =>
   def fromThenable[A](iot: IO[Thenable[A]]): IO[A] =
     asyncForIO.fromThenable(iot)
 
+  def fromThenableCancelable[A](iot: IO[(Thenable[A], IO[Unit])]): IO[A] =
+    asyncForIO.fromThenableCancelable(iot)
+
   def fromPromise[A](iop: IO[Promise[A]]): IO[A] =
     asyncForIO.fromPromise(iop)
+
+  def fromPromiseCancelable[A](iop: IO[(Promise[A], IO[Unit])]): IO[A] =
+    asyncForIO.fromPromiseCancelable(iop)
 
   def realTimeDate: IO[js.Date] = asyncForIO.realTimeDate
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1380,10 +1380,16 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
    * }}}
    *
    * @see
-   *   [[IO#unsafeToFuture]]
+   *   [[IO#unsafeToFuture]], [[fromFutureCancelable]]
    */
   def fromFuture[A](fut: IO[Future[A]]): IO[A] =
     asyncForIO.fromFuture(fut)
+
+  /**
+   * Like [[fromFuture]], but is cancelable via the provided finalizer.
+   */
+  def fromFutureCancelable[A](fut: IO[(Future[A], IO[Unit])]): IO[A] =
+    asyncForIO.fromFutureCancelable(fut)
 
   /**
    * Run two IO tasks concurrently, and return the first to finish, either in success or error.

--- a/kernel/js/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
+++ b/kernel/js/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
@@ -22,24 +22,36 @@ private[kernel] trait AsyncPlatform[F[_]] { this: Async[F] =>
 
   def fromPromise[A](iop: F[Promise[A]]): F[A] = fromThenable(widen(iop))
 
+  def fromPromiseCancelable[A](iop: F[(Promise[A], F[Unit])]): F[A] =
+    fromThenableCancelable(widen(iop))
+
   def fromThenable[A](iot: F[Thenable[A]]): F[A] =
     flatMap(iot) { t =>
       async_[A] { cb =>
-        val onFulfilled: Function1[A, Unit | Thenable[Unit]] =
-          (v: A) => cb(Right(v)): Unit | Thenable[Unit]
-
-        val onRejected: Function1[Any, Unit | Thenable[Unit]] = { (a: Any) =>
-          val e = a match {
-            case th: Throwable => th
-            case _ => JavaScriptException(a)
-          }
-
-          cb(Left(e)): Unit | Thenable[Unit]
-        }
-
-        t.`then`[Unit](onFulfilled, defined(onRejected))
-
+        t.`then`[Unit](mkOnFulfilled(cb), defined(mkOnRejected(cb)))
         ()
       }
     }
+
+  def fromThenableCancelable[A](iot: F[(Thenable[A], F[Unit])]): F[A] =
+    flatMap(iot) {
+      case (t, fin) =>
+        async[A] { cb =>
+          as(delay(t.`then`[Unit](mkOnFulfilled(cb), defined(mkOnRejected(cb)))), Some(fin))
+        }
+    }
+
+  @inline private[this] def mkOnFulfilled[A](
+      cb: Either[Throwable, A] => Unit): Function1[A, Unit | Thenable[Unit]] =
+    (v: A) => cb(Right(v)): Unit | Thenable[Unit]
+
+  @inline private[this] def mkOnRejected[A](
+      cb: Either[Throwable, A] => Unit): Function1[Any, Unit | Thenable[Unit]] = { (a: Any) =>
+    val e = a match {
+      case th: Throwable => th
+      case _ => JavaScriptException(a)
+    }
+
+    cb(Left(e)): Unit | Thenable[Unit]
+  }
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -150,12 +150,26 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
 
   /**
    * Lifts a [[scala.concurrent.Future]] into an `F` effect.
+   *
+   * @see
+   *   [[fromFutureCancelable]] for a cancelable version
    */
   def fromFuture[A](fut: F[Future[A]]): F[A] =
     flatMap(fut) { f =>
       flatMap(executionContext) { implicit ec =>
         async_[A](cb => f.onComplete(t => cb(t.toEither)))
       }
+    }
+
+  /**
+   * Like [[fromFuture]], but is cancelable via the provided finalizer.
+   */
+  def fromFutureCancelable[A](futCancel: F[(Future[A], F[Unit])]): F[A] =
+    flatMap(futCancel) {
+      case (fut, fin) =>
+        flatMap(executionContext) { implicit ec =>
+          async[A](cb => as(delay(fut.onComplete(t => cb(t.toEither))), Some(fin)))
+        }
     }
 
   /**

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1400,6 +1400,16 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         }
       }
 
+      "round trip cancelable through s.c.Future" in ticked { implicit ticker =>
+        forAll { (ioa: IO[Int]) =>
+          ioa eqv IO.fromFutureCancelable(
+            IO(ioa.unsafeToFutureCancelable()).map {
+              case (fut, fin) => (fut, IO.fromFuture(IO(fin())))
+            }
+          )
+        }
+      }
+
       "canceled through s.c.Future is errored" in ticked { implicit ticker =>
         val test =
           IO.fromFuture(IO(IO.canceled.as(-1).unsafeToFuture())).handleError(_ => 42)


### PR DESCRIPTION
Cherry-picks [51bd498](https://github.com/typelevel/cats-effect/pull/3597/commits/51bd49841d681062c250e5655c8737079b30ded1) to the 2.4.x branch.

Motivation: allow libraries published against 2.4.x to prepare for smooth transition to the new semantics of `fromFuture` and friends under 2.5.0