### PR TITLE
ResourceApp extends IOApp (breaking change)

### DIFF
--- a/core/shared/src/main/scala/cats/effect/ResourceApp.scala
+++ b/core/shared/src/main/scala/cats/effect/ResourceApp.scala
@@ -98,7 +98,8 @@ object ResourceApp {
      */
     def resource: Resource[IO, Unit]
 
-    final def resource(args: List[String]): Resource[IO, ExitCode] = resource.as(ExitCode.Success)
+    final def resource(args: List[String]): Resource[IO, ExitCode] =
+      resource.as(ExitCode.Success)
   }
 
   /**

--- a/core/shared/src/main/scala/cats/effect/ResourceApp.scala
+++ b/core/shared/src/main/scala/cats/effect/ResourceApp.scala
@@ -69,22 +69,16 @@ import cats.syntax.all._
  * @see
  *   [[ResourceApp.Forever]]
  */
-trait ResourceApp { self =>
+trait ResourceApp extends IOApp { self =>
 
   /**
    * @see
    *   [[IOApp.run]]
    */
-  def run(args: List[String]): Resource[IO, ExitCode]
+  def resource(args: List[String]): Resource[IO, ExitCode]
 
-  final def main(args: Array[String]): Unit = {
-    val ioApp = new IOApp {
-      override def run(args: List[String]): IO[ExitCode] =
-        self.run(args).use(IO.pure(_))
-    }
-
-    ioApp.main(args)
-  }
+  override def run(args: List[String]): IO[ExitCode] =
+    self.resource(args).use(IO.pure(_))
 }
 
 object ResourceApp {
@@ -102,9 +96,9 @@ object ResourceApp {
      * @see
      *   [[cats.effect.IOApp.Simple!.run:cats\.effect\.IO[Unit]*]]
      */
-    def run: Resource[IO, Unit]
+    def resource: Resource[IO, Unit]
 
-    final def run(args: List[String]): Resource[IO, ExitCode] = run.as(ExitCode.Success)
+    final def resource(args: List[String]): Resource[IO, ExitCode] = resource.as(ExitCode.Success)
   }
 
   /**
@@ -116,7 +110,7 @@ object ResourceApp {
    * @see
    *   [[cats.effect.kernel.Resource!.useForever]]
    */
-  trait Forever { self =>
+  trait Forever extends IOApp { self =>
 
     /**
      * Identical to [[ResourceApp.run]] except that it delegates to
@@ -126,15 +120,9 @@ object ResourceApp {
      * @see
      *   [[ResourceApp.run]]
      */
-    def run(args: List[String]): Resource[IO, Unit]
+    def resource(args: List[String]): Resource[IO, Unit]
 
-    final def main(args: Array[String]): Unit = {
-      val ioApp = new IOApp {
-        override def run(args: List[String]): IO[ExitCode] =
-          self.run(args).useForever
-      }
-
-      ioApp.main(args)
-    }
+    override def run(args: List[String]): IO[ExitCode] =
+      self.resource(args).useForever
   }
 }

--- a/example/jvm/src/main/scala/cats/effect/example/ForeverExample.scala
+++ b/example/jvm/src/main/scala/cats/effect/example/ForeverExample.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020-2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package example
+
+object ForeverExample extends ResourceApp.Forever {
+
+  def resource(args: List[String]): Resource[IO, Unit] =
+    Resource.eval(
+      IO.println(s"worker thread count: ${computeWorkerThreadCount}") *>
+        IO.raiseError(new RuntimeException("boom"))
+    )
+}

--- a/example/jvm/src/main/scala/cats/effect/example/ResourceExample.scala
+++ b/example/jvm/src/main/scala/cats/effect/example/ResourceExample.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020-2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+package example
+
+object ResourceExample extends ResourceApp.Simple {
+
+  def resource: Resource[IO, Unit] =
+    Resource.eval(
+      IO.println(s"worker thread count: ${computeWorkerThreadCount}") *>
+        IO.println(s"runtime config: ${runtimeConfig}")
+    )
+}


### PR DESCRIPTION
## Reason

I would like `ResourceApp` to have access to all the runtime configurations available in `IOApp`, such as `computeWorkerThreadCount`, `reportFailure` and `runtimeConfig`, which are currently not exposed.

This is mainly to start the conversation more than expecting this PR to be merged, as this is a *breaking change* (`run` is now named `resource` in `ResourceApp`).

I am not sure if this can be done in any better way, perhaps a package-private constraint instead of `protected`?