### PR TITLE
Add `snapshot` to `MapRef`

### DIFF
--- a/tests/shared/src/test/scala/cats/effect/std/MapRefSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/MapRefSpec.scala
@@ -133,6 +133,18 @@ class MapRefSpec extends BaseSpec {
 
       op.map(a => a must_=== true)
     }
+
+    "snapshot - return currently available key-value pairs" in real {
+      val entries = Map("key_1" -> "value_1", "key_2" -> "value_2")
+
+      val op = for {
+        r <- MapRef.ofSingleImmutableMap[IO, String, String]()
+        _ <- entries.toSeq.traverse_ { case (k, v) => r(k).set(Some(v)) }
+        snapshot <- r.snapshot
+      } yield snapshot
+
+      op.map(a => a must_=== entries)
+    }
   }
 
   "MapRef.ofShardedImmutableMapRef" should {
@@ -159,6 +171,18 @@ class MapRefSpec extends BaseSpec {
       } yield out
 
       test.map(a => a must_=== Some(expect))
+    }
+
+    "snapshot - return currently available key-value pairs" in real {
+      val entries = Map("key_1" -> "value_1", "key_2" -> "value_2")
+
+      val op = for {
+        r <- MapRef.ofShardedImmutableMap[IO, String, String](8)
+        _ <- entries.toSeq.traverse_ { case (k, v) => r(k).set(Some(v)) }
+        snapshot <- r.snapshot
+      } yield snapshot
+
+      op.map(a => a must_=== entries)
     }
   }
 
@@ -281,6 +305,18 @@ class MapRefSpec extends BaseSpec {
       } yield result == Some(1)
 
       op.map(a => a must_=== true)
+    }
+
+    "snapshot - return currently available key-value pairs" in real {
+      val entries = Map("key_1" -> "value_1", "key_2" -> "value_2")
+
+      val op = for {
+        r <- MapRef.ofConcurrentHashMap[IO, String, String]()
+        _ <- entries.toSeq.traverse_ { case (k, v) => r(k).set(Some(v)) }
+        snapshot <- r.snapshot
+      } yield snapshot
+
+      op.map(a => a must_=== entries)
     }
   }
 


### PR DESCRIPTION
### Motivation

`MapRef` can be considered as a replacement for `Ref[F, Map[K, V]]`. However, currently, there is no way to retrieve all available values.

#### Why not add `snapshot` method directly to the `MapRef` trait?

Two reasons:
- We cannot implement `snapshot` for the `def fromSeqRefs[F[_]: Functor, K, V]` (`traverse` requires `Applicative`)
- For the majority of the implementations, the result type would be `Map[K, Option[V]]`, which is suboptimal

