### PR TITLE
Catch stray exceptions in `uncancelable` body

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -555,7 +555,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
     IO.OnCancel(this, fin)
 
   def onError(f: Throwable => IO[Unit]): IO[A] =
-    handleErrorWith(t => f(t).attempt *> IO.raiseError(t))
+    handleErrorWith(t => f(t).voidError *> IO.raiseError(t))
 
   def race[B](that: IO[B]): IO[Either[A, B]] =
     IO.race(this, that)

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1314,6 +1314,9 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         test must nonTerminate
       }
 
+      "catch stray exceptions in uncancelable" in ticked { implicit ticker =>
+        IO.uncancelable[Unit](_ => throw new RuntimeException).voidError must completeAs(())
+      }
     }
 
     "finalization" should {


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/3609.