### PR TITLE
Try quoting labels in release notes config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,14 +2,14 @@ changelog:
   categories:
     - title: Features
       labels:
-        - :mushroom: enhancement
+        - ':mushroom: enhancement'
     - title: Bug Fixes
       labels:
-        - :beetle: bug
+        - ':beetle: bug'
     - title: Behind the Scenes
       labels:
-        - :gear: infrastructure
-        - :robot:
+        - ':gear: infrastructure'
+        - ':robot:'
     - title: Documentation
       labels:
-        - :books: docs
+        - ':books: docs'


### PR DESCRIPTION
Not sure if this will fix it, but something seems to be broken 😕 

```
Could not parse .github/release.yml: Tried to load unspecified class: Symbol
```