### PR TITLE
Fix Hotswap.get being blocked by Hotswap.swap

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
@@ -131,12 +131,12 @@ object Hotswap {
         new Hotswap[F, R] {
 
           override def swap(next: Resource[F, R]): F[R] =
-            exclusive.surround {
-              F.uncancelable { poll =>
-                poll(next.allocated).flatMap {
-                  case (r, fin) =>
-                    swapFinalizer(Acquired(r, fin)).as(r)
-                }
+            F.uncancelable { poll =>
+              poll(next.allocated).flatMap {
+                case (r, fin) =>
+                  exclusive.surround {
+                    swapFinalizer(Acquired(r, poll(fin))).as(r)
+                  }
               }
             }
 

--- a/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
@@ -135,7 +135,7 @@ object Hotswap {
               poll(next.allocated).flatMap {
                 case (r, fin) =>
                   exclusive.surround {
-                    swapFinalizer(Acquired(r, poll(fin))).as(r)
+                    swapFinalizer(Acquired(r, fin)).as(r)
                   }
               }
             }

--- a/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
@@ -134,9 +134,9 @@ object Hotswap {
             F.uncancelable { poll =>
               poll(next.allocated).flatMap {
                 case (r, fin) =>
-                  exclusive.surround {
-                    swapFinalizer(Acquired(r, fin)).as(r)
-                  }
+                  poll(exclusive.surround {
+                    swapFinalizer(Acquired(r, fin)).uncancelable.as(r)
+                  }).onCancel(fin)
               }
             }
 

--- a/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
@@ -18,10 +18,10 @@ package cats
 package effect
 package std
 
+import cats.effect.Resource
 import cats.effect.kernel.Ref
 
 import scala.concurrent.duration._
-import cats.effect.Resource
 
 class HotswapSpec extends BaseSpec { outer =>
 
@@ -106,12 +106,13 @@ class HotswapSpec extends BaseSpec { outer =>
       go must completeAs(())
     }
 
-    "not block current resource while swap is instantiating new one" in ticked { implicit ticker =>
-      val go = Hotswap.create[IO, Unit].use { hs =>
-        hs.swap(Resource.eval(IO.sleep(1.minute) *> IO.unit)).start *>
-          hs.get.use_.timeout(1.second) *> IO.unit
-      }
-      go must completeAs(())
+    "not block current resource while swap is instantiating new one" in ticked {
+      implicit ticker =>
+        val go = Hotswap.create[IO, Unit].use { hs =>
+          hs.swap(Resource.eval(IO.sleep(1.minute) *> IO.unit)).start *>
+            hs.get.use_.timeout(1.second) *> IO.unit
+        }
+        go must completeAs(())
     }
   }
 

--- a/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
@@ -23,8 +23,6 @@ import cats.effect.kernel.Ref
 import scala.concurrent.duration._
 import cats.effect.Resource
 
-import scala.language.postfixOps
-
 class HotswapSpec extends BaseSpec { outer =>
 
   sequential

--- a/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
@@ -20,10 +20,9 @@ package std
 
 import cats.effect.kernel.Ref
 
-import scala.concurrent.duration.*
+import scala.concurrent.duration._
 import cats.effect.Resource
 
-import java.util.concurrent.TimeoutException
 import scala.language.postfixOps
 
 class HotswapSpec extends BaseSpec { outer =>


### PR DESCRIPTION
`Hotswap#swap` currently acquires all permits for its Semaphore during allocation of the `next` Resource, blocking `Hotswap#get` until the new Resource has been instantiated. In many use cases this will not be perceptible but if the Resource has a long initialization time, any calls to `get` will block until the new Resource is ready... effectively undermining the very premise of Hotswap.