### PR TITLE
Add catch-all category for unlabeled PRs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -13,3 +13,7 @@ changelog:
     - title: Documentation
       labels:
         - ':books: docs'
+    # Not for published notes, just to make sure we don't forget any accidentally unlabeled PRs
+    - title: Uncategorized
+      labels:
+        - '*'


### PR DESCRIPTION
So we don't forget to mention a PR and acknowledge the contributor. I noticed because my own PR was missing 🙄 