### PR TITLE
Rewrote `Dispatcher`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -980,8 +980,10 @@ lazy val std = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         // Rewrote Dispatcher
         ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Dispatcher$Mode"),
         ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Dispatcher$Mode$"),
-        ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Dispatcher$Mode$Parallel$"),
-        ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Dispatcher$Mode$Sequential$")
+        ProblemFilters.exclude[MissingClassProblem](
+          "cats.effect.std.Dispatcher$Mode$Parallel$"),
+        ProblemFilters.exclude[MissingClassProblem](
+          "cats.effect.std.Dispatcher$Mode$Sequential$")
       )
   )
   .jsSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -975,7 +975,13 @@ lazy val std = crossProject(JSPlatform, JVMPlatform, NativePlatform)
           "cats.effect.std.Queue$UnsafeUnbounded$Cell"),
         // introduced by #3480
         // adds method to sealed Hotswap
-        ProblemFilters.exclude[ReversedMissingMethodProblem]("cats.effect.std.Hotswap.get")
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("cats.effect.std.Hotswap.get"),
+        // introduced by #3923
+        // Rewrote Dispatcher
+        ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Dispatcher$Mode"),
+        ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Dispatcher$Mode$"),
+        ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Dispatcher$Mode$Parallel$"),
+        ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Dispatcher$Mode$Sequential$")
       )
   )
   .jsSettings(

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -300,11 +300,11 @@ object Dispatcher {
                       worker.queue.unsafeOffer(reg)
 
                       def cancel(): Future[Unit] = {
-                        reg.action = null.asInstanceOf[F[Unit]]
-
                         stateR.get() match {
                           case RegState.Unstarted =>
                             val latch = Promise[Unit]()
+
+                            reg.action = null.asInstanceOf[F[Unit]]
 
                             if (stateR.compareAndSet(RegState.Unstarted, RegState.CancelRequested(latch)))
                               latch.future

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -214,7 +214,7 @@ object Dispatcher {
    * at the cost of ordering, which is not guaranteed in parallel mode. With the sequential modes, there
    * is only a single worker.
    *
-   * On the impure side, the queue bit is the easy part: it's just a `LinkedBlockingQueue` which
+   * On the impure side, the queue bit is the easy part: it's just a `UnsafeUnbounded` (queue) which
    * accepts Registration(s). It's easiest to think of this a bit like an actor model, where the
    * `Worker` is the actor and the enqueue is the send. Whenever we send a unit of work, that
    * message has an `AtomicReference` which allows us to back-propagate a cancelation action. That

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -609,10 +609,10 @@ object Dispatcher {
   private val RightUnit: Right[Nothing, Unit] = Right(())
 
   // MPSC assumption
-  private final class UnsafeAsyncQueue[F[_]: Async, A] {
-    private[this] val buffer = new UnsafeUnbounded[A]()
+  private final class UnsafeAsyncQueue[F[_]: Async, A]
+      extends AtomicReference[Either[Throwable, Unit] => Unit](null) { latchR =>
 
-    private[this] val latchR = new AtomicReference[Either[Throwable, Unit] => Unit](null)
+    private[this] val buffer = new UnsafeUnbounded[A]()
 
     def unsafeOffer(a: A): Unit = {
       val _ = buffer.put(a)

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -280,7 +280,7 @@ object Dispatcher {
           workersF evalMap { workers =>
             Async[F].executionContext flatMap { ec =>
               val launchAll = 0.until(workers.length).toList traverse_ { i =>
-                supervisor.supervise(workers(i).run).void
+                supervisor.supervise(workers(i).run)
               }
 
               launchAll.as(new Dispatcher[F] {

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -481,7 +481,7 @@ object Dispatcher {
           }
 
         case Registration.Finalizer(action) =>
-          supervisor.supervise(action).void
+          supervisor.supervise(action).void.voidError
 
         case Registration.PoisonPill() =>
           Sync[F].delay(doneR.set(true))

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -317,6 +317,7 @@ object Dispatcher {
                       val reg = new Registration.Primary(promisory.void, stateR)
                       worker.queue.unsafeOffer(reg)
 
+                      @tailrec
                       def cancel(): Future[Unit] = {
                         stateR.get() match {
                           case RegState.Unstarted =>

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -34,6 +34,7 @@ import cats.effect.kernel.syntax.all._
 import cats.effect.std.Dispatcher.parasiticEC
 import cats.syntax.all._
 
+import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.Failure
 

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -329,12 +329,14 @@ object Dispatcher {
                             else
                               cancel()
 
-                          case RegState.Running(cancel) =>
+                          case r: RegState.Running[_] =>
+                            val cancel = r.cancel // indirection needed for Scala 2.12
+
                             val latch = Promise[Unit]()
                             val _ = inner(cancel, latch, true)
                             latch.future
 
-                          case RegState.CancelRequested(latch) => latch.future
+                          case r: RegState.CancelRequested[_] => r.latch.future
                           case RegState.Completed => Future.successful(())
                         }
                       }

--- a/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala
@@ -296,10 +296,21 @@ object Dispatcher {
                     // forward atomicity guarantees onto promise completion
                     val promisory = MonadCancel[F] uncancelable { poll =>
                       // invalidate the cancel action when we're done
-                      poll(fe.guarantee(Sync[F].delay(stateR.set(RegState.Completed))))
-                        .redeemWith(
-                          e => Sync[F].delay(result.failure(e)),
-                          a => Sync[F].delay(result.success(a)))
+                      val completeState = Sync[F].delay {
+                        stateR.getAndSet(RegState.Completed) match {
+                          case RegState.CancelRequested(latch) =>
+                            // we already have a cancel, must complete it:
+                            latch.trySuccess(()) // `try` because we're racing with `Worker`
+                            ()
+                          case RegState.Unstarted | RegState.Running(_) =>
+                            ()
+                          case RegState.Completed =>
+                            throw new AssertionError("unexpected Completed state")
+                        }
+                      }
+                      poll(fe.guarantee(completeState)).redeemWith(
+                        e => Sync[F].delay(result.failure(e)),
+                        a => Sync[F].delay(result.success(a)))
                     }
 
                     val worker =
@@ -416,10 +427,8 @@ object Dispatcher {
                     }
                   }
                 } else {
-                  val withCompletion =
-                    action.guarantee(Sync[F].delay(reg.stateR.set(RegState.Completed)))
 
-                  executor(withCompletion) { cancelF =>
+                  executor(action) { cancelF =>
                     Sync[F] defer {
                       if (reg
                           .stateR
@@ -429,8 +438,10 @@ object Dispatcher {
                         reg.stateR.get() match {
                           case RegState.CancelRequested(latch) =>
                             supervisor
-                              .supervise(
-                                cancelF.guarantee(Sync[F].delay(latch.success(())).void))
+                              .supervise(cancelF.guarantee(Sync[F].delay {
+                                latch.trySuccess(())
+                                ()
+                              }))
                               .void
 
                           case RegState.Completed =>

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -570,6 +570,17 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
         }
       }
 
+      "complete / cancel race" in real {
+        val tsk = dispatcher.use { dispatcher =>
+          IO.fromFuture(IO {
+            val (_, cancel) = dispatcher.unsafeToFutureCancelable(IO.unit)
+            val cancelFut = cancel()
+            cancelFut
+          })
+        }
+
+        tsk.replicateA_(if (isJVM) 10000 else 1).as(ok)
+      }
     }
   }
 

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -114,8 +114,9 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
             0.until(length) foreach { i =>
               runner.unsafeRunAndForget(results.update(_ :+ i).guarantee(gate.release))
             }
-          } *> gate.await
+          }
         }
+        _ <- gate.await
 
         vec <- results.get
         _ <- IO(vec mustEqual 0.until(length).toVector)

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -114,9 +114,8 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
             0.until(length) foreach { i =>
               runner.unsafeRunAndForget(results.update(_ :+ i).guarantee(gate.release))
             }
-          }
+          } *> gate.await
         }
-        _ <- gate.await
 
         vec <- results.get
         _ <- IO(vec mustEqual 0.until(length).toVector)

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -281,15 +281,18 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
 
     // https://github.com/typelevel/cats-effect/issues/3898
     "not hang when cancelling" in real {
-      dispatcher.use { dispatcher =>
-        IO.fromFuture {
+      val test = dispatcher.use { dispatcher =>
+        val action = IO.fromFuture {
           IO {
             val (_, cancel) = dispatcher.unsafeToFutureCancelable(IO.never)
             cancel()
           }
-        }.replicateA_(1000)
-          .as(ok)
+        }
+
+        action.replicateA_(1000)
       }
+
+      test.parReplicateA_(100).as(ok)
     }
 
     /*"fail to terminate when running one's own release in all modes" in real {

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -295,7 +295,10 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
         action.replicateA_(1000)
       }
 
-      test.parReplicateA_(100).as(ok)
+      if (isJVM)
+        test.parReplicateA_(100).as(ok)
+      else
+        test.as(ok)
     }
   }
 

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -141,7 +141,9 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
           latch2 <- IO.deferred[Unit]
           latch3 <- IO.deferred[Unit]
 
-          (_, cancel) <- IO(runner.unsafeToFutureCancelable(IO.unit))
+          pair <- IO(runner.unsafeToFutureCancelable(IO.unit))
+          (_, cancel) = pair
+
           _ <- IO(
             runner.unsafeRunAndForget(latch1.complete(()) *> latch2.get *> latch3.complete(())))
 
@@ -163,7 +165,8 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
             latch1 <- IO.deferred[Unit]
             latch2 <- IO.deferred[Unit]
 
-            (_, cancel) <- IO(runner.unsafeToFutureCancelable(latch1.get))
+            pair <- IO(runner.unsafeToFutureCancelable(latch1.get))
+            (_, cancel) = pair
 
             _ <- latch1.complete(())
             // the particularly scary case is where the cancel action gets in queue before the next action
@@ -475,7 +478,8 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
             action = (latch0.complete(()) *> IO.never)
               .onCancel(latch1.complete(()) *> latch2.get)
 
-            (_, cancel) <- IO(runner.unsafeToFutureCancelable(action))
+            pair <- IO(runner.unsafeToFutureCancelable(action))
+            (_, cancel) = pair
 
             _ <- latch0.get
 

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -294,14 +294,6 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
 
       test.parReplicateA_(100).as(ok)
     }
-
-    /*"fail to terminate when running one's own release in all modes" in real {
-      val test = dispatcher.allocated flatMap {
-        case (runner, release) => IO(runner.unsafeRunAndForget(release))
-      }
-
-      TestControl.executeEmbed(test).attempt.flatMap(e => IO(e must beLeft))
-    }*/
   }
 
   private def common(dispatcher: Resource[IO, Dispatcher[IO]], cancelable: Boolean) = {

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -66,7 +66,7 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
 
   "sequential dispatcher (cancelable = true)" should {
     "await = true" >> {
-      val D = Dispatcher.sequential[IO](await = true, cancelable = true)
+      val D = Dispatcher.sequentialCancelable[IO](await = true)
 
       sequential(D, true)
 
@@ -80,7 +80,7 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
     }
 
     "await = false" >> {
-      val D = Dispatcher.sequential[IO](await = false, cancelable = true)
+      val D = Dispatcher.sequentialCancelable[IO](await = false)
 
       sequential(D, true)
 

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -87,13 +87,12 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
                 // either the task didn't run at all (i.e.,
                 // it was cancelled before starting), or
                 // it ran and already finished completely:
-                (ctr1.get, ctr2.get).flatMapN { (v1, v2) =>
-                  IO(v1 mustEqual v2)
-                }
+                (ctr1.get, ctr2.get).flatMapN { (v1, v2) => IO(v1 mustEqual v2) }
               }
             }
           }
-        }.replicateA_(10000).as(ok)
+        }.replicateA_(10000)
+          .as(ok)
       }
     }
 

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -91,7 +91,7 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
               }
             }
           }
-        }.replicateA_(10000)
+        }.replicateA_(if (isJVM) 10000 else 1)
           .as(ok)
       }
     }

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -470,29 +470,33 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
 
       "support multiple concurrent cancelations" in real {
         dispatcher use { runner =>
+          val count = new AtomicInteger(0)
+
           for {
             latch0 <- IO.deferred[Unit]
             latch1 <- IO.deferred[Unit]
             latch2 <- IO.deferred[Unit]
 
-            countR <- IO.ref(0)
-
-            action = (latch0.complete(()) *> IO.never).onCancel(latch1.complete(()) *> latch2.get)
+            action = (latch0.complete(()) *> IO.never)
+              .onCancel(latch1.complete(()) *> latch2.get)
 
             (_, cancel) <- IO(runner.unsafeToFutureCancelable(action))
 
             _ <- latch0.get
-            cancelAction = IO.fromFuture(IO(cancel())) *> countR.update(_ + 1)
-            _ <- IO(runner.unsafeRunAndForget(cancelAction))
-            _ <- IO(runner.unsafeRunAndForget(cancelAction))
-            _ <- IO(runner.unsafeRunAndForget(cancelAction))
+
+            ec <- IO.executionContext
+            cancelAction = IO(cancel().onComplete(_ => count.getAndIncrement())(ec))
+            _ <- cancelAction
+            _ <- cancelAction
+            _ <- cancelAction
 
             _ <- latch1.get
             _ <- IO.sleep(100.millis)
-            count <- countR.get
-            _ <- IO(count mustEqual 0)
+            _ <- IO(count.get() mustEqual 0)
 
             _ <- latch2.complete(())
+            _ <- IO.sleep(100.millis)
+            _ <- IO(count.get() mustEqual 3)
           } yield ok
         }
       }

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -292,7 +292,7 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
           }
         }
 
-        action.replicateA_(1000)
+        action.replicateA_(if (isJVM) 1000 else 1)
       }
 
       if (isJVM)

--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -285,7 +285,7 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
             }
           }
 
-          rec.use(_ => IO.unit)
+          rec.use(_ => awaitAll)
         }
       } yield ok
     }


### PR DESCRIPTION
I have fixed many things. I possibly also made new problems. I think it's more maintainable now, but who am I to say?

I wrote a long comment in the middle which kind of explains the implementation, but the tldr is we're now very explicit about the impure submission queue and its associated race conditions. Those race conditions are fully resolved out by `Worker`, including the cancelation state machine. On the "actually do stuff" side is `Executor`, which is quite simple for the existing modes and quite complex for the new mode: `sequentialCancelable`.

Speaking of which, I added a third mode because I didn't realize it wasn't already the semantics of the second mode (`sequential`). Whoops. Anyway, we might not want to expose this one since I'm not sure anyone wants it, but I did all the work so here you go. Mostly I wanted to prove that it was possible. And it is… just hard.

Oh, I also removed and rewrote a bunch of tests which either weren't right, weren't reliable, or weren't interesting. I added a few new tests covering cases we probably should have always had. I don't *think* I missed anything, but who can say? Please enjoy.