### PR TITLE
Remove unneeded `notifyParked` when worker transitions to blocking

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -798,8 +798,6 @@ private final class WorkerThread(
    *   code path can be exercised is through `IO.delay`, which already handles exceptions.
    */
   override def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
-    val rnd = random
-
     if (blocking) {
       // This `WorkerThread` is already inside an enclosing blocking region.
       // There is no need to spawn another `WorkerThread`. Instead, directly

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -800,8 +800,6 @@ private final class WorkerThread(
   override def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
     val rnd = random
 
-    pool.notifyParked(rnd)
-
     if (blocking) {
       // This `WorkerThread` is already inside an enclosing blocking region.
       // There is no need to spawn another `WorkerThread`. Instead, directly


### PR DESCRIPTION
This seems to be a remnant of an old mechanism that submitted to the external queue when a thread transitioned to blocking. In the current mechanism a new worker thread cleanly replaces the current thread, so there is no work _newly_ created (and available for stealing) or any tasks submitted to the external queue, and the call to `notifyParked` is superfluous.

Draft while I run some benchmarks as an additional smoke test ... update: seems fine 👍 