### PR TITLE
Removes language:postfixOps from tutorial as it is not used. (3.x)

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -44,7 +44,7 @@ name := "cats-effect-tutorial"
 
 version := "3.5.3"
 
-scalaVersion := "2.13.11"
+scalaVersion := "2.13.13"
 
 libraryDependencies += "org.typelevel" %% "cats-effect" % "3.5.3" withSources() withJavadoc()
 
@@ -52,15 +52,14 @@ scalacOptions ++= Seq(
   "-feature",
   "-deprecation",
   "-unchecked",
-  "-language:postfixOps"
 )
 ```
 
-Also make sure that you use a recent version of `sbt`, _e.g._ `1.9.7`. You can set
+Also make sure that you use a recent version of `sbt`, _e.g._ `1.9.8`. You can set
 the `sbt` version in `project/build.properties` file:
 
 ```scala
-sbt.version=1.9.7
+sbt.version=1.9.8
 ```
 
 Almost all code snippets in this tutorial can be pasted and compiled right in


### PR DESCRIPTION
I basically pasted the tutorial into a new sbt project and it compiles
fine without.