### PR TITLE
Dispatcher: test cleanup

### DIFF
--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -360,7 +360,7 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
       implicit ticker =>
         val test = dispatcher.allocated.flatMap {
           case (runner, release) =>
-            IO(runner.unsafeRunAndForget(IO.sleep(50.millis) *> release)) *>
+            IO(runner.unsafeRunAndForget(release)) *>
               IO.sleep(100.millis) *>
               IO(runner.unsafeRunAndForget(IO(ko)) must throwAn[IllegalStateException])
         }


### PR DESCRIPTION
Just removing the extra sleep that was added here: https://github.com/typelevel/cats-effect/pull/3593. The sleep was added as part of a short-term fix for flakiness and now that the second check on alive (and possible cancellation of the submitted task) is gone, this test shouldn't flake. 

I added a `.replicateA(20000)` on line 366 to convince myself that this was stable 🤞🏻 