### PR TITLE
Implement async dropping queue

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/QueueBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/QueueBenchmark.scala
@@ -115,6 +115,22 @@ class QueueBenchmark {
   def unboundedAsyncEnqueueDequeueContended(): Unit =
     Queue.unboundedForAsync[IO, Unit].flatMap(enqueueDequeueContended(_)).unsafeRunSync()
 
+  @Benchmark
+  def droppingConcurrentEnqueueDequeueOne(): Unit =
+    Queue.droppingForConcurrent[IO, Unit](size).flatMap(enqueueDequeueOne(_)).unsafeRunSync()
+
+  @Benchmark
+  def droppingConcurrentEnqueueDequeueMany(): Unit =
+    Queue.droppingForConcurrent[IO, Unit](size).flatMap(enqueueDequeueMany(_)).unsafeRunSync()
+
+  @Benchmark
+  def droppingAsyncEnqueueDequeueOne(): Unit =
+    Queue.droppingForAsync[IO, Unit](size).flatMap(enqueueDequeueOne(_)).unsafeRunSync()
+
+  @Benchmark
+  def droppingAsyncEnqueueDequeueMany(): Unit =
+    Queue.droppingForAsync[IO, Unit](size).flatMap(enqueueDequeueMany(_)).unsafeRunSync()
+
   private[this] def enqueueDequeueOne(q: Queue[IO, Unit]): IO[Unit] = {
     def loop(i: Int): IO[Unit] =
       if (i > 0)

--- a/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
@@ -418,7 +418,11 @@ class UnboundedQueueSpec extends BaseSpec with QueueTests[Queue] {
 class DroppingQueueSpec extends BaseSpec with QueueTests[Queue] {
   sequential
 
-  "DroppingQueue" should {
+  "DroppingQueue (concurrent)" should {
+    droppingQueueTests(i => if (i < 1) Queue.dropping(i) else Queue.droppingForConcurrent(i))
+  }
+
+  "DroppingQueue (async)" should {
     droppingQueueTests(Queue.dropping)
   }
 


### PR DESCRIPTION
Closes #4141.

Benchmarks:
```
Throughput              Async                       Concurrent
enqueueDequeueMany      281.571 ± 4.388 ops/s       144.713 ± 2.057 ops/s
enqueueDequeueOne       281.266 ± 4.599 ops/s       173.974 ± 3.129 ops/s

GC alloc rate           Async                       Concurrent
enqueueDequeueMany      3273.366 ± 51.235 MB/sec    5860.556 ±  82.691 MB/sec
enqueueDequeueOne       3058.866 ± 50.114 MB/sec    6784.491 ± 123.139 MB/sec

GC alloc rate norm      Async                       Concurrent
enqueueDequeueMany      12191147.081 ±  2.533 B/op  42468767.945 ± 65.343 B/op
enqueueDequeueOne       11404702.192 ± 11.867 B/op  40895828.996 ±  4.205 B/op

GC count                Async                       Concurrent
enqueueDequeueMany      898.000  counts             771.000  counts
enqueueDequeueOne       1030.000 counts             1315.000 counts

GC time                 Async                       Concurrent
enqueueDequeueMany      519.000 ms                  1130.000 ms
enqueueDequeueOne       578.000 ms                  771.000  ms
```