### PR TITLE
Implement a safer `Resource.attempt` which releases acquired resource(s) in case of error

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
+++ b/core/jvm/src/main/scala/cats/effect/metrics/JvmCpuStarvationMetrics.scala
@@ -66,7 +66,7 @@ private[effect] object JvmCpuStarvationMetrics {
         case (mbeanServer, _) => IO.blocking(mbeanServer.unregisterMBean(mBeanObjectName))
       }
       .map(_._2)
-      .handleErrorWith[CpuStarvationMetrics, Throwable] { th =>
+      .handleErrorWith[CpuStarvationMetrics] { th =>
         Resource.eval(Console[IO].errorln(warning(th))).map(_ => new NoOpCpuStarvationMetrics)
       }
   }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -731,7 +731,7 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
     Resource.applyFull[F, Either[Throwable, A]] { poll =>
       poll(allocatedCase).attempt.map {
         case Right((a, r)) => (a.asRight[Throwable], r)
-        case error => (error, _ => F.unit)
+        case error => (error.asInstanceOf[Either[Throwable, A]], _ => F.unit)
       }
     }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1303,7 +1303,7 @@ private[effect] trait ResourceHOInstances3 extends ResourceHOInstances4 {
 
 private[effect] trait ResourceHOInstances4 extends ResourceHOInstances5 {
   @deprecated("Use MonadCancelThrow instances", "3.6.0")
-  def catsEffectMonadErrorForResource[F[_], E](
+  implicit def catsEffectMonadErrorForResource[F[_], E](
       implicit F0: MonadError[F, E]): MonadError[Resource[F, *], E] =
     new ResourceMonadError[F, E] {
       def F = F0

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1302,7 +1302,9 @@ private[effect] trait ResourceHOInstances3 extends ResourceHOInstances4 {
 }
 
 private[effect] trait ResourceHOInstances4 extends ResourceHOInstances5 {
-  @deprecated("Use MonadCancelThrow instances", "3.6.0")
+  @deprecated(
+    "Bring an implicit MonadCancelThrow[F] into scope to get the fixed Resource instance",
+    "3.6.0")
   implicit def catsEffectMonadErrorForResource[F[_], E](
       implicit F0: MonadError[F, E]): MonadError[Resource[F, *], E] =
     new ResourceMonadError[F, E] {

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -724,8 +724,8 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
   }
 
   def attempt(implicit F: MonadCancelThrow[F]): Resource[F, Either[Throwable, A]] =
-    Resource.applyCase[F, Either[Throwable, A]] {
-      allocatedCase.attempt.map {
+    Resource.applyFull[F, Either[Throwable, A]] { poll =>
+      poll(allocatedCase).attempt.map {
         case Left(error) => (error.asLeft[A], _ => ().pure[F])
         case Right((a, r)) => (a.asRight[Throwable], r)
       }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -731,8 +731,16 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
       }
     }
 
+  @deprecated("Use overload with MonadCancelThrow", "3.6.0")
   def handleErrorWith[B >: A, E](f: E => Resource[F, B])(
-      implicit F: ApplicativeError[F, E]): Resource[F, B] =
+      F: ApplicativeError[F, E]): Resource[F, B] =
+    attempt(F).flatMap {
+      case Right(a) => Resource.pure(a)
+      case Left(e) => f(e)
+    }
+
+  def handleErrorWith[B >: A](f: Throwable => Resource[F, B])(
+      implicit F: MonadCancelThrow[F]): Resource[F, B] =
     attempt(F).flatMap {
       case Right(a) => Resource.pure(a)
       case Left(e) => f(e)

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -703,7 +703,7 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
   @deprecated("Use overload with MonadCancelThrow", "3.6.0")
   def attempt[E](F: ApplicativeError[F, E]): Resource[F, Either[E, A]] =
     F match {
-      case x: Sync[_] =>
+      case x: Sync[F] =>
         attempt(x).asInstanceOf[Resource[F, Either[E, A]]]
       case _ =>
         implicit val x: ApplicativeError[F, E] = F
@@ -1302,7 +1302,8 @@ private[effect] trait ResourceHOInstances3 extends ResourceHOInstances4 {
 }
 
 private[effect] trait ResourceHOInstances4 extends ResourceHOInstances5 {
-  implicit def catsEffectMonadErrorForResource[F[_], E](
+  @deprecated("Use MonadCancelThrow instances", "3.6.0")
+  def catsEffectMonadErrorForResource[F[_], E](
       implicit F0: MonadError[F, E]): MonadError[Resource[F, *], E] =
     new ResourceMonadError[F, E] {
       def F = F0

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -1172,6 +1172,28 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
     }
   }
 
+  "attempt" >> {
+
+    "releases resource on error" in ticked { implicit ticker =>
+      IO.ref(0)
+        .flatMap { ref =>
+          val resource = Resource.make(ref.update(_ + 1))(_ => ref.update(_ + 1))
+          val error = Resource.raiseError[IO, Unit, Throwable](new Exception)
+          (resource *> error).attempt.use { _ => ref.get.map { _ must be_==(2) } }
+        }
+        .void must completeAs(())
+    }
+
+    "acquire is interruptible" in ticked { implicit ticker =>
+      val sleep = IO.sleep(1.second)
+      val timeout = 500.millis
+      IO.ref(false).flatMap { ref =>
+        val r = Resource.makeFull[IO, Unit] { poll => poll(sleep).onCancel(ref.set(true)) }(_ => IO.unit)
+        r.attempt.timeout(timeout).attempt.use_ *> ref.get
+      } must completeAs(true)
+    }
+  }
+
   "uncancelable" >> {
     "does not suppress errors within use" in real {
       case object TestException extends RuntimeException

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -1179,7 +1179,9 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
         .flatMap { ref =>
           val resource = Resource.make(ref.update(_ + 1))(_ => ref.update(_ + 1))
           val error = Resource.raiseError[IO, Unit, Throwable](new Exception)
-          (resource *> error).attempt.use { _ => ref.get.map { _ must be_==(2) } }
+          (resource *> error).attempt.use { r =>
+            IO(r must beLeft) *> ref.get.map { _ must be_==(2) }
+          }
         }
         .void must completeAs(())
     }

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -1188,7 +1188,8 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
       val sleep = IO.sleep(1.second)
       val timeout = 500.millis
       IO.ref(false).flatMap { ref =>
-        val r = Resource.makeFull[IO, Unit] { poll => poll(sleep).onCancel(ref.set(true)) }(_ => IO.unit)
+        val r = Resource.makeFull[IO, Unit] { poll => poll(sleep).onCancel(ref.set(true)) }(_ =>
+          IO.unit)
         r.attempt.timeout(timeout).attempt.use_ *> ref.get
       } must completeAs(true)
     }

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -1185,7 +1185,7 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
     }
 
     "acquire is interruptible" in ticked { implicit ticker =>
-      val sleep = IO.sleep(1.second)
+      val sleep = IO.never
       val timeout = 500.millis
       IO.ref(false).flatMap { ref =>
         val r = Resource.makeFull[IO, Unit] { poll => poll(sleep).onCancel(ref.set(true)) }(_ =>


### PR DESCRIPTION
This is my solution for #3757, 

As I discussed with @armanbilge, the new method requires `MonadCancelThrow` in order to use `Resource.allocatedCase` which handles releasing acquired resource(s) in case of error. This pr also removed implicit `ApplicativeError` and deprecated the current attempt method.

~~This is a draft as it still needs to add tests and address some issues that I'll comment in the pr. But please give me early feedback.~~