### PR TITLE
link to `MapRef` docs in site sidebar

### DIFF
--- a/site-docs/sidebars.json
+++ b/site-docs/sidebars.json
@@ -44,6 +44,7 @@
       "std/dispatcher",
       "std/env",
       "std/hotswap",
+      "std/mapref",
       "std/mutex",
       "std/pqueue",
       "std/queue",


### PR DESCRIPTION
Currently not in the sidebar so no one can find it! I think this is all that's necessary