### PR TITLE
Execute `IO.blocking` on WSTP without `BlockContext` indirection

### DIFF
--- a/core/js-native/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js-native/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -36,6 +36,7 @@ private[effect] sealed abstract class WorkStealingThreadPool private ()
       task: Runnable,
       fallback: Scheduler): Runnable
   private[effect] def canExecuteBlockingCode(): Boolean
+  private[effect] def prepareBlocking(): Unit
   private[unsafe] def liveTraces(): (
       Map[Runnable, Trace],
       Map[WorkerThread, (Thread.State, Option[(Runnable, Trace)], Map[Runnable, Trace])],

--- a/core/js-native/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/js-native/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -36,7 +36,7 @@ private[effect] sealed abstract class WorkStealingThreadPool private ()
       task: Runnable,
       fallback: Scheduler): Runnable
   private[effect] def canExecuteBlockingCode(): Boolean
-  private[effect] def prepareBlocking(): Unit
+  private[effect] def prepareForBlocking(): Unit
   private[unsafe] def liveTraces(): (
       Map[Runnable, Trace],
       Map[WorkerThread, (Thread.State, Option[(Runnable, Trace)], Map[Runnable, Trace])],

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -492,12 +492,12 @@ private[effect] final class WorkStealingThreadPool(
     val thread = Thread.currentThread()
     if (thread.isInstanceOf[WorkerThread]) {
       val worker = thread.asInstanceOf[WorkerThread]
-      if (worker.canExecuteBlockingCodeOn(this))
+      if (worker.canExecuteBlockingCodeOn(this)) {
         worker.prepareBlocking()
-      true
-    } else {
-      false
+        return true
+      }
     }
+    false
   }
 
   /**

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -492,12 +492,20 @@ private[effect] final class WorkStealingThreadPool(
     val thread = Thread.currentThread()
     if (thread.isInstanceOf[WorkerThread]) {
       val worker = thread.asInstanceOf[WorkerThread]
-      if (worker.canExecuteBlockingCodeOn(this)) {
-        worker.prepareBlocking()
-        return true
-      }
+      worker.canExecuteBlockingCodeOn(this)
+    } else {
+      false
     }
-    false
+  }
+
+  /**
+   * Prepares the current thread for running blocking code. This should be called only if
+   * [[canExecuteBlockingCode]] returns `true`.
+   */
+  private[effect] def prepareBlocking(): Unit = {
+    val thread = Thread.currentThread()
+    val worker = thread.asInstanceOf[WorkerThread]
+    worker.prepareBlocking()
   }
 
   /**

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -485,8 +485,8 @@ private[effect] final class WorkStealingThreadPool(
   }
 
   /**
-   * Checks if the blocking code can be executed in the current context and, if so, prepares it
-   * for blocking. Only returns true for worker threads that belong to this execution context.
+   * Checks if the blocking code can be executed in the current context (only returns true for
+   * worker threads that belong to this execution context).
    */
   private[effect] def canExecuteBlockingCode(): Boolean = {
     val thread = Thread.currentThread()

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -502,10 +502,10 @@ private[effect] final class WorkStealingThreadPool(
    * Prepares the current thread for running blocking code. This should be called only if
    * [[canExecuteBlockingCode]] returns `true`.
    */
-  private[effect] def prepareBlocking(): Unit = {
+  private[effect] def prepareForBlocking(): Unit = {
     val thread = Thread.currentThread()
     val worker = thread.asInstanceOf[WorkerThread]
-    worker.prepareBlocking()
+    worker.prepareForBlocking()
   }
 
   /**

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -485,14 +485,16 @@ private[effect] final class WorkStealingThreadPool(
   }
 
   /**
-   * Checks if the blocking code can be executed in the current context (only returns true for
-   * worker threads that belong to this execution context).
+   * Checks if the blocking code can be executed in the current context and, if so, prepares it
+   * for blocking. Only returns true for worker threads that belong to this execution context.
    */
   private[effect] def canExecuteBlockingCode(): Boolean = {
     val thread = Thread.currentThread()
     if (thread.isInstanceOf[WorkerThread]) {
       val worker = thread.asInstanceOf[WorkerThread]
-      worker.canExecuteBlockingCodeOn(this)
+      if (worker.canExecuteBlockingCodeOn(this))
+        worker.prepareBlocking()
+      true
     } else {
       false
     }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -792,10 +792,6 @@ private final class WorkerThread(
    * continue, it will be cached for a period of time instead. Finally, the `blocking` flag is
    * useful when entering nested blocking regions. In this case, there is no need to spawn a
    * replacement worker thread.
-   *
-   * @note
-   *   There is no reason to enclose any code in a `try/catch` block because the only way this
-   *   code path can be exercised is through `IO.delay`, which already handles exceptions.
    */
   def prepareForBlocking(): Unit = {
     val rnd = random
@@ -856,6 +852,10 @@ private final class WorkerThread(
 
   /**
    * A mechanism for executing support code before executing a blocking action.
+   *
+   * @note
+   *   There is no reason to enclose any code in a `try/catch` block because the only way this
+   *   code path can be exercised is through `IO.delay`, which already handles exceptions.
    */
   override def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
     prepareForBlocking()

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -797,7 +797,7 @@ private final class WorkerThread(
    *   There is no reason to enclose any code in a `try/catch` block because the only way this
    *   code path can be exercised is through `IO.delay`, which already handles exceptions.
    */
-  def prepareBlocking(): Unit = {
+  def prepareForBlocking(): Unit = {
     val rnd = random
 
     pool.notifyParked(rnd)
@@ -858,7 +858,7 @@ private final class WorkerThread(
    * A mechanism for executing support code before executing a blocking action.
    */
   override def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
-    prepareBlocking()
+    prepareForBlocking()
     thunk
   }
 

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -803,7 +803,7 @@ private final class WorkerThread(
     pool.notifyParked(rnd)
 
     if (blocking) {
-      // This `WorkerThread` is already inside an enclosing blocking region.
+      // This `WorkerThread` has already been prepared for blocking.
       // There is no need to spawn another `WorkerThread`.
     } else {
       // Spawn a new `WorkerThread` to take the place of this thread, as the
@@ -817,7 +817,7 @@ private final class WorkerThread(
         cedeBypass = null
       }
 
-      // Logically enter the blocking region.
+      // Logically become a blocking thread
       blocking = true
 
       val prefix = pool.blockerThreadPrefix

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -817,7 +817,7 @@ private final class WorkerThread(
         cedeBypass = null
       }
 
-      // Logically become a blocking thread
+      // Logically become a blocking thread.
       blocking = true
 
       val prefix = pool.blockerThreadPrefix

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -804,8 +804,7 @@ private final class WorkerThread(
 
     if (blocking) {
       // This `WorkerThread` is already inside an enclosing blocking region.
-      // There is no need to spawn another `WorkerThread`. Instead, directly
-      // execute the blocking action.
+      // There is no need to spawn another `WorkerThread`.
     } else {
       // Spawn a new `WorkerThread` to take the place of this thread, as the
       // current thread prepares to execute a blocking action.

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -991,6 +991,8 @@ private final class IOFiber[A](
             if (ec.isInstanceOf[WorkStealingThreadPool]) {
               val wstp = ec.asInstanceOf[WorkStealingThreadPool]
               if (wstp.canExecuteBlockingCode()) {
+                wstp.prepareBlocking()
+
                 var error: Throwable = null
                 val r =
                   try {

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -994,7 +994,7 @@ private final class IOFiber[A](
                 var error: Throwable = null
                 val r =
                   try {
-                    scala.concurrent.blocking(cur.thunk())
+                    cur.thunk()
                   } catch {
                     case t if NonFatal(t) =>
                       error = t

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -991,7 +991,7 @@ private final class IOFiber[A](
             if (ec.isInstanceOf[WorkStealingThreadPool]) {
               val wstp = ec.asInstanceOf[WorkStealingThreadPool]
               if (wstp.canExecuteBlockingCode()) {
-                wstp.prepareBlocking()
+                wstp.prepareForBlocking()
 
                 var error: Throwable = null
                 val r =


### PR DESCRIPTION
We already have all the fantastic machinery to execute blocking code on a `WorkerThread` and it is pointless to indirect through the `BlockContext` interface when we can just invoke this mechanism directly.