### PR TITLE
Allow that the renamed blocker thread is terminated

### DIFF
--- a/tests/jvm/src/test/scala/cats/effect/unsafe/WorkerThreadNameSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/unsafe/WorkerThreadNameSpec.scala
@@ -20,6 +20,8 @@ import cats.effect.{BaseSpec, IO}
 import cats.effect.testkit.TestInstances
 import cats.syntax.all._
 
+import scala.concurrent.duration._
+
 class WorkerThreadNameSpec extends BaseSpec with TestInstances {
 
   override def runtime(): IORuntime = {
@@ -33,7 +35,8 @@ class WorkerThreadNameSpec extends BaseSpec with TestInstances {
         IORuntime.createWorkStealingComputeThreadPool(
           threads = 1,
           threadPrefix = s"io-compute-${getClass.getName}",
-          blockerThreadPrefix = s"io-blocker-${getClass.getName}")
+          blockerThreadPrefix = s"io-blocker-${getClass.getName}",
+          runtimeBlockingExpiration = 10.minutes)
 
       IORuntime(
         compute,


### PR DESCRIPTION
In WorkerThreadNameSpec, if the thread is readded to the compute pool, we still check that it has been renamed and has the correct index, but if the thread has been terminated in the mean time, that is ok as well.

Closes #3704