### PR TITLE
Add `ownPoller` 

### DIFF
--- a/core/jvm-native/src/main/scala/cats/effect/unsafe/PollingSystem.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/unsafe/PollingSystem.scala
@@ -104,7 +104,7 @@ abstract class PollingSystem {
 
 }
 
-trait PollingContext[P] {
+sealed trait PollingContext[P] {
 
   /**
    * Register a callback to obtain a thread-local `Poller`
@@ -118,6 +118,8 @@ trait PollingContext[P] {
    */
   def ownPoller(poller: P): Boolean
 }
+
+private[unsafe] trait UnsealedPollingContext[P] extends PollingContext[P]
 
 object PollingSystem {
 

--- a/core/jvm-native/src/main/scala/cats/effect/unsafe/PollingSystem.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/unsafe/PollingSystem.scala
@@ -51,7 +51,7 @@ abstract class PollingSystem {
   /**
    * Creates a new instance of the user-facing interface.
    */
-  def makeApi(provider: PollerProvider[Poller]): Api
+  def makeApi(ctx: PollingContext[Poller]): Api
 
   /**
    * Creates a new instance of the thread-local data structure used for polling.
@@ -104,7 +104,7 @@ abstract class PollingSystem {
 
 }
 
-trait PollerProvider[P] {
+trait PollingContext[P] {
 
   /**
    * Register a callback to obtain a thread-local `Poller`

--- a/core/jvm-native/src/main/scala/cats/effect/unsafe/PollingSystem.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/unsafe/PollingSystem.scala
@@ -50,13 +50,8 @@ abstract class PollingSystem {
 
   /**
    * Creates a new instance of the user-facing interface.
-   *
-   * @param access
-   *   callback to obtain a thread-local `Poller`.
-   * @return
-   *   an instance of the user-facing interface `Api`.
    */
-  def makeApi(access: (Poller => Unit) => Unit): Api
+  def makeApi(provider: PollerProvider[Poller]): Api
 
   /**
    * Creates a new instance of the thread-local data structure used for polling.
@@ -109,7 +104,20 @@ abstract class PollingSystem {
 
 }
 
-private object PollingSystem {
+trait PollerProvider[P] {
+
+  /**
+   * Register a callback to obtain a thread-local `Poller`
+   */
+  def accessPoller(cb: P => Unit): Unit
+
+  /**
+   * Returns `true` if it is safe to interact with this `Poller`
+   */
+  def ownPoller(poller: P): Boolean
+}
+
+object PollingSystem {
 
   /**
    * Type alias for a `PollingSystem` that has a specified `Poller` type.

--- a/core/jvm-native/src/main/scala/cats/effect/unsafe/PollingSystem.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/unsafe/PollingSystem.scala
@@ -112,7 +112,9 @@ trait PollerProvider[P] {
   def accessPoller(cb: P => Unit): Unit
 
   /**
-   * Returns `true` if it is safe to interact with this `Poller`
+   * Returns `true` if it is safe to interact with this `Poller`. Implementors of this method
+   * may be best-effort: it is always safe to return `false`, so callers must have an adequate
+   * fallback for the non-owning case.
    */
   def ownPoller(poller: P): Boolean
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -152,7 +152,7 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
 
     (
       threadPool,
-      pollingSystem.makeApi(threadPool.accessPoller),
+      pollingSystem.makeApi(threadPool),
       { () =>
         unregisterMBeans()
         threadPool.shutdown()

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SelectorSystem.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SelectorSystem.scala
@@ -25,16 +25,16 @@ import java.util.Iterator
 
 import SelectorSystem._
 
-final class SelectorSystem private (selectorProvider: SelectorProvider) extends PollingSystem {
+final class SelectorSystem private (provider: SelectorProvider) extends PollingSystem {
 
   type Api = Selector
 
   def close(): Unit = ()
 
   def makeApi(ctx: PollingContext[Poller]): Selector =
-    new SelectorImpl(ctx, selectorProvider)
+    new SelectorImpl(ctx, provider)
 
-  def makePoller(): Poller = new Poller(selectorProvider.openSelector())
+  def makePoller(): Poller = new Poller(provider.openSelector())
 
   def closePoller(poller: Poller): Unit =
     poller.selector.close()

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SleepSystem.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SleepSystem.scala
@@ -26,7 +26,7 @@ object SleepSystem extends PollingSystem {
 
   def close(): Unit = ()
 
-  def makeApi(provider: PollerProvider[Poller]): Api = this
+  def makeApi(ctx: PollingContext[Poller]): Api = this
 
   def makePoller(): Poller = this
 

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SleepSystem.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SleepSystem.scala
@@ -26,7 +26,7 @@ object SleepSystem extends PollingSystem {
 
   def close(): Unit = ()
 
-  def makeApi(access: (Poller => Unit) => Unit): Api = this
+  def makeApi(provider: PollerProvider[Poller]): Api = this
 
   def makePoller(): Poller = this
 

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -72,7 +72,7 @@ private[effect] final class WorkStealingThreadPool[P <: AnyRef](
     reportFailure0: Throwable => Unit
 ) extends ExecutionContextExecutor
     with Scheduler
-    with PollerProvider[P] {
+    with PollingContext[P] {
 
   import TracingConstants._
   import WorkStealingThreadPoolConstants._

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -72,7 +72,7 @@ private[effect] final class WorkStealingThreadPool[P <: AnyRef](
     reportFailure0: Throwable => Unit
 ) extends ExecutionContextExecutor
     with Scheduler
-    with PollingContext[P] {
+    with UnsealedPollingContext[P] {
 
   import TracingConstants._
   import WorkStealingThreadPoolConstants._

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * system when compared to a fixed size thread pool whose worker threads all draw tasks from a
  * single global work queue.
  */
-private final class WorkerThread[P](
+private final class WorkerThread[P <: AnyRef](
     idx: Int,
     // Local queue instance with exclusive write access.
     private[this] var queue: LocalQueue,
@@ -290,6 +290,9 @@ private final class WorkerThread[P](
     fiberBag.forEach(r => foreign ++= captureTrace(r))
     foreign.toMap
   }
+
+  private[unsafe] def ownsPoller(poller: P): Boolean =
+    poller eq _poller
 
   private[unsafe] def ownsTimers(timers: TimerHeap): Boolean =
     sleepers eq timers

--- a/core/native/src/main/scala/cats/effect/unsafe/EpollSystem.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/EpollSystem.scala
@@ -47,8 +47,8 @@ object EpollSystem extends PollingSystem {
 
   def close(): Unit = ()
 
-  def makeApi(provider: PollerProvider[Poller]): Api =
-    new FileDescriptorPollerImpl(provider)
+  def makeApi(ctx: PollingContext[Poller]): Api =
+    new FileDescriptorPollerImpl(ctx)
 
   def makePoller(): Poller = {
     val fd = epoll_create1(0)
@@ -67,7 +67,7 @@ object EpollSystem extends PollingSystem {
   def interrupt(targetThread: Thread, targetPoller: Poller): Unit = ()
 
   private final class FileDescriptorPollerImpl private[EpollSystem] (
-      provider: PollerProvider[Poller])
+      ctx: PollingContext[Poller])
       extends FileDescriptorPoller {
 
     def registerFileDescriptor(
@@ -78,7 +78,7 @@ object EpollSystem extends PollingSystem {
       Resource {
         (Mutex[IO], Mutex[IO]).flatMapN { (readMutex, writeMutex) =>
           IO.async_[(PollHandle, IO[Unit])] { cb =>
-            provider.accessPoller { epoll =>
+            ctx.accessPoller { epoll =>
               val handle = new PollHandle(readMutex, writeMutex)
               epoll.register(fd, reads, writes, handle, cb)
             }

--- a/core/native/src/main/scala/cats/effect/unsafe/EpollSystem.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/EpollSystem.scala
@@ -47,8 +47,8 @@ object EpollSystem extends PollingSystem {
 
   def close(): Unit = ()
 
-  def makeApi(access: (Poller => Unit) => Unit): Api =
-    new FileDescriptorPollerImpl(access)
+  def makeApi(provider: PollerProvider[Poller]): Api =
+    new FileDescriptorPollerImpl(provider)
 
   def makePoller(): Poller = {
     val fd = epoll_create1(0)
@@ -67,7 +67,7 @@ object EpollSystem extends PollingSystem {
   def interrupt(targetThread: Thread, targetPoller: Poller): Unit = ()
 
   private final class FileDescriptorPollerImpl private[EpollSystem] (
-      access: (Poller => Unit) => Unit)
+      provider: PollerProvider[Poller])
       extends FileDescriptorPoller {
 
     def registerFileDescriptor(
@@ -78,7 +78,7 @@ object EpollSystem extends PollingSystem {
       Resource {
         (Mutex[IO], Mutex[IO]).flatMapN { (readMutex, writeMutex) =>
           IO.async_[(PollHandle, IO[Unit])] { cb =>
-            access { epoll =>
+            provider.accessPoller { epoll =>
               val handle = new PollHandle(readMutex, writeMutex)
               epoll.register(fd, reads, writes, handle, cb)
             }

--- a/core/native/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -31,7 +31,7 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
     val loop = new EventLoopExecutorScheduler[system.Poller](64, system)
     val poller = loop.poller
     val api = system.makeApi(
-      new PollingContext[system.Poller] {
+      new UnsealedPollingContext[system.Poller] {
         def accessPoller(cb: system.Poller => Unit) = cb(poller)
         def ownPoller(poller: system.Poller) = true
       }

--- a/core/native/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/IORuntimeCompanionPlatform.scala
@@ -31,7 +31,7 @@ private[unsafe] abstract class IORuntimeCompanionPlatform { this: IORuntime.type
     val loop = new EventLoopExecutorScheduler[system.Poller](64, system)
     val poller = loop.poller
     val api = system.makeApi(
-      new PollerProvider[system.Poller] {
+      new PollingContext[system.Poller] {
         def accessPoller(cb: system.Poller => Unit) = cb(poller)
         def ownPoller(poller: system.Poller) = true
       }

--- a/core/native/src/main/scala/cats/effect/unsafe/KqueueSystem.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/KqueueSystem.scala
@@ -46,8 +46,8 @@ object KqueueSystem extends PollingSystem {
 
   def close(): Unit = ()
 
-  def makeApi(provider: PollerProvider[Poller]): FileDescriptorPoller =
-    new FileDescriptorPollerImpl(provider)
+  def makeApi(ctx: PollingContext[Poller]): FileDescriptorPoller =
+    new FileDescriptorPollerImpl(ctx)
 
   def makePoller(): Poller = {
     val fd = kqueue()
@@ -67,7 +67,7 @@ object KqueueSystem extends PollingSystem {
   def interrupt(targetThread: Thread, targetPoller: Poller): Unit = ()
 
   private final class FileDescriptorPollerImpl private[KqueueSystem] (
-      provider: PollerProvider[Poller]
+      ctx: PollingContext[Poller]
   ) extends FileDescriptorPoller {
     def registerFileDescriptor(
         fd: Int,
@@ -76,7 +76,7 @@ object KqueueSystem extends PollingSystem {
     ): Resource[IO, FileDescriptorPollHandle] =
       Resource.eval {
         (Mutex[IO], Mutex[IO]).mapN {
-          new PollHandle(provider, fd, _, _)
+          new PollHandle(ctx, fd, _, _)
         }
       }
   }
@@ -86,7 +86,7 @@ object KqueueSystem extends PollingSystem {
     (filter.toLong << 32) | ident.toLong
 
   private final class PollHandle(
-      provider: PollerProvider[Poller],
+      ctx: PollingContext[Poller],
       fd: Int,
       readMutex: Mutex[IO],
       writeMutex: Mutex[IO]
@@ -101,7 +101,7 @@ object KqueueSystem extends PollingSystem {
             else
               IO.async[Unit] { kqcb =>
                 IO.async_[Option[IO[Unit]]] { cb =>
-                  provider.accessPoller { kqueue =>
+                  ctx.accessPoller { kqueue =>
                     kqueue.evSet(fd, EVFILT_READ, EV_ADD.toUShort, kqcb)
                     cb(Right(Some(IO(kqueue.removeCallback(fd, EVFILT_READ)))))
                   }
@@ -121,7 +121,7 @@ object KqueueSystem extends PollingSystem {
             else
               IO.async[Unit] { kqcb =>
                 IO.async_[Option[IO[Unit]]] { cb =>
-                  provider.accessPoller { kqueue =>
+                  ctx.accessPoller { kqueue =>
                     kqueue.evSet(fd, EVFILT_WRITE, EV_ADD.toUShort, kqcb)
                     cb(Right(Some(IO(kqueue.removeCallback(fd, EVFILT_WRITE)))))
                   }

--- a/core/native/src/main/scala/cats/effect/unsafe/PollingExecutorScheduler.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/PollingExecutorScheduler.scala
@@ -32,7 +32,7 @@ abstract class PollingExecutorScheduler(pollEvery: Int)
       type Poller = outer.type
       private[this] var needsPoll = true
       def close(): Unit = ()
-      def makeApi(provider: PollerProvider[Poller]): Api = outer
+      def makeApi(ctx: PollingContext[Poller]): Api = outer
       def makePoller(): Poller = outer
       def closePoller(poller: Poller): Unit = ()
       def poll(poller: Poller, nanos: Long, reportFailure: Throwable => Unit): Boolean = {

--- a/core/native/src/main/scala/cats/effect/unsafe/PollingExecutorScheduler.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/PollingExecutorScheduler.scala
@@ -32,7 +32,7 @@ abstract class PollingExecutorScheduler(pollEvery: Int)
       type Poller = outer.type
       private[this] var needsPoll = true
       def close(): Unit = ()
-      def makeApi(access: (Poller => Unit) => Unit): Api = outer
+      def makeApi(provider: PollerProvider[Poller]): Api = outer
       def makePoller(): Poller = outer
       def closePoller(poller: Poller): Unit = ()
       def poll(poller: Poller, nanos: Long, reportFailure: Throwable => Unit): Boolean = {

--- a/core/native/src/main/scala/cats/effect/unsafe/SleepSystem.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/SleepSystem.scala
@@ -24,7 +24,7 @@ object SleepSystem extends PollingSystem {
 
   def close(): Unit = ()
 
-  def makeApi(provider: PollerProvider[Poller]): Api = this
+  def makeApi(ctx: PollingContext[Poller]): Api = this
 
   def makePoller(): Poller = this
 

--- a/core/native/src/main/scala/cats/effect/unsafe/SleepSystem.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/SleepSystem.scala
@@ -24,7 +24,7 @@ object SleepSystem extends PollingSystem {
 
   def close(): Unit = ()
 
-  def makeApi(access: (Poller => Unit) => Unit): Api = this
+  def makeApi(provider: PollerProvider[Poller]): Api = this
 
   def makePoller(): Poller = this
 

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -20,7 +20,7 @@ import cats.effect.std.Semaphore
 import cats.effect.unsafe.{
   IORuntime,
   IORuntimeConfig,
-  PollerProvider,
+  PollingContext,
   PollingSystem,
   SleepSystem,
   WorkStealingThreadPool
@@ -514,10 +514,10 @@ trait IOPlatformSpecification extends DetectPlatform { self: BaseSpec with Scala
             }
           }
 
-          def makeApi(provider: PollerProvider[Poller]): DummySystem.Api =
+          def makeApi(ctx: PollingContext[Poller]): DummySystem.Api =
             new DummyPoller {
               def poll = IO.async_[Unit] { cb =>
-                provider.accessPoller { poller =>
+                ctx.accessPoller { poller =>
                   poller.getAndUpdate(cb :: _)
                   ()
                 }

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -20,6 +20,7 @@ import cats.effect.std.Semaphore
 import cats.effect.unsafe.{
   IORuntime,
   IORuntimeConfig,
+  PollerProvider,
   PollingSystem,
   SleepSystem,
   WorkStealingThreadPool
@@ -513,10 +514,10 @@ trait IOPlatformSpecification extends DetectPlatform { self: BaseSpec with Scala
             }
           }
 
-          def makeApi(access: (Poller => Unit) => Unit): DummySystem.Api =
+          def makeApi(provider: PollerProvider[Poller]): DummySystem.Api =
             new DummyPoller {
               def poll = IO.async_[Unit] { cb =>
-                access { poller =>
+                provider.accessPoller { poller =>
                   poller.getAndUpdate(cb :: _)
                   ()
                 }


### PR DESCRIPTION
This PR introduces a mechanism for checking if a given poller is "owned" by the current thread and thus is safe to interact with. This is useful primarily for cancelation, which may be requested from any thread, but can happy-path additional cleanup operations when on the owning thread.

The existing `accessPoller` and new `ownPoller` methods are now bundled up in a `PollerProvider` API.

Finally, `SelectorSystem` is improved to use `ownPoller` to attempt to remove the linked list node for a canceled selection operation, instead of simply clearing it.

Closes https://github.com/typelevel/cats-effect/issues/4009.
