### PR TITLE
Don't set `turbo := false` in Scastie

### DIFF
--- a/scripts/data/scastie.sbt
+++ b/scripts/data/scastie.sbt
@@ -4,5 +4,3 @@ scalacOptions ++= Seq(
   "-feature",
   "-unchecked"
 )
-
-turbo := false


### PR DESCRIPTION
The default `turbo := true` used by Scastie was bugged in https://github.com/typelevel/cats-effect/issues/1818 but recently fixed in https://github.com/typelevel/cats-effect/pull/3604. When I tested it for that PR it does offer a snappy experience and is probably better than the default `fork := false` which is still known to be broken in https://github.com/typelevel/cats-effect/issues/2251.