### PR TITLE
Implement `Fiber#join` via `asyncCheckAttempt`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -160,15 +160,21 @@ private final class IOFiber[A](
   }
 
   /* this is swapped for an `IO.pure(outcome)` when we complete */
-  private[this] var _join: IO[OutcomeIO[A]] = IO.async { cb =>
+  private[this] var _join: IO[OutcomeIO[A]] = IO.asyncCheckAttempt { cb =>
     IO {
-      val stack = registerListener(oc => cb(Right(oc)))
+      if (outcome == null) {
+        val back = callbacks.push(oc => cb(Right(oc)))
 
-      if (stack eq null)
-        Some(IO.unit) /* we were already invoked, so no `CallbackStack` needs to be managed */
-      else {
-        val handle = stack.currentHandle()
-        Some(IO(stack.clearCurrent(handle)))
+        /* double-check */
+        if (outcome != null) {
+          back.clearCurrent(back.currentHandle())
+          Right(outcome)
+        } else {
+          val handle = back.currentHandle()
+          Left(Some(IO(back.clearCurrent(handle))))
+        }
+      } else {
+        Right(outcome)
       }
     }
   }
@@ -1166,26 +1172,6 @@ private final class IOFiber[A](
    */
   private def setCallback(cb: OutcomeIO[A] => Unit): Unit = {
     callbacks.unsafeSetCallback(cb)
-  }
-
-  /* can return null, meaning that no CallbackStack needs to be later invalidated */
-  private[this] def registerListener(
-      listener: OutcomeIO[A] => Unit): CallbackStack[OutcomeIO[A]] = {
-    if (outcome == null) {
-      val back = callbacks.push(listener)
-
-      /* double-check */
-      if (outcome != null) {
-        back.clearCurrent(back.currentHandle())
-        listener(outcome) /* the implementation of async saves us from double-calls */
-        null
-      } else {
-        back
-      }
-    } else {
-      listener(outcome)
-      null
-    }
   }
 
   @tailrec


### PR DESCRIPTION
Sam and I noticed this while working on https://github.com/typelevel/cats-effect/issues/3940. Probably the old implementation was bugged due to the second race condition described in https://github.com/typelevel/cats-effect/issues/3087?