### PR TITLE
Try to address `DispatcherSpec` timeout in CI

### DIFF
--- a/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/DispatcherSpec.scala
@@ -387,7 +387,7 @@ class DispatcherSpec extends BaseSpec with DetectPlatform {
               IO.fromFuture(IO(runner.unsafeToFuture(latch.complete(()))))
           }
         }
-        .replicateA_(if (isJVM) 1000 else 1)
+        .replicateA_(if (isJVM) 500 else 1)
         .as(ok)
     }
   }


### PR DESCRIPTION
It was here: https://github.com/typelevel/cats-effect/actions/runs/8717231327/job/23912110075?pr=4054#step:24:4873.

```
[error]     ! cancelation race does not block a worker
[error]      cats.effect.TestTimeoutException: null (Runners.scala:120)
[error] cats.effect.Runners.$anonfun$timeout$1(Runners.scala:120)
[error] cats.effect.unsafe.WorkStealingThreadPool.$anonfun$sleep$1(WorkStealingThreadPool.scala:672)
[error] cats.effect.unsafe.WorkStealingThreadPool.$anonfun$sleep$1$adapted(WorkStealingThreadPool.scala:672)
[error] cats.effect.unsafe.WorkerThread.run(WorkerThread.scala:723)
```