### PR TITLE
Apply `@static` annotation internally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -114,7 +114,7 @@ val MacOS = "macos-latest"
 
 val Scala212 = "2.12.18"
 val Scala213 = "2.13.12"
-val Scala3 = "3.4.0-RC1-bin-20240112-c50f2ff-NIGHTLY"
+val Scala3 = "3.3.1"
 
 ThisBuild / crossScalaVersions := Seq(Scala3, Scala212, Scala213)
 ThisBuild / githubWorkflowScalaVersions := crossScalaVersions.value

--- a/build.sbt
+++ b/build.sbt
@@ -114,7 +114,7 @@ val MacOS = "macos-latest"
 
 val Scala212 = "2.12.18"
 val Scala213 = "2.13.12"
-val Scala3 = "3.3.1"
+val Scala3 = "3.4.0-RC1-bin-20240112-c50f2ff-NIGHTLY"
 
 ThisBuild / crossScalaVersions := Seq(Scala3, Scala212, Scala213)
 ThisBuild / githubWorkflowScalaVersions := crossScalaVersions.value

--- a/build.sbt
+++ b/build.sbt
@@ -767,7 +767,12 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
           ProblemFilters.exclude[DirectMissingMethodProblem](
             "cats.effect.unsafe.WorkStealingThreadPool.this"),
           // annoying consequence of reverting #2473
-          ProblemFilters.exclude[AbstractClassProblem]("cats.effect.ExitCode")
+          ProblemFilters.exclude[AbstractClassProblem]("cats.effect.ExitCode"),
+          // #3934 which made these internal vals into proper static fields
+          ProblemFilters.exclude[DirectMissingMethodProblem](
+            "cats.effect.unsafe.IORuntime.allRuntimes"),
+          ProblemFilters.exclude[DirectMissingMethodProblem](
+            "cats.effect.unsafe.IORuntime.globalFatalFailureHandled")
         )
       } else Seq()
     }

--- a/core/js/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/js/src/main/scala/cats/effect/CallbackStack.scala
@@ -62,9 +62,6 @@ private final class CallbackStackOps[A](private val callbacks: js.Array[A => Uni
 }
 
 private object CallbackStack {
-  @inline def apply[A](cb: A => Unit): CallbackStack[A] =
-    js.Array(cb).asInstanceOf[CallbackStack[A]]
-
   @inline implicit def ops[A](stack: CallbackStack[A]): CallbackStackOps[A] =
     new CallbackStackOps(stack.asInstanceOf[js.Array[A => Unit]])
 

--- a/core/js/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/js/src/main/scala/cats/effect/CallbackStack.scala
@@ -62,7 +62,7 @@ private final class CallbackStackOps[A](private val callbacks: js.Array[A => Uni
 }
 
 private object CallbackStack {
-  @inline def of[A](cb: A => Unit): CallbackStack[A] =
+  @inline def apply[A](cb: A => Unit): CallbackStack[A] =
     js.Array(cb).asInstanceOf[CallbackStack[A]]
 
   @inline implicit def ops[A](stack: CallbackStack[A]): CallbackStackOps[A] =

--- a/core/js/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/js/src/main/scala/cats/effect/CallbackStack.scala
@@ -62,7 +62,7 @@ private final class CallbackStackOps[A](private val callbacks: js.Array[A => Uni
 }
 
 private object CallbackStack {
-  @inline def apply[A](cb: A => Unit): CallbackStack[A] =
+  @inline def of[A](cb: A => Unit): CallbackStack[A] =
     js.Array(cb).asInstanceOf[CallbackStack[A]]
 
   @inline implicit def ops[A](stack: CallbackStack[A]): CallbackStackOps[A] =

--- a/core/js/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/js/src/main/scala/cats/effect/CallbackStack.scala
@@ -62,6 +62,9 @@ private final class CallbackStackOps[A](private val callbacks: js.Array[A => Uni
 }
 
 private object CallbackStack {
+  @inline def of[A](cb: A => Unit): CallbackStack[A] =
+    js.Array(cb).asInstanceOf[CallbackStack[A]]
+
   @inline implicit def ops[A](stack: CallbackStack[A]): CallbackStackOps[A] =
     new CallbackStackOps(stack.asInstanceOf[js.Array[A => Unit]])
 

--- a/core/js/src/main/scala/cats/effect/Platform.scala
+++ b/core/js/src/main/scala/cats/effect/Platform.scala
@@ -20,4 +20,6 @@ private object Platform {
   final val isJs = true
   final val isJvm = false
   final val isNative = false
+
+  class static extends scala.annotation.Annotation
 }

--- a/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
@@ -16,6 +16,8 @@
 
 package cats.effect
 
+import org.typelevel.scalaccompat.annotation._
+
 private final class ArrayStack[A <: AnyRef](
     private[this] var buffer: Array[AnyRef],
     private[this] var index: Int) {
@@ -78,8 +80,8 @@ private final class ArrayStack[A <: AnyRef](
 
 private object ArrayStack {
 
-  def apply[A <: AnyRef](): ArrayStack[A] = new ArrayStack()
+  @static3 def apply[A <: AnyRef](): ArrayStack[A] = new ArrayStack()
 
-  def apply[A <: AnyRef](size: Int): ArrayStack[A] = new ArrayStack(size)
+  @static3 def apply[A <: AnyRef](size: Int): ArrayStack[A] = new ArrayStack(size)
 
 }

--- a/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
@@ -16,7 +16,7 @@
 
 package cats.effect
 
-import org.typelevel.scalaccompat.annotation._
+import Platform.static
 
 private final class ArrayStack[A <: AnyRef](
     private[this] var buffer: Array[AnyRef],
@@ -80,8 +80,8 @@ private final class ArrayStack[A <: AnyRef](
 
 private object ArrayStack {
 
-  @static3 def apply[A <: AnyRef](): ArrayStack[A] = new ArrayStack()
+  @static def apply[A <: AnyRef](): ArrayStack[A] = new ArrayStack()
 
-  @static3 def apply[A <: AnyRef](size: Int): ArrayStack[A] = new ArrayStack(size)
+  @static def apply[A <: AnyRef](size: Int): ArrayStack[A] = new ArrayStack(size)
 
 }

--- a/core/jvm-native/src/main/scala/cats/effect/ByteStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/ByteStack.scala
@@ -18,7 +18,7 @@ package cats.effect
 
 import org.typelevel.scalaccompat.annotation._
 
-private final class ByteStack private ()
+private[effect] final class ByteStack
 
 private object ByteStack {
 

--- a/core/jvm-native/src/main/scala/cats/effect/ByteStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/ByteStack.scala
@@ -16,7 +16,7 @@
 
 package cats.effect
 
-import org.typelevel.scalaccompat.annotation._
+import Platform.static
 
 private[effect] final class ByteStack
 
@@ -24,7 +24,7 @@ private object ByteStack {
 
   type T = Array[Int]
 
-  @static3 final def toDebugString(
+  @static final def toDebugString(
       stack: Array[Int],
       translate: Byte => String = _.toString): String = {
     val count = size(stack)
@@ -44,10 +44,10 @@ private object ByteStack {
       .toString
   }
 
-  @static3 final def create(initialMaxOps: Int): Array[Int] =
+  @static final def create(initialMaxOps: Int): Array[Int] =
     new Array[Int](1 + 1 + ((initialMaxOps - 1) >> 3)) // count-slot + 1 for each set of 8 ops
 
-  @static3 final def growIfNeeded(stack: Array[Int], count: Int): Array[Int] = {
+  @static final def growIfNeeded(stack: Array[Int], count: Int): Array[Int] = {
     if ((1 + ((count + 1) >> 3)) < stack.length) {
       stack
     } else {
@@ -57,7 +57,7 @@ private object ByteStack {
     }
   }
 
-  @static3 final def push(stack: Array[Int], op: Byte): Array[Int] = {
+  @static final def push(stack: Array[Int], op: Byte): Array[Int] = {
     val c = stack(0) // current count of elements
     val use = growIfNeeded(stack, c) // alias so we add to the right place
     val s = (c >> 3) + 1 // current slot in `use`
@@ -67,24 +67,24 @@ private object ByteStack {
     use
   }
 
-  @static3 final def size(stack: Array[Int]): Int =
+  @static final def size(stack: Array[Int]): Int =
     stack(0)
 
-  @static3 final def isEmpty(stack: Array[Int]): Boolean =
+  @static final def isEmpty(stack: Array[Int]): Boolean =
     stack(0) < 1
 
-  @static3 final def read(stack: Array[Int], pos: Int): Byte = {
+  @static final def read(stack: Array[Int], pos: Int): Byte = {
     if (pos < 0 || pos >= stack(0)) throw new ArrayIndexOutOfBoundsException()
     ((stack((pos >> 3) + 1) >>> ((pos & 7) << 2)) & 0x0000000f).toByte
   }
 
-  @static3 final def peek(stack: Array[Int]): Byte = {
+  @static final def peek(stack: Array[Int]): Byte = {
     val c = stack(0) - 1
     if (c < 0) throw new ArrayIndexOutOfBoundsException()
     ((stack((c >> 3) + 1) >>> ((c & 7) << 2)) & 0x0000000f).toByte
   }
 
-  @static3 final def pop(stack: Array[Int]): Byte = {
+  @static final def pop(stack: Array[Int]): Byte = {
     val op = peek(stack)
     stack(0) -= 1
     op

--- a/core/jvm-native/src/main/scala/cats/effect/ByteStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/ByteStack.scala
@@ -16,11 +16,17 @@
 
 package cats.effect
 
+import org.typelevel.scalaccompat.annotation._
+
+private final class ByteStack private ()
+
 private object ByteStack {
 
   type T = Array[Int]
 
-  final def toDebugString(stack: Array[Int], translate: Byte => String = _.toString): String = {
+  @static3 final def toDebugString(
+      stack: Array[Int],
+      translate: Byte => String = _.toString): String = {
     val count = size(stack)
     ((count - 1) to 0 by -1)
       .foldLeft(
@@ -38,10 +44,10 @@ private object ByteStack {
       .toString
   }
 
-  final def create(initialMaxOps: Int): Array[Int] =
+  @static3 final def create(initialMaxOps: Int): Array[Int] =
     new Array[Int](1 + 1 + ((initialMaxOps - 1) >> 3)) // count-slot + 1 for each set of 8 ops
 
-  final def growIfNeeded(stack: Array[Int], count: Int): Array[Int] = {
+  @static3 final def growIfNeeded(stack: Array[Int], count: Int): Array[Int] = {
     if ((1 + ((count + 1) >> 3)) < stack.length) {
       stack
     } else {
@@ -51,7 +57,7 @@ private object ByteStack {
     }
   }
 
-  final def push(stack: Array[Int], op: Byte): Array[Int] = {
+  @static3 final def push(stack: Array[Int], op: Byte): Array[Int] = {
     val c = stack(0) // current count of elements
     val use = growIfNeeded(stack, c) // alias so we add to the right place
     val s = (c >> 3) + 1 // current slot in `use`
@@ -61,24 +67,24 @@ private object ByteStack {
     use
   }
 
-  final def size(stack: Array[Int]): Int =
+  @static3 final def size(stack: Array[Int]): Int =
     stack(0)
 
-  final def isEmpty(stack: Array[Int]): Boolean =
+  @static3 final def isEmpty(stack: Array[Int]): Boolean =
     stack(0) < 1
 
-  final def read(stack: Array[Int], pos: Int): Byte = {
+  @static3 final def read(stack: Array[Int], pos: Int): Byte = {
     if (pos < 0 || pos >= stack(0)) throw new ArrayIndexOutOfBoundsException()
     ((stack((pos >> 3) + 1) >>> ((pos & 7) << 2)) & 0x0000000f).toByte
   }
 
-  final def peek(stack: Array[Int]): Byte = {
+  @static3 final def peek(stack: Array[Int]): Byte = {
     val c = stack(0) - 1
     if (c < 0) throw new ArrayIndexOutOfBoundsException()
     ((stack((c >> 3) + 1) >>> ((c & 7) << 2)) & 0x0000000f).toByte
   }
 
-  final def pop(stack: Array[Int]): Byte = {
+  @static3 final def pop(stack: Array[Int]): Byte = {
     val op = peek(stack)
     stack(0) -= 1
     op

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -16,6 +16,8 @@
 
 package cats.effect
 
+import org.typelevel.scalaccompat.annotation._
+
 import scala.annotation.tailrec
 
 import java.util.concurrent.atomic.AtomicReference
@@ -149,5 +151,8 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
 }
 
 private object CallbackStack {
+  @static3 def of[A](cb: A => Unit): CallbackStack[A] =
+    new CallbackStack(cb)
+
   type Handle = Byte
 }

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -149,8 +149,5 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
 }
 
 private object CallbackStack {
-  def apply[A](cb: A => Unit): CallbackStack[A] =
-    new CallbackStack(cb)
-
   type Handle = Byte
 }

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -22,7 +22,7 @@ import scala.annotation.tailrec
 
 import java.util.concurrent.atomic.AtomicReference
 
-private final class CallbackStack[A](private[this] var callback: A => Unit)
+private final class CallbackStack[A] private (private[this] var callback: A => Unit)
     extends AtomicReference[CallbackStack[A]] {
 
   def push(next: A => Unit): CallbackStack[A] = {
@@ -151,7 +151,7 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
 }
 
 private object CallbackStack {
-  @static3 def of[A](cb: A => Unit): CallbackStack[A] =
+  @static3 def apply[A](cb: A => Unit): CallbackStack[A] =
     new CallbackStack(cb)
 
   type Handle = Byte

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -22,7 +22,7 @@ import scala.annotation.tailrec
 
 import java.util.concurrent.atomic.AtomicReference
 
-private final class CallbackStack[A] private (private[this] var callback: A => Unit)
+private final class CallbackStack[A](private[this] var callback: A => Unit)
     extends AtomicReference[CallbackStack[A]] {
 
   def push(next: A => Unit): CallbackStack[A] = {
@@ -151,7 +151,7 @@ private final class CallbackStack[A] private (private[this] var callback: A => U
 }
 
 private object CallbackStack {
-  @static3 def apply[A](cb: A => Unit): CallbackStack[A] =
+  @static3 def of[A](cb: A => Unit): CallbackStack[A] =
     new CallbackStack(cb)
 
   type Handle = Byte

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -16,11 +16,11 @@
 
 package cats.effect
 
-import org.typelevel.scalaccompat.annotation._
-
 import scala.annotation.tailrec
 
 import java.util.concurrent.atomic.AtomicReference
+
+import Platform.static
 
 private final class CallbackStack[A](private[this] var callback: A => Unit)
     extends AtomicReference[CallbackStack[A]] {
@@ -151,7 +151,7 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
 }
 
 private object CallbackStack {
-  @static3 def of[A](cb: A => Unit): CallbackStack[A] =
+  @static def of[A](cb: A => Unit): CallbackStack[A] =
     new CallbackStack(cb)
 
   type Handle = Byte

--- a/core/jvm/src/main/scala/cats/effect/Platform.scala
+++ b/core/jvm/src/main/scala/cats/effect/Platform.scala
@@ -20,4 +20,6 @@ private object Platform {
   final val isJs = false
   final val isJvm = true
   final val isNative = false
+
+  type static = org.typelevel.scalaccompat.annotation.static3
 }

--- a/core/native/src/main/scala/cats/effect/Platform.scala
+++ b/core/native/src/main/scala/cats/effect/Platform.scala
@@ -20,4 +20,6 @@ private object Platform {
   final val isJs = false
   final val isJvm = false
   final val isNative = true
+
+  class static extends scala.annotation.Annotation
 }

--- a/core/shared/src/main/scala/cats/effect/ContState.scala
+++ b/core/shared/src/main/scala/cats/effect/ContState.scala
@@ -18,9 +18,9 @@ package cats.effect
 
 import cats.effect.unsafe.WeakBag
 
-import org.typelevel.scalaccompat.annotation._
-
 import java.util.concurrent.atomic.AtomicReference
+
+import Platform.static
 
 /**
  * Possible states (held in the `AtomicReference`):
@@ -51,6 +51,6 @@ private object ContState {
    * important. It must be private (so that no user code can access it), and it mustn't be used
    * for any other purpose.
    */
-  @static3 private val waitingSentinel: Either[Throwable, Any] =
+  @static private val waitingSentinel: Either[Throwable, Any] =
     new Right(null)
 }

--- a/core/shared/src/main/scala/cats/effect/ContState.scala
+++ b/core/shared/src/main/scala/cats/effect/ContState.scala
@@ -18,6 +18,8 @@ package cats.effect
 
 import cats.effect.unsafe.WeakBag
 
+import org.typelevel.scalaccompat.annotation._
+
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -49,6 +51,6 @@ private object ContState {
    * important. It must be private (so that no user code can access it), and it mustn't be used
    * for any other purpose.
    */
-  private val waitingSentinel: Either[Throwable, Any] =
+  @static3 private val waitingSentinel: Either[Throwable, Any] =
     new Right(null)
 }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -44,8 +44,6 @@ import cats.effect.tracing.{Tracing, TracingEvent}
 import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
 
-import org.typelevel.scalaccompat.annotation._
-
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.{
   CancellationException,
@@ -60,6 +58,8 @@ import scala.util.control.NonFatal
 
 import java.util.UUID
 import java.util.concurrent.Executor
+
+import Platform.static
 
 /**
  * A pure abstraction representing the intention to perform a side effect, where the result of
@@ -1111,8 +1111,8 @@ private[effect] trait IOLowPriorityImplicits {
 
 object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
 
-  @static3 private[this] val _alignForIO = new IOAlign
-  @static3 private[this] val _asyncForIO: kernel.Async[IO] = new IOAsync
+  @static private[this] val _alignForIO = new IOAlign
+  @static private[this] val _asyncForIO: kernel.Async[IO] = new IOAsync
 
   /**
    * Newtype encoding for an `IO` datatype that has a `cats.Applicative` capable of doing

--- a/core/shared/src/main/scala/cats/effect/IODeferred.scala
+++ b/core/shared/src/main/scala/cats/effect/IODeferred.scala
@@ -56,7 +56,7 @@ private final class IODeferred[A] extends Deferred[IO, A] {
   }
 
   private[this] val cell = new AtomicReference(initial)
-  private[this] val callbacks = CallbackStack[Right[Nothing, A]](null)
+  private[this] val callbacks = CallbackStack.of[Right[Nothing, A]](null)
   private[this] val clearCounter = new AtomicInteger
 
   def complete(a: A): IO[Boolean] = IO {

--- a/core/shared/src/main/scala/cats/effect/IODeferred.scala
+++ b/core/shared/src/main/scala/cats/effect/IODeferred.scala
@@ -56,7 +56,7 @@ private final class IODeferred[A] extends Deferred[IO, A] {
   }
 
   private[this] val cell = new AtomicReference(initial)
-  private[this] val callbacks = CallbackStack.of[Right[Nothing, A]](null)
+  private[this] val callbacks = CallbackStack[Right[Nothing, A]](null)
   private[this] val clearCounter = new AtomicInteger
 
   def complete(a: A): IO[Boolean] = IO {

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -87,7 +87,7 @@ private final class IOFiber[A](
   private[this] var currentCtx: ExecutionContext = startEC
   private[this] val objectState: ArrayStack[AnyRef] = ArrayStack()
   private[this] val finalizers: ArrayStack[IO[Unit]] = ArrayStack()
-  private[this] val callbacks: CallbackStack[OutcomeIO[A]] = CallbackStack(cb)
+  private[this] val callbacks: CallbackStack[OutcomeIO[A]] = CallbackStack.of(cb)
   private[this] var resumeTag: Byte = ExecR
   private[this] var resumeIO: IO[Any] = startIO
   private[this] val runtime: IORuntime = rt

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -20,6 +20,8 @@ import cats.arrow.FunctionK
 import cats.effect.tracing._
 import cats.effect.unsafe._
 
+import org.typelevel.scalaccompat.annotation._
+
 import scala.annotation.{switch, tailrec}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -1569,11 +1571,11 @@ private final class IOFiber[A](
 
 private object IOFiber {
   /* prefetch */
-  private[IOFiber] val TypeBlocking = Sync.Type.Blocking
-  private[IOFiber] val OutcomeCanceled = Outcome.Canceled()
-  private[effect] val RightUnit = Right(())
+  @static3 private[IOFiber] val TypeBlocking = Sync.Type.Blocking
+  @static3 private[IOFiber] val OutcomeCanceled = Outcome.Canceled()
+  @static3 private[effect] val RightUnit = Right(())
 
-  def onFatalFailure(t: Throwable): Nothing = {
+  @static3 def onFatalFailure(t: Throwable): Nothing = {
     val interrupted = Thread.interrupted()
 
     if (IORuntime.globalFatalFailureHandled.compareAndSet(false, true)) {

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -87,7 +87,7 @@ private final class IOFiber[A](
   private[this] var currentCtx: ExecutionContext = startEC
   private[this] val objectState: ArrayStack[AnyRef] = ArrayStack()
   private[this] val finalizers: ArrayStack[IO[Unit]] = ArrayStack()
-  private[this] val callbacks: CallbackStack[OutcomeIO[A]] = CallbackStack.of(cb)
+  private[this] val callbacks: CallbackStack[OutcomeIO[A]] = CallbackStack(cb)
   private[this] var resumeTag: Byte = ExecR
   private[this] var resumeIO: IO[Any] = startIO
   private[this] val runtime: IORuntime = rt

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -98,7 +98,7 @@ private final class IOFiber[A](
    * Ideally these would be on the stack, but they can't because we sometimes need to
    * relocate our runloop to another fiber.
    */
-  private[this] var conts: ByteStack = _
+  private[this] var conts: ByteStack.T = _
 
   private[this] var canceled: Boolean = false
   private[this] var masks: Int = 0

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -20,8 +20,6 @@ import cats.arrow.FunctionK
 import cats.effect.tracing._
 import cats.effect.unsafe._
 
-import org.typelevel.scalaccompat.annotation._
-
 import scala.annotation.{switch, tailrec}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -29,6 +27,8 @@ import scala.util.control.NonFatal
 
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.atomic.AtomicBoolean
+
+import Platform.static
 
 /*
  * Rationale on memory barrier exploitation in this class...
@@ -1571,11 +1571,11 @@ private final class IOFiber[A](
 
 private object IOFiber {
   /* prefetch */
-  @static3 private[IOFiber] val TypeBlocking = Sync.Type.Blocking
-  @static3 private[IOFiber] val OutcomeCanceled = Outcome.Canceled()
-  @static3 private[effect] val RightUnit = Right(())
+  @static private[IOFiber] val TypeBlocking = Sync.Type.Blocking
+  @static private[IOFiber] val OutcomeCanceled = Outcome.Canceled()
+  @static private[effect] val RightUnit = Right(())
 
-  @static3 def onFatalFailure(t: Throwable): Nothing = {
+  @static def onFatalFailure(t: Throwable): Nothing = {
     val interrupted = Thread.interrupted()
 
     if (IORuntime.globalFatalFailureHandled.compareAndSet(false, true)) {

--- a/core/shared/src/main/scala/cats/effect/SyncIO.scala
+++ b/core/shared/src/main/scala/cats/effect/SyncIO.scala
@@ -22,13 +22,13 @@ import cats.effect.syntax.monadCancel._
 import cats.kernel.{Monoid, Semigroup}
 import cats.syntax.all._
 
-import org.typelevel.scalaccompat.annotation._
-
 import scala.annotation.{switch, tailrec}
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.duration._
 import scala.util.Try
 import scala.util.control.NonFatal
+
+import Platform.static
 
 /**
  * A pure abstraction representing the intention to perform a side effect, where the result of
@@ -398,8 +398,8 @@ private[effect] trait SyncIOLowPriorityImplicits {
 
 object SyncIO extends SyncIOCompanionPlatform with SyncIOLowPriorityImplicits {
 
-  @static3 private[this] val Delay = Sync.Type.Delay
-  @static3 private[this] val _syncForSyncIO: Sync[SyncIO] = new SyncIOSync
+  @static private[this] val Delay = Sync.Type.Delay
+  @static private[this] val _syncForSyncIO: Sync[SyncIO] = new SyncIOSync
 
   // constructors
 

--- a/core/shared/src/main/scala/cats/effect/SyncIO.scala
+++ b/core/shared/src/main/scala/cats/effect/SyncIO.scala
@@ -22,6 +22,8 @@ import cats.effect.syntax.monadCancel._
 import cats.kernel.{Monoid, Semigroup}
 import cats.syntax.all._
 
+import org.typelevel.scalaccompat.annotation._
+
 import scala.annotation.{switch, tailrec}
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.duration._
@@ -396,7 +398,8 @@ private[effect] trait SyncIOLowPriorityImplicits {
 
 object SyncIO extends SyncIOCompanionPlatform with SyncIOLowPriorityImplicits {
 
-  private[this] val Delay = Sync.Type.Delay
+  @static3 private[this] val Delay = Sync.Type.Delay
+  @static3 private[this] val _syncForSyncIO: Sync[SyncIO] = new SyncIOSync
 
   // constructors
 
@@ -576,48 +579,48 @@ object SyncIO extends SyncIOCompanionPlatform with SyncIOLowPriorityImplicits {
     def functor: Functor[SyncIO] = Functor[SyncIO]
   }
 
-  private[this] val _syncForSyncIO: Sync[SyncIO] =
-    new Sync[SyncIO]
+  private[this] final class SyncIOSync
+      extends Sync[SyncIO]
       with StackSafeMonad[SyncIO]
       with MonadCancel.Uncancelable[SyncIO, Throwable] {
 
-      def pure[A](x: A): SyncIO[A] =
-        SyncIO.pure(x)
+    def pure[A](x: A): SyncIO[A] =
+      SyncIO.pure(x)
 
-      def raiseError[A](e: Throwable): SyncIO[A] =
-        SyncIO.raiseError(e)
+    def raiseError[A](e: Throwable): SyncIO[A] =
+      SyncIO.raiseError(e)
 
-      def handleErrorWith[A](fa: SyncIO[A])(f: Throwable => SyncIO[A]): SyncIO[A] =
-        fa.handleErrorWith(f)
+    def handleErrorWith[A](fa: SyncIO[A])(f: Throwable => SyncIO[A]): SyncIO[A] =
+      fa.handleErrorWith(f)
 
-      def flatMap[A, B](fa: SyncIO[A])(f: A => SyncIO[B]): SyncIO[B] =
-        fa.flatMap(f)
+    def flatMap[A, B](fa: SyncIO[A])(f: A => SyncIO[B]): SyncIO[B] =
+      fa.flatMap(f)
 
-      def monotonic: SyncIO[FiniteDuration] =
-        SyncIO.monotonic
+    def monotonic: SyncIO[FiniteDuration] =
+      SyncIO.monotonic
 
-      def realTime: SyncIO[FiniteDuration] =
-        SyncIO.realTime
+    def realTime: SyncIO[FiniteDuration] =
+      SyncIO.realTime
 
-      def suspend[A](hint: Sync.Type)(thunk: => A): SyncIO[A] =
-        Suspend(hint, () => thunk)
+    def suspend[A](hint: Sync.Type)(thunk: => A): SyncIO[A] =
+      Suspend(hint, () => thunk)
 
-      override def attempt[A](fa: SyncIO[A]): SyncIO[Either[Throwable, A]] =
-        fa.attempt
+    override def attempt[A](fa: SyncIO[A]): SyncIO[Either[Throwable, A]] =
+      fa.attempt
 
-      override def redeem[A, B](fa: SyncIO[A])(recover: Throwable => B, f: A => B): SyncIO[B] =
-        fa.redeem(recover, f)
+    override def redeem[A, B](fa: SyncIO[A])(recover: Throwable => B, f: A => B): SyncIO[B] =
+      fa.redeem(recover, f)
 
-      override def redeemWith[A, B](
-          fa: SyncIO[A])(recover: Throwable => SyncIO[B], bind: A => SyncIO[B]): SyncIO[B] =
-        fa.redeemWith(recover, bind)
+    override def redeemWith[A, B](
+        fa: SyncIO[A])(recover: Throwable => SyncIO[B], bind: A => SyncIO[B]): SyncIO[B] =
+      fa.redeemWith(recover, bind)
 
-      override def unit: SyncIO[Unit] =
-        SyncIO.unit
+    override def unit: SyncIO[Unit] =
+      SyncIO.unit
 
-      def forceR[A, B](fa: SyncIO[A])(fb: SyncIO[B]): SyncIO[B] =
-        fa.attempt.productR(fb)
-    }
+    def forceR[A, B](fa: SyncIO[A])(fb: SyncIO[B]): SyncIO[B] =
+      fa.attempt.productR(fb)
+  }
 
   implicit def syncForSyncIO: Sync[SyncIO] with MonadCancel[SyncIO, Throwable] = _syncForSyncIO
 

--- a/core/shared/src/main/scala/cats/effect/package.scala
+++ b/core/shared/src/main/scala/cats/effect/package.scala
@@ -80,6 +80,4 @@ package object effect {
   val Ref = cekernel.Ref
 
   private[effect] type IOLocalState = scala.collection.immutable.Map[IOLocal[_], Any]
-
-  private[effect] type ByteStack = ByteStack.T
 }

--- a/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package cats.effect.tracing
+package cats.effect
+package tracing
 
-import org.typelevel.scalaccompat.annotation._
+import Platform.static
 
 private[effect] final class RingBuffer private (logSize: Int) {
 
@@ -61,6 +62,6 @@ private[effect] final class RingBuffer private (logSize: Int) {
 }
 
 private[effect] object RingBuffer {
-  @static3 def empty(logSize: Int): RingBuffer =
+  @static def empty(logSize: Int): RingBuffer =
     new RingBuffer(logSize)
 }

--- a/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/RingBuffer.scala
@@ -16,6 +16,8 @@
 
 package cats.effect.tracing
 
+import org.typelevel.scalaccompat.annotation._
+
 private[effect] final class RingBuffer private (logSize: Int) {
 
   private[this] val length = 1 << logSize
@@ -59,6 +61,6 @@ private[effect] final class RingBuffer private (logSize: Int) {
 }
 
 private[effect] object RingBuffer {
-  def empty(logSize: Int): RingBuffer =
+  @static3 def empty(logSize: Int): RingBuffer =
     new RingBuffer(logSize)
 }

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -22,7 +22,7 @@ import org.typelevel.scalaccompat.annotation._
 
 import scala.collection.mutable.ArrayBuffer
 
-private[effect] final class Tracing private ()
+private[effect] final class Tracing
 
 private[effect] object Tracing extends TracingPlatform {
 

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -18,29 +18,33 @@ package cats.effect.tracing
 
 import cats.effect.{IOFiber, Trace}
 
+import org.typelevel.scalaccompat.annotation._
+
 import scala.collection.mutable.ArrayBuffer
+
+private[effect] final class Tracing private ()
 
 private[effect] object Tracing extends TracingPlatform {
 
   import TracingConstants._
 
-  private[this] final val TurnRight = "╰"
+  @static3 private[this] final val TurnRight = "╰"
   // private[this] final val InverseTurnRight = "╭"
-  private[this] final val Junction = "├"
+  @static3 private[this] final val Junction = "├"
   // private[this] final val Line = "│"
 
-  private[tracing] def buildEvent(): TracingEvent = {
+  @static3 private[tracing] def buildEvent(): TracingEvent = {
     new TracingEvent.StackTrace()
   }
 
-  private[this] final val runLoopFilter: Array[String] =
+  @static3 private[this] final val runLoopFilter: Array[String] =
     Array(
       "cats.effect.",
       "scala.runtime.",
       "scala.scalajs.runtime.",
       "scala.scalanative.runtime.")
 
-  private[tracing] final val stackTraceClassNameFilter: Array[String] = Array(
+  @static3 private[tracing] final val stackTraceClassNameFilter: Array[String] = Array(
     "cats.",
     "sbt.",
     "java.",
@@ -50,7 +54,7 @@ private[effect] object Tracing extends TracingPlatform {
     "org.scalajs."
   )
 
-  private[tracing] def combineOpAndCallSite(
+  @static3 private[tracing] def combineOpAndCallSite(
       methodSite: StackTraceElement,
       callSite: StackTraceElement): StackTraceElement = {
     val methodSiteMethodName = methodSite.getMethodName
@@ -64,7 +68,7 @@ private[effect] object Tracing extends TracingPlatform {
     )
   }
 
-  private[tracing] def isInternalClass(className: String): Boolean = {
+  @static3 private[tracing] def isInternalClass(className: String): Boolean = {
     var i = 0
     val len = stackTraceClassNameFilter.length
     while (i < len) {
@@ -75,7 +79,7 @@ private[effect] object Tracing extends TracingPlatform {
     false
   }
 
-  private[this] def getOpAndCallSite(
+  @static3 private[this] def getOpAndCallSite(
       stackTrace: Array[StackTraceElement]): StackTraceElement = {
     val len = stackTrace.length
     var idx = 1
@@ -98,7 +102,10 @@ private[effect] object Tracing extends TracingPlatform {
     null
   }
 
-  def augmentThrowable(enhancedExceptions: Boolean, t: Throwable, events: RingBuffer): Unit = {
+  @static3 def augmentThrowable(
+      enhancedExceptions: Boolean,
+      t: Throwable,
+      events: RingBuffer): Unit = {
     def applyRunLoopFilter(ste: StackTraceElement): Boolean = {
       val name = ste.getClassName
       var i = 0
@@ -144,13 +151,13 @@ private[effect] object Tracing extends TracingPlatform {
     }
   }
 
-  def getFrames(events: RingBuffer): List[StackTraceElement] =
+  @static3 def getFrames(events: RingBuffer): List[StackTraceElement] =
     events
       .toList()
       .collect { case ev: TracingEvent.StackTrace => getOpAndCallSite(ev.getStackTrace) }
       .filter(_ ne null)
 
-  def prettyPrint(trace: Trace): String = {
+  @static3 def prettyPrint(trace: Trace): String = {
     val frames = trace.toList
 
     frames
@@ -163,7 +170,7 @@ private[effect] object Tracing extends TracingPlatform {
       .mkString(System.lineSeparator())
   }
 
-  def captureTrace(runnable: Runnable): Option[(Runnable, Trace)] = {
+  @static3 def captureTrace(runnable: Runnable): Option[(Runnable, Trace)] = {
     runnable match {
       case f: IOFiber[_] if f.isDone => None
       case f: IOFiber[_] => Some(runnable -> f.captureTrace())

--- a/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
+++ b/core/shared/src/main/scala/cats/effect/tracing/Tracing.scala
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package cats.effect.tracing
-
-import cats.effect.{IOFiber, Trace}
-
-import org.typelevel.scalaccompat.annotation._
+package cats.effect
+package tracing
 
 import scala.collection.mutable.ArrayBuffer
+
+import Platform.static
 
 private[effect] final class Tracing
 
@@ -28,23 +27,23 @@ private[effect] object Tracing extends TracingPlatform {
 
   import TracingConstants._
 
-  @static3 private[this] final val TurnRight = "╰"
+  @static private[this] final val TurnRight = "╰"
   // private[this] final val InverseTurnRight = "╭"
-  @static3 private[this] final val Junction = "├"
+  @static private[this] final val Junction = "├"
   // private[this] final val Line = "│"
 
-  @static3 private[tracing] def buildEvent(): TracingEvent = {
+  @static private[tracing] def buildEvent(): TracingEvent = {
     new TracingEvent.StackTrace()
   }
 
-  @static3 private[this] final val runLoopFilter: Array[String] =
+  @static private[this] final val runLoopFilter: Array[String] =
     Array(
       "cats.effect.",
       "scala.runtime.",
       "scala.scalajs.runtime.",
       "scala.scalanative.runtime.")
 
-  @static3 private[tracing] final val stackTraceClassNameFilter: Array[String] = Array(
+  @static private[tracing] final val stackTraceClassNameFilter: Array[String] = Array(
     "cats.",
     "sbt.",
     "java.",
@@ -54,7 +53,7 @@ private[effect] object Tracing extends TracingPlatform {
     "org.scalajs."
   )
 
-  @static3 private[tracing] def combineOpAndCallSite(
+  @static private[tracing] def combineOpAndCallSite(
       methodSite: StackTraceElement,
       callSite: StackTraceElement): StackTraceElement = {
     val methodSiteMethodName = methodSite.getMethodName
@@ -68,7 +67,7 @@ private[effect] object Tracing extends TracingPlatform {
     )
   }
 
-  @static3 private[tracing] def isInternalClass(className: String): Boolean = {
+  @static private[tracing] def isInternalClass(className: String): Boolean = {
     var i = 0
     val len = stackTraceClassNameFilter.length
     while (i < len) {
@@ -79,7 +78,7 @@ private[effect] object Tracing extends TracingPlatform {
     false
   }
 
-  @static3 private[this] def getOpAndCallSite(
+  @static private[this] def getOpAndCallSite(
       stackTrace: Array[StackTraceElement]): StackTraceElement = {
     val len = stackTrace.length
     var idx = 1
@@ -102,7 +101,7 @@ private[effect] object Tracing extends TracingPlatform {
     null
   }
 
-  @static3 def augmentThrowable(
+  @static def augmentThrowable(
       enhancedExceptions: Boolean,
       t: Throwable,
       events: RingBuffer): Unit = {
@@ -151,13 +150,13 @@ private[effect] object Tracing extends TracingPlatform {
     }
   }
 
-  @static3 def getFrames(events: RingBuffer): List[StackTraceElement] =
+  @static def getFrames(events: RingBuffer): List[StackTraceElement] =
     events
       .toList()
       .collect { case ev: TracingEvent.StackTrace => getOpAndCallSite(ev.getStackTrace) }
       .filter(_ ne null)
 
-  @static3 def prettyPrint(trace: Trace): String = {
+  @static def prettyPrint(trace: Trace): String = {
     val frames = trace.toList
 
     frames
@@ -170,7 +169,7 @@ private[effect] object Tracing extends TracingPlatform {
       .mkString(System.lineSeparator())
   }
 
-  @static3 def captureTrace(runnable: Runnable): Option[(Runnable, Trace)] = {
+  @static def captureTrace(runnable: Runnable): Option[(Runnable, Trace)] = {
     runnable match {
       case f: IOFiber[_] if f.isDone => None
       case f: IOFiber[_] => Some(runnable -> f.captureTrace())

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -21,6 +21,8 @@ import scala.concurrent.ExecutionContext
 
 import java.util.concurrent.atomic.AtomicBoolean
 
+import Platform.static
+
 @annotation.implicitNotFound("""Could not find an implicit IORuntime.
 
 Instead of calling unsafe methods directly, consider using cats.effect.IOApp, which
@@ -110,9 +112,9 @@ object IORuntime extends IORuntimeCompanionPlatform {
   private[effect] def testRuntime(ec: ExecutionContext, scheduler: Scheduler): IORuntime =
     new IORuntime(ec, ec, scheduler, Nil, new NoOpFiberMonitor(), () => (), IORuntimeConfig())
 
-  private[effect] final val allRuntimes: ThreadSafeHashtable[IORuntime] =
+  @static private[effect] final val allRuntimes: ThreadSafeHashtable[IORuntime] =
     new ThreadSafeHashtable(4)
 
-  private[effect] final val globalFatalFailureHandled: AtomicBoolean =
+  @static private[effect] final val globalFatalFailureHandled: AtomicBoolean =
     new AtomicBoolean(false)
 }


### PR DESCRIPTION
Liberally applies the Scala 3 [`@static` annotation](https://www.scala-lang.org/api/current/scala/annotation/static.html) to CE internals (via the scalac-compat shim). These `val`s and `def`s now compile to and are accessed as true Java `static`s. In theory this could give us a performance boost, at worst it shouldn't hurt.

So far I have not figured out how to apply this annotation binary-compatibly for public-facing APIs.
- https://github.com/lampepfl/dotty/issues/19394