### PR TITLE
Remove `IORuntime` from `allRuntimes` on shutdown

### DIFF
--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -18,6 +18,7 @@ package cats.effect
 package unsafe
 
 import scala.concurrent.ExecutionContext
+import scala.util.chaining._
 
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -42,7 +43,7 @@ final class IORuntime private[unsafe] (
     val scheduler: Scheduler,
     private[effect] val pollers: List[Any],
     private[effect] val fiberMonitor: FiberMonitor,
-    val shutdown: () => Unit,
+    defaultShutdown: () => Unit,
     val config: IORuntimeConfig
 ) {
 
@@ -55,6 +56,9 @@ final class IORuntime private[unsafe] (
   private[effect] val autoYieldThreshold: Int = config.autoYieldThreshold
   private[effect] val enhancedExceptions: Boolean = config.enhancedExceptions
   private[effect] val traceBufferLogSize: Int = config.traceBufferLogSize
+
+  val shutdown: () => Unit =
+    (() => IORuntime.allRuntimes.remove(this, this.hashCode())).pipe(_ => defaultShutdown)
 
   override def toString: String = s"IORuntime($compute, $scheduler, $config)"
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -70,7 +70,7 @@ object IORuntime extends IORuntimeCompanionPlatform {
       config: IORuntimeConfig): IORuntime = {
     val fiberMonitor = FiberMonitor(compute)
     val unregister = registerFiberMonitorMBean(fiberMonitor)
-    def unregisterAndShutdown(): Unit = {
+    def unregisterAndShutdown: () => Unit = () => {
       unregister()
       shutdown()
       allRuntimes.remove(runtime, runtime.hashCode())

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -17,12 +17,10 @@
 package cats.effect
 package unsafe
 
-import scala.concurrent.ExecutionContext
-import scala.util.chaining._
+import cats.effect.Platform.static
 
 import java.util.concurrent.atomic.AtomicBoolean
-
-import Platform.static
+import scala.concurrent.ExecutionContext
 
 @annotation.implicitNotFound("""Could not find an implicit IORuntime.
 
@@ -58,7 +56,10 @@ final class IORuntime private[unsafe] (
   private[effect] val traceBufferLogSize: Int = config.traceBufferLogSize
 
   val shutdown: () => Unit =
-    (() => IORuntime.allRuntimes.remove(this, this.hashCode())).pipe(_ => defaultShutdown)
+    () => {
+      IORuntime.allRuntimes.remove(this, this.hashCode())
+      defaultShutdown()
+    }
 
   override def toString: String = s"IORuntime($compute, $scheduler, $config)"
 }

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -70,7 +70,7 @@ object IORuntime extends IORuntimeCompanionPlatform {
       config: IORuntimeConfig): IORuntime = {
     val fiberMonitor = FiberMonitor(compute)
     val unregister = registerFiberMonitorMBean(fiberMonitor)
-    def unregisterAndShutdown: () => Unit = () => {
+    def unregisterAndShutdown(): Unit = {
       unregister()
       shutdown()
       allRuntimes.remove(runtime, runtime.hashCode())

--- a/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
+++ b/core/shared/src/main/scala/cats/effect/unsafe/IORuntime.scala
@@ -19,8 +19,9 @@ package unsafe
 
 import cats.effect.Platform.static
 
-import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.ExecutionContext
+
+import java.util.concurrent.atomic.AtomicBoolean
 
 @annotation.implicitNotFound("""Could not find an implicit IORuntime.
 

--- a/tests/shared/src/test/scala/cats/effect/unsafe/IORuntimeSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/unsafe/IORuntimeSpec.scala
@@ -1,0 +1,22 @@
+package cats.effect.unsafe
+
+import cats.effect.BaseSpec
+
+class IORuntimeSpec extends BaseSpec {
+
+  "IORuntimeSpec" should {
+    "cleanup allRuntimes collection on shutdown" in {
+      val (defaultScheduler, closeScheduler) = Scheduler.createDefaultScheduler()
+
+      val runtime = IORuntime(null, null, defaultScheduler, closeScheduler, IORuntimeConfig())
+
+      IORuntime.allRuntimes.unsafeHashtable().find(_ == runtime) must beEqualTo(Some(runtime))
+
+      val _ = runtime.shutdown()
+
+      IORuntime.allRuntimes.unsafeHashtable().find(_ == runtime) must beEqualTo(None)
+    }
+
+  }
+
+}


### PR DESCRIPTION
The PR originated from question on discord https://discord.com/channels/632277896739946517/632278585700384799/1254741830042652772 

Whenever the IORuntime is created through `apply` method it is being added to the `allRuntimes` collection.
Unfortunately it seems that is not removed anywhere. 

This PR tries to remove the created `IORuntime` from `allRuntimes` collection. 
I tried to keep the api as close as it was, but as the `allRuntimes` collection require `runtime` and the `hashCode` to be supplied to remove function I struggled a bit. 

I am open for comments and suggestions. Let me know which branch I should target, not sure if change is backward and forward compatible