### PR TITLE
Temporarily disable Cirrus ARM jobs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 jvm_highcore_task:
   container:
-    image: sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.5_8_1.8.2_3.2.2
+    image: sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.5_8_1.9.0_3.3.0
     cpu: 4
     memory: 8G
   matrix:
@@ -11,18 +11,18 @@ jvm_highcore_task:
     - name: JVM high-core-count 3
       script: sbt '++ 3' testsJVM/test
 
-jvm_arm_highcore_task:
-  arm_container:
-    image: sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.5_8_1.8.2_3.2.2
-    cpu: 4
-    memory: 8G
-  matrix:
-    - name: JVM ARM high-core-count 2.12
-      script: sbt '++ 2.12' testsJVM/test
-    - name: JVM ARM high-core-count 2.13
-      script: sbt '++ 2.13' testsJVM/test stressTests/Jcstress/run
-    - name: JVM ARM high-core-count 3
-      script: sbt '++ 3' testsJVM/test
+# jvm_arm_highcore_task:
+#   arm_container:
+#     image: sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.5_8_1.9.0_3.3.0
+#     cpu: 4
+#     memory: 8G
+#   matrix:
+#     - name: JVM ARM high-core-count 2.12
+#       script: sbt '++ 2.12' testsJVM/test
+#     - name: JVM ARM high-core-count 2.13
+#       script: sbt '++ 2.13' testsJVM/test stressTests/Jcstress/run
+#     - name: JVM ARM high-core-count 3
+#       script: sbt '++ 3' testsJVM/test
 
 jvm_macos_highcore_task:
   macos_instance:
@@ -43,18 +43,18 @@ jvm_macos_highcore_task:
         - brew install sbt
         - sbt '++ 3' testsJVM/test
 
-native_arm_task:
-  arm_container:
-    dockerfile: .cirrus/Dockerfile
-    cpu: 2
-    memory: 8G
-  matrix:
-    - name: Native ARM 2.12
-      script: sbt '++ 2.12' testsNative/test
-    - name: Native ARM 2.13
-      script: sbt '++ 2.13' testsNative/test
-    - name: Native ARM 3
-      script: sbt '++ 3' testsNative/test
+# native_arm_task:
+#   arm_container:
+#     dockerfile: .cirrus/Dockerfile
+#     cpu: 2
+#     memory: 8G
+#   matrix:
+#     - name: Native ARM 2.12
+#       script: sbt '++ 2.12' testsNative/test
+#     - name: Native ARM 2.13
+#       script: sbt '++ 2.13' testsNative/test
+#     - name: Native ARM 3
+#       script: sbt '++ 3' testsNative/test
 
 native_macos_task:
   macos_instance:

--- a/.cirrus/Dockerfile
+++ b/.cirrus/Dockerfile
@@ -1,3 +1,3 @@
-FROM sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.5_8_1.8.2_3.2.2
+FROM sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.5_8_1.9.0_3.3.0
 
 RUN apt-get update && apt-get install -y clang


### PR DESCRIPTION
Also updates the docker images.

backports https://github.com/typelevel/cats-effect/pull/3696