### PR TITLE
Use `IOApp#reportFailure` instead of `printStackTrace()` for blocking EC

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -388,7 +388,11 @@ trait IOApp {
           )
 
         val (blocking, blockDown) =
-          IORuntime.createDefaultBlockingExecutionContext()
+          IORuntime.createDefaultBlockingExecutionContext(
+            threadPrefix = "io-blocking",
+            reportFailure =
+              (t: Throwable) => reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime)
+          )
 
         IORuntime(
           compute,


### PR DESCRIPTION
fixes #3993 