### PR TITLE
Refactor `CallbackStack` based on new "pack locking" strategy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -660,7 +660,9 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.Thunk"),
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.Thunk$"),
       // #3943, refactored internal private CallbackStack data structure
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.CallbackStack.push")
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.CallbackStack.push"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "cats.effect.CallbackStack.currentHandle")
     ) ++ {
       if (tlIsScala3.value) {
         // Scala 3 specific exclusions

--- a/build.sbt
+++ b/build.sbt
@@ -819,7 +819,9 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         ProblemFilters.exclude[IncompatibleTemplateDefProblem]("cats.effect.CallbackStack"),
         // introduced by #3642, which optimized the BatchingMacrotaskExecutor
         ProblemFilters.exclude[MissingClassProblem](
-          "cats.effect.unsafe.BatchingMacrotaskExecutor$executeBatchTaskRunnable$")
+          "cats.effect.unsafe.BatchingMacrotaskExecutor$executeBatchTaskRunnable$"),
+        // #3943, refactored internal private CallbackStack data structure
+        ProblemFilters.exclude[Problem]("cats.effect.CallbackStackOps.*")
       )
     },
     mimaBinaryIssueFilters ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -658,7 +658,9 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         "cats.effect.unsafe.WorkerThread.sleep"),
       // #3787, internal utility that was no longer needed
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.Thunk"),
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.Thunk$")
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.Thunk$"),
+      // #3943, refactored internal private CallbackStack data structure
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.CallbackStack.push")
     ) ++ {
       if (tlIsScala3.value) {
         // Scala 3 specific exclusions

--- a/core/js/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/js/src/main/scala/cats/effect/CallbackStack.scala
@@ -49,16 +49,19 @@ private final class CallbackStackOps[A](private val callbacks: js.Array[A => Uni
       .asInstanceOf[Boolean]
 
   /**
-   * Removes the current callback from the queue.
+   * Removes the callback referenced by a handle. Returns `true` if the data structure was
+   * cleaned up immediately, `false` if a subsequent call to [[pack]] is required.
    */
-  @inline def clearHandle(handle: Handle[A]): Unit =
+  @inline def clearHandle(handle: Handle[A]): Boolean = {
     // deleting an index from a js.Array makes it sparse (aka "holey"), so no memory leak
     js.special.delete(callbacks, handle)
+    true
+  }
 
   @inline def clear(): Unit =
     callbacks.length = 0 // javascript is crazy!
 
-  @inline def pack(bound: Int): Int = bound
+  @inline def pack(bound: Int): Int = 0
 }
 
 private object CallbackStack {

--- a/core/js/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/js/src/main/scala/cats/effect/CallbackStack.scala
@@ -61,7 +61,10 @@ private final class CallbackStackOps[A](private val callbacks: js.Array[A => Uni
   @inline def clear(): Unit =
     callbacks.length = 0 // javascript is crazy!
 
-  @inline def pack(bound: Int): Int = 0
+  @inline def pack(bound: Int): Int = {
+    val _ = bound
+    0
+  }
 }
 
 private object CallbackStack {

--- a/core/js/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/js/src/main/scala/cats/effect/CallbackStack.scala
@@ -61,10 +61,8 @@ private final class CallbackStackOps[A](private val callbacks: js.Array[A => Uni
   @inline def clear(): Unit =
     callbacks.length = 0 // javascript is crazy!
 
-  @inline def pack(bound: Int): Int = {
-    val _ = bound
-    0
-  }
+  @inline def pack(bound: Int): Int =
+    bound - bound // aka 0, but so bound is not unused ...
 }
 
 private object CallbackStack {

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -181,8 +181,10 @@ private object CallbackStack {
           val prev = root.get()
           if (prev.next eq this) { // prev is our new parent, we are its tail
             this.packTail(bound, removed, prev)
-          } else { // we were unable to remove ourselves, but we can still pack our tail
+          } else if (next != null) { // we were unable to remove ourselves, but we can still pack our tail
             next.packTail(bound - 1, removed, this)
+          } else {
+            removed
           }
         }
       } else {

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -84,10 +84,12 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
   }
 
   /**
-   * Removes the callback referenced by a handle.
+   * Removes the callback referenced by a handle. Returns `true` if the data structure was
+   * cleaned up immediately, `false` if a subsequent call to [[pack]] is required.
    */
-  def clearHandle(handle: CallbackStack.Handle[A]): Unit = {
+  def clearHandle(handle: CallbackStack.Handle[A]): Boolean = {
     handle.clear()
+    false
   }
 
   /**
@@ -139,6 +141,8 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
     } else {
       0
     }
+
+  override def toString(): String = s"CallbackStack($callback, ${get()})"
 
 }
 
@@ -231,5 +235,7 @@ private object CallbackStack {
         }
       }
     }
+
+    override def toString(): String = s"Node($callback, $next)"
   }
 }

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -197,7 +197,7 @@ private object CallbackStack {
           0
         } else {
           if (bound > 0)
-            next.packTail(bound - 1, 0, this)
+            next.packTail(bound - 1, removed, this)
           else
             0
         }

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -172,10 +172,10 @@ private object CallbackStack {
             removed + 1
           } else {
             // note this can cause the bound to go negative, which is fine
-            root.get().packHead(bound - 1, removed + 1, root)
+            next.packHead(bound - 1, removed + 1, root)
           }
-        } else { // get the new top of the stack and start over
-          root.get().packHead(bound, removed, root)
+        } else { // we were unable to remove ourselves, but we can still pack our tail
+          packTail(bound - 1, removed, this)
         }
       } else {
         if (next == null) {

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -59,7 +59,7 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
    * iff *any* callbacks were invoked.
    */
   def apply(a: A): Boolean = {
-    // TODO should we read allowedToPack for memory effect?
+    // see also note about data races in Node#packTail
 
     val cb = callback
     var invoked = if (cb != null) {

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -194,12 +194,12 @@ private object CallbackStack {
       } else {
         if (next == null) {
           // bottomed out
-          0
+          removed
         } else {
           if (bound > 0)
             next.packTail(bound - 1, removed, this)
           else
-            0
+            removed
         }
       }
     }

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -129,14 +129,15 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
    */
   def pack(bound: Int): Int =
     if (allowedToPack.compareAndSet(true, false)) {
-      val got = head.get()
-      val rtn =
+      try {
+        val got = head.get()
         if (got ne null)
           got.packHead(bound, 0, this)
         else
           0
-      allowedToPack.set(true)
-      rtn
+      } finally {
+        allowedToPack.set(true)
+      }
     } else {
       0
     }

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -161,6 +161,9 @@ private object CallbackStack {
       callback = null
     }
 
+    /**
+     * Packs this head node
+     */
     @tailrec
     def packHead(bound: Int, removed: Int, root: CallbackStack[A]): Int = {
       val next = this.next // local copy
@@ -174,8 +177,13 @@ private object CallbackStack {
             // note this can cause the bound to go negative, which is fine
             next.packHead(bound - 1, removed + 1, root)
           }
-        } else { // we were unable to remove ourselves, but we can still pack our tail
-          packTail(bound - 1, removed, this)
+        } else {
+          val prev = root.get()
+          if (prev.next eq this) { // prev is our new parent, we are its tail
+            this.packTail(bound, removed, prev)
+          } else { // we were unable to remove ourselves, but we can still pack our tail
+            next.packTail(bound - 1, removed, this)
+          }
         }
       } else {
         if (next == null) {
@@ -190,6 +198,9 @@ private object CallbackStack {
       }
     }
 
+    /**
+     * Packs this non-head node
+     */
     @tailrec
     private def packTail(bound: Int, removed: Int, prev: Node[A]): Int = {
       val next = this.next // local copy

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -188,7 +188,8 @@ private object CallbackStack {
           }
         } else {
           val prev = root.get()
-          if (prev.getNext() eq this) { // prev is our new parent, we are its tail
+          if ((prev != null) && (prev.getNext() eq this)) {
+            // prev is our new parent, we are its tail
             this.packTail(bound, removed, prev)
           } else if (next != null) { // we were unable to remove ourselves, but we can still pack our tail
             next.packTail(bound - 1, removed, this)

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -18,8 +18,7 @@ package cats.effect
 
 import scala.annotation.tailrec
 
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
 import CallbackStack.Handle
 import CallbackStack.Node

--- a/core/shared/src/main/scala/cats/effect/IODeferred.scala
+++ b/core/shared/src/main/scala/cats/effect/IODeferred.scala
@@ -26,11 +26,13 @@ private final class IODeferred[A] extends Deferred[IO, A] {
         val handle = callbacks.push(cb)
 
         def clear(): Unit = {
-          callbacks.clearHandle(handle)
-          val clearCount = clearCounter.incrementAndGet()
-          if ((clearCount & (clearCount - 1)) == 0) // power of 2
-            clearCounter.addAndGet(-callbacks.pack(clearCount))
-          ()
+          val removed = callbacks.clearHandle(handle)
+          if (!removed) {
+            val clearCount = clearCounter.incrementAndGet()
+            if ((clearCount & (clearCount - 1)) == 0) // power of 2
+              clearCounter.addAndGet(-callbacks.pack(clearCount))
+            ()
+          }
         }
 
         val back = cell.get()

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -160,15 +160,21 @@ private final class IOFiber[A](
   }
 
   /* this is swapped for an `IO.pure(outcome)` when we complete */
-  private[this] var _join: IO[OutcomeIO[A]] = IO.async { cb =>
+  private[this] var _join: IO[OutcomeIO[A]] = IO.asyncCheckAttempt { cb =>
     IO {
-      val stack = registerListener(oc => cb(Right(oc)))
+      if (outcome == null) {
+        val back = callbacks.push(oc => cb(Right(oc)))
 
-      if (stack eq null)
-        Some(IO.unit) /* we were already invoked, so no `CallbackStack` needs to be managed */
-      else {
-        val handle = stack.currentHandle()
-        Some(IO(stack.clearCurrent(handle)))
+        /* double-check */
+        if (outcome != null) {
+          back.clearCurrent(back.currentHandle())
+          Right(outcome)
+        } else {
+          val handle = back.currentHandle()
+          Left(Some(IO(back.clearCurrent(handle))))
+        }
+      } else {
+        Right(outcome)
       }
     }
   }
@@ -1166,26 +1172,6 @@ private final class IOFiber[A](
    */
   private def setCallback(cb: OutcomeIO[A] => Unit): Unit = {
     callbacks.unsafeSetCallback(cb)
-  }
-
-  /* can return null, meaning that no CallbackStack needs to be later invalidated */
-  private[this] def registerListener(
-      listener: OutcomeIO[A] => Unit): CallbackStack[OutcomeIO[A]] = {
-    if (outcome == null) {
-      val back = callbacks.push(listener)
-
-      /* double-check */
-      if (outcome != null) {
-        back.clearCurrent(back.currentHandle())
-        listener(outcome) /* the implementation of async saves us from double-calls */
-        null
-      } else {
-        back
-      }
-    } else {
-      listener(outcome)
-      null
-    }
   }
 
   @tailrec

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -170,7 +170,7 @@ private final class IOFiber[A](
           callbacks.clearHandle(handle)
           Right(outcome)
         } else {
-          Left(Some(IO(callbacks.clearHandle(handle))))
+          Left(Some(IO { callbacks.clearHandle(handle); () }))
         }
       } else {
         Right(outcome)

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -163,15 +163,14 @@ private final class IOFiber[A](
   private[this] var _join: IO[OutcomeIO[A]] = IO.asyncCheckAttempt { cb =>
     IO {
       if (outcome == null) {
-        val back = callbacks.push(oc => cb(Right(oc)))
+        val handle = callbacks.push(oc => cb(Right(oc)))
 
         /* double-check */
         if (outcome != null) {
-          back.clearCurrent(back.currentHandle())
+          callbacks.clearHandle(handle)
           Right(outcome)
         } else {
-          val handle = back.currentHandle()
-          Left(Some(IO(back.clearCurrent(handle))))
+          Left(Some(IO(callbacks.clearHandle(handle))))
         }
       } else {
         Right(outcome)
@@ -1061,7 +1060,7 @@ private final class IOFiber[A](
     outcome = oc
 
     try {
-      if (!callbacks(oc, false) && runtime.config.reportUnhandledFiberErrors) {
+      if (!callbacks(oc) && runtime.config.reportUnhandledFiberErrors) {
         oc match {
           case Outcome.Errored(e) => currentCtx.reportFailure(e)
           case _ => ()

--- a/tests/shared/src/test/scala/cats/effect/CallbackStackSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/CallbackStackSpec.scala
@@ -47,6 +47,15 @@ class CallbackStackSpec extends BaseSpec {
           .as(ok)
       }
     }
+
+    "pack runs concurrently with clear" in real {
+      IO {
+        val stack = CallbackStack[Unit](null)
+        val handle = stack.push(_ => ())
+        stack.clearHandle(handle)
+        stack
+      }.flatMap(stack => IO(stack.pack(1)).both(IO(stack.clear()))).replicateA_(1000).as(ok)
+    }
   }
 
 }

--- a/tests/shared/src/test/scala/cats/effect/CallbackStackSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/CallbackStackSpec.scala
@@ -45,8 +45,6 @@ class CallbackStackSpec extends BaseSpec {
           val pack = IO(stack.pack(1))
           (pack.both(clear *> pack), pack).mapN {
             case ((x, y), z) =>
-              if ((x + y + z) != 2)
-                println((x, y, z))
               (x + y + z) must beEqualTo(2)
           }
       }.replicateA_(1000)

--- a/tests/shared/src/test/scala/cats/effect/CallbackStackSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/CallbackStackSpec.scala
@@ -23,7 +23,7 @@ class CallbackStackSpec extends BaseSpec {
       val stack = CallbackStack[Unit](null)
       val handle = stack.push(_ => ())
       stack.push(_ => ())
-      stack.clearHandle(handle) must beFalse
+      stack.clearHandle(handle)
       stack.pack(1) must beEqualTo(1)
     }
 


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/3940. Very fun collaboration with @samspills but credit to @mernst-github for proposing the idea of guarding `pack` in https://github.com/typelevel/cats-effect/issues/3940#issuecomment-1883123013.

The new callback stack is made up of two data types:
1. `CallbackStack.Node`, a singly-linked list of callbacks
2. `CallbackStack` itself, which holds:
    - an `AtomicReference` to the head `Node`, and
    - an `AtomicBoolean` lock `allowedToPack`, used for guarding `pack`

Pushing to the stack is a straighforward CAS of the head.

`pack` is the only method that modifies the list.
- the `AtomicBoolean` lock guarantees that only one `pack` operation is running at a time, and is also used to publish the modifications to subsequent packs
- if a call to `pack` is unable to acquire the lock, it gives up immediately

Invoking the callbacks is not guarded by the lock. This means that the modifications by `pack` may not be visible, and in fact `pack`ing can even occur concurrently while iterating over the list. This is actually okay:
- the list is only ever modified to _remove_ `Node`s, since additions happen by CASing the pointer to the head `Node`
- thus, if while iterating over the list we follow a stale pointer to a next `Node` that was actually removed, we take a "detour" but do eventually visit all the `Node`s in the list