### PR TITLE
Revised `Queue.synchronous` internals to simplify concurrent hand-off

### DIFF
--- a/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
@@ -94,7 +94,7 @@ class BoundedQueueSpec extends BaseSpec with QueueTests[Queue] with DetectPlatfo
         _ <- IO.race(taker.joinWithNever, q.offer(()).delayBy(500.millis))
       } yield ()
 
-      test.parReplicateA(if (isJS || isNative) 1 else 500).as(ok)
+      test.parReplicateA(if (isJS || isNative) 1 else 1000).as(ok)
     }
   }
 


### PR DESCRIPTION
Fixes #3587 

This revises the state machine to ensure that `take` gets the value at the same time that it gets the `offer` latch, rather than splitting that into two linearization points. That split was fundamentally unsound (and also over-complicated). By moving things into a single linearization point (via the CAS on `Ref`), we should have fully eliminated the last of the race conditions here.

Previous race conditions in this area will manifest as a `take` which gets a result from an `offer` *as* that `offer` is canceled. This is fine though, because `take` has its value, `offer` is unblocked (because it's canceled), and the `Queue` itself will be empty.