### PR TITLE
Only run mdoc on Temurin 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
       - shell: bash
         run: sbt '++ ${{ matrix.scala }}' '${{ matrix.ci }}'
 
-      - if: (matrix.scala == '2.13.12' || matrix.scala == '3.3.1') && matrix.ci == 'ciJVM'
+      - if: (matrix.scala == '2.13.12' || matrix.scala == '3.3.1') && matrix.ci == 'ciJVM' && matrix.java == 'temurin@17
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' docs/mdoc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
       - shell: bash
         run: sbt '++ ${{ matrix.scala }}' '${{ matrix.ci }}'
 
-      - if: (matrix.scala == '2.13.12' || matrix.scala == '3.3.1') && matrix.ci == 'ciJVM' && matrix.java == 'temurin@17
+      - if: (matrix.scala == '2.13.12' || matrix.scala == '3.3.1') && matrix.ci == 'ciJVM' && matrix.java == 'temurin@17'
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' docs/mdoc
 

--- a/build.sbt
+++ b/build.sbt
@@ -190,7 +190,8 @@ ThisBuild / githubWorkflowBuild := Seq("JVM", "JS", "Native").map { platform =>
   WorkflowStep.Sbt(
     List("docs/mdoc"),
     cond = Some(
-      s"(matrix.scala == '$Scala213' || matrix.scala == '$Scala3') && matrix.ci == 'ciJVM'")),
+      s"(matrix.scala == '$Scala213' || matrix.scala == '$Scala3') && matrix.ci == 'ciJVM' && matrix.java == '${LatestJava.render}")
+  ),
   WorkflowStep.Run(
     List("example/test-jvm.sh ${{ matrix.scala }}"),
     name = Some("Test Example JVM App Within Sbt"),

--- a/build.sbt
+++ b/build.sbt
@@ -190,7 +190,7 @@ ThisBuild / githubWorkflowBuild := Seq("JVM", "JS", "Native").map { platform =>
   WorkflowStep.Sbt(
     List("docs/mdoc"),
     cond = Some(
-      s"(matrix.scala == '$Scala213' || matrix.scala == '$Scala3') && matrix.ci == 'ciJVM' && matrix.java == '${LatestJava.render}")
+      s"(matrix.scala == '$Scala213' || matrix.scala == '$Scala3') && matrix.ci == 'ciJVM' && matrix.java == '${LatestJava.render}'")
   ),
   WorkflowStep.Run(
     List("example/test-jvm.sh ${{ matrix.scala }}"),


### PR DESCRIPTION
[It's been so broken we didn't realize.](https://github.com/typelevel/cats-effect/actions/runs/7317327789/job/19932728325#step:23:22)

Latest mdoc releases only support JDK 11+. I chose JDK 17 here because we use it for both Scala 2.13 and Scala 3 in the CI matrix and we want to run mdoc for both of those.