### PR TITLE
Directly get secure random data to array on native

### DIFF
--- a/std/native/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
+++ b/std/native/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
@@ -30,19 +30,12 @@ private[std] trait SecureRandomCompanionPlatform {
 
     override def nextBytes(bytes: Array[Byte]): Unit = {
       val len = bytes.length
-      val buffer = stackalloc[Byte](256)
       var i = 0
       while (i < len) {
         val n = Math.min(256, len - i)
-        if (sysrandom.getentropy(buffer, n.toULong) < 0)
+        if (sysrandom.getentropy(bytes.at(i), n.toULong) < 0)
           throw new RuntimeException(s"getentropy: ${errno.errno}")
-
-        var j = 0L
-        while (j < n) {
-          bytes(i) = buffer(j)
-          i += 1
-          j += 1
-        }
+        i += n
       }
     }
 

--- a/std/native/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
+++ b/std/native/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
@@ -18,7 +18,8 @@ package cats.effect.std
 
 import org.typelevel.scalaccompat.annotation._
 
-import scala.scalanative.libc.errno
+import scala.scalanative.libc.errno._
+import scala.scalanative.libc.string._
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 
@@ -34,7 +35,7 @@ private[std] trait SecureRandomCompanionPlatform {
       while (i < len) {
         val n = Math.min(256, len - i)
         if (sysrandom.getentropy(bytes.at(i), n.toULong) < 0)
-          throw new RuntimeException(s"getentropy: ${errno.errno}")
+          throw new RuntimeException(fromCString(strerror(errno)))
         i += n
       }
     }


### PR DESCRIPTION
Now that we can directly access the pointer backing an array, we no longer need a buffer.