### PR TITLE
Optimize `Dispatcher#unsafeRunAndForget`

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -315,13 +315,6 @@ object Dispatcher {
       }
     } yield {
       new Dispatcher[F] {
-        override def unsafeRunAndForget[A](fa: F[A]): Unit = {
-          unsafeRunAsync(fa) {
-            case Left(t) => ec.reportFailure(t)
-            case Right(_) => ()
-          }
-        }
-
         def unsafeToFutureCancelable[E](fe: F[E]): (Future[E], () => Future[Unit]) = {
           val promise = Promise[E]()
 

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -311,11 +311,13 @@ object Dispatcher {
       }
     } yield {
       new Dispatcher[F] {
-        override def unsafeRunAndForget[A](fa: F[A]): Unit = {
-          unsafeToFuture(fa).onComplete {
-            case Failure(ex) => ec.reportFailure(ex)
-            case _ => ()
-          }(parasiticEC)
+        def unsafeRunAndForget[A](fa: F[A]): Unit = {
+          unsafeToFutureCancelable(fa)
+            ._1
+            .onComplete {
+              case Failure(ex) => ec.reportFailure(ex)
+              case _ => ()
+            }(parasiticEC)
         }
 
         def unsafeToFutureCancelable[E](fe: F[E]): (Future[E], () => Future[Unit]) = {


### PR DESCRIPTION
~~Removed default `Dispatcher#unsafeRunAndForget` as it was never used.~~
Cannot be removed in 3.5.x. due to bincompat.

Optimized the remaining implementation of `unsafeRunAndForget` so it does not go through `unsafeRunAsync` and extra allocation.

![dispatcher-flame-graph](https://github.com/typelevel/cats-effect/assets/807154/56ada021-fd75-4bda-bf7a-64d8a21b83f8)
