### PR TITLE
Don't use `object` for `executeBatchTaskRunnable`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -794,7 +794,10 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
           "cats.effect.unsafe.ES2021FiberMonitor.this"),
         // introduced by #3324, which specialized CallbackStack for JS
         // internal API change
-        ProblemFilters.exclude[IncompatibleTemplateDefProblem]("cats.effect.CallbackStack")
+        ProblemFilters.exclude[IncompatibleTemplateDefProblem]("cats.effect.CallbackStack"),
+        // introduced by #3642, which optimized the BatchingMacrotaskExecutor
+        ProblemFilters.exclude[MissingClassProblem](
+          "cats.effect.unsafe.BatchingMacrotaskExecutor$executeBatchTaskRunnable$")
       )
     },
     mimaBinaryIssueFilters ++= {

--- a/core/js/src/main/scala/cats/effect/unsafe/BatchingMacrotaskExecutor.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/BatchingMacrotaskExecutor.scala
@@ -56,7 +56,7 @@ private[effect] final class BatchingMacrotaskExecutor(
   private[this] var needsReschedule = true
   private[this] val fibers = new JSArrayQueue[IOFiber[_]]
 
-  private[this] object executeBatchTaskRunnable extends Runnable {
+  private[this] val executeBatchTaskRunnable = new Runnable {
     def run() = {
       // do up to batchSize tasks
       var i = 0


### PR DESCRIPTION
Stupid micro-optimization. `object`s are lazy initialized which adds a pointless penalty on every access.