### PR TITLE
Add timed variant for IO[Unit]

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -853,6 +853,9 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
   private[effect] def timeoutAndForget(duration: FiniteDuration): IO[A] =
     timeoutAndForget(duration: Duration)
 
+  def timed(implicit env: A <:< Unit) : IO[FiniteDuration] =
+    timed.map(_._1)
+
   def timed: IO[(FiniteDuration, A)] =
     Clock[IO].timed(this)
 


### PR DESCRIPTION
Hello folks! 
I'm not sure about the solution but I encountered this "problem" enough times to submit this PR.
Basically when you want to use `timed` on an `IO[Unit]` you have to map the result to just keep the left side of the tuple. 
It would be nice to have a method to this directly within `IO`. 

My proposal here introduces breaking changes, other more conservative solutions would be to use a dedicated name for this case such as:
- `timed_`
- `timedIgnore` (with or without `and` )
- `timedL` or `timedR` it depends on which side you see it 
- `timedOnly`

Let me know what do you think! 
Thank :) 


