### PR TITLE
Fix cancelation leak in `fromFuture`, `fromFutureCancelable`

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -212,9 +212,9 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
    *   [[fromFutureCancelable]] for a cancelable version
    */
   def fromFuture[A](fut: F[Future[A]]): F[A] =
-    flatMap(fut) { f =>
-      flatMap(executionContext) { implicit ec =>
-        async_[A](cb => f.onComplete(t => cb(t.toEither)))
+    async_[A] { cb =>
+      flatMap(fut) { f =>
+        map(executionContext) { implicit ec => f.onComplete(t => cb(t.toEither)) }
       }
     }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -222,11 +222,13 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
    * Like [[fromFuture]], but is cancelable via the provided finalizer.
    */
   def fromFutureCancelable[A](futCancel: F[(Future[A], F[Unit])]): F[A] =
-    flatMap(futCancel) {
-      case (fut, fin) =>
-        flatMap(executionContext) { implicit ec =>
-          async[A](cb => as(delay(fut.onComplete(t => cb(t.toEither))), Some(fin)))
-        }
+    async[A] { cb =>
+      flatMap(futCancel) {
+        case (fut, fin) =>
+          flatMap(executionContext) { implicit ec =>
+            as(delay(fut.onComplete(t => cb(t.toEither))), Some(fin))
+          }
+      }
     }
 
   /**

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -226,7 +226,7 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
       uncancelable { poll =>
         flatMap(poll(futCancel)) {
           case (fut, fin) =>
-            async[A](cb => as(delay(fut.onComplete(t => cb(t.toEither))), Some(fin)))
+            poll(async[A](cb => as(delay(fut.onComplete(t => cb(t.toEither))), Some(fin))))
         }
       }
     }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -213,7 +213,9 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
    */
   def fromFuture[A](fut: F[Future[A]]): F[A] =
     flatMap(executionContext) { implicit ec =>
-      flatMap(fut) { f => async_[A](cb => f.onComplete(t => cb(t.toEither))) }
+      uncancelable { poll =>
+        flatMap(poll(fut)) { f => async_[A](cb => f.onComplete(t => cb(t.toEither))) }
+      }
     }
 
   /**

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Async.scala
@@ -226,7 +226,9 @@ trait Async[F[_]] extends AsyncPlatform[F] with Sync[F] with Temporal[F] {
       uncancelable { poll =>
         flatMap(poll(futCancel)) {
           case (fut, fin) =>
-            poll(async[A](cb => as(delay(fut.onComplete(t => cb(t.toEither))), Some(fin))))
+            onCancel(
+              poll(async[A](cb => as(delay(fut.onComplete(t => cb(t.toEither))), Some(unit)))),
+              fin)
         }
       }
     }

--- a/tests/shared/src/test/scala/cats/effect/kernel/AsyncSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/AsyncSpec.scala
@@ -17,22 +17,20 @@
 package cats.effect
 package kernel
 
-import cats.syntax.all._
 import cats.{Eq, Order, StackSafeMonad}
 import cats.arrow.FunctionK
 import cats.effect.laws.AsyncTests
-import cats.laws.discipline.arbitrary._
 import cats.effect.testkit.TestControl
 import cats.effect.unsafe.IORuntimeConfig
-
-import cats.effect.std.Random
+import cats.laws.discipline.arbitrary._
 
 import org.scalacheck.{Arbitrary, Cogen, Prop}
 import org.scalacheck.Arbitrary.arbitrary
 import org.typelevel.discipline.specs2.mutable.Discipline
 
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.{ExecutionContext, Promise}
 import scala.concurrent.duration._
+
 import java.util.concurrent.atomic.AtomicBoolean
 
 class AsyncSpec extends BaseSpec with Discipline {

--- a/tests/shared/src/test/scala/cats/effect/kernel/AsyncSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/AsyncSpec.scala
@@ -23,7 +23,6 @@ import cats.effect.laws.AsyncTests
 import cats.effect.testkit.TestControl
 import cats.effect.unsafe.IORuntimeConfig
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
 
 import org.scalacheck.{Arbitrary, Cogen, Prop}
 import org.scalacheck.Arbitrary.arbitrary

--- a/tests/shared/src/test/scala/cats/effect/kernel/AsyncSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/AsyncSpec.scala
@@ -81,7 +81,7 @@ class AsyncSpec extends BaseSpec with Discipline {
       val smallDelay: IO[Unit] = IO.sleep(10.millis)
       def mkf() = Promise[Unit]().future
 
-      val run = for {
+      val go = for {
         canceled <- IO(new AtomicBoolean)
         fiber <- IO.fromFutureCancelable {
           IO(mkf()).map(f => f -> IO(canceled.set(true)))
@@ -91,7 +91,7 @@ class AsyncSpec extends BaseSpec with Discipline {
         res <- IO(canceled.get() mustEqual true)
       } yield res
 
-      List.fill(100)(run).sequence
+      TestControl.executeEmbed(go, IORuntimeConfig(1, 2)).replicateA(1000)
 
     }
 

--- a/tests/shared/src/test/scala/cats/effect/kernel/AsyncSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/AsyncSpec.scala
@@ -17,13 +17,13 @@
 package cats.effect
 package kernel
 
-import cats.syntax.all._
 import cats.{Eq, Order, StackSafeMonad}
 import cats.arrow.FunctionK
 import cats.effect.laws.AsyncTests
 import cats.effect.testkit.TestControl
 import cats.effect.unsafe.IORuntimeConfig
 import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 
 import org.scalacheck.{Arbitrary, Cogen, Prop}
 import org.scalacheck.Arbitrary.arbitrary


### PR DESCRIPTION
Fix leak in `fromFutureCancelable` and `fromFuture`. Addresses https://github.com/typelevel/cats-effect/issues/3891