### PR TITLE
Optimize `Dispatcher#{unsafeRunAsync,unsafeRunAndForget}`

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -70,17 +70,15 @@ trait Dispatcher[F[_]] extends DispatcherPlatform[F] {
    * Submits an effect to be executed with fire-and-forget semantics.
    */
   def unsafeRunAndForget[A](fa: F[A]): Unit =
-    unsafeToFutureCancelable(fa)
-      ._1
-      .onComplete {
-        case Failure(ex) => ex.printStackTrace()
-        case _ => ()
-      }(parasiticEC)
+    unsafeToFuture(fa).onComplete {
+      case Failure(ex) => ex.printStackTrace()
+      case _ => ()
+    }(parasiticEC)
 
   // package-private because it's just an internal utility which supports specific implementations
   // anyone who needs this type of thing should use unsafeToFuture and then onComplete
   private[std] def unsafeRunAsync[A](fa: F[A])(cb: Either[Throwable, A] => Unit): Unit =
-    unsafeToFutureCancelable(fa)._1.onComplete(t => cb(t.toEither))(parasiticEC)
+    unsafeToFuture(fa).onComplete(t => cb(t.toEither))(parasiticEC)
 }
 
 object Dispatcher {

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -20,12 +20,13 @@ import cats.effect.kernel.{Async, Outcome, Resource}
 import cats.effect.std.Dispatcher.parasiticEC
 import cats.syntax.all._
 
-import java.util.concurrent.ThreadLocalRandom
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
+
+import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
 /**
  * A fiber-based supervisor utility for evaluating effects across an impure boundary. This is


### PR DESCRIPTION
It looks like the parasitic EC need not be instantiated on every `unsafeRunAsync` call.