### PR TITLE
Fix major branch PR in release script

### DIFF
--- a/scripts/make-release-prs.sh
+++ b/scripts/make-release-prs.sh
@@ -16,28 +16,32 @@ new_version="$2"
 
 minor_base=series/$(echo $new_version | sed -E 's/([0-9]+).([0-9]+).[0-9]+/\1.\2.x/')
 major_base=series/$(echo $new_version | sed -E 's/([0-9]+).[0-9]+.[0-9]+/\1.x/')
-branch="release/$new_version-minor"
+minor_branch="release/$new_version-minor"
+major_branch="release/$new_version-major"
 
 cd "$(mktemp -d)"
 git clone git@github.com:typelevel/cats-effect.git
 cd 'cats-effect'
 
-git checkout -b $branch origin/$minor_base
+git checkout -b $minor_branch origin/$minor_base
 "$primary_base/scripts/update-versions.sh" --base . $old_version $new_version
 git commit -a -m "Update versions for $new_version"
-git push origin $branch
+git push origin $minor_branch
 
 gh pr create \
   --fill \
   --base $minor_base \
   --repo typelevel/cats-effect \
-  --head typelevel:$branch \
+  --head typelevel:$minor_branch \
   --label ':robot:'
+
+git checkout -b $major_branch
+git push origin $major_branch
 
 gh pr create \
   --title "Merge changes from $new_version into $major_base" \
   --body '' \
   --base $major_base \
   --repo typelevel/cats-effect \
-  --head typelevel:$branch \
+  --head typelevel:$major_branch \
   --label ':robot:'


### PR DESCRIPTION
https://github.com/typelevel/cats-effect/pull/3707 and https://github.com/typelevel/cats-effect/pull/3708 became a mess because two PRs were opened from the same branch.