### PR TITLE
Fix starvation demo app in tuning guide

### DIFF
--- a/docs/core/starvation-and-tuning.md
+++ b/docs/core/starvation-and-tuning.md
@@ -29,7 +29,10 @@ import cats.syntax.all._
 object StarveThyself extends IOApp.Simple {
   val run = 
     0.until(100).toList parTraverse_ { i =>
-      IO.println(s"running #$i") >> IO(Thread.sleep(10000))
+      IO {
+        println(s"running #$i")
+        Thread.sleep(10000)
+      }
     }
 }
 ```


### PR DESCRIPTION
The demo actually wasn't starving because the fiber remained on the blocking thread it was shunted to for the preceding `IO.println`.

Further reading: https://typelevel.org/cats-effect/docs/faq#why-is-my-io-running-on-a-blocking-thread

h/t @felher