### PR TITLE
Check supervisor status before submitting a task

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -269,7 +269,8 @@ object Supervisor {
             private[this] val allFibers: F[List[Fiber[F, Throwable, _]]] =
               stateRef.get.map(_.values.toList)
 
-            val joinAll: F[Unit] = closed.set(true) *> allFibers.flatMap(_.traverse_(_.join.void))
+            val joinAll: F[Unit] =
+              closed.set(true) *> allFibers.flatMap(_.traverse_(_.join.void))
             val cancelAll: F[Unit] =
               closed.set(true) *> allFibers.flatMap(_.parUnorderedTraverse(_.cancel).void)
 

--- a/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
@@ -75,6 +75,27 @@ class SupervisorSpec extends BaseSpec {
       test must completeAs(Outcome.canceled[IO, Throwable, Unit])
     }
 
+    "raise an error when fiber submits task to a closed supervisor" in real {
+      val test = constructor(false, None).use(supervisor =>
+        for {
+          p <- IO.deferred[Throwable]
+          _ <- (IO.sleep(1.second) *> supervisor
+            .supervise(IO.unit)
+            .onError(error => p.complete(error).void)).start
+          _ <- supervisor.supervise(IO.unit)
+        } yield p)
+
+      test.flatMap(_.get.map(_ must beAnInstanceOf[IllegalStateException]))
+    }
+
+    "raise an error when using a leaked supervisor" in real {
+      val test = constructor(false, None)
+        .use(supervisor => supervisor.supervise(IO.unit).as(supervisor))
+        .flatMap(supervisor => supervisor.supervise(IO.unit))
+
+      test.mustFailWith[IllegalStateException]
+    }
+
     "await active fibers when supervisor exits with await = true" in ticked { implicit ticker =>
       val test = constructor(true, None).use { supervisor =>
         supervisor.supervise(IO.never[Unit]).void


### PR DESCRIPTION
Fixes #3394 

Tried to encapsulate the `status` of the `Supervisor.State` within itself. This way, whenever `joinAll` or `cancellAll` are called, the `Supervisor` will be considered closed and not accept any new tasks. 

Since supervising a task isn't an atomic operation, 2 checks have been added to ensure that the `Supervisor` is not closed. One check right before running the `Fiber` and one check after the task has been registered (which also implies cleanup).
 