### PR TITLE
Immediately surface fatal errors in `IO.raiseError`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -319,7 +319,11 @@ private final class IOFiber[A](
 
             case 1 =>
               val error = ioe.asInstanceOf[Error]
-              runLoop(failed(error.t, 0), nextCancelation - 1, nextAutoCede)
+              val ex = error.t
+              if (!NonFatal(ex))
+                onFatalFailure(ex)
+
+              runLoop(failed(ex, 0), nextCancelation - 1, nextAutoCede)
 
             case 2 =>
               val delay = ioe.asInstanceOf[Delay[Any]]
@@ -386,7 +390,11 @@ private final class IOFiber[A](
 
             case 1 =>
               val error = ioe.asInstanceOf[Error]
-              runLoop(failed(error.t, 0), nextCancelation - 1, nextAutoCede)
+              val ex = error.t
+              if (!NonFatal(ex))
+                onFatalFailure(ex)
+
+              runLoop(failed(ex, 0), nextCancelation - 1, nextAutoCede)
 
             case 2 =>
               val delay = ioe.asInstanceOf[Delay[Any]]

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -241,10 +241,11 @@ private final class IOFiber[A](
 
         case 1 =>
           val cur = cur0.asInstanceOf[Error]
-          if (!NonFatal(cur.t))
-            onFatalFailure(cur.t)
+          val ex = cur.t
+          if (!NonFatal(ex))
+            onFatalFailure(ex)
 
-          runLoop(failed(cur.t, 0), nextCancelation, nextAutoCede)
+          runLoop(failed(ex, 0), nextCancelation, nextAutoCede)
 
         case 2 =>
           val cur = cur0.asInstanceOf[Delay[Any]]
@@ -437,6 +438,8 @@ private final class IOFiber[A](
             case 1 =>
               val error = ioa.asInstanceOf[Error]
               val t = error.t
+              if (!NonFatal(t))
+                onFatalFailure(t)
               // We need to augment the exception here because it doesn't get
               // forwarded to the `failed` path.
               Tracing.augmentThrowable(runtime.enhancedExceptions, t, tracingEvents)

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -241,6 +241,9 @@ private final class IOFiber[A](
 
         case 1 =>
           val cur = cur0.asInstanceOf[Error]
+          if (!NonFatal(cur.t))
+            onFatalFailure(cur.t)
+
           runLoop(failed(cur.t, 0), nextCancelation, nextAutoCede)
 
         case 2 =>

--- a/tests/js/src/main/scala/catseffect/examplesplatform.scala
+++ b/tests/js/src/main/scala/catseffect/examplesplatform.scala
@@ -47,6 +47,8 @@ package examples {
     register(FatalError)
     register(RaiseFatalErrorAttempt)
     register(RaiseFatalErrorHandle)
+    register(RaiseFatalErrorMap)
+    register(RaiseFatalErrorFlatMap)
     registerRaw(FatalErrorRaw)
     register(Canceled)
     registerLazy("catseffect.examples.GlobalRacingInit", GlobalRacingInit)

--- a/tests/js/src/main/scala/catseffect/examplesplatform.scala
+++ b/tests/js/src/main/scala/catseffect/examplesplatform.scala
@@ -45,6 +45,8 @@ package examples {
     register(Arguments)
     register(NonFatalError)
     register(FatalError)
+    register(RaiseFatalErrorAttempt)
+    register(RaiseFatalErrorHandle)
     registerRaw(FatalErrorRaw)
     register(Canceled)
     registerLazy("catseffect.examples.GlobalRacingInit", GlobalRacingInit)

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -201,6 +201,20 @@ class IOAppSpec extends Specification {
           h.stdout() must not(contain("sadness"))
         }
 
+        "exit on raising a fatal error inside a map" in {
+          val h = platform(RaiseFatalErrorMap, List.empty)
+          h.awaitStatus() mustEqual 1
+          h.stderr() must contain("Boom!")
+          h.stdout() must not(contain("sadness"))
+        }
+
+        "exit on raising a fatal error inside a flatMap" in {
+          val h = platform(RaiseFatalErrorFlatMap, List.empty)
+          h.awaitStatus() mustEqual 1
+          h.stderr() must contain("Boom!")
+          h.stdout() must not(contain("sadness"))
+        }
+
         "warn on global runtime collision" in {
           val h = platform(GlobalRacingInit, List.empty)
           h.awaitStatus() mustEqual 0

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -187,6 +187,20 @@ class IOAppSpec extends Specification {
           h.stderr() must contain("Boom!")
         }
 
+        "exit on raising a fatal error with attempt" in {
+          val h = platform(RaiseFatalErrorAttempt, List.empty)
+          h.awaitStatus() mustEqual 1
+          h.stderr() must contain ("Boom!")
+          h.stdout() must not(contain("sadness"))
+        }
+
+        "exit on raising a fatal error with handleError" in {
+          val h = platform(RaiseFatalErrorHandle, List.empty)
+          h.awaitStatus() mustEqual 1
+          h.stderr() must contain ("Boom!")
+          h.stdout() must not(contain("sadness"))
+        }
+
         "warn on global runtime collision" in {
           val h = platform(GlobalRacingInit, List.empty)
           h.awaitStatus() mustEqual 0

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -190,14 +190,14 @@ class IOAppSpec extends Specification {
         "exit on raising a fatal error with attempt" in {
           val h = platform(RaiseFatalErrorAttempt, List.empty)
           h.awaitStatus() mustEqual 1
-          h.stderr() must contain ("Boom!")
+          h.stderr() must contain("Boom!")
           h.stdout() must not(contain("sadness"))
         }
 
         "exit on raising a fatal error with handleError" in {
           val h = platform(RaiseFatalErrorHandle, List.empty)
           h.awaitStatus() mustEqual 1
-          h.stderr() must contain ("Boom!")
+          h.stderr() must contain("Boom!")
           h.stdout() must not(contain("sadness"))
         }
 

--- a/tests/shared/src/main/scala/catseffect/examples.scala
+++ b/tests/shared/src/main/scala/catseffect/examples.scala
@@ -58,6 +58,24 @@ package examples {
     }
   }
 
+  object RaiseFatalErrorAttempt extends IOApp {
+    def run(args: List[String]): IO[ExitCode] = {
+      IO.raiseError[Unit](new OutOfMemoryError("Boom!"))
+        .attempt
+        .flatMap(_ => IO.println("sadness"))
+        .as(ExitCode.Success)
+    }
+  }
+
+  object RaiseFatalErrorHandle extends IOApp {
+    def run(args: List[String]): IO[ExitCode] = {
+      IO.raiseError[Unit](new OutOfMemoryError("Boom!"))
+        .handleError(_ => ())
+        .flatMap(_ => IO.println("sadness"))
+        .as(ExitCode.Success)
+    }
+  }
+
   object Canceled extends IOApp {
     def run(args: List[String]): IO[ExitCode] =
       IO.canceled.as(ExitCode.Success)

--- a/tests/shared/src/main/scala/catseffect/examples.scala
+++ b/tests/shared/src/main/scala/catseffect/examples.scala
@@ -76,6 +76,26 @@ package examples {
     }
   }
 
+  object RaiseFatalErrorMap extends IOApp {
+    def run(args: List[String]): IO[ExitCode] = {
+      IO.raiseError[Unit](new OutOfMemoryError("Boom!"))
+        .map(_ => ())
+        .handleError(_ => ())
+        .flatMap(_ => IO.println("sadness"))
+        .as(ExitCode.Success)
+    }
+  }
+
+  object RaiseFatalErrorFlatMap extends IOApp {
+    def run(args: List[String]): IO[ExitCode] = {
+      IO.raiseError[Unit](new OutOfMemoryError("Boom!"))
+        .flatMap(_ => IO(()))
+        .handleError(_ => ())
+        .flatMap(_ => IO.println("sadness"))
+        .as(ExitCode.Success)
+    }
+  }
+
   object Canceled extends IOApp {
     def run(args: List[String]): IO[ExitCode] =
       IO.canceled.as(ExitCode.Success)

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -349,14 +349,15 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
       "immediately surface fatal errors" in ticked { implicit ticker =>
         import scala.util.control.NonFatal
         val io = IO.raiseError[Unit](new VirtualMachineError {}).voidError
-        
-        val fatalThrown = try {
-          unsafeRun[Unit](io)
-          false
-        } catch {
-          case t if NonFatal(t) => false
-          case _: Throwable => true
-        }
+
+        val fatalThrown =
+          try {
+            unsafeRun[Unit](io)
+            false
+          } catch {
+            case t if NonFatal(t) => false
+            case _: Throwable => true
+          }
         IO(fatalThrown) must completeAs(true)
       }
     }

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -347,16 +347,15 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
       }
 
       "immediately surface fatal errors" in ticked { implicit ticker =>
-        import scala.util.control.NonFatal
-        val io = IO.raiseError[Unit](new VirtualMachineError {}).voidError
+        val error = new VirtualMachineError {}
+        val io = IO.raiseError[Unit](error).voidError
 
         val fatalThrown =
           try {
             unsafeRun[Unit](io)
             false
           } catch {
-            case t if NonFatal(t) => false
-            case _: Throwable => true
+            case t: Throwable => t eq error
           }
         IO(fatalThrown) must completeAs(true)
       }

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -345,20 +345,6 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         } yield reported
         test must completeAs(true)
       }
-
-      "immediately surface fatal errors" in ticked { implicit ticker =>
-        val error = new VirtualMachineError {}
-        val io = IO.raiseError[Unit](error).voidError
-
-        val fatalThrown =
-          try {
-            unsafeRun[Unit](io)
-            false
-          } catch {
-            case t: Throwable => t eq error
-          }
-        IO(fatalThrown) must completeAs(true)
-      }
     }
 
     "suspension of side effects" should {

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -345,6 +345,20 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         } yield reported
         test must completeAs(true)
       }
+
+      "immediately surface fatal errors" in ticked { implicit ticker =>
+        import scala.util.control.NonFatal
+        val io = IO.raiseError[Unit](new VirtualMachineError {}).voidError
+        
+        val fatalThrown = try {
+          unsafeRun[Unit](io)
+          false
+        } catch {
+          case t if NonFatal(t) => false
+          case _: Throwable => true
+        }
+        IO(fatalThrown) must completeAs(true)
+      }
     }
 
     "suspension of side effects" should {


### PR DESCRIPTION
Resolves https://github.com/typelevel/cats-effect/issues/3767

From my understanding, the problem was that manually raising fatal errors through 'raiseError' was not treated the same as a fatal error thrown inside a delay within `IOFiber`. This PR just adds a check in the `Error` case to call `onFatalFailure` if a raised error is a fatal error.

Sorry this has taken so long. I was struggling to figure out how to test a fatal error is thrown without it crashing the test until I discovered `unsafeRun` exists.