### PR TITLE
Adjusted `Queue.synchronous` to include a two-phase commit

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Queue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Queue.scala
@@ -245,9 +245,9 @@ object Queue {
                 val removeListener = stateR modify {
                   case SyncState(offerers, takers) =>
                     // like filter, but also returns a Boolean indicating whether it was found
-                    def filterFound[A <: AnyRef](
-                        in: ScalaQueue[A],
-                        out: ScalaQueue[A]): (Boolean, ScalaQueue[A]) = {
+                    def filterFound[Z <: AnyRef](
+                        in: ScalaQueue[Z],
+                        out: ScalaQueue[Z]): (Boolean, ScalaQueue[Z]) = {
 
                       if (in.isEmpty) {
                         (false, out)
@@ -255,7 +255,7 @@ object Queue {
                         val (head, tail) = in.dequeue
 
                         if (head eq latch)
-                          (true, out.enqueueAll(tail))
+                          (true, out ++ tail)
                         else
                           filterFound(tail, out.enqueue(head))
                       }

--- a/std/shared/src/main/scala/cats/effect/std/Queue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Queue.scala
@@ -245,6 +245,7 @@ object Queue {
                 val removeListener = stateR modify {
                   case SyncState(offerers, takers) =>
                     // like filter, but also returns a Boolean indicating whether it was found
+                    @tailrec
                     def filterFound[Z <: AnyRef](
                         in: ScalaQueue[Z],
                         out: ScalaQueue[Z]): (Boolean, ScalaQueue[Z]) = {

--- a/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
@@ -72,6 +72,35 @@ class BoundedQueueSpec extends BaseSpec with QueueTests[Queue] with DetectPlatfo
       test must completeAs(0.until(5).toList)
     }
 
+    "not lose offer when taker is canceled during exchange" in real {
+      val test = for {
+        q <- Queue.synchronous[IO, Unit]
+        latch <- CountDownLatch[IO](2)
+        offererDone <- IO.ref(false)
+
+        _ <- (latch.release *> latch.await *> q.offer(())).guarantee(offererDone.set(true)).start
+        taker <- (latch.release *> latch.await *> q.take).start
+
+        _ <- latch.await
+        _ <- taker.cancel
+
+        // we should either have received the value successfully, or we left the value in queue
+        // what we *don't* want is to remove the value and then lose it due to cancelation
+        oc <- taker.join
+
+        _ <- if (oc.isCanceled) {
+          // we (maybe) hit the race condition
+          // if we lost the value, q.take will hang
+          offererDone.get.flatMap(b => IO(b must beFalse)) *> q.take
+        } else {
+          // we definitely didn't hit the race condition, because we got the value in taker
+          IO.unit
+        }
+      } yield ok
+
+      test.parReplicateA_(10000).as(ok)
+    }
+
     "not lose takers when offerer is canceled and there are no other takers" in real {
       val test = for {
         q <- Queue.synchronous[IO, Unit]

--- a/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
@@ -101,7 +101,7 @@ class BoundedQueueSpec extends BaseSpec with QueueTests[Queue] with DetectPlatfo
           }
       } yield ok
 
-      test.parReplicateA_(10000).as(ok)
+      test.parReplicateA_(if (isJVM) 10000 else 1).as(ok)
     }
 
     "not lose takers when offerer is canceled and there are no other takers" in real {


### PR DESCRIPTION
Fixes #3603 

Okay I think I finally got it. `synchronous` preserves the "at least once" guarantee while also preserving the "only one value at a time", which means it boils down to "exactly once". The only thing that makes this modestly not-insane is the fact that we can lose values on the `offer` side, just not on the `take` side, meaning that we don't need commits in both directions. Thus, the fix here is to introduce a signaling mechanism from `take` to `offer` which effectively releases `offer` and confirms that we have the `A` in `take` and we are no longer cancelable. There are some tradeoffs to this, but given that we're going for exactly-once delivery, tradeoffs should absolutely be expected.