### PR TITLE
Reset auto-cede counter after `blocking`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1003,7 +1003,8 @@ private final class IOFiber[A](
                   }
 
                 val next = if (error eq null) succeeded(r, 0) else failed(error, 0)
-                runLoop(next, nextCancelation, nextAutoCede)
+                // reset auto-cede counter
+                runLoop(next, nextCancelation, runtime.autoYieldThreshold)
               } else {
                 blockingFallback(cur)
               }


### PR DESCRIPTION
One more optimization for blocking ops. Closes https://github.com/typelevel/cats-effect/issues/3848.