### PR TITLE
Expand the example of using Random[F] in the doc

### DIFF
--- a/docs/std/random.md
+++ b/docs/std/random.md
@@ -48,13 +48,29 @@ Random.scalaUtilRandom[IO]
 
 ## Using `Random`
 ```scala mdoc
-import cats.Functor
-import cats.syntax.functor._
+import cats.effect.std.{Console, Random, SecureRandom}
+import cats.effect.{IO, IOApp}
+import cats.{Functor, FlatMap}
+import cats.syntax.all.toFlatMapOps
+import cats.syntax.all.toFunctorOps
 
-def dieRoll[F[_]: Functor: Random]: F[Int] =
-  Random[F].betweenInt(0, 6).map(_ + 1) // `6` is excluded from the range
+def dieRoll[F[_] : Functor : Random]: F[Int] =
+  Random[F].betweenInt(0, 6).map(_ + 1)
+
+def showMagicNumber[F[_] : Console : FlatMap](id: String, rnd: F[Random[F]]): F[Unit] =
+  for {
+    given Random[F] <- rnd
+    i               <- dieRoll[F]
+    _               <- Console[F].println(s"$id: $i")
+  } yield a
+ 
+val app = showMagicNumber("rnd", Random.scalaUtilRandom[IO]) *> showMagicNumber("sec-rnd", SecureRandom.javaSecuritySecureRandom)
+
+// required for unsafeRunSync()
+import cats.effect.unsafe.implicits.global    
+
+app.unsafeRunSync()
 ```
-
 ## Derivation
 
 An instance of `cats.effect.std.Random` can be created by any data type

--- a/docs/std/random.md
+++ b/docs/std/random.md
@@ -62,7 +62,7 @@ def showMagicNumber[F[_] : Console : FlatMap](id: String, rnd: F[Random[F]]): F[
     given Random[F] <- rnd
     i               <- dieRoll[F]
     _               <- Console[F].println(s"$id: $i")
-  } yield a
+  } yield ()
  
 val app = showMagicNumber("rnd", Random.scalaUtilRandom[IO]) *> showMagicNumber("sec-rnd", SecureRandom.javaSecuritySecureRandom)
 

--- a/docs/std/random.md
+++ b/docs/std/random.md
@@ -56,22 +56,32 @@ import cats.syntax.all.toFunctorOps
 def dieRoll[F[_] : Functor : Random]: F[Int] =
   Random[F].betweenInt(0, 6).map(_ + 1)
 
+// Scala 2.x & 3.x
 def showMagicNumber[F[_] : Console : FlatMap](id: String, rnd: F[Random[F]]): F[Unit] =
-  // Scala 2.x & 3.x
   rnd.flatMap(implicit rnd => dieRoll[F].flatMap(i => Console[F].println(s"$id: $i")))
 
+// Scala 2.x with better-monadic-for compiler plugin
+def showMagicNumber_bmf[F[_] : Console : FlatMap](id: String, rnd: F[Random[F]]): F[Unit] =
+  for {
+    implicit0(it: Random[F]) <- rnd
+    i <- dieRoll[F]
+    _ <- Console[F].println(s"$id: $i")
+  } yield ()
+
 /* Scala 3.x only
+def showMagicNumber3[F[_] : Console : FlatMap](id: String, rnd: F[Random[F]]): F[Unit] = 
   for {
     given Random[F] <- rnd
     i               <- dieRoll[F]
     _               <- Console[F].println(s"$id: $i")
   } yield ()
  */
- 
+
 val app = showMagicNumber("rnd", Random.scalaUtilRandom[IO])
 
 // required for unsafeRunSync()
-import cats.effect.unsafe.implicits.global    
+
+import cats.effect.unsafe.implicits.global
 
 app.unsafeRunSync()
 ```

--- a/docs/std/random.md
+++ b/docs/std/random.md
@@ -48,7 +48,7 @@ Random.scalaUtilRandom[IO]
 
 ## Using `Random`
 ```scala mdoc
-import cats.effect.std.{Console, Random}
+import cats.effect.std.{Console, Random, SecureRandom}
 import cats.{Functor, FlatMap}
 import cats.syntax.all.toFlatMapOps
 import cats.syntax.all.toFunctorOps
@@ -78,7 +78,8 @@ def showMagicNumber3[F[_] : Console : FlatMap](id: String, rnd: F[Random[F]]): F
   } yield ()
  */
 
-val app = showMagicNumber("rnd", Random.scalaUtilRandom[IO])
+val app = showMagicNumber("rnd", Random.scalaUtilRandom[IO]) *>
+  showMagicNumber[IO]("sec-rnd", SecureRandom.javaSecuritySecureRandom[IO])
 
 // required for unsafeRunSync()
 

--- a/docs/std/random.md
+++ b/docs/std/random.md
@@ -60,13 +60,14 @@ def dieRoll[F[_] : Functor : Random]: F[Int] =
 def showMagicNumber[F[_] : Console : FlatMap](id: String, rnd: F[Random[F]]): F[Unit] =
   rnd.flatMap(implicit rnd => dieRoll[F].flatMap(i => Console[F].println(s"$id: $i")))
 
-// Scala 2.x with better-monadic-for compiler plugin
+/* Scala 2.x with better-monadic-for compiler plugin
 def showMagicNumber_bmf[F[_] : Console : FlatMap](id: String, rnd: F[Random[F]]): F[Unit] =
   for {
     implicit0(it: Random[F]) <- rnd
     i <- dieRoll[F]
     _ <- Console[F].println(s"$id: $i")
   } yield ()
+ */
 
 /* Scala 3.x only
 def showMagicNumber3[F[_] : Console : FlatMap](id: String, rnd: F[Random[F]]): F[Unit] = 

--- a/docs/std/random.md
+++ b/docs/std/random.md
@@ -48,8 +48,7 @@ Random.scalaUtilRandom[IO]
 
 ## Using `Random`
 ```scala mdoc
-import cats.effect.std.{Console, Random, SecureRandom}
-import cats.effect.{IO, IOApp}
+import cats.effect.std.{Console, Random}
 import cats.{Functor, FlatMap}
 import cats.syntax.all.toFlatMapOps
 import cats.syntax.all.toFunctorOps
@@ -58,13 +57,18 @@ def dieRoll[F[_] : Functor : Random]: F[Int] =
   Random[F].betweenInt(0, 6).map(_ + 1)
 
 def showMagicNumber[F[_] : Console : FlatMap](id: String, rnd: F[Random[F]]): F[Unit] =
+  // Scala 2.x & 3.x
+  rnd.flatMap(implicit rnd => dieRoll[F].flatMap(i => Console[F].println(s"$id: $i")))
+
+/* Scala 3.x only
   for {
     given Random[F] <- rnd
     i               <- dieRoll[F]
     _               <- Console[F].println(s"$id: $i")
   } yield ()
+ */
  
-val app = showMagicNumber("rnd", Random.scalaUtilRandom[IO]) *> showMagicNumber("sec-rnd", SecureRandom.javaSecuritySecureRandom)
+val app = showMagicNumber("rnd", Random.scalaUtilRandom[IO])
 
 // required for unsafeRunSync()
 import cats.effect.unsafe.implicits.global    


### PR DESCRIPTION
I want to expand the example of using Random[F] mentioned in https://typelevel.org/cats-effect/docs/std/random#using-random for clarity and make it into a ready-to-run example