### PR TITLE
Add explanatory comment to Mutex implementation

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Mutex.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Mutex.scala
@@ -87,6 +87,12 @@ object Mutex {
   )(
       implicit F: Concurrent[F]
   ) extends Mutex[F] {
+
+    // This is a variant of the Craig, Landin, and Hagersten
+    // (CLH) queue lock. Queue nodes (called cells below)
+    // are `Deferred`s, so fibers can suspend and wake up
+    // (instead of spinning, like in the original algorithm).
+
     // Awakes whoever is waiting for us with the next cell in the queue.
     private def awakeCell(
         ourCell: ConcurrentImpl.WaitingCell[F],


### PR DESCRIPTION
Apparently, this thing has a name: `Craig, Landin, and Hagersten lock`.

Further reading (unfortunately I can't link a PDF):
Magnussen, P., A. Landin, and E. Hagersten. Queue locks on cache coherent multiprocessors. 8th Intl. Parallel Processing Symposium, Cancun, Mexico, Apr. 1994.