### PR TITLE
Reset the global runtime when it is shutdown.

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOApp.scala
+++ b/core/js/src/main/scala/cats/effect/IOApp.scala
@@ -209,7 +209,12 @@ trait IOApp {
         val compute = IORuntime.createBatchingMacrotaskExecutor(reportFailure = t =>
           reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime))
 
-        IORuntime(compute, compute, IORuntime.defaultScheduler, () => (), runtimeConfig)
+        IORuntime(
+          compute,
+          compute,
+          IORuntime.defaultScheduler,
+          () => IORuntime.resetGlobal(),
+          runtimeConfig)
       }
 
       _runtime = IORuntime.global

--- a/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -45,14 +45,14 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
   private[effect] def resetGlobal(): Unit =
     _global = null
 
-  lazy val global: IORuntime = {
+  def global: IORuntime = {
     if (_global == null) {
       installGlobal {
         IORuntime(
           defaultComputeExecutionContext,
           defaultComputeExecutionContext,
           defaultScheduler,
-          () => (),
+          () => resetGlobal(),
           IORuntimeConfig())
       }
     }

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -355,6 +355,7 @@ trait IOApp {
           { () =>
             compDown()
             blockDown()
+            IORuntime.resetGlobal()
           },
           runtimeConfig)
       }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -176,7 +176,7 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
     (Scheduler.fromScheduledExecutor(scheduler), { () => scheduler.shutdown() })
   }
 
-  private[this] var _global: IORuntime = null
+  @volatile private[this] var _global: IORuntime = null
 
   // we don't need to synchronize this with IOApp, because we control the main thread
   // so instead we just yolo it since the lazy val already synchronizes its own initialization
@@ -192,13 +192,13 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
   private[effect] def resetGlobal(): Unit =
     _global = null
 
-  lazy val global: IORuntime = {
+  def global: IORuntime = {
     if (_global == null) {
       installGlobal {
         val (compute, _) = createWorkStealingComputeThreadPool()
         val (blocking, _) = createDefaultBlockingExecutionContext()
 
-        IORuntime(compute, blocking, compute, () => (), IORuntimeConfig())
+        IORuntime(compute, blocking, compute, () => resetGlobal(), IORuntimeConfig())
       }
     }
 

--- a/core/native/src/main/scala/cats/effect/IOApp.scala
+++ b/core/native/src/main/scala/cats/effect/IOApp.scala
@@ -197,8 +197,9 @@ trait IOApp {
           IORuntime.defaultComputeExecutionContext,
           IORuntime.defaultComputeExecutionContext,
           IORuntime.defaultScheduler,
-          () => (),
-          runtimeConfig)
+          () => IORuntime.resetGlobal(),
+          runtimeConfig
+        )
       }
 
       _runtime = IORuntime.global

--- a/core/native/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -38,14 +38,14 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
   private[effect] def resetGlobal(): Unit =
     _global = null
 
-  lazy val global: IORuntime = {
+  def global: IORuntime = {
     if (_global == null) {
       installGlobal {
         IORuntime(
           defaultComputeExecutionContext,
           defaultComputeExecutionContext,
           defaultScheduler,
-          () => (),
+          () => resetGlobal(),
           IORuntimeConfig())
       }
     }

--- a/core/shared/src/main/scala/cats/effect/unsafe/implicits.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/implicits.scala
@@ -17,5 +17,5 @@
 package cats.effect.unsafe
 
 object implicits {
-  implicit val global: IORuntime = IORuntime.global
+  implicit def global: IORuntime = IORuntime.global
 }

--- a/tests/js/src/main/scala/catseffect/examplesplatform.scala
+++ b/tests/js/src/main/scala/catseffect/examplesplatform.scala
@@ -48,6 +48,7 @@ package examples {
     registerRaw(FatalErrorRaw)
     register(Canceled)
     registerLazy("catseffect.examples.GlobalRacingInit", GlobalRacingInit)
+    registerLazy("catseffect.examples.GlobalShutdown", GlobalShutdown)
     register(ShutdownHookImmediateTimeout)
     register(LiveFiberSnapshot)
     register(FatalErrorUnsafeRun)

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -195,6 +195,14 @@ class IOAppSpec extends Specification {
           h.stderr() must not(contain("boom"))
         }
 
+        "reset global runtime on shutdown" in {
+          val h = platform(GlobalShutdown, List.empty)
+          h.awaitStatus() mustEqual 0
+          h.stderr() must not contain
+            "Cats Effect global runtime already initialized; custom configurations will be ignored"
+          h.stderr() must not(contain("boom"))
+        }
+
         "warn on cpu starvation" in {
           val h = platform(CpuStarvation, List.empty)
           h.awaitStatus()

--- a/tests/shared/src/main/scala/catseffect/examples.scala
+++ b/tests/shared/src/main/scala/catseffect/examples.scala
@@ -79,6 +79,23 @@ package examples {
       Console[IO].errorln("boom").whenA(!r.eq(runtime)) >> IO.pure(ExitCode.Success)
   }
 
+  object GlobalShutdown extends IOApp {
+
+    var r: IORuntime = null
+
+    def foo(): Unit = {
+      // touch the global runtime to force its initialization
+      r = cats.effect.unsafe.implicits.global
+      ()
+    }
+
+    foo()
+    r.shutdown()
+
+    def run(args: List[String]): IO[ExitCode] =
+      Console[IO].errorln("boom").whenA(r.eq(runtime)) >> IO.pure(ExitCode.Success)
+  }
+
   object LiveFiberSnapshot extends IOApp.Simple {
 
     import scala.concurrent.duration._


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/1818. (`publishLocal`ed and confirmed manually)

If the global runtime is shutdown, then it should be reset so that another global can be installed. This prevents the awkward situation where tasks are submitted to a global that's actually not alive, which was causing the hang in https://github.com/typelevel/cats-effect/issues/1818#issuecomment-1536987188.