### PR TITLE
Use configure-pagefile-action on Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,13 @@ jobs:
         shell: bash
         run: gu install native-image
 
+      - name: Configure Windows Pagefile
+        if: matrix.os == 'windows-latest'
+        uses: al-cheb/configure-pagefile-action@v1.3
+        with:
+          minimum-size: 2GB
+          maximum-size: 8GB
+
       - name: Check that workflows are up to date
         shell: bash
         run: sbt githubWorkflowCheck

--- a/build.sbt
+++ b/build.sbt
@@ -158,6 +158,12 @@ ThisBuild / githubWorkflowBuildPreamble ++= Seq(
     List("gu install native-image"),
     name = Some("Install GraalVM Native Image"),
     cond = Some(s"matrix.java == '${GraalVM.render}'")
+  ),
+  WorkflowStep.Use(
+    UseRef.Public("al-cheb", "configure-pagefile-action", "v1.3"),
+    name = Some("Configure Windows Pagefile"),
+    params = Map("minimum-size" -> "2GB", "maximum-size" -> "8GB"),
+    cond = Some(s"matrix.os == '$Windows'")
   )
 )
 


### PR DESCRIPTION
Seeing this in Windows CI pretty often:
```
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x0000000090000000, 117440512, 0) failed; error='The paging file is too small for this operation to complete' (DOS error/errno=1455)
```

So we can try this action h/t https://github.com/scala-native/scala-native/issues/3195#issuecomment-1459999323