### PR TITLE
Prevent `Hotswap#get` from acquiring a lock when there is no `Resource` present

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
@@ -121,15 +121,13 @@ object Hotswap {
       def raise(message: String): F[Unit] =
         F.raiseError[Unit](new RuntimeException(message))
 
-      def shared(state: Ref[F, State]): Resource[F, Unit] =
-        Resource.makeFull[F, Unit] { poll =>
-          poll(
-            state.get.flatMap {
-              case Acquired(_, _) => semaphore.acquire
-              case _ => F.unit
-            }
-          )
-        } { _ => semaphore.release }
+      def shared(state: Ref[F, State]): Resource[F, Boolean] =
+        Resource.makeFull[F, Boolean] { poll =>
+          state.get.flatMap {
+            case Acquired(_, _) => poll(semaphore.acquire.as(true))
+            case _ => F.pure(false)
+          }
+        } { r => if (r) semaphore.release else F.unit }
 
       def exclusive: Resource[F, Unit] =
         Resource.makeFull[F, Unit](poll => poll(semaphore.acquireN(Long.MaxValue)))(_ =>

--- a/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
@@ -141,7 +141,7 @@ object Hotswap {
 
           override def get: Resource[F, Option[R]] =
             Resource.makeFull[F, Option[R]] { poll =>
-              poll(semaphore.acquire) *>
+              poll(semaphore.acquire) *> // acquire shared lock
                 state.get.flatMap {
                   case Acquired(r, _) => F.pure(Some(r))
                   case _ => semaphore.release.as(None)

--- a/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Hotswap.scala
@@ -73,9 +73,8 @@ sealed trait Hotswap[F[_], R] {
   def swap(next: Resource[F, R]): F[R]
 
   /**
-   * Acquires a shared lock to retrieve the current resource, if it exists. The returned
-   * resource is guaranteed to be available for its duration. The lock is released if the
-   * current resource does not exist.
+   * Gets the current resource, if it exists. The returned resource is guaranteed to be
+   * available for the duration of the returned resource.
    */
   def get: Resource[F, Option[R]]
 

--- a/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
@@ -170,9 +170,8 @@ class HotswapSpec extends BaseSpec { outer =>
       implicit ticker =>
         val go = Hotswap.create[IO, Unit].use { hs =>
           hs.get.useForever.start *>
-            hs.swap(IO.sleep(1.second).toResource) *>
             IO.sleep(2.seconds) *>
-            hs.get.use_.timeout(1.second).void
+            hs.swap(Resource.unit)
         }
         go must completeAs(())
     }

--- a/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/HotswapSpec.scala
@@ -165,6 +165,16 @@ class HotswapSpec extends BaseSpec { outer =>
 
       TestControl.executeEmbed(go, IORuntimeConfig(1, 2)).replicateA_(1000) must completeAs(())
     }
-  }
 
+    "get should not acquire a lock when there is no resource present" in ticked {
+      implicit ticker =>
+        val go = Hotswap.create[IO, Unit].use { hs =>
+          hs.get.useForever.start *>
+            hs.swap(IO.sleep(1.second).toResource) *>
+            IO.sleep(2.seconds) *>
+            hs.get.use_.timeout(1.second).void
+        }
+        go must completeAs(())
+    }
+  }
 }


### PR DESCRIPTION
Resolves #3802 