### PR TITLE
optimize `IO.whenA`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1620,7 +1620,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
    *   [[IO.raiseWhen]] for conditionally raising an error
    */
   def whenA(cond: Boolean)(action: => IO[Unit]): IO[Unit] =
-    Applicative[IO].whenA(cond)(action)
+    if (cond) action else IO.unit
 
   /**
    * Returns the given argument if `cond` is false, otherwise `IO.Unit`
@@ -1631,7 +1631,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits {
    *   [[IO.raiseWhen]] for conditionally raising an error
    */
   def unlessA(cond: Boolean)(action: => IO[Unit]): IO[Unit] =
-    Applicative[IO].unlessA(cond)(action)
+    whenA(!cond)(action)
 
   /**
    * Returns `raiseError` when the `cond` is true, otherwise `IO.unit`

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -16,24 +16,7 @@
 
 package cats.effect
 
-import cats.{
-  Align,
-  Alternative,
-  Applicative,
-  CommutativeApplicative,
-  Eval,
-  Functor,
-  Id,
-  Monad,
-  Monoid,
-  Now,
-  Parallel,
-  Semigroup,
-  SemigroupK,
-  Show,
-  StackSafeMonad,
-  Traverse
-}
+import cats.{Align, Alternative, CommutativeApplicative, Eval, Functor, Id, Monad, Monoid, Now, Parallel, Semigroup, SemigroupK, Show, StackSafeMonad, Traverse}
 import cats.data.Ior
 import cats.effect.instances.spawn
 import cats.effect.kernel.CancelScope

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -16,7 +16,23 @@
 
 package cats.effect
 
-import cats.{Align, Alternative, CommutativeApplicative, Eval, Functor, Id, Monad, Monoid, Now, Parallel, Semigroup, SemigroupK, Show, StackSafeMonad, Traverse}
+import cats.{
+  Align,
+  Alternative,
+  CommutativeApplicative,
+  Eval,
+  Functor,
+  Id,
+  Monad,
+  Monoid,
+  Now,
+  Parallel,
+  Semigroup,
+  SemigroupK,
+  Show,
+  StackSafeMonad,
+  Traverse
+}
 import cats.data.Ior
 import cats.effect.instances.spawn
 import cats.effect.kernel.CancelScope


### PR DESCRIPTION
I noticed that this simple recursive loop
```scala
def loop(i: Long): IO[Unit] =
  IO.whenA(i % 1000_000 == 0)(IO.println(i / 1000_000)).flatMap{ _ =>
    IO.whenA(i < Long.MaxValue)(loop(i + 1))
  }

loop(0).unsafeRunSync()
```
ends with
```
1071
1072
1073
java.lang.NegativeArraySizeException: -2147483648
	at cats.effect.ArrayStack.checkAndGrow(ArrayStack.scala:73)
	at cats.effect.ArrayStack.push(ArrayStack.scala:34)
	at cats.effect.IOFiber.runLoop(IOFiber.scala:367)
	at cats.effect.IOFiber.autoCedeR(IOFiber.scala:1423)
	at cats.effect.IOFiber.run(IOFiber.scala:119)
	at cats.effect.unsafe.WorkerThread.run(WorkerThread.scala:743)
```
While the equivalent `if else` code seems to keep running without noticeable GC pauses.