### PR TITLE
Prefer `Arrays.copyOf` over `new Array` + `System.arraycopy`

### DIFF
--- a/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
@@ -16,6 +16,8 @@
 
 package cats.effect
 
+import java.util.Arrays
+
 private final class ArrayStack[A <: AnyRef](
     private[this] var buffer: Array[AnyRef],
     private[this] var index: Int) {
@@ -70,9 +72,7 @@ private final class ArrayStack[A <: AnyRef](
   private[this] def checkAndGrow(): Unit =
     if (index >= buffer.length) {
       val len = buffer.length
-      val buffer2 = new Array[AnyRef](len * 2)
-      System.arraycopy(buffer, 0, buffer2, 0, len)
-      buffer = buffer2
+      buffer = Arrays.copyOf(buffer, len * 2)
     }
 }
 

--- a/core/jvm-native/src/main/scala/cats/effect/ByteStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/ByteStack.scala
@@ -16,6 +16,8 @@
 
 package cats.effect
 
+import java.util.Arrays
+
 private object ByteStack {
 
   type T = Array[Int]
@@ -45,9 +47,7 @@ private object ByteStack {
     if ((1 + ((count + 1) >> 3)) < stack.length) {
       stack
     } else {
-      val bigger = new Array[Int](stack.length << 1)
-      System.arraycopy(stack, 0, bigger, 0, stack.length) // Count in stack(0) copied "for free"
-      bigger
+      Arrays.copyOf(stack, 2 * stack.length) // Count in stack(0) copied "for free"
     }
   }
 


### PR DESCRIPTION
`Arrays.copyOf` is an intrinsic.