### PR TITLE
Changed tutorial so consumers are not overwhelmed by producers

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -899,7 +899,7 @@ previous example this program shall run forever until the user presses CTRL-C.
 
 ### Producer consumer with bounded queue
 Having a bounded queue implies that producers, when the queue is full, will wait
-(be 'filter blocked') until there is some empty bucket available to be
+(be 'fiber blocked') until there is some empty bucket available to be
 filled.  So an implementation needs to keep track of these waiting producers. To
 do so we will add a new queue `offerers` that will be added to the `State`
 alongside `takers`.  For each waiting producer the `offerers` queue will keep a


### PR DESCRIPTION
The second section of the tutorial describes how to use fibers to solve the producer-consumer problem. Thing is, as the code is now, producers outpace consumers so much that consumers seem to be 'frozen'. The explication seems to be the `Ref.modify` run by consumers is way slower than the `Ref.getAndUpdate` call run by producers. This forces consumers to retry once and again to run the `modify` call.

This PR is to add text [at the end of the first subsection](https://lrodero.github.io/cats-effect/docs/tutorial#issue-1-the-producer-outpaces-the-consumer) (the one introducing a 'naive' solution to the producers-consumers problem) to describe the problem and to propose several solutions: using a `.sleep` call (the one used in the code samples); using `AtomicCell` instead of `Ref`, or using a bounded queue (which is implemented in another section afterwards).

The new version of the tutorial can be read online [here](https://lrodero.github.io/cats-effect/docs/tutorial). All code samples are available [here](https://github.com/lrodero/cats-effect-tutorial).

Other minor changes:
* Typo as in PR #3760
* In copy file section merge `transfer` and `transmit` functions in a single one `transfer` in order to simplify code and ease understanding
* In code samples use `Sync[F].whenA` instead of `if ... else Sync[F].unit`
* Updated sbt version (1.9.3)
* Changed wrong path `catseffecttutorial.CopyFile` to correct one `catseffecttutorial.copyfile.CopyFile`