### PR TITLE
Dispatcher: remove `alive` in favour of nullifying queues

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -258,12 +258,10 @@ object Dispatcher {
               var i = 0
               while (i < workers) {
                 val st = state(i)
-                if ((st.get() ne Nil) & (st.get() ne null)) {
+                if (st.get() ne null) {
                   val list = if (done) st.getAndSet(null) else st.getAndSet(Nil)
-                  if (list ne null) {
+                  if ((list ne null) && (list ne Nil)) {
                     buffer ++= list.reverse // FIFO order here is a form of fairness
-                  } else {
-                    println("SRP :: st.getAndSet returned null") // TODO
                   }
                 }
                 i += 1

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -247,16 +247,24 @@ object Dispatcher {
       supervisor <- Supervisor[F](await, Some((_: Outcome[F, Throwable, _]) => true))
 
       _ <- {
-        def step(state: Array[AtomicReference[List[Registration]]], await: F[Unit]): F[Unit] =
+        def step(
+            state: Array[AtomicReference[List[Registration]]],
+            await: F[Unit],
+            doneR: AtomicBoolean): F[Unit] =
           for {
+            done <- F.delay(doneR.get())
             regs <- F delay {
               val buffer = mutable.ListBuffer.empty[Registration]
               var i = 0
               while (i < workers) {
                 val st = state(i)
-                if (st.get() ne Nil) {
-                  val list = st.getAndSet(Nil)
-                  buffer ++= list.reverse // FIFO order here is a form of fairness
+                if ((st.get() ne Nil) & (st.get() ne null)) {
+                  val list = if (done) st.getAndSet(null) else st.getAndSet(Nil)
+                  if (list ne null) {
+                    buffer ++= list.reverse // FIFO order here is a form of fairness
+                  } else {
+                    println("SRP :: st.getAndSet returned null") // TODO
+                  }
                 }
                 i += 1
               }
@@ -294,7 +302,7 @@ object Dispatcher {
           F.delay(latch.set(Noop)) *> // reset latch
             // if we're marked as done, yield immediately to give other fibers a chance to shut us down
             // we might loop on this a few times since we're marked as done before the supervisor is canceled
-            F.delay(doneR.get()).ifM(F.cede, step(state, await))
+            F.delay(doneR.get()).ifM(F.cede, step(state, await, doneR))
         }
 
         0.until(workers).toList traverse_ { n =>
@@ -303,7 +311,7 @@ object Dispatcher {
             val worker = dispatcher(doneR, latch, states(n))
             val release = F.delay(latch.getAndSet(Open)())
             Resource.make(supervisor.supervise(worker)) { _ =>
-              F.delay(doneR.set(true)) *> step(states(n), F.unit) *> release
+              F.delay(doneR.set(true)) *> step(states(n), F.unit, doneR) *> release
             }
           }
         }
@@ -361,9 +369,12 @@ object Dispatcher {
           @tailrec
           def enqueue(state: AtomicReference[List[Registration]], reg: Registration): Unit = {
             val curr = state.get()
-            val next = reg :: curr
-
-            if (!state.compareAndSet(curr, next)) enqueue(state, reg)
+            if (curr eq null) {
+              throw new IllegalStateException("dispatcher already shutdown")
+            } else {
+              val next = reg :: curr
+              if (!state.compareAndSet(curr, next)) enqueue(state, reg)
+            }
           }
 
           if (alive.get()) {
@@ -410,13 +421,13 @@ object Dispatcher {
             }
 
             // double-check after we already put things in the structure
-            if (alive.get()) {
-              (promise.future, cancel)
-            } else {
-              // we were shutdown *during* the enqueue
-              cancel()
-              throw new IllegalStateException("dispatcher already shutdown")
-            }
+            // if (alive.get()) {
+            (promise.future, cancel)
+            // } else {
+            //   // we were shutdown *during* the enqueue
+            //   cancel()
+            //   throw new IllegalStateException("dispatcher already shutdown")
+            // }
           } else {
             throw new IllegalStateException("dispatcher already shutdown")
           }

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -314,10 +314,6 @@ object Dispatcher {
           }
         }
       }
-
-      // Alive is the innermost resource so that when releasing
-      // the very first thing we do is set dispatcher to un-alive
-      alive <- Resource.make(F.delay(new AtomicBoolean(true)))(ref => F.delay(ref.set(false)))
     } yield {
       new Dispatcher[F] {
         override def unsafeRunAndForget[A](fa: F[A]): Unit = {
@@ -375,60 +371,49 @@ object Dispatcher {
             }
           }
 
-          if (alive.get()) {
-            val (state, lt) = if (workers > 1) {
-              val rand = ThreadLocalRandom.current()
-              val dispatcher = rand.nextInt(workers)
-              val inner = rand.nextInt(workers)
+          val (state, lt) = if (workers > 1) {
+            val rand = ThreadLocalRandom.current()
+            val dispatcher = rand.nextInt(workers)
+            val inner = rand.nextInt(workers)
 
-              (states(dispatcher)(inner), latches(dispatcher))
-            } else {
-              (states(0)(0), latches(0))
-            }
-
-            val reg = Registration(action, registerCancel _)
-            enqueue(state, reg)
-
-            if (lt.get() ne Open) {
-              val f = lt.getAndSet(Open)
-              f()
-            }
-
-            val cancel = { () =>
-              reg.lazySet(false)
-
-              @tailrec
-              def loop(): Future[Unit] = {
-                val state = cancelState.get()
-                state match {
-                  case CancelInit =>
-                    val promise = Promise[Unit]()
-                    if (!cancelState.compareAndSet(state, CanceledNoToken(promise))) {
-                      loop()
-                    } else {
-                      promise.future
-                    }
-                  case CanceledNoToken(promise) =>
-                    promise.future
-                  case CancelToken(cancelToken) =>
-                    cancelToken()
-                }
-              }
-
-              loop()
-            }
-
-            // double-check after we already put things in the structure
-            // if (alive.get()) {
-            (promise.future, cancel)
-            // } else {
-            //   // we were shutdown *during* the enqueue
-            //   cancel()
-            //   throw new IllegalStateException("dispatcher already shutdown")
-            // }
+            (states(dispatcher)(inner), latches(dispatcher))
           } else {
-            throw new IllegalStateException("dispatcher already shutdown")
+            (states(0)(0), latches(0))
           }
+
+          val reg = Registration(action, registerCancel _)
+          enqueue(state, reg)
+
+          if (lt.get() ne Open) {
+            val f = lt.getAndSet(Open)
+            f()
+          }
+
+          val cancel = { () =>
+            reg.lazySet(false)
+
+            @tailrec
+            def loop(): Future[Unit] = {
+              val state = cancelState.get()
+              state match {
+                case CancelInit =>
+                  val promise = Promise[Unit]()
+                  if (!cancelState.compareAndSet(state, CanceledNoToken(promise))) {
+                    loop()
+                  } else {
+                    promise.future
+                  }
+                case CanceledNoToken(promise) =>
+                  promise.future
+                case CancelToken(cancelToken) =>
+                  cancelToken()
+              }
+            }
+
+            loop()
+          }
+
+          (promise.future, cancel)
         }
       }
     }


### PR DESCRIPTION
This idea came from conversations with Arman!

If workers close their own state queues as they're marked done, then we can remove the double check on alive when submitting work. If a task is submitted to a queue successfully it _will_ be seen by that worker. Or if the worker has already closed the queue, then submitting the task will fail entirely. If workers are controlling their own queues in this way, I'm not convinced we need the alive ref at all! So I've gone so far as to remove it entirely.

