### PR TITLE
Fix issue #4002

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1206,7 +1206,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
           lift(k(resume)) flatMap {
             case Right(a) => G.pure(a)
             case Left(Some(fin)) => G.onCancel(poll(get), lift(fin))
-            case Left(None) => poll(get)
+            case Left(None) => get
           }
         }
       }

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -608,6 +608,17 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         outerR mustEqual 1
         innerR mustEqual 2
       }
+
+      "be uncancelable if None finalizer" in ticked { implicit ticker =>
+        val t = IO.asyncCheckAttempt[Int] { _ => IO.pure(Left(None)) }
+        val test = for {
+          fib <- t.start
+          _ <- IO(ticker.ctx.tick())
+          _ <- fib.cancel
+        } yield ()
+
+        test must nonTerminate
+      }
     }
 
     "async" should {


### PR DESCRIPTION
This PR makes `IO#asyncCheckAttempt` work the same as `Async#asyncCheckAttempt`. So both will be uncancelable when suspended with a `None` finalizer. Closes #4002.