### PR TITLE
Cirrus CI cutbacks ...

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,68 +4,50 @@ jvm_highcore_task:
     cpu: 4
     memory: 8G
   matrix:
-    - name: JVM high-core-count 2.12
-      script: sbt '++ 2.12' testsJVM/test
     - name: JVM high-core-count 2.13
-      script: sbt '++ 2.13' testsJVM/test stressTests/Jcstress/run
+      script: sbt '++ 2.13' testsJVM/test
     - name: JVM high-core-count 3
       script: sbt '++ 3' testsJVM/test
 
-# jvm_arm_highcore_task:
-#   arm_container:
-#     image: sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.5_8_1.9.0_3.3.0
-#     cpu: 4
-#     memory: 8G
-#   matrix:
-#     - name: JVM ARM high-core-count 2.12
-#       script: sbt '++ 2.12' testsJVM/test
-#     - name: JVM ARM high-core-count 2.13
-#       script: sbt '++ 2.13' testsJVM/test stressTests/Jcstress/run
-#     - name: JVM ARM high-core-count 3
-#       script: sbt '++ 3' testsJVM/test
+jvm_arm_highcore_task:
+  arm_container:
+    image: sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.5_8_1.9.0_3.3.0
+    cpu: 4
+    memory: 8G
+  matrix:
+    - name: JVM ARM high-core-count 2.13
+      script: sbt '++ 2.13' testsJVM/test
+    - name: JVM ARM high-core-count 3
+      script: sbt '++ 3' testsJVM/test
 
 jvm_macos_highcore_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-base:latest
-    cpu: 4
-    memory: 8G
   matrix:
-    - name: JVM Apple Silicon high-core-count 2.12
-      script: 
-        - brew install sbt
-        - sbt '++ 2.12' testsJVM/test
     - name: JVM Apple Silicon high-core-count 2.13
       script:
         - brew install sbt
-        - sbt '++ 2.13' testsJVM/test stressTests/Jcstress/run
+        - sbt '++ 2.13' testsJVM/test
     - name: JVM Apple Silicon high-core-count 3
       script:
         - brew install sbt
         - sbt '++ 3' testsJVM/test
 
-# native_arm_task:
-#   arm_container:
-#     dockerfile: .cirrus/Dockerfile
-#     cpu: 2
-#     memory: 8G
-#   matrix:
-#     - name: Native ARM 2.12
-#       script: sbt '++ 2.12' testsNative/test
-#     - name: Native ARM 2.13
-#       script: sbt '++ 2.13' testsNative/test
-#     - name: Native ARM 3
-#       script: sbt '++ 3' testsNative/test
+native_arm_task:
+  arm_container:
+    dockerfile: .cirrus/Dockerfile
+    cpu: 2
+    memory: 8G
+  matrix:
+    - name: Native ARM 2.13
+      script: sbt '++ 2.13' testsNative/test
+    - name: Native ARM 3
+      script: sbt '++ 3' testsNative/test
 
 native_macos_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-base:latest
-    cpu: 2
-    memory: 8G
   matrix:
-    - name: Native Apple Silicon 2.12
-      script: 
-        - brew install sbt
-        - sbt '++ 2.12' testsNative/test
     - name: Native Apple Silicon 2.13
       script:
         - brew install sbt

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,10 +28,6 @@ jvm_macos_highcore_task:
       script:
         - brew install sbt
         - sbt '++ 2.13' testsJVM/test
-    - name: JVM Apple Silicon high-core-count 3
-      script:
-        - brew install sbt
-        - sbt '++ 3' testsJVM/test
 
 native_arm_task:
   arm_container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,10 +24,10 @@ jvm_macos_highcore_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-base:latest
   matrix:
-    - name: JVM Apple Silicon high-core-count 2.13
+    - name: JVM Apple Silicon high-core-count 3
       script:
         - brew install sbt
-        - sbt '++ 2.13' testsJVM/test
+        - sbt '++ 3' testsJVM/test
 
 native_arm_task:
   arm_container:
@@ -35,8 +35,6 @@ native_arm_task:
     cpu: 2
     memory: 8G
   matrix:
-    - name: Native ARM 2.13
-      script: sbt '++ 2.13' testsNative/test
     - name: Native ARM 3
       script: sbt '++ 3' testsNative/test
 
@@ -44,10 +42,6 @@ native_macos_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-base:latest
   matrix:
-    - name: Native Apple Silicon 2.13
-      script:
-        - brew install sbt
-        - sbt '++ 2.13' testsNative/test
     - name: Native Apple Silicon 3
       script:
         - brew install sbt


### PR DESCRIPTION
I missed this, but apparently last month Cirrus CI announced that it is no longer allowing unlimited use for free 😕 

https://cirrus-ci.org/blog/2023/07/17/limiting-free-usage-of-cirrus-ci/

Here's our usage over the last few months, measured in "credits". Green is macOS, blue Linux. Our new allowance will be 50 credits per month 😕 

<details>

<img width="896" alt="Screen Shot 2023-08-28 at 6 42 53 PM" src="https://github.com/armanbilge/cats-effect/assets/3119428/4f8f066e-d3a1-48c9-ad50-1f8bfafa826c">

</details>

So we need to do some serious belt-tightening, esp. wrt to the macOS CI jobs.

So far the changes I propose are:
1. Drop the JCStress tests, these take a _really_ long time.
2. Drop 2.12 jobs. It's just not worth it.
3. Only run Apple Silicon jobs for Scala 3.
4. Only run Scala Native jobs for Scala 3.

Meanwhile I restored the Linux ARM CI jobs for 2.13 (JVM) and 3 (JVM, Native). We really do need those ... hopefully they will not be so flaky this time.

Not sure if this is enough. We shall see ...