### PR TITLE
Use `dep` instead of `lib` in FAQ docs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,7 +9,7 @@ title: FAQ
 
 ```scala-cli
 //> using scala "2.13.8"
-//> using lib "org.typelevel::cats-effect::3.5.3"
+//> using dep "org.typelevel::cats-effect::3.5.3"
 
 import cats.effect._
 


### PR DESCRIPTION
The directive "lib" has been deprecated in favour of the directive "dep". Using  the lib directive "lib" results in a deprecation warning. See https://scala-cli.virtuslab.org/docs/release_notes#rename-using-lib-to-using-dep for more information.