### PR TITLE
Add `KeyedMutex`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1123,7 +1123,13 @@ lazy val std = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         ProblemFilters.exclude[FinalMethodProblem](
           "cats.effect.std.Dispatcher#RegState#Unstarted.toString"),
         ProblemFilters.exclude[DirectMissingMethodProblem](
-          "cats.effect.std.Dispatcher#Registration#Primary.*")
+          "cats.effect.std.Dispatcher#Registration#Primary.*"),
+        // #4065, moved to its own file.
+        ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Mutex$ConcurrentImpl$"),
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "cats.effect.std.Mutex#ConcurrentImpl.EmptyCell"),
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "cats.effect.std.Mutex#ConcurrentImpl.LockQueueCell")
       )
   )
   .jsSettings(

--- a/docs/core/native-image.md
+++ b/docs/core/native-image.md
@@ -67,4 +67,4 @@ Benchmark 1: ./target/native-image/cats-effect-3-hello-world
 ```
 
 Another way to get your cats effect app compiled with native-image is to leverage
-the package command of scala-cli, like in the [example](../faq.md#Native-Image-Example)
+the package command of scala-cli, like in the [example](../faq.md#native-image-example).

--- a/docs/core/scala-native.md
+++ b/docs/core/scala-native.md
@@ -52,7 +52,7 @@ Benchmark 1: ./target/native-image/cats-effect-3-hello-world-out
 ```
 
 Another way to get your cats effect app compiled to a native executable is to leverage
-the package command of scala-cli, like in the [example](../faq.md#Scala-Native-Example)
+the package command of scala-cli, like in the [example](../faq.md#scala-native-example).
 
 ## Limitations
 

--- a/docs/std/keyed-mutex.md
+++ b/docs/std/keyed-mutex.md
@@ -1,0 +1,43 @@
+---
+id: keyed-mutex
+title: KeyedMutex
+---
+
+`KeyedMutex` is a concurrency primitive that can be used to give access to a keyed resource
+to only **one** fiber at a time.
+
+```scala mdoc:silent
+import cats.effect.Resource
+
+trait KeyedMutex[F[_], K] {
+  def lock(key: K): Resource[F, Unit]
+}
+```
+
+You can think of it as a `Key => Mutex`.
+In other words, you get a different lock per each key.
+
+**Caution**: This lock is not reentrant,
+thus doing `mutex.lock(key).surround(mutex.lock(key).use_`
+will deadlock.
+
+## Using `KeyedMutex`
+
+```scala mdoc:reset:silent
+import cats.effect.IO
+import cats.effect.std.{KeyedMutex, MapRef}
+
+trait State
+trait Key
+
+class Service(mutex: KeyedMutex[IO, Key], mapref: MapRef[IO, Key, State]) {
+  def modify(key: Key)(f: State => IO[State]): IO[Unit] =
+    mutex.lock(key).surround {
+      for {
+        current <- mapref(key).get
+        next <- f(current)
+        _ <- mapref(key).set(next)
+      } yield ()
+    }
+}
+```

--- a/docs/std/mutex.md
+++ b/docs/std/mutex.md
@@ -6,28 +6,32 @@ title: Mutex
 `Mutex` is a concurrency primitive that can be used to give access to a resource to only **one**
 fiber at a time. Basically, it's a [`Semaphore`](./semaphore.md) with a single available permit.
 
-```scala
+```scala mdoc:silent
+import cats.effect.Resource
+
 trait Mutex[F[_]] {
   def lock: Resource[F, Unit]
 }
 ```
 
-**Caution**: This lock is not reentrant, thus this `mutex.lock.surround(mutex.lock.use_)` will
-deadlock.
+**Caution**: This lock is not reentrant,
+thus doing `mutex.lock.surround(mutex.lock.use_)`
+will deadlock.
 
 ## Using `Mutex`
 
-```scala mdoc:silent
+```scala mdoc:reset:silent
 import cats.effect.{IO, Ref}
 import cats.effect.std.Mutex
 
 trait State
 class Service(mutex: Mutex[IO], ref: Ref[IO, State]) {
-  def withState(f: State => IO[Unit]): IO[Unit] = 
+  def modify(f: State => IO[State]): IO[Unit] =
     mutex.lock.surround {
       for {
         current <- ref.get
-        _ <- f(current)
+        next <- f(current)
+        _ <- ref.set(next)
       } yield ()
     }
 }

--- a/std/shared/src/main/scala/cats/effect/std/KeyedMutex.scala
+++ b/std/shared/src/main/scala/cats/effect/std/KeyedMutex.scala
@@ -54,9 +54,9 @@ object KeyedMutex {
    */
   def apply[F[_], K](implicit F: Concurrent[F]): F[KeyedMutex[F, K]] =
     Ref
-      .of[F, ConcurrentImpl.LockQueueCell](
-        // Initialize the state with an already completed cell.
-        ConcurrentImpl.EmptyCell
+      .of[F, Map[K, ConcurrentImpl.LockQueueCell]](
+        // Initialize the state with an empty Map.
+        Map.empty
       )
       .map(state => new ConcurrentImpl[F, K](state))
 
@@ -66,35 +66,43 @@ object KeyedMutex {
    */
   def in[F[_], G[_], K](implicit F: Sync[F], G: Async[G]): F[KeyedMutex[G, K]] =
     Ref
-      .in[F, G, ConcurrentImpl.LockQueueCell](
-        // Initialize the state with an already completed cell.
-        ConcurrentImpl.EmptyCell
+      .in[F, G, Map[K, ConcurrentImpl.LockQueueCell]](
+        // Initialize the state with an empty Map.
+        Map.empty
       )
       .map(state => new ConcurrentImpl[G, K](state))
 
   private final class ConcurrentImpl[F[_], K](
-      state: Ref[F, ConcurrentImpl.LockQueueCell]
+      state: Ref[F, Map[K, ConcurrentImpl.LockQueueCell]]
   )(
       implicit F: Concurrent[F]
   ) extends KeyedMutex[F, K] {
 
     // This is a variant of the Craig, Landin, and Hagersten
-    // (CLH) queue lock. Queue nodes (called cells below)
-    // are `Deferred`s, so fibers can suspend and wake up
+    // (CLH) queue lock for each key.
+    // Queue nodes (called cells below) are `Deferred`s,
+    // so fibers can suspend and wake up
     // (instead of spinning, like in the original algorithm).
 
     // Awakes whoever is waiting for us with the next cell in the queue.
     private def awakeCell(
+        key: K,
         ourCell: ConcurrentImpl.WaitingCell[F],
         nextCell: ConcurrentImpl.LockQueueCell
     ): F[Unit] =
       state.access.flatMap {
-        // If the current last cell in the queue is our cell,
+        // If the current last cell in the queue for the given key is our cell,
         // then that means nobody is waiting for us.
         // Thus, we can just set the state to the next cell in the queue.
+        // Also, if the next cell is the empty one, we can just remove the key from the map.
         // Otherwise, we awake whoever is waiting for us.
-        case (lastCell, setter) =>
-          if (lastCell eq ourCell) setter(nextCell)
+        case (map, setter) =>
+          val lastCell = map(key) // Safe.
+          if (lastCell eq ourCell)
+            if (nextCell eq ConcurrentImpl.EmptyCell)
+              setter(map.removed(key))
+            else
+              setter(map.updated(key, value = nextCell))
           else F.pure(false)
       } flatMap {
         case false => ourCell.complete(nextCell).void
@@ -103,47 +111,55 @@ object KeyedMutex {
 
     // Cancels a Fiber waiting for the Mutex.
     private def cancel(
+        key: K,
         ourCell: ConcurrentImpl.WaitingCell[F],
         nextCell: ConcurrentImpl.LockQueueCell
     ): F[Unit] =
-      awakeCell(ourCell, nextCell)
+      awakeCell(key, ourCell, nextCell)
 
     // Acquires the Mutex.
-    private def acquire(poll: Poll[F]): F[ConcurrentImpl.WaitingCell[F]] =
+    private def acquire(key: K)(poll: Poll[F]): F[ConcurrentImpl.WaitingCell[F]] =
       ConcurrentImpl.LockQueueCell[F].flatMap { ourCell =>
-        // Atomically get the last cell in the queue,
+        // Atomically get the last cell in the queue for the given key,
         // and put ourselves as the last one.
-        state.getAndSet(ourCell).flatMap { lastCell =>
-          // Then we check what the next cell is.
-          // There are two options:
-          //  + EmptyCell: Signaling that the mutex is free.
-          //  + WaitingCell: Which means there is someone ahead of us in the queue.
-          //    Thus, we wait for that cell to complete; and then check again.
-          //
-          // Only the waiting process is cancelable.
-          // If we are cancelled while waiting,
-          // we notify our waiter with the cell ahead of us.
-          def loop(
-              nextCell: ConcurrentImpl.LockQueueCell
-          ): F[ConcurrentImpl.WaitingCell[F]] =
-            if (nextCell eq ConcurrentImpl.EmptyCell) F.pure(ourCell)
-            else {
-              F.onCancel(
-                poll(nextCell.asInstanceOf[ConcurrentImpl.WaitingCell[F]].get),
-                cancel(ourCell, nextCell)
-              ).flatMap(loop)
-            }
+        state
+          .modify { map =>
+            val newMap = map.updated(key, value = ourCell)
+            val lastCell = map.getOrElse(key, default = ConcurrentImpl.EmptyCell)
 
-          loop(nextCell = lastCell)
-        }
+            newMap -> lastCell
+          }
+          .flatMap { lastCell =>
+            // Then we check what the next cell is.
+            // There are two options:
+            //  + EmptyCell: Signaling that the mutex is free.
+            //  + WaitingCell: Which means there is someone ahead of us in the queue.
+            //    Thus, we wait for that cell to complete; and then check again.
+            //
+            // Only the waiting process is cancelable.
+            // If we are cancelled while waiting,
+            // we notify our waiter with the cell ahead of us.
+            def loop(
+                nextCell: ConcurrentImpl.LockQueueCell
+            ): F[ConcurrentImpl.WaitingCell[F]] =
+              if (nextCell eq ConcurrentImpl.EmptyCell) F.pure(ourCell)
+              else {
+                F.onCancel(
+                  poll(nextCell.asInstanceOf[ConcurrentImpl.WaitingCell[F]].get),
+                  cancel(key, ourCell, nextCell)
+                ).flatMap(loop)
+              }
+
+            loop(nextCell = lastCell)
+          }
       }
 
     // Releases the Mutex.
-    private def release(ourCell: ConcurrentImpl.WaitingCell[F]): F[Unit] =
-      awakeCell(ourCell, nextCell = ConcurrentImpl.EmptyCell)
+    private def release(key: K)(ourCell: ConcurrentImpl.WaitingCell[F]): F[Unit] =
+      awakeCell(key, ourCell, nextCell = ConcurrentImpl.EmptyCell)
 
     override def lock(key: K): Resource[F, Unit] =
-      Resource.makeFull[F, ConcurrentImpl.WaitingCell[F]](acquire)(release).void
+      Resource.makeFull[F, ConcurrentImpl.WaitingCell[F]](acquire(key))(release(key)).void
 
     override def mapK[G[_]](f: F ~> G)(implicit G: MonadCancel[G, _]): KeyedMutex[G, K] =
       new KeyedMutex.TransformedKeyedMutex(this, f)

--- a/std/shared/src/main/scala/cats/effect/std/KeyedMutex.scala
+++ b/std/shared/src/main/scala/cats/effect/std/KeyedMutex.scala
@@ -24,8 +24,8 @@ import cats.syntax.all._
 /**
  * A purely functional keyed mutex.
  *
- * A mutex is a concurrency primitive that can be used to give access to a resource to only one
- * fiber at a time; e.g. a [[cats.effect.kernel.Ref]].
+ * A keyed mutex is a concurrency primitive that can be used to give access to a keyed resource
+ * to only one fiber at a time; e.g. a [[cats.effect.std.MapRef]].
  *
  * '''Note''': This lock is not reentrant, thus this
  * `mutex.lock(key).surround(mutex.lock(key).use_)` will deadlock.

--- a/std/shared/src/main/scala/cats/effect/std/KeyedMutex.scala
+++ b/std/shared/src/main/scala/cats/effect/std/KeyedMutex.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020-2025 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package std
+
+import cats.effect.kernel._
+import cats.syntax.all._
+
+/**
+ * A purely functional keyed mutex.
+ *
+ * A mutex is a concurrency primitive that can be used to give access to a resource to only one
+ * fiber at a time; e.g. a [[cats.effect.kernel.Ref]].
+ *
+ * '''Note''': This lock is not reentrant, thus this
+ * `mutex.lock(key).surround(mutex.lock(key).use_)` will deadlock.
+ *
+ * @see
+ *   [[cats.effect.std.Mutex]]
+ */
+abstract class KeyedMutex[F[_], K] {
+
+  /**
+   * Returns a [[cats.effect.kernel.Resource]] that acquires the lock for the given `key`, holds
+   * it for the lifetime of the resource, then releases it.
+   */
+  def lock(key: K): Resource[F, Unit]
+
+  /**
+   * Modify the context `F` using natural transformation `f`.
+   */
+  def mapK[G[_]](f: F ~> G)(implicit G: MonadCancel[G, _]): KeyedMutex[G, K]
+}
+
+object KeyedMutex {
+
+  /**
+   * Creates a new `KeyedMutex`.
+   */
+  def apply[F[_], K](implicit F: Concurrent[F]): F[KeyedMutex[F, K]] =
+    ???
+
+  /**
+   * Creates a new `KeyedMutex`. Like `apply` but initializes state using another effect
+   * constructor.
+   */
+  def in[F[_], G[_], K](implicit F: Sync[F], G: Async[G]): F[KeyedMutex[G, K]] =
+    ???
+}

--- a/std/shared/src/main/scala/cats/effect/std/KeyedMutex.scala
+++ b/std/shared/src/main/scala/cats/effect/std/KeyedMutex.scala
@@ -55,7 +55,7 @@ object KeyedMutex {
    */
   def apply[F[_], K](implicit F: Concurrent[F]): F[KeyedMutex[F, K]] =
     MapRef[F, K, LockQueue.Cell].map { mapref =>
-      new ConcurrentImpl[F, K](
+      new ConcurrentImpl(
         // Initialize the state with an already completed cell.
         state = MapRef.defaultedMapRef(mapref, default = LockQueue.EmptyCell)
       )
@@ -67,7 +67,7 @@ object KeyedMutex {
    */
   def in[F[_], G[_], K](implicit F: Sync[F], G: Async[G]): F[KeyedMutex[G, K]] =
     MapRef.inConcurrentHashMap[F, G, K, LockQueue.Cell]().map { mapref =>
-      new ConcurrentImpl[G, K](
+      new ConcurrentImpl(
         // Initialize the state with an already completed cell.
         state = MapRef.defaultedMapRef(mapref, default = LockQueue.EmptyCell)
       )

--- a/std/shared/src/main/scala/cats/effect/std/KeyedMutex.scala
+++ b/std/shared/src/main/scala/cats/effect/std/KeyedMutex.scala
@@ -44,149 +44,58 @@ abstract class KeyedMutex[F[_], K] {
   /**
    * Modify the context `F` using natural transformation `f`.
    */
-  def mapK[G[_]](f: F ~> G)(implicit G: MonadCancel[G, _]): KeyedMutex[G, K]
+  def mapK[G[_]](f: F ~> G)(implicit G: MonadCancel[G, ?]): KeyedMutex[G, K]
 }
 
 object KeyedMutex {
+  private implicit val cellEq: Eq[LockQueue.Cell] = Eq.fromUniversalEquals
 
   /**
    * Creates a new `KeyedMutex`.
    */
   def apply[F[_], K](implicit F: Concurrent[F]): F[KeyedMutex[F, K]] =
-    Ref
-      .of[F, Map[K, ConcurrentImpl.LockQueueCell]](
-        // Initialize the state with an empty Map.
-        Map.empty
+    MapRef[F, K, LockQueue.Cell].map { mapref =>
+      new ConcurrentImpl[F, K](
+        // Initialize the state with an already completed cell.
+        state = MapRef.defaultedMapRef(mapref, default = LockQueue.EmptyCell)
       )
-      .map(state => new ConcurrentImpl[F, K](state))
+    }
 
   /**
    * Creates a new `KeyedMutex`. Like `apply` but initializes state using another effect
    * constructor.
    */
   def in[F[_], G[_], K](implicit F: Sync[F], G: Async[G]): F[KeyedMutex[G, K]] =
-    Ref
-      .in[F, G, Map[K, ConcurrentImpl.LockQueueCell]](
-        // Initialize the state with an empty Map.
-        Map.empty
+    MapRef.inConcurrentHashMap[F, G, K, LockQueue.Cell]().map { mapref =>
+      new ConcurrentImpl[G, K](
+        // Initialize the state with an already completed cell.
+        state = MapRef.defaultedMapRef(mapref, default = LockQueue.EmptyCell)
       )
-      .map(state => new ConcurrentImpl[G, K](state))
+    }
 
   private final class ConcurrentImpl[F[_], K](
-      state: Ref[F, Map[K, ConcurrentImpl.LockQueueCell]]
+      state: MapRef[F, K, LockQueue.Cell]
   )(
       implicit F: Concurrent[F]
   ) extends KeyedMutex[F, K] {
-
-    // This is a variant of the Craig, Landin, and Hagersten
-    // (CLH) queue lock for each key.
-    // Queue nodes (called cells below) are `Deferred`s,
-    // so fibers can suspend and wake up
-    // (instead of spinning, like in the original algorithm).
-
-    // Awakes whoever is waiting for us with the next cell in the queue.
-    private def awakeCell(
-        key: K,
-        ourCell: ConcurrentImpl.WaitingCell[F],
-        nextCell: ConcurrentImpl.LockQueueCell
-    ): F[Unit] =
-      state.access.flatMap {
-        // If the current last cell in the queue for the given key is our cell,
-        // then that means nobody is waiting for us.
-        // Thus, we can just set the state to the next cell in the queue.
-        // Also, if the next cell is the empty one, we can just remove the key from the map.
-        // Otherwise, we awake whoever is waiting for us.
-        case (map, setter) =>
-          val lastCell = map(key) // Safe.
-          if (lastCell eq ourCell)
-            if (nextCell eq ConcurrentImpl.EmptyCell)
-              setter(map - key)
-            else
-              setter(map.updated(key, value = nextCell))
-          else F.pure(false)
-      } flatMap {
-        case false => ourCell.complete(nextCell).void
-        case true => F.unit
-      }
-
-    // Cancels a Fiber waiting for the Mutex.
-    private def cancel(
-        key: K,
-        ourCell: ConcurrentImpl.WaitingCell[F],
-        nextCell: ConcurrentImpl.LockQueueCell
-    ): F[Unit] =
-      awakeCell(key, ourCell, nextCell)
-
-    // Acquires the Mutex.
-    private def acquire(key: K)(poll: Poll[F]): F[ConcurrentImpl.WaitingCell[F]] =
-      ConcurrentImpl.LockQueueCell[F].flatMap { ourCell =>
-        // Atomically get the last cell in the queue for the given key,
-        // and put ourselves as the last one.
-        state
-          .modify { map =>
-            val newMap = map.updated(key, value = ourCell)
-            val lastCell = map.getOrElse(key, default = ConcurrentImpl.EmptyCell)
-
-            newMap -> lastCell
-          }
-          .flatMap { lastCell =>
-            // Then we check what the next cell is.
-            // There are two options:
-            //  + EmptyCell: Signaling that the mutex is free.
-            //  + WaitingCell: Which means there is someone ahead of us in the queue.
-            //    Thus, we wait for that cell to complete; and then check again.
-            //
-            // Only the waiting process is cancelable.
-            // If we are cancelled while waiting,
-            // we notify our waiter with the cell ahead of us.
-            def loop(
-                nextCell: ConcurrentImpl.LockQueueCell
-            ): F[ConcurrentImpl.WaitingCell[F]] =
-              if (nextCell eq ConcurrentImpl.EmptyCell) F.pure(ourCell)
-              else {
-                F.onCancel(
-                  poll(nextCell.asInstanceOf[ConcurrentImpl.WaitingCell[F]].get),
-                  cancel(key, ourCell, nextCell)
-                ).flatMap(loop)
-              }
-
-            loop(nextCell = lastCell)
-          }
-      }
-
-    // Releases the Mutex.
-    private def release(key: K)(ourCell: ConcurrentImpl.WaitingCell[F]): F[Unit] =
-      awakeCell(key, ourCell, nextCell = ConcurrentImpl.EmptyCell)
-
     override def lock(key: K): Resource[F, Unit] =
-      Resource.makeFull[F, ConcurrentImpl.WaitingCell[F]](acquire(key))(release(key)).void
+      LockQueue.lock(queue = state(key))
 
-    override def mapK[G[_]](f: F ~> G)(implicit G: MonadCancel[G, _]): KeyedMutex[G, K] =
-      new KeyedMutex.TransformedKeyedMutex(this, f)
-  }
-
-  private object ConcurrentImpl {
-    // Represents a queue of waiters for the mutex.
-    private[KeyedMutex] final type LockQueueCell = AnyRef
-    // Represents the first cell of the queue.
-    private[KeyedMutex] final type EmptyCell = LockQueueCell
-    private[KeyedMutex] final val EmptyCell: EmptyCell = null
-    // Represents a waiting cell in the queue.
-    private[KeyedMutex] final type WaitingCell[F[_]] = Deferred[F, LockQueueCell]
-
-    private[KeyedMutex] def LockQueueCell[F[_]](implicit F: Concurrent[F]): F[WaitingCell[F]] =
-      Deferred[F, LockQueueCell]
+    override def mapK[G[_]](f: F ~> G)(implicit G: MonadCancel[G, ?]): KeyedMutex[G, K] =
+      new TransformedKeyedMutex(this, f)
   }
 
   private final class TransformedKeyedMutex[F[_], G[_], K](
       underlying: KeyedMutex[F, K],
       f: F ~> G
-  )(implicit F: MonadCancel[F, _], G: MonadCancel[G, _])
-      extends KeyedMutex[G, K] {
+  )(
+      implicit F: MonadCancel[F, ?],
+      G: MonadCancel[G, ?]
+  ) extends KeyedMutex[G, K] {
     override def lock(key: K): Resource[G, Unit] =
       underlying.lock(key).mapK(f)
 
-    override def mapK[H[_]](f: G ~> H)(implicit H: MonadCancel[H, _]): KeyedMutex[H, K] =
-      new KeyedMutex.TransformedKeyedMutex(this, f)
+    override def mapK[H[_]](f: G ~> H)(implicit H: MonadCancel[H, ?]): KeyedMutex[H, K] =
+      new TransformedKeyedMutex(this, f)
   }
 }

--- a/std/shared/src/main/scala/cats/effect/std/KeyedMutex.scala
+++ b/std/shared/src/main/scala/cats/effect/std/KeyedMutex.scala
@@ -100,7 +100,7 @@ object KeyedMutex {
           val lastCell = map(key) // Safe.
           if (lastCell eq ourCell)
             if (nextCell eq ConcurrentImpl.EmptyCell)
-              setter(map.removed(key))
+              setter(map - key)
             else
               setter(map.updated(key, value = nextCell))
           else F.pure(false)

--- a/std/shared/src/main/scala/cats/effect/std/KeyedMutex.scala
+++ b/std/shared/src/main/scala/cats/effect/std/KeyedMutex.scala
@@ -53,12 +53,124 @@ object KeyedMutex {
    * Creates a new `KeyedMutex`.
    */
   def apply[F[_], K](implicit F: Concurrent[F]): F[KeyedMutex[F, K]] =
-    ???
+    Ref
+      .of[F, ConcurrentImpl.LockQueueCell](
+        // Initialize the state with an already completed cell.
+        ConcurrentImpl.EmptyCell
+      )
+      .map(state => new ConcurrentImpl[F, K](state))
 
   /**
    * Creates a new `KeyedMutex`. Like `apply` but initializes state using another effect
    * constructor.
    */
   def in[F[_], G[_], K](implicit F: Sync[F], G: Async[G]): F[KeyedMutex[G, K]] =
-    ???
+    Ref
+      .in[F, G, ConcurrentImpl.LockQueueCell](
+        // Initialize the state with an already completed cell.
+        ConcurrentImpl.EmptyCell
+      )
+      .map(state => new ConcurrentImpl[G, K](state))
+
+  private final class ConcurrentImpl[F[_], K](
+      state: Ref[F, ConcurrentImpl.LockQueueCell]
+  )(
+      implicit F: Concurrent[F]
+  ) extends KeyedMutex[F, K] {
+
+    // This is a variant of the Craig, Landin, and Hagersten
+    // (CLH) queue lock. Queue nodes (called cells below)
+    // are `Deferred`s, so fibers can suspend and wake up
+    // (instead of spinning, like in the original algorithm).
+
+    // Awakes whoever is waiting for us with the next cell in the queue.
+    private def awakeCell(
+        ourCell: ConcurrentImpl.WaitingCell[F],
+        nextCell: ConcurrentImpl.LockQueueCell
+    ): F[Unit] =
+      state.access.flatMap {
+        // If the current last cell in the queue is our cell,
+        // then that means nobody is waiting for us.
+        // Thus, we can just set the state to the next cell in the queue.
+        // Otherwise, we awake whoever is waiting for us.
+        case (lastCell, setter) =>
+          if (lastCell eq ourCell) setter(nextCell)
+          else F.pure(false)
+      } flatMap {
+        case false => ourCell.complete(nextCell).void
+        case true => F.unit
+      }
+
+    // Cancels a Fiber waiting for the Mutex.
+    private def cancel(
+        ourCell: ConcurrentImpl.WaitingCell[F],
+        nextCell: ConcurrentImpl.LockQueueCell
+    ): F[Unit] =
+      awakeCell(ourCell, nextCell)
+
+    // Acquires the Mutex.
+    private def acquire(poll: Poll[F]): F[ConcurrentImpl.WaitingCell[F]] =
+      ConcurrentImpl.LockQueueCell[F].flatMap { ourCell =>
+        // Atomically get the last cell in the queue,
+        // and put ourselves as the last one.
+        state.getAndSet(ourCell).flatMap { lastCell =>
+          // Then we check what the next cell is.
+          // There are two options:
+          //  + EmptyCell: Signaling that the mutex is free.
+          //  + WaitingCell: Which means there is someone ahead of us in the queue.
+          //    Thus, we wait for that cell to complete; and then check again.
+          //
+          // Only the waiting process is cancelable.
+          // If we are cancelled while waiting,
+          // we notify our waiter with the cell ahead of us.
+          def loop(
+              nextCell: ConcurrentImpl.LockQueueCell
+          ): F[ConcurrentImpl.WaitingCell[F]] =
+            if (nextCell eq ConcurrentImpl.EmptyCell) F.pure(ourCell)
+            else {
+              F.onCancel(
+                poll(nextCell.asInstanceOf[ConcurrentImpl.WaitingCell[F]].get),
+                cancel(ourCell, nextCell)
+              ).flatMap(loop)
+            }
+
+          loop(nextCell = lastCell)
+        }
+      }
+
+    // Releases the Mutex.
+    private def release(ourCell: ConcurrentImpl.WaitingCell[F]): F[Unit] =
+      awakeCell(ourCell, nextCell = ConcurrentImpl.EmptyCell)
+
+    override def lock(key: K): Resource[F, Unit] =
+      Resource.makeFull[F, ConcurrentImpl.WaitingCell[F]](acquire)(release).void
+
+    override def mapK[G[_]](f: F ~> G)(implicit G: MonadCancel[G, _]): KeyedMutex[G, K] =
+      new KeyedMutex.TransformedKeyedMutex(this, f)
+  }
+
+  private object ConcurrentImpl {
+    // Represents a queue of waiters for the mutex.
+    private[KeyedMutex] final type LockQueueCell = AnyRef
+    // Represents the first cell of the queue.
+    private[KeyedMutex] final type EmptyCell = LockQueueCell
+    private[KeyedMutex] final val EmptyCell: EmptyCell = null
+    // Represents a waiting cell in the queue.
+    private[KeyedMutex] final type WaitingCell[F[_]] = Deferred[F, LockQueueCell]
+
+    private[KeyedMutex] def LockQueueCell[F[_]](implicit F: Concurrent[F]): F[WaitingCell[F]] =
+      Deferred[F, LockQueueCell]
+  }
+
+  private final class TransformedKeyedMutex[F[_], G[_], K](
+      underlying: KeyedMutex[F, K],
+      f: F ~> G
+  )(implicit F: MonadCancel[F, _], G: MonadCancel[G, _])
+      extends KeyedMutex[G, K] {
+    override def lock(key: K): Resource[G, Unit] =
+      underlying.lock(key).mapK(f)
+
+    override def mapK[H[_]](f: G ~> H)(implicit H: MonadCancel[H, _]): KeyedMutex[H, K] =
+      new KeyedMutex.TransformedKeyedMutex(this, f)
+  }
 }

--- a/std/shared/src/main/scala/cats/effect/std/LockQueue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/LockQueue.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020-2025 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package std
+
+import cats.effect.kernel._
+import cats.syntax.all._
+
+// Represents a queue of waiters for the lock.
+private[effect] object LockQueue {
+  // Phantom type for the cells in the queue.
+  final type Cell = AnyRef
+
+  // Represents the first cell of the queue.
+  final val EmptyCell: Cell = null
+
+  // Represents a waiting cell in the queue.
+  final type WaitingCell[F[_]] = Deferred[F, Cell]
+
+  // Creates a new waiting cell.
+  def WaitingCell[F[_]](implicit F: Concurrent[F]): F[WaitingCell[F]] =
+    Deferred[F, Cell]
+
+  // This is a variant of the Craig, Landin, and Hagersten (CLH) queue lock.
+  // Queue nodes (called cells below) are `Deferred`s,
+  // so fibers can suspend and wake up (instead of spinning, like in the original algorithm).
+  def lock[F[_]](
+      queue: Ref[F, Cell]
+  )(
+      implicit F: Concurrent[F]
+  ): Resource[F, Unit] = {
+    // Awakes whoever is waiting for our waiting cell,
+    // and give them the next cell in the queue.
+    def awakeCell(
+        ourCell: WaitingCell[F],
+        nextCell: Cell
+    ): F[Unit] =
+      queue.access.flatMap {
+        // If the current last cell in the queue is our cell,
+        // then that means nobody is waiting for us.
+        // Thus, we can just set the state to the next cell in the queue.
+        // Otherwise, we awake whoever is waiting for us.
+        case (lastCell, setter) =>
+          if (lastCell eq ourCell) setter(nextCell)
+          else F.pure(false)
+      } flatMap {
+        case false => ourCell.complete(nextCell).void
+        case true => F.unit
+      }
+
+    // Cancels a Fiber waiting for the Lock.
+    def cancel(
+        ourCell: WaitingCell[F],
+        nextCell: Cell
+    ): F[Unit] =
+      awakeCell(ourCell, nextCell)
+
+    // Acquires the Lock.
+    def acquire(poll: Poll[F]): F[WaitingCell[F]] =
+      WaitingCell[F].flatMap { ourCell =>
+        // Atomically get the last cell in the queue,
+        // and put ourselves as the last one.
+        queue.getAndSet(ourCell).flatMap { lastCell =>
+          // Then we check what the next cell is.
+          // There are two options:
+          //  + EmptyCell: Signaling that the lock is free.
+          //  + WaitingCell: Which means there is someone ahead of us in the queue.
+          //    Thus, we wait for that cell to complete; and then check again.
+          //
+          // Only the waiting process is cancelable.
+          // If we are cancelled while waiting,
+          // we notify our waiter with the cell ahead of us.
+          def loop(
+              nextCell: Cell
+          ): F[WaitingCell[F]] =
+            if (nextCell eq EmptyCell) F.pure(ourCell)
+            else {
+              F.onCancel(
+                poll(nextCell.asInstanceOf[WaitingCell[F]].get),
+                cancel(ourCell, nextCell)
+              ).flatMap(loop)
+            }
+
+          loop(nextCell = lastCell)
+        }
+      }
+
+    // Releases the Lock.
+    def release(ourCell: WaitingCell[F]): F[Unit] =
+      awakeCell(ourCell, nextCell = EmptyCell)
+
+    // The Lock is a Resource over a new waiting cell at the end of the queue.
+    Resource.makeFull[F, WaitingCell[F]](acquire)(release).void
+  }
+}

--- a/std/shared/src/main/scala/cats/effect/std/Mutex.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Mutex.scala
@@ -71,7 +71,7 @@ object Mutex {
         // Initialize the state with an already completed cell.
         LockQueue.EmptyCell
       )
-      .map(state => new ConcurrentImpl[F](state))
+      .map(state => new ConcurrentImpl(state))
 
   /**
    * Creates a new `Mutex`. Like `apply` but initializes state using another effect constructor.
@@ -82,7 +82,7 @@ object Mutex {
         // Initialize the state with an already completed cell.
         LockQueue.EmptyCell
       )
-      .map(state => new ConcurrentImpl[G](state))
+      .map(state => new ConcurrentImpl(state))
 
   private final class ConcurrentImpl[F[_]](
       state: Ref[F, LockQueue.Cell]

--- a/std/shared/src/main/scala/cats/effect/std/Mutex.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Mutex.scala
@@ -43,6 +43,8 @@ import cats.syntax.all._
  *
  * @see
  *   [[cats.effect.std.AtomicCell]]
+ * @see
+ *   [[cats.effect.std.KeyedMutex]]
  */
 abstract class Mutex[F[_]] {
 

--- a/tests/shared/src/test/scala/cats/effect/std/KeyedMutexSuite.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/KeyedMutexSuite.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020-2025 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package std
+
+import cats.arrow.FunctionK
+import cats.syntax.all._
+
+import scala.concurrent.duration._
+
+final class KeyedMutexSuite extends BaseSuite {
+  final override def executionTimeout = super.executionTimeout * 6
+
+  tests("ConcurrentKeyedMutex", KeyedMutex.apply[IO, Int])
+  tests("KeyedMutex with dual constructors", KeyedMutex.in[IO, IO, Int])
+  tests("MapK'd KeyedMutex", KeyedMutex[IO, Int].map(_.mapK[IO](FunctionK.id)))
+
+  def tests(name: String, keyedMutex: IO[KeyedMutex[IO, Int]]) = {
+    real(
+      s"${name} should execute action if free in the given key"
+    ) {
+      val p = keyedMutex.flatMap { m => m.lock(key = 0).surround(IO.unit) }
+
+      p.mustEqual(())
+    }
+
+    real(
+      s"${name} should be reusable in the same key"
+    ) {
+      val p = keyedMutex.flatMap { m =>
+        m.lock(key = 0).surround(IO.unit) >>
+          m.lock(key = 0).surround(IO.unit)
+      }
+
+      p.mustEqual(())
+    }
+
+    ticked(
+      s"${name} should block action if not free in the given key"
+    ) { implicit ticker =>
+      val p = keyedMutex.flatMap { m =>
+        m.lock(key = 0).surround(IO.never) >>
+          m.lock(key = 0).surround(IO.unit)
+      }
+
+      assertNonTerminate(p)
+    }
+
+    ticked(
+      s"${name} should not block action if using a different key"
+    ) { implicit ticker =>
+      val p = keyedMutex.flatMap { m =>
+        IO.race(
+          m.lock(key = 0).surround(IO.never),
+          IO.sleep(1.second) >> m.lock(key = 1).surround(IO.unit)
+        ).void
+      }
+
+      assertCompleteAs(p, ())
+    }
+
+    ticked(
+      s"${name} should support concurrent usage in the same key"
+    ) { implicit ticker =>
+      val p = keyedMutex.flatMap { m =>
+        val usage = IO.sleep(1.second) >> m.lock(key = 0).surround(IO.sleep(1.second))
+
+        (usage, usage).parTupled.void
+      }
+
+      assertCompleteAs(p, ())
+    }
+
+    ticked(
+      s"${name} should support concurrent usage in different keys"
+    ) { implicit ticker =>
+      val p = keyedMutex.flatMap { m =>
+        def usage(key: Int): IO[Unit] =
+          IO.sleep(1.second) >> m.lock(key).surround(IO.sleep(1.second))
+
+        List.range(start = 1, end = 10).parTraverse_(usage)
+      }
+
+      assertCompleteAs(p, ())
+    }
+  }
+}


### PR DESCRIPTION
Extention to the current `Mutex` class to support one look per `key`.

I extracted the `LockQueue` and `lock` implementations into their own file to allow reuse.

I added a basic suite of tests, mostly focused on multiple key interactions.
Since each key is, in essence, its own `Mutex` I don't think we need to replicate all the complex `Mutex` tests... since those are actually tests for the `LockQueue`.