### PR TITLE
Fix a few Supervisor bugs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -895,7 +895,8 @@ lazy val tests: CrossProject = crossProject(JSPlatform, JVMPlatform, NativePlatf
   )
   .jvmSettings(
     Test / fork := true,
-    Test / javaOptions += s"-Dsbt.classpath=${(Test / fullClasspath).value.map(_.data.getAbsolutePath).mkString(File.pathSeparator)}"
+    Test / javaOptions += s"-Dsbt.classpath=${(Test / fullClasspath).value.map(_.data.getAbsolutePath).mkString(File.pathSeparator)}",
+    // Test / javaOptions += "-XX:ActiveProcessorCount=2",
   )
 
 lazy val testsJS = tests.js

--- a/build.sbt
+++ b/build.sbt
@@ -982,7 +982,9 @@ lazy val std = crossProject(JSPlatform, JVMPlatform, NativePlatform)
           "cats.effect.std.Queue$UnsafeUnbounded$Cell"),
         // introduced by #3480
         // adds method to sealed Hotswap
-        ProblemFilters.exclude[ReversedMissingMethodProblem]("cats.effect.std.Hotswap.get")
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("cats.effect.std.Hotswap.get"),
+        // #3972, private trait
+        ProblemFilters.exclude[IncompatibleTemplateDefProblem]("cats.effect.std.Supervisor$State"),
       )
   )
   .jsSettings(

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -329,8 +329,12 @@ object Supervisor {
             case map => (map.updated(token, fiber), true)
           }
 
-        private[this] val allFibers: F[List[Fiber[F, Throwable, _]]] =
+        private[this] val allFibers: F[List[Fiber[F, Throwable, _]]] = {
+          // we're closing, so we won't need the state any more,
+          // so we're using `null` as a sentinel to reject later
+          // insertions in `add`:
           stateRef.getAndSet(null).map(_.values.toList)
+        }
 
         val joinAll: F[Unit] = allFibers.flatMap(_.traverse_(_.join.void))
 

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -232,6 +232,9 @@ object Supervisor {
             cleanup = state.remove(token)
             fiber <- monitor(fa, done.set(true) >> cleanup)
             _ <- state.add(token, fiber)
+            // `cleanup` could run *before* the previous line
+            // (if `fa` is very fast), in which case it doesn't
+            // remove the fiber from the state, so we re-check:
             _ <- done.get.ifM(cleanup, F.unit)
           } yield fiber
         }

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -320,7 +320,7 @@ object Supervisor {
 
         def remove(token: Unique.Token): F[Unit] = stateRef.update {
           case null => null
-          case map => map.removed(token)
+          case map => map - token
         }
 
         def add(token: Unique.Token, fiber: Fiber[F, Throwable, _]): F[Boolean] =

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -255,8 +255,8 @@ object Supervisor {
                                           cleanup
                                         } else {
                                           // this should never happen
-                                          cleanup *> F.raiseError(
-                                            new AssertionError("unexpected fiber"))
+                                          cleanup *> F.raiseError(new AssertionError(
+                                            "unexpected fiber (this is a bug in Supervisor)"))
                                         }
                                     }
                                   case _ =>
@@ -290,7 +290,13 @@ object Supervisor {
               // shutting down, inserting into state will
               // fail; so we need to wait for the positive result
               // of inserting, before actually doing the task:
-              insertResult.get.ifM(fa, F.canceled *> F.never[A]),
+              insertResult
+                .get
+                .ifM(
+                  fa,
+                  F.canceled *> F.raiseError[A](new AssertionError(
+                    "supervised fiber couldn't cancel (this is a bug in Supervisor)"))
+                ),
               done.set(true) *> cleanup
             )
             insertOk <- state.add(token, fiber)

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -285,8 +285,8 @@ object Supervisor {
             fiber <- monitor(
               // if the supervisor have been (or is now)
               // shutting down, inserting into state will
-              // fail; so we need to wait for the result
-              // of inserting before actually doing the task:
+              // fail; so we need to wait for the positive result
+              // of inserting, before actually doing the task:
               insertResult.get.ifM(fa, F.canceled *> F.never[A]),
               done.set(true) *> cleanup
             )

--- a/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
@@ -17,9 +17,9 @@
 package cats.effect
 package std
 
-import org.specs2.specification.core.Fragments
-
 import cats.syntax.all._
+
+import org.specs2.specification.core.Fragments
 
 import scala.concurrent.duration._
 

--- a/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
@@ -27,7 +27,7 @@ class SupervisorSpec extends BaseSpec with DetectPlatform {
 
   sequential
 
-  override def executionTimeout = 30.seconds
+  override def executionTimeout = 60.seconds
 
   "Supervisor" should {
     "concurrent" >> {

--- a/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
@@ -236,29 +236,6 @@ class SupervisorSpec extends BaseSpec with DetectPlatform {
       test.start.flatMap(_.join).as(ok).timeoutTo(2.seconds, IO(false must beTrue))
     }
 
-    "self-cancel loop" in real {
-      IO.ref(0L).flatMap { counter =>
-        constructor(true, Some(_ => true))
-          .use { supervisor =>
-            val task = counter.update(_ + 1L) *> IO.canceled
-            supervisor.supervise(task) *> IO.sleep(100.millis)
-          }
-          .flatMap { _ => counter.get.flatMap { count => IO(count must beGreaterThan(1L)) } }
-      }
-    }
-
-    "lots of simple tasks" in real {
-      val N = if (isJVM) 10000 else 5
-      IO.ref(0L).flatMap { counter =>
-        constructor(true, Some(_ => false))
-          .use { supervisor =>
-            val task = counter.update(_ + 1L)
-            supervisor.supervise(task).parReplicateA(N).void
-          }
-          .flatMap { _ => counter.get.flatMap { count => IO(count mustEqual N) } }
-      }
-    }
-
     "supervise / finalize race" in real {
       superviseFinalizeRace(constructor(false, None), IO.never[Unit])
     }


### PR DESCRIPTION
This PR fixes a few bugs in `Supervisor` (and creates an unknown number of new ones ;-).

Fixed bugs (at least the ones I remember spotting; I tried to write tests for them, couldn't for all of them):

- #3394
- With `checkRestart`, `cancel` allowed and didn't wait for one last restart.
- `supervise`/close race (although, due to #3394, close wasn't effective anyway).
- With `checkRestart`, if `cancel` cancelled the working fiber before it did anything, the finalizer (which removes the fiber from the map) did not run. (This was effectively a memory leak.)