### PR TITLE
Make useForever polymorphic rather than speciailising it to Nothing

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -220,8 +220,8 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
    *
    * The finalisers run when the resulting program fails or gets interrupted.
    */
-  def useForever(implicit F: Spawn[F]): F[Nothing] =
-    use[Nothing](_ => F.never)
+  def useForever[B](implicit F: Spawn[F]): F[B] =
+    use[B](_ => F.never[B])
 
   /**
    * Allocates a resource and closes it immediately.


### PR DESCRIPTION
I'd prefer if I could pick a type for this, eg. `ExitCode`.

I write apps like this:

```
class MyApp extends IOApp {
  def run(args: Args): IO[ExitCode] =
    for {
      config <- readConfig
      otherStuff <- setUpOtherStuff(config)
      ec <- httpServer.resource.useForever
    } yield ec
}
```

and with the `Nothing` type, the Scala compiler warns me about dead code, but if I use `httpServer.resource.use(_ => IO.never[ExitCode])` then it works fine. Hence, I propose changing `useForever` to work like this.