### PR TITLE
Make `IO#onError` consistent with `ApplicativeError`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -585,7 +585,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
 
   @deprecated("Use onError with PartialFunction argument", "3.6.0")
   def onError(f: Throwable => IO[Unit]): IO[A] = {
-    val pf: PartialFunction[Throwable, IO[Unit]] = { case t => f(t) }
+    val pf: PartialFunction[Throwable, IO[Unit]] = { case t => f(t).reportError }
     onError(pf)
   }
 
@@ -596,8 +596,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    * Implements `ApplicativeError.onError`.
    */
   def onError(pf: PartialFunction[Throwable, IO[Unit]]): IO[A] =
-    handleErrorWith(t =>
-      pf.applyOrElse(t, (_: Throwable) => IO.unit).reportError *> IO.raiseError(t))
+    handleErrorWith(t => pf.applyOrElse(t, (_: Throwable) => IO.unit) *> IO.raiseError(t))
 
   /**
    * Like `Parallel.parProductL`

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1995,6 +1995,9 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits with TuplePara
     override def handleError[A](fa: IO[A])(f: Throwable => A): IO[A] =
       fa.handleError(f)
 
+    override def onError[A](fa: IO[A])(pf: PartialFunction[Throwable, IO[Unit]]): IO[A] =
+      fa.onError(pf)
+
     override def timeout[A](fa: IO[A], duration: FiniteDuration)(
         implicit ev: TimeoutException <:< Throwable): IO[A] = {
       fa.timeout(duration)

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -590,8 +590,10 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
     IO.OnCancel(this, fin)
 
   @deprecated("Use onError with PartialFunction argument", "3.6.0")
-  def onError(f: Throwable => IO[Unit]): IO[A] =
-    handleErrorWith(t => f(t).voidError *> IO.raiseError(t))
+  def onError(f: Throwable => IO[Unit]): IO[A] = {
+    val pf: PartialFunction[Throwable, IO[Unit]] = { case t => f(t) }
+    onError(pf)
+  }
 
   /**
    * Execute a callback on certain errors, then rethrow them. Any non matching error is rethrown

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -493,7 +493,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
         IO.executionContext.flatMap(ec => IO(ec.reportFailure(t)))
       }
 
-      poll(this).onCancel(finalizer).onError(_ => handled).flatTap(_ => finalizer)
+      poll(this).onCancel(finalizer).onError { case _ => handled }.flatTap(_ => finalizer)
     }
 
   /**
@@ -519,10 +519,11 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
   def guaranteeCase(finalizer: OutcomeIO[A @uncheckedVariance] => IO[Unit]): IO[A] =
     IO.uncancelable { poll =>
       val finalized = poll(this).onCancel(finalizer(Outcome.canceled))
-      val handled = finalized.onError { e =>
-        finalizer(Outcome.errored(e)).handleErrorWith { t =>
-          IO.executionContext.flatMap(ec => IO(ec.reportFailure(t)))
-        }
+      val handled = finalized.onError {
+        case e =>
+          finalizer(Outcome.errored(e)).handleErrorWith { t =>
+            IO.executionContext.flatMap(ec => IO(ec.reportFailure(t)))
+          }
       }
       handled.flatTap(a => finalizer(Outcome.succeeded(IO.pure(a))))
     }


### PR DESCRIPTION
This also deprecates the old `IO.onError` function and replace it's usage with the new one.

Close #4058 