### PR TITLE
Fix off-by-1 in `CallbackStack#pack`

### DIFF
--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -127,7 +127,7 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
       } else {
         if (child == null) {
           // bottomed out
-          removed
+          removed + 1
         } else {
           // note this can cause the bound to go negative, which is fine
           child.packInternal(bound - 1, removed + 1, parent)

--- a/tests/shared/src/test/scala/cats/effect/CallbackStackSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/CallbackStackSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020-2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+class CallbackStackSpec extends BaseSpec {
+
+  "CallbackStack" should {
+    "correctly report the number removed" in {
+      val stack = CallbackStack[Unit](null)
+      val pushed = stack.push(_ => ())
+      val handle = pushed.currentHandle()
+      pushed.clearCurrent(handle)
+      stack.pack(1) must beEqualTo(1)
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/3935.

An off-by-1 error was causing `pack()` to under-report how many `CallbackStack` nodes were removed. Thus the `clearCounter` in `IODeferred` was continually growing, causing `pack`ing to occur less and less frequently such that the stack would grow unboundedly large.