### PR TITLE
Fix #4066: shut down executors when `IORuntime.global` shuts down

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -195,10 +195,15 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
   def global: IORuntime = {
     if (_global == null) {
       installGlobal {
-        val (compute, _) = createWorkStealingComputeThreadPool()
-        val (blocking, _) = createDefaultBlockingExecutionContext()
+        val (compute, computeDown) = createWorkStealingComputeThreadPool()
+        val (blocking, blockingDown) = createDefaultBlockingExecutionContext()
+        val shutdown = () => {
+          computeDown()
+          blockingDown()
+          resetGlobal()
+        }
 
-        IORuntime(compute, blocking, compute, () => resetGlobal(), IORuntimeConfig())
+        IORuntime(compute, blocking, compute, shutdown, IORuntimeConfig())
       }
     }
 

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -285,13 +285,6 @@ class IOAppSpec extends Specification {
         h.stderr() must not(contain("Promise already completed"))
       }
 
-      "shut down WSTP on fatal error without IOApp" in {
-        val h = platform(FatalErrorShutsDownRt, List.empty)
-        h.awaitStatus()
-        h.stdout() must not(contain("sadness"))
-        h.stdout() must contain("done")
-      }
-
       "exit on canceled" in {
         val h = platform(Canceled, List.empty)
         h.awaitStatus() mustEqual 1
@@ -340,6 +333,13 @@ class IOAppSpec extends Specification {
           h.awaitStatus() mustEqual 1
           h.stderr() must contain("java.lang.InterruptedException")
           ok
+        }
+
+        "shut down WSTP on fatal error without IOApp" in {
+          val h = platform(FatalErrorShutsDownRt, List.empty)
+          h.awaitStatus()
+          h.stdout() must not(contain("sadness"))
+          h.stdout() must contain("done")
         }
 
         "support main thread evaluation" in {

--- a/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOAppSpec.scala
@@ -285,6 +285,13 @@ class IOAppSpec extends Specification {
         h.stderr() must not(contain("Promise already completed"))
       }
 
+      "shut down WSTP on fatal error without IOApp" in {
+        val h = platform(FatalErrorShutsDownRt, List.empty)
+        h.awaitStatus()
+        h.stdout() must not(contain("sadness"))
+        h.stdout() must contain("done")
+      }
+
       "exit on canceled" in {
         val h = platform(Canceled, List.empty)
         h.awaitStatus() mustEqual 1


### PR DESCRIPTION
Fixes #4066. Related to #4055.