### PR TITLE
Clear the CallbackStack more aggressively

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -662,7 +662,9 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       // #3943, refactored internal private CallbackStack data structure
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("cats.effect.CallbackStack.push"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
-        "cats.effect.CallbackStack.currentHandle")
+        "cats.effect.CallbackStack.currentHandle"),
+      // #3973, remove clear from internal private CallbackStack
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.CallbackStack.clear")
     ) ++ {
       if (tlIsScala3.value) {
         // Scala 3 specific exclusions

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -77,7 +77,9 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
         currentNode.clear()
         invoked = true
       }
-      currentNode = currentNode.getNext()
+      val nextNode = currentNode.getNext()
+      currentNode.setNext(null)
+      currentNode = nextNode
     }
 
     invoked
@@ -99,8 +101,10 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
     callback = null
     var currentNode = head.get()
     while (currentNode ne null) {
+      val nextNode = currentNode.getNext()
       currentNode.clear()
-      currentNode = currentNode.getNext()
+      currentNode.setNext(null)
+      currentNode = nextNode
     }
     head.lazySet(null)
   }

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -74,6 +74,7 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
       val cb = currentNode.getCallback()
       if (cb != null) {
         cb(a)
+        currentNode.clear()
         invoked = true
       }
       currentNode = currentNode.getNext()

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -97,6 +97,11 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
    */
   def clear(): Unit = {
     callback = null
+    var currentNode = head.get()
+    while (currentNode ne null) {
+      currentNode.clear()
+      currentNode = currentNode.getNext()
+    }
     head.lazySet(null)
   }
 

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -60,29 +60,42 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
    */
   def apply(a: A): Boolean = {
     // see also note about data races in Node#packTail
-
-    val cb = callback
-    var invoked = if (cb != null) {
-      cb(a)
-      true
-    } else {
-      false
-    }
     var currentNode = head.get()
-
-    while (currentNode ne null) {
-      val cb = currentNode.getCallback()
-      if (cb != null) {
+    try {
+      val cb = callback
+      var invoked = if (cb != null) {
         cb(a)
-        currentNode.clear()
-        invoked = true
+        true
+      } else {
+        false
       }
-      val nextNode = currentNode.getNext()
-      currentNode.setNext(null)
-      currentNode = nextNode
-    }
 
-    invoked
+      // note that we're tearing down the callback stack structure behind us as we go
+      while (currentNode ne null) {
+        val cb = currentNode.getCallback()
+        if (cb != null) {
+          cb(a)
+          currentNode.clear()
+          invoked = true
+        }
+        val nextNode = currentNode.getNext()
+        currentNode.setNext(null)
+        currentNode = nextNode
+      }
+      head.lazySet(null)
+
+      invoked
+    } finally {
+      // if a callback throws, we stop invoking remaining callbacks
+      // but we continue the process of tearing down the stack to prevent memory leaks
+      while (currentNode ne null) {
+        val nextNode = currentNode.getNext()
+        currentNode.clear()
+        currentNode.setNext(null)
+        currentNode = nextNode
+      }
+      head.lazySet(null)
+    }
   }
 
   /**
@@ -92,21 +105,6 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
   def clearHandle(handle: CallbackStack.Handle[A]): Boolean = {
     handle.clear()
     false
-  }
-
-  /**
-   * Nulls all references in this callback stack.
-   */
-  def clear(): Unit = {
-    callback = null
-    var currentNode = head.get()
-    while (currentNode ne null) {
-      val nextNode = currentNode.getNext()
-      currentNode.clear()
-      currentNode.setNext(null)
-      currentNode = nextNode
-    }
-    head.lazySet(null)
   }
 
   /**

--- a/core/shared/src/main/scala/cats/effect/IODeferred.scala
+++ b/core/shared/src/main/scala/cats/effect/IODeferred.scala
@@ -61,7 +61,6 @@ private final class IODeferred[A] extends Deferred[IO, A] {
   def complete(a: A): IO[Boolean] = IO {
     if (cell.compareAndSet(initial, IO.pure(a))) {
       val _ = callbacks(Right(a))
-      callbacks.clear() // avoid leaks
       true
     } else {
       false

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1059,15 +1059,11 @@ private final class IOFiber[A](
 
     outcome = oc
 
-    try {
-      if (!callbacks(oc) && runtime.config.reportUnhandledFiberErrors) {
-        oc match {
-          case Outcome.Errored(e) => currentCtx.reportFailure(e)
-          case _ => ()
-        }
+    if (!callbacks(oc) && runtime.config.reportUnhandledFiberErrors) {
+      oc match {
+        case Outcome.Errored(e) => currentCtx.reportFailure(e)
+        case _ => ()
       }
-    } finally {
-      callbacks.clear() /* avoid leaks */
     }
 
     /*

--- a/tests/shared/src/test/scala/cats/effect/CallbackStackSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/CallbackStackSpec.scala
@@ -52,14 +52,6 @@ class CallbackStackSpec extends BaseSpec with DetectPlatform {
       }
     }
 
-    "pack runs concurrently with clear" in real {
-      IO {
-        val stack = CallbackStack[Unit](null)
-        val handle = stack.push(_ => ())
-        stack.clearHandle(handle)
-        stack
-      }.flatMap(stack => IO(stack.pack(1)).both(IO(stack.clear()))).parReplicateA_(1000).as(ok)
-    }
   }
 
 }


### PR DESCRIPTION
I'm still seeing a CallbackStack leak at $work with the most recent 3.5.3 release 😓 I chatted it over with Arman, and we think it's the situation he outlined here: https://github.com/typelevel/cats-effect/pull/3943#discussion_r1448077903

This PR updates `apply` to clean up the stack as it goes, ~and the `clear` method to null everything out much more aggressively~ Actually, I've removed the `clear` method on the stack, and added a `try` / `finally` to the apply so that `apply` will finish tearing down if a callback throws an exception. This is necessary because by tearing down as `apply` goes, `clear` would have no way to access the node that `apply` got to, as the links between `head` and that node would have been broken. 