### PR TITLE
`register`->`access`

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/SelectorSystem.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SelectorSystem.scala
@@ -30,8 +30,8 @@ final class SelectorSystem private (provider: SelectorProvider) extends PollingS
 
   def close(): Unit = ()
 
-  def makeApi(register: (Poller => Unit) => Unit): Selector =
-    new SelectorImpl(register, provider)
+  def makeApi(access: (Poller => Unit) => Unit): Selector =
+    new SelectorImpl(access, provider)
 
   def makePoller(): Poller = new Poller(provider.openSelector())
 
@@ -107,13 +107,13 @@ final class SelectorSystem private (provider: SelectorProvider) extends PollingS
   }
 
   final class SelectorImpl private[SelectorSystem] (
-      register: (Poller => Unit) => Unit,
+      access: (Poller => Unit) => Unit,
       val provider: SelectorProvider
   ) extends Selector {
 
     def select(ch: SelectableChannel, ops: Int): IO[Int] = IO.async { selectCb =>
       IO.async_[CallbackNode] { cb =>
-        register { data =>
+        access { data =>
           try {
             val selector = data.selector
             val key = ch.keyFor(selector)

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SleepSystem.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SleepSystem.scala
@@ -26,7 +26,7 @@ object SleepSystem extends PollingSystem {
 
   def close(): Unit = ()
 
-  def makeApi(register: (Poller => Unit) => Unit): Api = this
+  def makeApi(access: (Poller => Unit) => Unit): Api = this
 
   def makePoller(): Poller = this
 

--- a/core/native/src/main/scala/cats/effect/unsafe/KqueueSystem.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/KqueueSystem.scala
@@ -46,8 +46,8 @@ object KqueueSystem extends PollingSystem {
 
   def close(): Unit = ()
 
-  def makeApi(register: (Poller => Unit) => Unit): FileDescriptorPoller =
-    new FileDescriptorPollerImpl(register)
+  def makeApi(access: (Poller => Unit) => Unit): FileDescriptorPoller =
+    new FileDescriptorPollerImpl(access)
 
   def makePoller(): Poller = {
     val fd = kqueue()
@@ -67,7 +67,7 @@ object KqueueSystem extends PollingSystem {
   def interrupt(targetThread: Thread, targetPoller: Poller): Unit = ()
 
   private final class FileDescriptorPollerImpl private[KqueueSystem] (
-      register: (Poller => Unit) => Unit
+      access: (Poller => Unit) => Unit
   ) extends FileDescriptorPoller {
     def registerFileDescriptor(
         fd: Int,
@@ -76,7 +76,7 @@ object KqueueSystem extends PollingSystem {
     ): Resource[IO, FileDescriptorPollHandle] =
       Resource.eval {
         (Mutex[IO], Mutex[IO]).mapN {
-          new PollHandle(register, fd, _, _)
+          new PollHandle(access, fd, _, _)
         }
       }
   }
@@ -86,7 +86,7 @@ object KqueueSystem extends PollingSystem {
     (filter.toLong << 32) | ident.toLong
 
   private final class PollHandle(
-      register: (Poller => Unit) => Unit,
+      access: (Poller => Unit) => Unit,
       fd: Int,
       readMutex: Mutex[IO],
       writeMutex: Mutex[IO]
@@ -101,7 +101,7 @@ object KqueueSystem extends PollingSystem {
             else
               IO.async[Unit] { kqcb =>
                 IO.async_[Option[IO[Unit]]] { cb =>
-                  register { kqueue =>
+                  access { kqueue =>
                     kqueue.evSet(fd, EVFILT_READ, EV_ADD.toUShort, kqcb)
                     cb(Right(Some(IO(kqueue.removeCallback(fd, EVFILT_READ)))))
                   }
@@ -121,7 +121,7 @@ object KqueueSystem extends PollingSystem {
             else
               IO.async[Unit] { kqcb =>
                 IO.async_[Option[IO[Unit]]] { cb =>
-                  register { kqueue =>
+                  access { kqueue =>
                     kqueue.evSet(fd, EVFILT_WRITE, EV_ADD.toUShort, kqcb)
                     cb(Right(Some(IO(kqueue.removeCallback(fd, EVFILT_WRITE)))))
                   }

--- a/core/native/src/main/scala/cats/effect/unsafe/PollingExecutorScheduler.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/PollingExecutorScheduler.scala
@@ -32,7 +32,7 @@ abstract class PollingExecutorScheduler(pollEvery: Int)
       type Poller = outer.type
       private[this] var needsPoll = true
       def close(): Unit = ()
-      def makeApi(register: (Poller => Unit) => Unit): Api = outer
+      def makeApi(access: (Poller => Unit) => Unit): Api = outer
       def makePoller(): Poller = outer
       def closePoller(poller: Poller): Unit = ()
       def poll(poller: Poller, nanos: Long, reportFailure: Throwable => Unit): Boolean = {

--- a/core/native/src/main/scala/cats/effect/unsafe/SleepSystem.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/SleepSystem.scala
@@ -24,7 +24,7 @@ object SleepSystem extends PollingSystem {
 
   def close(): Unit = ()
 
-  def makeApi(register: (Poller => Unit) => Unit): Api = this
+  def makeApi(access: (Poller => Unit) => Unit): Api = this
 
   def makePoller(): Poller = this
 

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -502,10 +502,10 @@ trait IOPlatformSpecification { self: BaseSpec with ScalaCheck =>
             }
           }
 
-          def makeApi(register: (Poller => Unit) => Unit): DummySystem.Api =
+          def makeApi(access: (Poller => Unit) => Unit): DummySystem.Api =
             new DummyPoller {
               def poll = IO.async_[Unit] { cb =>
-                register { poller =>
+                access { poller =>
                   poller.getAndUpdate(cb :: _)
                   ()
                 }


### PR DESCRIPTION
We renamed it in https://github.com/typelevel/cats-effect/pull/3752 but didn't propagate.