### PR TITLE
Treat non-positive sleep durations as `cede`s

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -900,13 +900,13 @@ private final class IOFiber[A](
 
         case 19 =>
           val cur = cur0.asInstanceOf[Sleep]
+          val delay = cur.delay
 
           val next =
-            if (cur.delay.length > 0)
+            if (delay.length > 0)
               IO.async[Unit] { cb =>
                 IO {
                   val scheduler = runtime.scheduler
-                  val delay = cur.delay
 
                   val cancel =
                     if (scheduler.isInstanceOf[WorkStealingThreadPool])

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1731,6 +1731,10 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         affected must beTrue
       }
 
+      "round up negative sleeps" in real {
+        IO.sleep(-1.seconds).as(ok)
+      }
+
       "timeout" should {
         "succeed" in real {
           val op = IO.pure(true).timeout(100.millis)


### PR DESCRIPTION
Closes https://github.com/typelevel/cats-effect/issues/3585. Sorry, I want to get v3.5.0 out-the-door 😅 