### PR TITLE
Fix #3898 for `Dispatcher.parallel`

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -278,7 +278,7 @@ object Dispatcher {
                       fork(action).flatMap(cancel => F.delay(prepareCancel(cancel)))
 
                     // Check for task cancelation before executing.
-                    F.delay(r.get()).ifM(supervise, F.unit)
+                    F.delay(r.get()).ifM(supervise, F.delay(prepareCancel(F.unit)))
                 }
               }
           } yield ()

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -216,6 +216,18 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
 
       TestControl.executeEmbed(rec.use(_ => IO(canceled must beTrue)))
     }
+
+    // https://github.com/typelevel/cats-effect/issues/3898
+    "not hang when cancelling" in real {
+      dispatcher.use { dispatcher =>
+        IO.fromFuture {
+          IO {
+            val (_, cancel) = dispatcher.unsafeToFutureCancelable(IO.never)
+            cancel()
+          }
+        }.replicateA_(1000).as(ok)
+      }
+    }
   }
 
   private def common(dispatcher: Resource[IO, Dispatcher[IO]]) = {

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -225,7 +225,8 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
             val (_, cancel) = dispatcher.unsafeToFutureCancelable(IO.never)
             cancel()
           }
-        }.replicateA_(1000).as(ok)
+        }.replicateA_(1000)
+          .as(ok)
       }
     }
   }


### PR DESCRIPTION
This seems to fix #3898 only for `Dispatcher.parallel`. (`Dispatcher.sequential` seems to be a completely different problem.)