### PR TITLE
Fix `Hotswap#get` being blocked by `Hotswap#swap`

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
@@ -136,7 +136,7 @@ object Hotswap {
                 case (r, fin) =>
                   exclusive.mapK(poll).onCancel(Resource.eval(fin)).surround {
                     swapFinalizer(Acquired(r, fin)).as(r)
-                  })
+                  }
               }
             }
 

--- a/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
@@ -134,9 +134,9 @@ object Hotswap {
             F.uncancelable { poll =>
               poll(next.allocated).flatMap {
                 case (r, fin) =>
-                  poll(exclusive.surround {
+                  poll(exclusive.onCancel(Resource.eval(fin)).surround {
                     swapFinalizer(Acquired(r, fin)).uncancelable.as(r)
-                  }).onCancel(fin)
+                  })
               }
             }
 

--- a/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
@@ -131,12 +131,12 @@ object Hotswap {
         new Hotswap[F, R] {
 
           override def swap(next: Resource[F, R]): F[R] =
-            exclusive.surround {
-              F.uncancelable { poll =>
-                poll(next.allocated).flatMap {
-                  case (r, fin) =>
-                    swapFinalizer(Acquired(r, fin)).as(r)
-                }
+            F.uncancelable { poll =>
+              poll(next.allocated).flatMap {
+                case (r, fin) =>
+                  poll(exclusive.surround {
+                    swapFinalizer(Acquired(r, fin)).uncancelable.as(r)
+                  }).onCancel(fin)
               }
             }
 

--- a/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
@@ -134,8 +134,8 @@ object Hotswap {
             F.uncancelable { poll =>
               poll(next.allocated).flatMap {
                 case (r, fin) =>
-                  poll(exclusive.onCancel(Resource.eval(fin)).surround {
-                    swapFinalizer(Acquired(r, fin)).uncancelable.as(r)
+                  exclusive.mapK(poll).onCancel(Resource.eval(fin)).surround {
+                    swapFinalizer(Acquired(r, fin)).as(r)
                   })
               }
             }

--- a/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
@@ -119,13 +119,14 @@ class HotswapSpec extends BaseSpec { outer =>
     "successfully cancel during swap and run finalizer if cancelation is requested while waiting for get to release" in ticked {
       implicit ticker =>
         val go = Ref.of[IO, List[String]](List()).flatMap { log =>
-          Hotswap[IO, Unit](logged(log, "a")).use { case (hs, _) =>
-            for {
-              _ <- hs.get.evalMap(_ => IO.sleep(1.minute)).use_.start
-              _ <- IO.sleep(2.seconds)
-              _ <- hs.swap(logged(log, "b")).timeoutTo(1.second, IO.unit)
-              value <- log.get
-            } yield value
+          Hotswap[IO, Unit](logged(log, "a")).use {
+            case (hs, _) =>
+              for {
+                _ <- hs.get.evalMap(_ => IO.sleep(1.minute)).use_.start
+                _ <- IO.sleep(2.seconds)
+                _ <- hs.swap(logged(log, "b")).timeoutTo(1.second, IO.unit)
+                value <- log.get
+              } yield value
           }
         }
 

--- a/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
@@ -140,7 +140,7 @@ class HotswapSpec extends BaseSpec { outer =>
         Hotswap[IO, Unit](Resource.unit)
           .use {
             case (hs, _) =>
-              hs.swap(Resource.make(open.set(true))(_ => open.set(false)))
+              hs.swap(Resource.make(open.set(true))(_ => open.getAndSet(false).map(_ should beTrue).void))
           }
           .race(IO.unit) *> open.get.map(_ must beFalse)
       }

--- a/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
@@ -113,7 +113,7 @@ class HotswapSpec extends BaseSpec { outer =>
         val go = Hotswap.create[IO, Unit].use { hs =>
           hs.swap(IO.sleep(1.minute).toResource).start *>
             IO.sleep(5.seconds) *>
-            hs.get.use_.timeout(1.second) *> IO.unit
+            hs.get.use_.timeout(1.second).void
         }
         go must completeAs(())
     }

--- a/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
@@ -140,7 +140,8 @@ class HotswapSpec extends BaseSpec { outer =>
         Hotswap[IO, Unit](Resource.unit)
           .use {
             case (hs, _) =>
-              hs.swap(Resource.make(open.set(true))(_ => open.getAndSet(false).map(_ should beTrue).void))
+              hs.swap(Resource.make(open.set(true))(_ =>
+                open.getAndSet(false).map(_ should beTrue).void))
           }
           .race(IO.unit) *> open.get.map(_ must beFalse)
       }


### PR DESCRIPTION
`Hotswap#swap` currently acquires all permits for its Semaphore during allocation of the `next` Resource, blocking `Hotswap#get` until the new Resource has been instantiated. In many use cases this will not be perceptible but if the Resource has a long initialization time, any calls to `get` will block until the new Resource is ready... effectively undermining the very premise of Hotswap.