### PR TITLE
Relax `access` semantics in `MapRef` implementations

### DIFF
--- a/tests/jvm/src/test/scala/cats/effect/std/MapRefJVMSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/std/MapRefJVMSpec.scala
@@ -104,21 +104,6 @@ class MapRefJVMSpec extends BaseSpec {
       op.map(a => a must_=== true)
     }
 
-    "access - setter should fail if called twice" in real {
-      val op = for {
-        r <- MapRef.ofScalaConcurrentTrieMap[IO, Unit, Int]
-        _ <- r(()).set(Some(0))
-        accessed <- r(()).access
-        (value, setter) = accessed
-        cond1 <- setter(value.map(_ + 1))
-        _ <- r(()).set(value)
-        cond2 <- setter(None)
-        result <- r(()).get
-      } yield cond1 && !cond2 && result == Some(0)
-
-      op.map(a => a must_=== true)
-    }
-
     "tryUpdate - modification occurs successfully" in real {
       val op = for {
         r <- MapRef.ofScalaConcurrentTrieMap[IO, Unit, Int]

--- a/tests/shared/src/test/scala/cats/effect/std/MapRefSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/MapRefSpec.scala
@@ -237,21 +237,6 @@ class MapRefSpec extends BaseSpec {
       op.map(a => a must_=== true)
     }
 
-    "access - setter should fail if called twice" in real {
-      val op = for {
-        r <- MapRef.ofConcurrentHashMap[IO, Unit, Int]()
-        _ <- r(()).set(Some(0))
-        accessed <- r(()).access
-        (value, setter) = accessed
-        cond1 <- setter(value.map(_ + 1))
-        _ <- r(()).set(value)
-        cond2 <- setter(None)
-        result <- r(()).get
-      } yield cond1 && !cond2 && result == Some(0)
-
-      op.map(a => a must_=== true)
-    }
-
     "tryUpdate - modification occurs successfully" in real {
       val op = for {
         r <- MapRef.ofConcurrentHashMap[IO, Unit, Int]()


### PR DESCRIPTION
In https://github.com/typelevel/cats-effect/pull/2901 we relaxed the semantics for `Ref` implementations, but this wasn't carried forward into `MapRef` implementations (which I think were subsumed into CE at a later date).