### PR TITLE
Seal - Simplified Deferred of Unit.

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOSeal.scala
+++ b/core/shared/src/main/scala/cats/effect/IOSeal.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020-2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+import cats.effect.kernel.Seal
+import java.util.concurrent.atomic.{AtomicInteger, AtomicBoolean}
+
+private final class IOSeal extends Seal[IO] {
+
+  private val doAwait = IO.asyncCheckAttempt[Unit] { cb =>
+    IO {
+      val stack = callbacks.push(cb)
+      val handle = stack.currentHandle()
+
+      def clear(): Unit = {
+        stack.clearCurrent(handle)
+        val clearCount = clearCounter.incrementAndGet()
+        if ((clearCount & (clearCount - 1)) == 0) // power of 2
+          clearCounter.addAndGet(-callbacks.pack(clearCount))
+        ()
+      }
+
+      if (isBrokenCell.get()) {
+        clear()
+        Right(())
+      } else
+          Left(Some(IO(clear())))
+    }
+  }
+
+  private[this] val isBrokenCell = new AtomicBoolean(false)
+  private[this] val callbacks = CallbackStack[Right[Nothing, Unit]](null)
+  private[this] val clearCounter = new AtomicInteger
+
+  def break: IO[Boolean] = IO {
+    if (isBrokenCell.compareAndSet(false, true)) {
+      val _ = callbacks(Right(()), false)
+      callbacks.clear() // avoid leaks
+      true
+    } else
+      false
+  }
+
+  def await: IO[Unit] = IO.defer(if (isBrokenCell.get()) IO.unit else doAwait)
+
+  def isBroken: IO[Boolean] = IO(isBrokenCell.get())
+}
+
+private object IOSeal // bincompat shim

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -22,13 +22,15 @@ import cats.effect.kernel.instances.spawn._
 import cats.effect.kernel.syntax.all._
 import cats.syntax.all._
 
-trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
+trait GenConcurrent[F[_], E] extends GenSpawn[F, E] { self =>
 
   import GenConcurrent._
 
   def ref[A](a: A): F[Ref[F, A]]
 
   def deferred[A]: F[Deferred[F, A]]
+
+  def seal: F[Seal[F]] = Seal.deferred[F](self)
 
   /**
    * Caches the result of `fa`.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Seal.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Seal.scala
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2020-2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package kernel
+
+import cats.syntax.all._
+
+import scala.annotation.tailrec
+import scala.collection.immutable.LongMap
+
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * A purely functional synchronization primitive which represents a one-way
+ * single-transition two-state machine
+ *
+ * When created, a `Seal` is unbroken. It can then be broken exactly once, and is never repaired.
+ *
+ * `wait` on an unbroken `Seal` will block until the `Seal` completed. `wait` on a
+ * broken `Seal` will always immediately return its content.
+ *
+ * `break` on an unbroken `Seal` will break it, notify any and all readers currently
+ * blocked on a call to `wait`, and returns true. `break` on a broken `Seal` 
+ * will just return false.
+ *
+ * Albeit even simpler than `Deferred`, `Seal` can be used in conjunction with [[Ref]] 
+ * or `Deferred` to build complex concurrent behaviour and data structures
+ *  like queues and semaphores.
+ *
+ * Finally, the blocking mentioned above is semantic, no actual threads are blocked by the
+ * implementation.
+ */
+abstract class Seal[F[_]] extends SealBreak[F] with SealRead[F] { self =>
+
+  /**
+   * Modify the context `F` using transformation `f`.
+   */
+  def mapK[G[_]](f: F ~> G): Seal[G] = new Seal[G] {
+    override def await: G[Unit] = f(self.await)
+    override def isBroken: G[Boolean] = f(self.isBroken)
+    override def break: G[Boolean] = f(self.break)
+  }
+}
+
+object Seal {
+
+  /**
+   * Creates an unset Seal. Every time you bind the resulting `F`, a new Seal is
+   * created. If you want to share one, pass it as an argument and `flatMap` once.
+   */
+  def apply[F[_]](implicit F: GenConcurrent[F, _]): F[Seal[F]] =
+    F.seal
+
+  /**
+   * Like `apply` but returns the newly allocated Seal directly instead of wrapping it in
+   * `F.delay`. This method is considered unsafe because it is not referentially transparent --
+   * it allocates mutable state. In general, you should prefer `apply` and use `flatMap` to get
+   * state sharing.
+   */
+  def unsafe[F[_]: Async]: Seal[F] = new AsyncSeal[F]
+
+  /**
+   * Like [[apply]] but initializes state using another effect constructor
+   */
+  def in[F[_], G[_]](implicit F: Sync[F], G: Async[G]): F[Seal[G]] =
+    F.delay(unsafe[G])
+
+  sealed abstract private class State
+  private object State {
+    case object Broken extends State
+    final case class Unbroken(waiting: LongMap[Unit => Unit], nextId: Long) extends State
+
+    val initialId = 1L
+    val dummyId = 0L
+  }
+
+  final class AsyncSeal[F[_]](implicit F: Async[F]) extends Seal[F] {
+    // shared mutable state
+    private[this] val ref = new AtomicReference[State](
+      State.Unbroken(LongMap.empty, State.initialId)
+    )
+
+    def await: F[Unit] = {
+      // side-effectful
+      def addReader(awakeReader: Unit => Unit): Long = {
+        @tailrec
+        def loop(): Long =
+          ref.get match {
+            case State.Broken =>
+              awakeReader(())
+              State.dummyId // never used
+            case s @ State.Unbroken(waiting, nextId) =>
+              val updated = State.Unbroken(
+                waiting + (nextId -> awakeReader),
+                nextId + 1
+              )
+              if (!ref.compareAndSet(s, updated)) loop()
+              else nextId
+          }
+
+        loop()
+      }
+
+      // side-effectful
+      def deleteReader(id: Long): Unit = {
+        @tailrec
+        def loop(): Unit =
+          ref.get match {
+            case State.Broken => ()
+            case s @ State.Unbroken(waiting, _) =>
+              val updated = s.copy(waiting = waiting - id)
+              if (!ref.compareAndSet(s, updated)) loop()
+              else ()
+          }
+
+        loop()
+      }
+
+      F.defer {
+        ref.get match {
+          case State.Broken =>
+            F.unit
+          case State.Unbroken(_, _) =>
+            F.async[Unit] { cb =>
+              F.delay(addReader(awakeReader = (_ => cb(Either.unit)))).map { id =>
+                // if canceled
+                F.delay(deleteReader(id)).some
+              }
+            }
+        }
+      }
+    }
+
+    def isBroken: F[Boolean] =
+      F.delay {
+        ref.get match {
+          case State.Broken => true
+          case State.Unbroken(_, _) => false
+        }
+      }
+
+    def break: F[Boolean] = {
+      def notifyReaders(readers: LongMap[Unit => Unit]): F[Unit] = {
+        // LongMap iterators return values in unsigned key order,
+        // which corresponds to the arrival order of readers since
+        // insertion is governed by a monotonically increasing id
+        val cursor = readers.valuesIterator
+        var acc = F.unit
+
+        while (cursor.hasNext) {
+          val next = cursor.next()
+          val task = F.delay(next(()))
+          acc = acc >> task
+        }
+
+        acc
+      }
+
+      // side-effectful (even though it returns F[Unit])
+      @tailrec
+      def loop(): F[Boolean] =
+        ref.get match {
+          case State.Broken =>
+            F.pure(false)
+          case s @ State.Unbroken(readers, _) =>
+            val updated = State.Broken
+            if (!ref.compareAndSet(s, updated)) loop()
+            else {
+              val notify = if (readers.isEmpty) F.unit else notifyReaders(readers)
+              notify.as(true)
+            }
+        }
+
+      F.uncancelable(_ => F.defer(loop()))
+    }
+  }
+
+  def deferred[F[_]](implicit F: GenConcurrent[F, _]): F[Seal[F]] =
+    Deferred[F, Unit].map(new DeferredSeal[F](_))
+
+  private class DeferredSeal[F[_]: cats.Functor](defer: Deferred[F, Unit]) extends Seal[F] {
+    def await: F[Unit] = defer.get
+    def isBroken: F[Boolean] = defer.tryGet.map(_.isDefined)
+    def break: F[Boolean] = defer.complete(())
+  }
+
+}
+
+trait SealRead[F[_]] extends Serializable {
+
+  /**
+   * If this seal is broken, it gets the pure unit value `F`. However, if the
+   * `Seal` is not broken yet, then it waits until it is broken. This wait
+   * may be canceled.
+   */
+  def await: F[Unit]
+
+  /**
+   * An action that, when performed, indicates if the seal is broken or not. 
+   */
+  def isBroken: F[Boolean]
+
+}
+
+trait SealBreak[F[_]] extends Serializable {
+
+  /**
+   * If this `Seal` is unbroken, breaks it, and notifies all
+   * readers currently blocked on a `read`. Returns true.
+   *
+   * If this `Seal` was already broken, returns false.
+   *
+   * Satisfies: `Seal[F].flatMap(r => r.break *> r.read) == true.pure[F]`
+   */
+  def break: F[Boolean]
+}


### PR DESCRIPTION
Concurrency libraries, such as those based on `cats-effect` such as FS2, often have this pattern in which a lightweight thread / fiber has to await (and be parked while waiting) on a condition, while other fiber will mark that the wait is over.

Notably, this is a synchronisation or control-flow problem, as it only relates to the ordering and sequencing between the processes performed by associated fibers. It is not a data-flow or communications problem, in which a fiber needs to wait until it can get a piece of data that is being computed by another one.

In cats-effect based libraries, such as FS2, a `Deferred[Unit]` is often use for this problem, but Deferred is a data-flow solution, not a control-flow solution.

This PR introduces a specialised variant of Deferred, a `Seal`, that is intended.
The word "Seal" is used in the sense of letter seals: all that matters is whether they are broken or not, they start unbroken, and they can only be broken once.