### PR TITLE
Add default constructor for `MapRef`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,39 +1,5 @@
 {
-  "name": "cats-effect",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {
-    "": {
-      "devDependencies": {
-        "source-map-support": "^0.5.19"
-      }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    }
-  },
+  "lockfileVersion": 1,
   "dependencies": {
     "buffer-from": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,39 @@
 {
-  "lockfileVersion": 1,
+  "name": "cats-effect",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "source-map-support": "^0.5.19"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    }
+  },
   "dependencies": {
     "buffer-from": {
       "version": "1.1.2",

--- a/std/shared/src/main/scala/cats/effect/std/MapRef.scala
+++ b/std/shared/src/main/scala/cats/effect/std/MapRef.scala
@@ -47,7 +47,7 @@ object MapRef extends MapRefCompanionPlatform {
 
   /**
    * Default constructor for [[MapRef]]. If [[Sync]] is available, it will delegate to
-   * [[ofConcurrentHashMap], otherwise it will fallback to [[ofShardedImmutableMap]].
+   * [[ofConcurrentHashMap]], otherwise it will fallback to [[ofShardedImmutableMap]].
    */
   def apply[F[_]: Concurrent, K, V]: F[MapRef[F, K, Option[V]]] = {
     Concurrent[F] match {

--- a/std/shared/src/main/scala/cats/effect/std/MapRef.scala
+++ b/std/shared/src/main/scala/cats/effect/std/MapRef.scala
@@ -46,8 +46,8 @@ trait MapRef[F[_], K, V] extends Function1[K, Ref[F, V]] {
 object MapRef extends MapRefCompanionPlatform {
 
   /**
-   * the default Constructor for MapRef. If Async is available, it will use a ConcurrentHashMap,
-   * otherwise it will use a sharded immutable map.
+   * Default constructor for [[MapRef]]. If [[Sync]] is available, it will delegate to [[ofConcurrentHashMap],
+   * otherwise it will fallback to [[ofShardedImmutableMap]].
    */
   def apply[F[_]: Concurrent, K, V]: F[MapRef[F, K, Option[V]]] = {
     Concurrent[F] match {

--- a/std/shared/src/main/scala/cats/effect/std/MapRef.scala
+++ b/std/shared/src/main/scala/cats/effect/std/MapRef.scala
@@ -46,8 +46,8 @@ trait MapRef[F[_], K, V] extends Function1[K, Ref[F, V]] {
 object MapRef extends MapRefCompanionPlatform {
 
   /**
-   * Default constructor for [[MapRef]]. If [[Sync]] is available, it will delegate to [[ofConcurrentHashMap],
-   * otherwise it will fallback to [[ofShardedImmutableMap]].
+   * Default constructor for [[MapRef]]. If [[Sync]] is available, it will delegate to
+   * [[ofConcurrentHashMap], otherwise it will fallback to [[ofShardedImmutableMap]].
    */
   def apply[F[_]: Concurrent, K, V]: F[MapRef[F, K, Option[V]]] = {
     Concurrent[F] match {

--- a/std/shared/src/main/scala/cats/effect/std/MapRef.scala
+++ b/std/shared/src/main/scala/cats/effect/std/MapRef.scala
@@ -60,12 +60,6 @@ object MapRef extends MapRefCompanionPlatform {
   }
 
   /**
-   * the default Constructor for MapRef with a default value.
-   */
-  def apply[F[_]: Concurrent, K, V: Eq](default: V): F[MapRef[F, K, V]] =
-    apply[F, K, V].map(defaultedMapRef(_, default))
-
-  /**
    * Creates a sharded map ref to reduce atomic contention on the Map, given an efficient and
    * equally distributed hash, the contention should allow for interaction like a general
    * datastructure.
@@ -542,5 +536,8 @@ object MapRef extends MapRefCompanionPlatform {
           val (set, out) = f(v)
           (set.some, out.some)
       }
+
+    def withDefaultValue(default: V)(implicit E: Eq[V], F: Functor[F]): MapRef[F, K, V] =
+      defaultedMapRef(mRef, default)
   }
 }

--- a/std/shared/src/main/scala/cats/effect/std/MapRef.scala
+++ b/std/shared/src/main/scala/cats/effect/std/MapRef.scala
@@ -49,14 +49,12 @@ object MapRef extends MapRefCompanionPlatform {
    * the default Constructor for MapRef. If Async is available, it will use a ConcurrentHashMap,
    * otherwise it will use a sharded immutable map.
    */
-  def apply[F[_]: Concurrent, K, V](): F[MapRef[F, K, Option[V]]] = {
-
+  def apply[F[_]: Concurrent, K, V]: F[MapRef[F, K, Option[V]]] = {
     Concurrent[F] match {
-      case a: Async[_] =>
-        implicit val async: Async[F] = a
-        ofConcurrentHashMap()
+      case s: Sync[F] =>
+        ofConcurrentHashMap()(s)
       case _ =>
-        ofShardedImmutableMap[F, K, V](Runtime.getRuntime.availableProcessors())
+        ofShardedImmutableMap[F, K, V](shardCount = Runtime.getRuntime.availableProcessors())
     }
 
   }

--- a/std/shared/src/main/scala/cats/effect/std/MapRef.scala
+++ b/std/shared/src/main/scala/cats/effect/std/MapRef.scala
@@ -46,6 +46,22 @@ trait MapRef[F[_], K, V] extends Function1[K, Ref[F, V]] {
 object MapRef extends MapRefCompanionPlatform {
 
   /**
+   * the default Constructor for MapRef.
+   * If Async is available, it will use a ConcurrentHashMap, otherwise it will use a sharded immutable map.
+   */
+  def apply[F[_]: Concurrent, K, V](): F[MapRef[F, K, Option[V]]] = {
+
+    Concurrent[F] match {
+      case a: Async[_] =>
+        implicit val async: Async[F] = a
+        ofConcurrentHashMap()
+      case _ =>
+        ofShardedImmutableMap[F, K, V](Runtime.getRuntime.availableProcessors())
+    }
+
+  }
+
+  /**
    * Creates a sharded map ref to reduce atomic contention on the Map, given an efficient and
    * equally distributed hash, the contention should allow for interaction like a general
    * datastructure.

--- a/std/shared/src/main/scala/cats/effect/std/MapRef.scala
+++ b/std/shared/src/main/scala/cats/effect/std/MapRef.scala
@@ -60,6 +60,12 @@ object MapRef extends MapRefCompanionPlatform {
   }
 
   /**
+   * the default Constructor for MapRef with a default value.
+   */
+  def apply[F[_]: Concurrent, K, V: Eq](default: V): F[MapRef[F, K, V]] =
+    apply[F, K, V].map(defaultedMapRef(_, default))
+
+  /**
    * Creates a sharded map ref to reduce atomic contention on the Map, given an efficient and
    * equally distributed hash, the contention should allow for interaction like a general
    * datastructure.

--- a/std/shared/src/main/scala/cats/effect/std/MapRef.scala
+++ b/std/shared/src/main/scala/cats/effect/std/MapRef.scala
@@ -46,8 +46,8 @@ trait MapRef[F[_], K, V] extends Function1[K, Ref[F, V]] {
 object MapRef extends MapRefCompanionPlatform {
 
   /**
-   * the default Constructor for MapRef.
-   * If Async is available, it will use a ConcurrentHashMap, otherwise it will use a sharded immutable map.
+   * the default Constructor for MapRef. If Async is available, it will use a ConcurrentHashMap,
+   * otherwise it will use a sharded immutable map.
    */
   def apply[F[_]: Concurrent, K, V](): F[MapRef[F, K, Option[V]]] = {
 


### PR DESCRIPTION
Adds an apply method for MapRef. If the Effect type is an instance of Async , the `ConcurrentHashMap` implementation will be used otherwise the `sharedImmutableMap` will be used with the number of shards set to the number of Processors determined by `Runtime.getRuntime.availableProcessors`.
The goal of this MR is to improve the UX for a user by having a sane default

closes #4136

P.S. as this is a first-time PR to this repo, please let me know if there are any conventions/practices, etc.. that I should be adhering to. TY