### PR TITLE
update CI to use graalvm@17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         scala: [3.2.2, 2.12.17, 2.13.10]
-        java: [temurin@8, temurin@11, temurin@17, graalvm@11]
+        java: [temurin@8, temurin@11, temurin@17, graalvm@17]
         ci: [ciJVM, ciNative, ciJS, ciFirefox, ciChrome]
         exclude:
           - scala: 3.2.2
@@ -39,7 +39,7 @@ jobs:
           - scala: 2.12.17
             java: temurin@17
           - scala: 2.12.17
-            java: graalvm@11
+            java: graalvm@17
           - os: windows-latest
             scala: 3.2.2
           - os: macos-latest
@@ -61,7 +61,7 @@ jobs:
           - ci: ciJS
             java: temurin@17
           - ci: ciJS
-            java: graalvm@11
+            java: graalvm@17
           - os: windows-latest
             ci: ciJS
           - os: macos-latest
@@ -71,7 +71,7 @@ jobs:
           - ci: ciFirefox
             java: temurin@17
           - ci: ciFirefox
-            java: graalvm@11
+            java: graalvm@17
           - os: windows-latest
             ci: ciFirefox
           - os: macos-latest
@@ -81,7 +81,7 @@ jobs:
           - ci: ciChrome
             java: temurin@17
           - ci: ciChrome
-            java: graalvm@11
+            java: graalvm@17
           - os: windows-latest
             ci: ciChrome
           - os: macos-latest
@@ -91,7 +91,7 @@ jobs:
           - ci: ciNative
             java: temurin@17
           - ci: ciNative
-            java: graalvm@11
+            java: graalvm@17
           - os: windows-latest
             ci: ciNative
           - os: macos-latest
@@ -101,7 +101,7 @@ jobs:
             ci: ciNative
             scala: 3.2.2
           - os: windows-latest
-            java: graalvm@11
+            java: graalvm@17
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -184,26 +184,26 @@ jobs:
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
-      - name: Download Java (graalvm@11)
-        id: download-java-graalvm-11
-        if: matrix.java == 'graalvm@11'
+      - name: Download Java (graalvm@17)
+        id: download-java-graalvm-17
+        if: matrix.java == 'graalvm@17'
         uses: typelevel/download-java@v2
         with:
           distribution: graalvm
-          java-version: 11
+          java-version: 17
 
-      - name: Setup Java (graalvm@11)
-        id: setup-java-graalvm-11
-        if: matrix.java == 'graalvm@11'
+      - name: Setup Java (graalvm@17)
+        id: setup-java-graalvm-17
+        if: matrix.java == 'graalvm@17'
         uses: actions/setup-java@v3
         with:
           distribution: jdkfile
-          java-version: 11
-          jdkFile: ${{ steps.download-java-graalvm-11.outputs.jdkFile }}
+          java-version: 17
+          jdkFile: ${{ steps.download-java-graalvm-17.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'graalvm@11' && steps.setup-java-graalvm-11.outputs.cache-hit == 'false'
+        if: matrix.java == 'graalvm@17' && steps.setup-java-graalvm-17.outputs.cache-hit == 'false'
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
@@ -219,7 +219,7 @@ jobs:
         run: npm install
 
       - name: Install GraalVM Native Image
-        if: matrix.java == 'graalvm@11'
+        if: matrix.java == 'graalvm@17'
         shell: bash
         run: gu install native-image
 
@@ -268,7 +268,7 @@ jobs:
         run: example/test-js.sh ${{ matrix.scala }}
 
       - name: Test GraalVM Native Image
-        if: matrix.scala == '2.13.10' && matrix.java == 'graalvm@11' && matrix.os == 'ubuntu-latest'
+        if: matrix.scala == '2.13.10' && matrix.java == 'graalvm@17' && matrix.os == 'ubuntu-latest'
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' graalVMExample/nativeImage graalVMExample/nativeImageRun
 
@@ -387,26 +387,26 @@ jobs:
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
-      - name: Download Java (graalvm@11)
-        id: download-java-graalvm-11
-        if: matrix.java == 'graalvm@11'
+      - name: Download Java (graalvm@17)
+        id: download-java-graalvm-17
+        if: matrix.java == 'graalvm@17'
         uses: typelevel/download-java@v2
         with:
           distribution: graalvm
-          java-version: 11
+          java-version: 17
 
-      - name: Setup Java (graalvm@11)
-        id: setup-java-graalvm-11
-        if: matrix.java == 'graalvm@11'
+      - name: Setup Java (graalvm@17)
+        id: setup-java-graalvm-17
+        if: matrix.java == 'graalvm@17'
         uses: actions/setup-java@v3
         with:
           distribution: jdkfile
-          java-version: 11
-          jdkFile: ${{ steps.download-java-graalvm-11.outputs.jdkFile }}
+          java-version: 17
+          jdkFile: ${{ steps.download-java-graalvm-17.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'graalvm@11' && steps.setup-java-graalvm-11.outputs.cache-hit == 'false'
+        if: matrix.java == 'graalvm@17' && steps.setup-java-graalvm-17.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
       - name: Download target directories (3.2.2, ciJVM)
@@ -631,26 +631,26 @@ jobs:
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
-      - name: Download Java (graalvm@11)
-        id: download-java-graalvm-11
-        if: matrix.java == 'graalvm@11'
+      - name: Download Java (graalvm@17)
+        id: download-java-graalvm-17
+        if: matrix.java == 'graalvm@17'
         uses: typelevel/download-java@v2
         with:
           distribution: graalvm
-          java-version: 11
+          java-version: 17
 
-      - name: Setup Java (graalvm@11)
-        id: setup-java-graalvm-11
-        if: matrix.java == 'graalvm@11'
+      - name: Setup Java (graalvm@17)
+        id: setup-java-graalvm-17
+        if: matrix.java == 'graalvm@17'
         uses: actions/setup-java@v3
         with:
           distribution: jdkfile
-          java-version: 11
-          jdkFile: ${{ steps.download-java-graalvm-11.outputs.jdkFile }}
+          java-version: 17
+          jdkFile: ${{ steps.download-java-graalvm-17.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'graalvm@11' && steps.setup-java-graalvm-11.outputs.cache-hit == 'false'
+        if: matrix.java == 'graalvm@17' && steps.setup-java-graalvm-17.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
       - name: Submit Dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -137,7 +137,7 @@ val LTSJava = JavaSpec.temurin("11")
 val LatestJava = JavaSpec.temurin("17")
 val ScalaJSJava = OldGuardJava
 val ScalaNativeJava = OldGuardJava
-val GraalVM = JavaSpec.graalvm("11")
+val GraalVM = JavaSpec.graalvm("17")
 
 ThisBuild / githubWorkflowJavaVersions := Seq(OldGuardJava, LTSJava, LatestJava, GraalVM)
 ThisBuild / githubWorkflowOSes := Seq(PrimaryOS, Windows, MacOS)


### PR DESCRIPTION
graalvm for jdk 11 was removed here: https://github.com/typelevel/jdk-index/pull/197