### PR TITLE
Fix typos

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -424,7 +424,7 @@ private[effect] final class WorkStealingThreadPool[P](
    * Updates the internal state to mark the given worker thread as parked.
    *
    * @note
-   *   This method is intentionally duplicated, to accomodate the unconditional code paths in
+   *   This method is intentionally duplicated, to accommodate the unconditional code paths in
    *   the [[WorkerThread]] runloop.
    */
   private[unsafe] def transitionWorkerToParked(): Unit = {

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -577,7 +577,7 @@ private final class WorkerThread[P](
             // The dequeued element was a batch of fibers. Enqueue the whole
             // batch on the local queue and execute the first fiber.
 
-            // Make room for the batch if the local queue cannot accomodate
+            // Make room for the batch if the local queue cannot accommodate
             // all of the fibers as is.
             queue.drainBatch(external, rnd)
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -689,7 +689,7 @@ running its `queueR.getAndUpdate` call than the consumer is running its
 update the `queueR` content.
 
 Can we alleviate this? Sure! There are a few options you can implement:
-1. Making the producer artifically slower by introducing a call to `Async[F].sleep`
+1. Making the producer artificially slower by introducing a call to `Async[F].sleep`
    (_e.g._ for 1 microsecond). Truth is, in real world scenarios a producer will
    not be as fast as in our example so this tweak is not that 'strange'. Note that
    to be able to use `sleep` now `F` requires an implicit `Async[F]` instance. The

--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/Generators.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/Generators.scala
@@ -40,7 +40,7 @@ trait Generators1[F[_]] extends Serializable {
   // Generators of base cases, with no recursion
   protected def baseGen[A: Arbitrary: Cogen]: List[(String, Gen[F[A]])] = {
     // prevent unused implicit param warnings, the params need to stay because
-    // this method is overriden in subtraits
+    // this method is overridden in subtraits
     val _ = (implicitly[Arbitrary[A]], implicitly[Cogen[A]])
     Nil
   }
@@ -49,7 +49,7 @@ trait Generators1[F[_]] extends Serializable {
   protected def recursiveGen[A: Arbitrary: Cogen](
       deeper: GenK[F]): List[(String, Gen[F[A]])] = {
     // prevent unused params warnings, the params need to stay because
-    // this method is overriden in subtraits
+    // this method is overridden in subtraits
     val _ = (deeper, implicitly[Arbitrary[A]], implicitly[Cogen[A]])
     Nil
   }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -131,7 +131,7 @@ import cats.syntax.all._
  *
  * {{{
  *
- *   // Starts a fiber that continously prints "A".
+ *   // Starts a fiber that continuously prints "A".
  *   // After 10 seconds, the resource scope exits so the fiber is canceled.
  *   F.background(F.delay(println("A")).foreverM).use { _ =>
  *     F.sleep(10.seconds)
@@ -202,7 +202,7 @@ trait GenSpawn[F[_], E] extends MonadCancel[F, E] with Unique[F] {
    *
    * {{{
    *
-   *   // Starts a fiber that continously prints "A".
+   *   // Starts a fiber that continuously prints "A".
    *   // After 10 seconds, the resource scope exits so the fiber is canceled.
    *   F.background(F.delay(println("A")).foreverM).use { _ =>
    *     F.sleep(10.seconds)

--- a/tests/native/src/test/scala/cats/effect/FileDescriptorPollerSpec.scala
+++ b/tests/native/src/test/scala/cats/effect/FileDescriptorPollerSpec.scala
@@ -130,7 +130,7 @@ class FileDescriptorPollerSpec extends BaseSpec {
         }
       }
 
-      // multiples of 64 to excercise ready queue draining logic
+      // multiples of 64 to exercise ready queue draining logic
       test(64) *> test(128) *>
         test(1000) // a big, non-64-multiple
     }

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -603,7 +603,7 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
       "propagate the exit case" in {
         import Resource.ExitCase
 
-        "use succesfully, test left" >> ticked { implicit ticker =>
+        "use successfully, test left" >> ticked { implicit ticker =>
           var got: ExitCase = null
           val r = Resource.onFinalizeCase(ec => IO { got = ec })
           r.both(Resource.unit).use(_ => IO.unit) must completeAs(())
@@ -725,7 +725,7 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
       "propagate the exit case" in {
         import Resource.ExitCase
 
-        "use succesfully, test left" >> ticked { implicit ticker =>
+        "use successfully, test left" >> ticked { implicit ticker =>
           var got: ExitCase = null
           val r = Resource.onFinalizeCase(ec => IO { got = ec })
           r.combineK(Resource.unit).use(_ => IO.unit) must completeAs(())


### PR DESCRIPTION
Fix some small typos I found. These should be non-semantic.