### PR TITLE
Added test to ensure inner worker awaits are canceled

### DIFF
--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -152,6 +152,13 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
           _ <- gate2.acquireN(2)
         } yield ok
       }
+
+      "cancel inner awaits when canceled" in ticked { implicit ticker =>
+        val work = Dispatcher.parallel[IO](await = false).useForever
+        val test = work.background.use(_ => IO.sleep(100.millis))
+
+        test must completeAs(())
+      }
     }
   }
 

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -366,7 +366,7 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
     }
 
     "cancel inner awaits when canceled" in ticked { implicit ticker =>
-      val work = Dispatcher.parallel[IO](await = false).useForever
+      val work = dispatcher.useForever
       val test = work.background.use(_ => IO.sleep(100.millis))
 
       test must completeAs(())

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -152,13 +152,6 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
           _ <- gate2.acquireN(2)
         } yield ok
       }
-
-      "cancel inner awaits when canceled" in ticked { implicit ticker =>
-        val work = Dispatcher.parallel[IO](await = false).useForever
-        val test = work.background.use(_ => IO.sleep(100.millis))
-
-        test must completeAs(())
-      }
     }
   }
 
@@ -370,6 +363,13 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
             IO.sleep(100.millis) *>
             IO(runner.unsafeRunAndForget(IO(ko)) must throwAn[IllegalStateException])
       }
+    }
+
+    "cancel inner awaits when canceled" in ticked { implicit ticker =>
+      val work = Dispatcher.parallel[IO](await = false).useForever
+      val test = work.background.use(_ => IO.sleep(100.millis))
+
+      test must completeAs(())
     }
   }
 


### PR DESCRIPTION
Closes #3534

Turns out this isn't actually a problem because we sequence `release` immediately thereafter, which *completes* the callback rather than canceling the `async`.