### PR TITLE
Add note to starvation docs re: cpus in k8s

### DIFF
--- a/docs/core/starvation-and-tuning.md
+++ b/docs/core/starvation-and-tuning.md
@@ -350,7 +350,7 @@ Of course, it's never as simple as doubling the number of vCPUs and halving the 
 
 #### Not Enough Threads - Running in Kubernetes
 
-One cause of "not enough threads" can be that the application is running inside kubernetes with a cpu_quota not configured. When the cpu limit is not configured, the jvm detects the number of available processors as 1, which will severely restrict what the runtime is able to do.
+One cause of "not enough threads" can be that the application is running inside kubernetes with a `cpu_quota` not configured. When the cpu limit is not configured, the JVM detects the number of available processors as 1, which will severely restrict what the runtime is able to do.
 
 This guide on [containerizing java applications for kubernetes](https://learn.microsoft.com/en-us/azure/developer/java/containers/kubernetes#understand-jvm-available-processors) goes into more detail on the mechanism involved.
 

--- a/docs/core/starvation-and-tuning.md
+++ b/docs/core/starvation-and-tuning.md
@@ -442,7 +442,7 @@ If this is not possible, the next-best approach is to rely on a circular buffer.
 
 > This scenario is specific to Kubernetes, Amazon ECS, and similar resource-controlled containerized deployments.
 
-In many Docker clusters, it is relatively standard practice to over-provision CPU credits by some factor (even 100% over-provisioning is quite common). What this effectively means is that the container environment will promise (or at least *allow*) *m* applications access to *n* vCPUs each, despite only *(m* n) / (1 + k)*CPUs being physically present across the underlying hardware cluster. In this equation, *k* is the over-provisioning factor, often referred to as "burst credits".
+In many Docker clusters, it is relatively standard practice to over-provision CPU credits by some factor (even 100% over-provisioning is quite common). What this effectively means is that the container environment will promise (or at least *allow*) *m* applications access to *n* vCPUs each, despite only *(m * n) / (1 + k)* CPUs being physically present across the underlying hardware cluster. In this equation, *k* is the over-provisioning factor, often referred to as "burst credits".
 
 This is a standard strategy because many applications are written in a fashion which is only loosely coupled to the underlying CPU count, to a large degree because many applications are simply not optimized to that extent. Cats Effect *is* optimized to take advantage of the precise number of underlying CPUs, and well-written Cats Effect applications inherit this optimization, meaning that they are inherently much more sensitive to this hardware factor than many other applications.
 

--- a/docs/core/starvation-and-tuning.md
+++ b/docs/core/starvation-and-tuning.md
@@ -456,7 +456,7 @@ As a very concrete example of this, if you have a cluster of 16 host instances i
 
 #### Kubernetes CPU Pinning
 
-Even if you have followed the above advice and avoided over-provisioning, the linux kernel scheduler is unfortunately not aware of the Cats Effect scheduler and will likely actively work against the Cats Effect scheduler by moving Cats Effect worker threads between different CPUs, thereby destroying CPU cache-locality. In certain environments we can prevent this by configuring Kubernetes to pin an application to a gviven set of CPUs:
+Even if you have followed the above advice and avoided over-provisioning, the Linux kernel scheduler is unfortunately not aware of the Cats Effect scheduler and will likely actively work against the Cats Effect scheduler by moving Cats Effect worker threads between different CPUs, thereby destroying CPU cache-locality. In certain environments we can prevent this by configuring Kubernetes to pin an application to a gviven set of CPUs:
 1. Set the [CPU Manager Policy to static](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy)
 2. Ensure that your pod is in the [Guaranteed QoS class](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#guaranteed)
 3. Request an integral number of CPUs for your Cats Effect application

--- a/docs/core/starvation-and-tuning.md
+++ b/docs/core/starvation-and-tuning.md
@@ -354,7 +354,7 @@ One cause of "not enough threads" can be that the application is running inside 
 
 This guide on [containerizing java applications for kubernetes](https://learn.microsoft.com/en-us/azure/developer/java/containers/kubernetes#understand-jvm-available-processors) goes into more detail on the mechanism involved.
 
-**All cats-effect applications running in kubernetes should have either a cpu_quota configured or use the jvm `-XX:ActiveProcessorCount` argument to explicitly tell the jvm how many cores to use.**
+**All Cats Effect applications running in kubernetes should have either a `cpu_quota` configured or use the jvm `-XX:ActiveProcessorCount` argument to explicitly tell the jvm how many cores to use.**
 
 ### Too Many Threads
 


### PR DESCRIPTION
This is a common "gotcha" when running in k8s.
Ideally we could automatically detect this environment in the CE runtime itself on initialization and warn the user proactively, but at least this gives people something to ctrl-f for in the doc