### PR TITLE
Optimize `liveTraces()` on JS

### DIFF
--- a/core/js/src/main/scala/cats/effect/unsafe/BatchingMacrotaskExecutor.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/BatchingMacrotaskExecutor.scala
@@ -62,17 +62,11 @@ private[effect] final class BatchingMacrotaskExecutor(
       var i = 0
       while (i < batchSize && !fibers.isEmpty()) {
         val fiber = fibers.take()
-
-        if (LinkingInfo.developmentMode)
-          if (fiberBag ne null)
-            fiberBag -= fiber
-
         try fiber.run()
         catch {
           case t if NonFatal(t) => reportFailure(t)
           case t: Throwable => IOFiber.onFatalFailure(t)
         }
-
         i += 1
       }
 
@@ -99,10 +93,6 @@ private[effect] final class BatchingMacrotaskExecutor(
    * batch.
    */
   def schedule(fiber: IOFiber[_]): Unit = {
-    if (LinkingInfo.developmentMode)
-      if (fiberBag ne null)
-        fiberBag += fiber
-
     fibers.offer(fiber)
 
     if (needsReschedule) {
@@ -116,8 +106,12 @@ private[effect] final class BatchingMacrotaskExecutor(
 
   def reportFailure(t: Throwable): Unit = reportFailure0(t)
 
-  def liveTraces(): Map[IOFiber[_], Trace] =
-    fiberBag.iterator.filterNot(_.isDone).map(f => f -> f.captureTrace()).toMap
+  def liveTraces(): Map[IOFiber[_], Trace] = {
+    val traces = Map.newBuilder[IOFiber[_], Trace]
+    fibers.foreach(f => if (!f.isDone) traces += f -> f.captureTrace())
+    fiberBag.foreach(f => if (!f.isDone) traces += f -> f.captureTrace())
+    traces.result()
+  }
 
   @inline private[this] def monitor(runnable: Runnable): Runnable =
     if (LinkingInfo.developmentMode)

--- a/core/js/src/main/scala/cats/effect/unsafe/JSArrayQueue.scala
+++ b/core/js/src/main/scala/cats/effect/unsafe/JSArrayQueue.scala
@@ -69,4 +69,25 @@ private final class JSArrayQueue[A] {
       }
     }
 
+  @inline def foreach(f: A => Unit): Unit =
+    if (empty) ()
+    else if (startIndex < endIndex) { // consecutive in middle of buffer
+      var i = startIndex
+      while (i < endIndex) {
+        f(buffer(i))
+        i += 1
+      }
+    } else { // split across tail and init of buffer
+      var i = startIndex
+      while (i < buffer.length) {
+        f(buffer(i))
+        i += 1
+      }
+      i = 0
+      while (i < endIndex) {
+        f(buffer(i))
+        i += 1
+      }
+    }
+
 }

--- a/tests/js/src/test/scala/cats/effect/unsafe/JSArrayQueueSpec.scala
+++ b/tests/js/src/test/scala/cats/effect/unsafe/JSArrayQueueSpec.scala
@@ -69,7 +69,7 @@ class JSArrayQueueSpec extends BaseSpec with ScalaCheck {
             }
         }
 
-        true must beTrue
+        ok
       }
     }
   }

--- a/tests/js/src/test/scala/cats/effect/unsafe/JSArrayQueueSpec.scala
+++ b/tests/js/src/test/scala/cats/effect/unsafe/JSArrayQueueSpec.scala
@@ -20,7 +20,7 @@ package unsafe
 import org.scalacheck.Prop.forAll
 import org.specs2.ScalaCheck
 
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.{ArrayDeque, ListBuffer}
 
 class JSArrayQueueSpec extends BaseSpec with ScalaCheck {
 
@@ -39,6 +39,37 @@ class JSArrayQueueSpec extends BaseSpec with ScalaCheck {
         while (!queue.isEmpty()) taken += queue.take()
 
         taken.toList must beEqualTo(stuff.flatten)
+      }
+    }
+
+    "iterate over contents in foreach" in {
+      forAll { (stuff: List[Option[Int]]) =>
+        val queue = new JSArrayQueue[Int]
+        val shadow = new ArrayDeque[Int]
+
+        def checkContents() = {
+          val builder = List.newBuilder[Int]
+          queue.foreach(builder += _)
+          builder.result() must beEqualTo(shadow.toList)
+        }
+
+        checkContents()
+
+        stuff.foreach {
+          case Some(i) =>
+            queue.offer(i)
+            shadow.append(i)
+            checkContents()
+          case None =>
+            if (!shadow.isEmpty) {
+              val got = queue.take()
+              val expected = shadow.removeHead()
+              got must beEqualTo(expected)
+              checkContents()
+            }
+        }
+
+        true must beTrue
       }
     }
   }

--- a/tests/js/src/test/scala/cats/effect/unsafe/JSArrayQueueSpec.scala
+++ b/tests/js/src/test/scala/cats/effect/unsafe/JSArrayQueueSpec.scala
@@ -20,7 +20,7 @@ package unsafe
 import org.scalacheck.Prop.forAll
 import org.specs2.ScalaCheck
 
-import scala.collection.mutable.{ArrayDeque, ListBuffer}
+import scala.collection.mutable.{ListBuffer, Queue}
 
 class JSArrayQueueSpec extends BaseSpec with ScalaCheck {
 
@@ -45,7 +45,7 @@ class JSArrayQueueSpec extends BaseSpec with ScalaCheck {
     "iterate over contents in foreach" in {
       forAll { (stuff: List[Option[Int]]) =>
         val queue = new JSArrayQueue[Int]
-        val shadow = new ArrayDeque[Int]
+        val shadow = new Queue[Int]
 
         def checkContents() = {
           val builder = List.newBuilder[Int]
@@ -58,12 +58,12 @@ class JSArrayQueueSpec extends BaseSpec with ScalaCheck {
         stuff.foreach {
           case Some(i) =>
             queue.offer(i)
-            shadow.append(i)
+            shadow.enqueue(i)
             checkContents()
           case None =>
             if (!shadow.isEmpty) {
               val got = queue.take()
-              val expected = shadow.removeHead()
+              val expected = shadow.dequeue()
               got must beEqualTo(expected)
               checkContents()
             }


### PR DESCRIPTION
This was a silly one: we already have a queue of fibers, so it's unnecessary to add/remove them from a separate fiber bag for monitoring. We can just directly iterate over the queue.