### PR TITLE
Remove workaround for `Scala3` in `Supervisor`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -907,50 +907,58 @@ lazy val std = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       "org.scalacheck" %%% "scalacheck" % ScalaCheckVersion % Test,
       "org.specs2" %%% "specs2-scalacheck" % Specs2Version % Test
     ),
-    mimaBinaryIssueFilters ++= Seq(
-      // introduced by #2604, Fix Console on JS
-      // changes to `cats.effect.std` package private code
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Console$SyncConsole"),
-      // introduced by #2951
-      // added configurability to Supervisor's scope termination behavior
-      // the following are package-private APIs
-      ProblemFilters.exclude[IncompatibleMethTypeProblem](
-        "cats.effect.std.Supervisor#State.add"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem](
-        "cats.effect.std.Supervisor#State.add"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem](
-        "cats.effect.std.Supervisor#State.joinAll"),
-      // introduced by #3000
-      // package-private or private stuff
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "cats.effect.std.Queue#AbstractQueue.onOfferNoCapacity"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem](
-        "cats.effect.std.Queue#AbstractQueue.onOfferNoCapacity"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "cats.effect.std.Queue#BoundedQueue.onOfferNoCapacity"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "cats.effect.std.Queue#CircularBufferQueue.onOfferNoCapacity"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "cats.effect.std.Queue#DroppingQueue.onOfferNoCapacity"),
-      // #3524, private class
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "cats.effect.std.MapRef#ConcurrentHashMapImpl.keys"),
-      // introduced by #3346
-      // private stuff
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Mutex$Impl"),
-      // introduced by #3347
-      // private stuff
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.AtomicCell$Impl"),
-      // introduced by #3409
-      // extracted UnsafeUnbounded private data structure
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$UnsafeUnbounded"),
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$UnsafeUnbounded$Cell"),
-      // introduced by #3480
-      // adds method to sealed Hotswap
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("cats.effect.std.Hotswap.get"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "cats.effect.std.Supervisor.apply$default$2")
-    )
+    mimaBinaryIssueFilters ++= {
+      if (tlIsScala3.value) {
+        Seq(
+          ProblemFilters.exclude[DirectMissingMethodProblem](
+            "cats.effect.std.Supervisor.apply$default$2")
+        )
+      } else Seq()
+    },
+    mimaBinaryIssueFilters ++=
+      Seq(
+        // introduced by #2604, Fix Console on JS
+        // changes to `cats.effect.std` package private code
+        ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Console$SyncConsole"),
+        // introduced by #2951
+        // added configurability to Supervisor's scope termination behavior
+        // the following are package-private APIs
+        ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "cats.effect.std.Supervisor#State.add"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem](
+          "cats.effect.std.Supervisor#State.add"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem](
+          "cats.effect.std.Supervisor#State.joinAll"),
+        // introduced by #3000
+        // package-private or private stuff
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "cats.effect.std.Queue#AbstractQueue.onOfferNoCapacity"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem](
+          "cats.effect.std.Queue#AbstractQueue.onOfferNoCapacity"),
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "cats.effect.std.Queue#BoundedQueue.onOfferNoCapacity"),
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "cats.effect.std.Queue#CircularBufferQueue.onOfferNoCapacity"),
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "cats.effect.std.Queue#DroppingQueue.onOfferNoCapacity"),
+        // #3524, private class
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "cats.effect.std.MapRef#ConcurrentHashMapImpl.keys"),
+        // introduced by #3346
+        // private stuff
+        ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Mutex$Impl"),
+        // introduced by #3347
+        // private stuff
+        ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.AtomicCell$Impl"),
+        // introduced by #3409
+        // extracted UnsafeUnbounded private data structure
+        ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$UnsafeUnbounded"),
+        ProblemFilters.exclude[MissingClassProblem](
+          "cats.effect.std.Queue$UnsafeUnbounded$Cell"),
+        // introduced by #3480
+        // adds method to sealed Hotswap
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("cats.effect.std.Hotswap.get")
+      )
   )
   .jsSettings(
     libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % MacrotaskExecutorVersion % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -947,7 +947,9 @@ lazy val std = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Queue$UnsafeUnbounded$Cell"),
       // introduced by #3480
       // adds method to sealed Hotswap
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("cats.effect.std.Hotswap.get")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("cats.effect.std.Hotswap.get"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "cats.effect.std.Supervisor.apply$default$2")
     )
   )
   .jsSettings(

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -206,8 +206,7 @@ object Dispatcher {
     val (workers, makeFork) =
       mode match {
         case Mode.Parallel =>
-          // TODO we have to do this for now because Scala 3 doesn't like it (lampepfl/dotty#15546)
-          (Cpus, Supervisor[F](await, None).map(s => s.supervise(_: F[Unit]).map(_.cancel)))
+          (Cpus, Supervisor[F](await).map(s => s.supervise(_: F[Unit]).map(_.cancel)))
 
         case Mode.Sequential =>
           (

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -127,7 +127,7 @@ object Supervisor {
 
   private[std] def apply[F[_]](
       await: Boolean,
-      checkRestart: Option[Outcome[F, Throwable, _] => Boolean] = None)(
+      checkRestart: Option[Outcome[F, Throwable, _] => Boolean])(
       implicit F: Concurrent[F]): Resource[F, Supervisor[F]] = {
     F match {
       case asyncF: Async[F] => applyForAsync(await, checkRestart)(asyncF)
@@ -136,10 +136,7 @@ object Supervisor {
   }
 
   def apply[F[_]: Concurrent]: Resource[F, Supervisor[F]] =
-    apply[F](
-      false,
-      None
-    ) // TODO we have to do this for now because Scala 3 doesn't like it (lampepfl/dotty#15546)
+    apply[F](false)
 
   private trait State[F[_]] {
     def remove(token: Unique.Token): F[Unit]


### PR DESCRIPTION
This is a follow-up to https://github.com/lampepfl/dotty/issues/15546.