### PR TITLE
Dispatcher: remove `alive` in favour of null state

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,10 +1,23 @@
 pull_request_rules:
-  - name: label scala-steward's PRs
+  - name: label typelevel-steward's PRs
     conditions:
-      - author=scala-steward
+      - author=typelevel-steward[bot]
+    actions:
+      label:
+        add: [':robot:']
+  - name: label typelevel-steward's update PRs
+    conditions:
+      - author=typelevel-steward[bot]
+      - body~=labels:.*library-update
     actions:
       label:
         add: [dependencies]
+  - name: label dependabots's PRs
+    conditions:
+      - author=dependabot[bot]
+    actions:
+      label:
+        add: [':robot:']
   - name: automatically merge dependabot docs PRs
     conditions:
       - author=dependabot[bot]

--- a/flake.lock
+++ b/flake.lock
@@ -2,15 +2,15 @@
   "nodes": {
     "devshell": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1682700442,
-        "narHash": "sha256-qjaAAcCYgp1pBBG7mY9z95ODUBZMtUpf0Qp3Gt/Wha0=",
+        "lastModified": 1683635384,
+        "narHash": "sha256-9goJTd05yOyD/McaMqZ4BUB8JW+mZMnZQJZ7VQ6C/Lw=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "fb6673fe9fe4409e3f43ca86968261e970918a83",
+        "rev": "5143ea68647c4cf5227e4ad2100db6671fc4c369",
         "type": "github"
       },
       "original": {
@@ -20,23 +20,8 @@
       }
     },
     "flake-utils": {
-      "locked": {
-        "lastModified": 1642700792,
-        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1681202837,
@@ -70,11 +55,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1683442750,
-        "narHash": "sha256-IiJ0WWW6OcCrVFl1ijE+gTaP0ChFfV6dNkJR05yStmw=",
+        "lastModified": 1684091592,
+        "narHash": "sha256-GBGqOd/owyHARCM/kz1OGnUUqEWGWEVcj9+zrl3vVlI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eb751d65225ec53de9cf3d88acbf08d275882389",
+        "rev": "3007746b3f5bfcb49e102b517bca891822a41b31",
         "type": "github"
       },
       "original": {
@@ -112,18 +97,33 @@
         "type": "github"
       }
     },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "typelevel-nix": {
       "inputs": {
         "devshell": "devshell",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1683546385,
-        "narHash": "sha256-QsxQsFlrturrBYY5nEp/J6UYe7NPL4i+QpXg+4HIl9o=",
+        "lastModified": 1684122828,
+        "narHash": "sha256-7HEDlQyRIhw5PLaC3NKiNAGTSrOsjWMT7+wGNaeWIQI=",
         "owner": "typelevel",
         "repo": "typelevel-nix",
-        "rev": "bb9774d68fa09d259f490c81546f36ec6774e96a",
+        "rev": "f5f013dbe26aeb40b6690d55ddddf3a4eb915159",
         "type": "github"
       },
       "original": {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.8.3

--- a/scalafix/project/build.properties
+++ b/scalafix/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.8.3

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -259,12 +259,10 @@ object Dispatcher {
               var i = 0
               while (i < workers) {
                 val st = state(i)
-                if ((st.get() ne Nil) & (st.get() ne null)) {
+                if (st.get() ne null) {
                   val list = if (done) st.getAndSet(null) else st.getAndSet(Nil)
-                  if (list ne null) {
+                  if ((list ne null) && (list ne Nil)) {
                     buffer ++= list.reverse // FIFO order here is a form of fairness
-                  } else {
-                    println("SRP :: st.getAndSet returned null") // TODO
                   }
                 }
                 i += 1


### PR DESCRIPTION
This idea came from conversations with Arman!

If workers close their own state queues as they're marked done, then we can remove the double check on `alive` when submitting work. If a task is submitted to a queue successfully it will be seen by that worker, if the worker has already closed the queue, then submitting the task will fail entirely. In fact, if workers are controlling their own queues in this way, I'm not convinced we need the `alive` ref at all, so I've gone so far as to remove it entirely. 