### PR TITLE
Cache `now` in `WorkerThread` in states 4-63

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
@@ -52,6 +52,15 @@ private[unsafe] abstract class SchedulerCompanionPlatform { this: Scheduler.type
         now.getEpochSecond * 1000000 + now.getLong(ChronoField.MICRO_OF_SECOND)
       }
 
-      def monotonicNanos() = System.nanoTime()
+      def monotonicNanos() = {
+        val back = System.nanoTime()
+
+        val thread = Thread.currentThread()
+        if (thread.isInstanceOf[WorkerThread]) {
+          thread.asInstanceOf[WorkerThread].now = back
+        }
+
+        back
+      }
     }
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SchedulerCompanionPlatform.scala
@@ -52,15 +52,6 @@ private[unsafe] abstract class SchedulerCompanionPlatform { this: Scheduler.type
         now.getEpochSecond * 1000000 + now.getLong(ChronoField.MICRO_OF_SECOND)
       }
 
-      def monotonicNanos() = {
-        val back = System.nanoTime()
-
-        val thread = Thread.currentThread()
-        if (thread.isInstanceOf[WorkerThread]) {
-          thread.asInstanceOf[WorkerThread].now = back
-        }
-
-        back
-      }
+      def monotonicNanos() = System.nanoTime()
     }
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -598,7 +598,16 @@ private[effect] final class WorkStealingThreadPool(
    */
   override def reportFailure(cause: Throwable): Unit = reportFailure0(cause)
 
-  override def monotonicNanos(): Long = System.nanoTime()
+  override def monotonicNanos(): Long = {
+    val back = System.nanoTime()
+
+    val thread = Thread.currentThread()
+    if (thread.isInstanceOf[WorkerThread]) {
+      thread.asInstanceOf[WorkerThread].now = back
+    }
+
+    back
+  }
 
   override def nowMillis(): Long = System.currentTimeMillis()
 

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -153,9 +153,13 @@ private final class WorkerThread(
   }
 
   def sleep(delay: FiniteDuration, callback: Right[Nothing, Unit] => Unit): Runnable = {
+    // take the opportunity to update the current time, just in case other timers can benefit
+    val _now = System.nanoTime()
+    now = _now
+
     // note that blockers aren't owned by the pool, meaning we only end up here if !blocking
     sleepers.insert(
-      now = System.nanoTime(),
+      now = _now,
       delay = delay.toNanos,
       callback = callback,
       tlr = random


### PR DESCRIPTION
I still want to see numbers which demonstrate the meaning of these types of things in realistic scenarios, but here's a quick draft that takes inspiration from libuv and minimizes the syscall. In particular, this caches the value of `nanoTime()` for states 4-63 (so, most of the time) and only refreshes it when either stealing, polling the external queue, or when the user evaluates `monotonic`. This does trade off timer granularity a bit, but it's still strictly better than what we had pre-3.5 (where timers would reenter through the external queue).

Fixes #3677 