### PR TITLE
Create 8-core Cirrus CI job

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,13 +3,11 @@ jvm_highcore_task:
   required_pr_labels: Cirrus JVM
   container:
     image: sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.5_8_1.9.0_3.3.0
-    cpu: 4
-    memory: 8G
+    cpu: 8
+    memory: 16G
   matrix:
     - name: JVM high-core-count 2.13
       script: sbt '++ 2.13' testsJVM/test
-    - name: JVM high-core-count 3
-      script: sbt '++ 3' testsJVM/test
 
 jvm_arm_highcore_task:
   only_if: $CIRRUS_TAG != '' || $CIRRUS_PR != ''


### PR DESCRIPTION
GHA Ubuntu CI runners now use 4 cores.

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

So to increase our coverage for high-core environments, we can merge two 4-core jobs from Cirrus into a single 8-core job.