### PR TITLE
Remove GraalVM from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-12]
         scala: [3.2.2, 2.12.17, 2.13.10]
-        java:
-          - temurin@8
-          - temurin@11
-          - temurin@17
-          - graalvm@17.0.12
+        java: [temurin@8, temurin@11, temurin@17]
         ci: [ciJVM, ciNative, ciJS, ciFirefox, ciChrome]
         exclude:
           - scala: 3.2.2
@@ -42,8 +38,6 @@ jobs:
             java: temurin@11
           - scala: 2.12.17
             java: temurin@17
-          - scala: 2.12.17
-            java: graalvm@17.0.12
           - os: windows-latest
             scala: 3.2.2
           - os: macos-12
@@ -64,8 +58,6 @@ jobs:
             java: temurin@11
           - ci: ciJS
             java: temurin@17
-          - ci: ciJS
-            java: graalvm@17.0.12
           - os: windows-latest
             ci: ciJS
           - os: macos-12
@@ -74,8 +66,6 @@ jobs:
             java: temurin@11
           - ci: ciFirefox
             java: temurin@17
-          - ci: ciFirefox
-            java: graalvm@17.0.12
           - os: windows-latest
             ci: ciFirefox
           - os: macos-12
@@ -84,8 +74,6 @@ jobs:
             java: temurin@11
           - ci: ciChrome
             java: temurin@17
-          - ci: ciChrome
-            java: graalvm@17.0.12
           - os: windows-latest
             ci: ciChrome
           - os: macos-12
@@ -94,8 +82,6 @@ jobs:
             java: temurin@11
           - ci: ciNative
             java: temurin@17
-          - ci: ciNative
-            java: graalvm@17.0.12
           - os: windows-latest
             ci: ciNative
           - os: macos-12
@@ -104,8 +90,6 @@ jobs:
           - os: macos-12
             ci: ciNative
             scala: 3.2.2
-          - os: windows-latest
-            java: graalvm@17.0.12
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -188,29 +172,6 @@ jobs:
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
-      - name: Download Java (graalvm@17.0.12)
-        id: download-java-graalvm-17.0.12
-        if: matrix.java == 'graalvm@17.0.12'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: graalvm
-          java-version: 17.0.12
-
-      - name: Setup Java (graalvm@17.0.12)
-        id: setup-java-graalvm-17.0.12
-        if: matrix.java == 'graalvm@17.0.12'
-        uses: actions/setup-java@v3
-        with:
-          distribution: jdkfile
-          java-version: 17.0.12
-          jdkFile: ${{ steps.download-java-graalvm-17.0.12.outputs.jdkFile }}
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'graalvm@17.0.12' && steps.setup-java-graalvm-17.0.12.outputs.cache-hit == 'false'
-        shell: bash
-        run: sbt '++ ${{ matrix.scala }}' reload +update
-
       - name: Setup NodeJS v18 LTS
         if: matrix.ci == 'ciJS'
         uses: actions/setup-node@v3
@@ -265,11 +226,6 @@ jobs:
         if: matrix.ci == 'ciJS' && matrix.os == 'ubuntu-latest'
         shell: bash
         run: example/test-js.sh ${{ matrix.scala }}
-
-      - name: Test GraalVM Native Image
-        if: matrix.scala == '2.13.10' && matrix.java == 'graalvm@17.0.12' && matrix.os == 'ubuntu-latest'
-        shell: bash
-        run: sbt '++ ${{ matrix.scala }}' graalVMExample/nativeImage graalVMExample/nativeImageRun
 
       - name: Test Example Native App Using Binary
         if: matrix.ci == 'ciNative' && matrix.os == 'ubuntu-latest'
@@ -384,28 +340,6 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
-        run: sbt '++ ${{ matrix.scala }}' reload +update
-
-      - name: Download Java (graalvm@17.0.12)
-        id: download-java-graalvm-17.0.12
-        if: matrix.java == 'graalvm@17.0.12'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: graalvm
-          java-version: 17.0.12
-
-      - name: Setup Java (graalvm@17.0.12)
-        id: setup-java-graalvm-17.0.12
-        if: matrix.java == 'graalvm@17.0.12'
-        uses: actions/setup-java@v3
-        with:
-          distribution: jdkfile
-          java-version: 17.0.12
-          jdkFile: ${{ steps.download-java-graalvm-17.0.12.outputs.jdkFile }}
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'graalvm@17.0.12' && steps.setup-java-graalvm-17.0.12.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
       - name: Download target directories (3.2.2, ciJVM)
@@ -633,28 +567,6 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
-        run: sbt '++ ${{ matrix.scala }}' reload +update
-
-      - name: Download Java (graalvm@17.0.12)
-        id: download-java-graalvm-17.0.12
-        if: matrix.java == 'graalvm@17.0.12'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: graalvm
-          java-version: 17.0.12
-
-      - name: Setup Java (graalvm@17.0.12)
-        id: setup-java-graalvm-17.0.12
-        if: matrix.java == 'graalvm@17.0.12'
-        uses: actions/setup-java@v3
-        with:
-          distribution: jdkfile
-          java-version: 17.0.12
-          jdkFile: ${{ steps.download-java-graalvm-17.0.12.outputs.jdkFile }}
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'graalvm@17.0.12' && steps.setup-java-graalvm-17.0.12.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
       - name: Submit Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-12]
         scala: [3.2.2, 2.12.17, 2.13.10]
-        java: [temurin@8, temurin@11, temurin@17, graalvm@21]
+        java:
+          - temurin@8
+          - temurin@11
+          - temurin@17
+          - graalvm@17.0.12
         ci: [ciJVM, ciNative, ciJS, ciFirefox, ciChrome]
         exclude:
           - scala: 3.2.2
@@ -39,7 +43,7 @@ jobs:
           - scala: 2.12.17
             java: temurin@17
           - scala: 2.12.17
-            java: graalvm@21
+            java: graalvm@17.0.12
           - os: windows-latest
             scala: 3.2.2
           - os: macos-12
@@ -61,7 +65,7 @@ jobs:
           - ci: ciJS
             java: temurin@17
           - ci: ciJS
-            java: graalvm@21
+            java: graalvm@17.0.12
           - os: windows-latest
             ci: ciJS
           - os: macos-12
@@ -71,7 +75,7 @@ jobs:
           - ci: ciFirefox
             java: temurin@17
           - ci: ciFirefox
-            java: graalvm@21
+            java: graalvm@17.0.12
           - os: windows-latest
             ci: ciFirefox
           - os: macos-12
@@ -81,7 +85,7 @@ jobs:
           - ci: ciChrome
             java: temurin@17
           - ci: ciChrome
-            java: graalvm@21
+            java: graalvm@17.0.12
           - os: windows-latest
             ci: ciChrome
           - os: macos-12
@@ -91,7 +95,7 @@ jobs:
           - ci: ciNative
             java: temurin@17
           - ci: ciNative
-            java: graalvm@21
+            java: graalvm@17.0.12
           - os: windows-latest
             ci: ciNative
           - os: macos-12
@@ -101,7 +105,7 @@ jobs:
             ci: ciNative
             scala: 3.2.2
           - os: windows-latest
-            java: graalvm@21
+            java: graalvm@17.0.12
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -184,26 +188,26 @@ jobs:
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
-      - name: Download Java (graalvm@21)
-        id: download-java-graalvm-21
-        if: matrix.java == 'graalvm@21'
+      - name: Download Java (graalvm@17.0.12)
+        id: download-java-graalvm-17.0.12
+        if: matrix.java == 'graalvm@17.0.12'
         uses: typelevel/download-java@v2
         with:
           distribution: graalvm
-          java-version: 21
+          java-version: 17.0.12
 
-      - name: Setup Java (graalvm@21)
-        id: setup-java-graalvm-21
-        if: matrix.java == 'graalvm@21'
+      - name: Setup Java (graalvm@17.0.12)
+        id: setup-java-graalvm-17.0.12
+        if: matrix.java == 'graalvm@17.0.12'
         uses: actions/setup-java@v3
         with:
           distribution: jdkfile
-          java-version: 21
-          jdkFile: ${{ steps.download-java-graalvm-21.outputs.jdkFile }}
+          java-version: 17.0.12
+          jdkFile: ${{ steps.download-java-graalvm-17.0.12.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'graalvm@21' && steps.setup-java-graalvm-21.outputs.cache-hit == 'false'
+        if: matrix.java == 'graalvm@17.0.12' && steps.setup-java-graalvm-17.0.12.outputs.cache-hit == 'false'
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
@@ -263,7 +267,7 @@ jobs:
         run: example/test-js.sh ${{ matrix.scala }}
 
       - name: Test GraalVM Native Image
-        if: matrix.scala == '2.13.10' && matrix.java == 'graalvm@21' && matrix.os == 'ubuntu-latest'
+        if: matrix.scala == '2.13.10' && matrix.java == 'graalvm@17.0.12' && matrix.os == 'ubuntu-latest'
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' graalVMExample/nativeImage graalVMExample/nativeImageRun
 
@@ -382,26 +386,26 @@ jobs:
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
-      - name: Download Java (graalvm@21)
-        id: download-java-graalvm-21
-        if: matrix.java == 'graalvm@21'
+      - name: Download Java (graalvm@17.0.12)
+        id: download-java-graalvm-17.0.12
+        if: matrix.java == 'graalvm@17.0.12'
         uses: typelevel/download-java@v2
         with:
           distribution: graalvm
-          java-version: 21
+          java-version: 17.0.12
 
-      - name: Setup Java (graalvm@21)
-        id: setup-java-graalvm-21
-        if: matrix.java == 'graalvm@21'
+      - name: Setup Java (graalvm@17.0.12)
+        id: setup-java-graalvm-17.0.12
+        if: matrix.java == 'graalvm@17.0.12'
         uses: actions/setup-java@v3
         with:
           distribution: jdkfile
-          java-version: 21
-          jdkFile: ${{ steps.download-java-graalvm-21.outputs.jdkFile }}
+          java-version: 17.0.12
+          jdkFile: ${{ steps.download-java-graalvm-17.0.12.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'graalvm@21' && steps.setup-java-graalvm-21.outputs.cache-hit == 'false'
+        if: matrix.java == 'graalvm@17.0.12' && steps.setup-java-graalvm-17.0.12.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
       - name: Download target directories (3.2.2, ciJVM)
@@ -631,26 +635,26 @@ jobs:
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
-      - name: Download Java (graalvm@21)
-        id: download-java-graalvm-21
-        if: matrix.java == 'graalvm@21'
+      - name: Download Java (graalvm@17.0.12)
+        id: download-java-graalvm-17.0.12
+        if: matrix.java == 'graalvm@17.0.12'
         uses: typelevel/download-java@v2
         with:
           distribution: graalvm
-          java-version: 21
+          java-version: 17.0.12
 
-      - name: Setup Java (graalvm@21)
-        id: setup-java-graalvm-21
-        if: matrix.java == 'graalvm@21'
+      - name: Setup Java (graalvm@17.0.12)
+        id: setup-java-graalvm-17.0.12
+        if: matrix.java == 'graalvm@17.0.12'
         uses: actions/setup-java@v3
         with:
           distribution: jdkfile
-          java-version: 21
-          jdkFile: ${{ steps.download-java-graalvm-21.outputs.jdkFile }}
+          java-version: 17.0.12
+          jdkFile: ${{ steps.download-java-graalvm-17.0.12.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'graalvm@21' && steps.setup-java-graalvm-21.outputs.cache-hit == 'false'
+        if: matrix.java == 'graalvm@17.0.12' && steps.setup-java-graalvm-17.0.12.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
       - name: Submit Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-12]
         scala: [3.2.2, 2.12.17, 2.13.10]
-        java: [temurin@8, temurin@11, temurin@17, graalvm@17]
+        java: [temurin@8, temurin@11, temurin@17, graalvm@21]
         ci: [ciJVM, ciNative, ciJS, ciFirefox, ciChrome]
         exclude:
           - scala: 3.2.2
@@ -39,7 +39,7 @@ jobs:
           - scala: 2.12.17
             java: temurin@17
           - scala: 2.12.17
-            java: graalvm@17
+            java: graalvm@21
           - os: windows-latest
             scala: 3.2.2
           - os: macos-12
@@ -61,7 +61,7 @@ jobs:
           - ci: ciJS
             java: temurin@17
           - ci: ciJS
-            java: graalvm@17
+            java: graalvm@21
           - os: windows-latest
             ci: ciJS
           - os: macos-12
@@ -71,7 +71,7 @@ jobs:
           - ci: ciFirefox
             java: temurin@17
           - ci: ciFirefox
-            java: graalvm@17
+            java: graalvm@21
           - os: windows-latest
             ci: ciFirefox
           - os: macos-12
@@ -81,7 +81,7 @@ jobs:
           - ci: ciChrome
             java: temurin@17
           - ci: ciChrome
-            java: graalvm@17
+            java: graalvm@21
           - os: windows-latest
             ci: ciChrome
           - os: macos-12
@@ -91,7 +91,7 @@ jobs:
           - ci: ciNative
             java: temurin@17
           - ci: ciNative
-            java: graalvm@17
+            java: graalvm@21
           - os: windows-latest
             ci: ciNative
           - os: macos-12
@@ -101,7 +101,7 @@ jobs:
             ci: ciNative
             scala: 3.2.2
           - os: windows-latest
-            java: graalvm@17
+            java: graalvm@21
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -184,26 +184,26 @@ jobs:
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
-      - name: Download Java (graalvm@17)
-        id: download-java-graalvm-17
-        if: matrix.java == 'graalvm@17'
+      - name: Download Java (graalvm@21)
+        id: download-java-graalvm-21
+        if: matrix.java == 'graalvm@21'
         uses: typelevel/download-java@v2
         with:
           distribution: graalvm
-          java-version: 17
+          java-version: 21
 
-      - name: Setup Java (graalvm@17)
-        id: setup-java-graalvm-17
-        if: matrix.java == 'graalvm@17'
+      - name: Setup Java (graalvm@21)
+        id: setup-java-graalvm-21
+        if: matrix.java == 'graalvm@21'
         uses: actions/setup-java@v3
         with:
           distribution: jdkfile
-          java-version: 17
-          jdkFile: ${{ steps.download-java-graalvm-17.outputs.jdkFile }}
+          java-version: 21
+          jdkFile: ${{ steps.download-java-graalvm-21.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'graalvm@17' && steps.setup-java-graalvm-17.outputs.cache-hit == 'false'
+        if: matrix.java == 'graalvm@21' && steps.setup-java-graalvm-21.outputs.cache-hit == 'false'
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
@@ -217,11 +217,6 @@ jobs:
         if: matrix.ci == 'ciJS'
         shell: bash
         run: npm install
-
-      - name: Install GraalVM Native Image
-        if: matrix.java == 'graalvm@17'
-        shell: bash
-        run: gu install native-image
 
       - name: Configure Windows Pagefile
         if: matrix.os == 'windows-latest'
@@ -268,7 +263,7 @@ jobs:
         run: example/test-js.sh ${{ matrix.scala }}
 
       - name: Test GraalVM Native Image
-        if: matrix.scala == '2.13.10' && matrix.java == 'graalvm@17' && matrix.os == 'ubuntu-latest'
+        if: matrix.scala == '2.13.10' && matrix.java == 'graalvm@21' && matrix.os == 'ubuntu-latest'
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' graalVMExample/nativeImage graalVMExample/nativeImageRun
 
@@ -387,26 +382,26 @@ jobs:
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
-      - name: Download Java (graalvm@17)
-        id: download-java-graalvm-17
-        if: matrix.java == 'graalvm@17'
+      - name: Download Java (graalvm@21)
+        id: download-java-graalvm-21
+        if: matrix.java == 'graalvm@21'
         uses: typelevel/download-java@v2
         with:
           distribution: graalvm
-          java-version: 17
+          java-version: 21
 
-      - name: Setup Java (graalvm@17)
-        id: setup-java-graalvm-17
-        if: matrix.java == 'graalvm@17'
+      - name: Setup Java (graalvm@21)
+        id: setup-java-graalvm-21
+        if: matrix.java == 'graalvm@21'
         uses: actions/setup-java@v3
         with:
           distribution: jdkfile
-          java-version: 17
-          jdkFile: ${{ steps.download-java-graalvm-17.outputs.jdkFile }}
+          java-version: 21
+          jdkFile: ${{ steps.download-java-graalvm-21.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'graalvm@17' && steps.setup-java-graalvm-17.outputs.cache-hit == 'false'
+        if: matrix.java == 'graalvm@21' && steps.setup-java-graalvm-21.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
       - name: Download target directories (3.2.2, ciJVM)
@@ -636,26 +631,26 @@ jobs:
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
-      - name: Download Java (graalvm@17)
-        id: download-java-graalvm-17
-        if: matrix.java == 'graalvm@17'
+      - name: Download Java (graalvm@21)
+        id: download-java-graalvm-21
+        if: matrix.java == 'graalvm@21'
         uses: typelevel/download-java@v2
         with:
           distribution: graalvm
-          java-version: 17
+          java-version: 21
 
-      - name: Setup Java (graalvm@17)
-        id: setup-java-graalvm-17
-        if: matrix.java == 'graalvm@17'
+      - name: Setup Java (graalvm@21)
+        id: setup-java-graalvm-21
+        if: matrix.java == 'graalvm@21'
         uses: actions/setup-java@v3
         with:
           distribution: jdkfile
-          java-version: 17
-          jdkFile: ${{ steps.download-java-graalvm-17.outputs.jdkFile }}
+          java-version: 21
+          jdkFile: ${{ steps.download-java-graalvm-21.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'graalvm@17' && steps.setup-java-graalvm-17.outputs.cache-hit == 'false'
+        if: matrix.java == 'graalvm@21' && steps.setup-java-graalvm-21.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
       - name: Submit Dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -137,9 +137,8 @@ val LTSJava = JavaSpec.temurin("11")
 val LatestJava = JavaSpec.temurin("17")
 val ScalaJSJava = OldGuardJava
 val ScalaNativeJava = OldGuardJava
-val GraalVM = JavaSpec.graalvm("17.0.12")
 
-ThisBuild / githubWorkflowJavaVersions := Seq(OldGuardJava, LTSJava, LatestJava, GraalVM)
+ThisBuild / githubWorkflowJavaVersions := Seq(OldGuardJava, LTSJava, LatestJava)
 ThisBuild / githubWorkflowOSes := Seq(PrimaryOS, Windows, MacOS)
 
 ThisBuild / githubWorkflowBuildPreamble ++= Seq(
@@ -189,12 +188,6 @@ ThisBuild / githubWorkflowBuild := Seq("JVM", "JS", "Native").map { platform =>
     name = Some("Test Example JavaScript App Using Node"),
     cond = Some(s"matrix.ci == 'ciJS' && matrix.os == '$PrimaryOS'")
   ),
-  WorkflowStep.Sbt(
-    List("graalVMExample/nativeImage", "graalVMExample/nativeImageRun"),
-    name = Some("Test GraalVM Native Image"),
-    cond = Some(
-      s"matrix.scala == '$Scala213' && matrix.java == '${GraalVM.render}' && matrix.os == '$PrimaryOS'")
-  ),
   WorkflowStep.Run(
     List("example/test-native.sh ${{ matrix.scala }}"),
     name = Some("Test Example Native App Using Binary"),
@@ -223,7 +216,7 @@ ThisBuild / githubWorkflowBuildMatrixExclusions := {
   val scalaJavaFilters = for {
     scala <- (ThisBuild / githubWorkflowScalaVersions).value.filterNot(Set(Scala213))
     java <- (ThisBuild / githubWorkflowJavaVersions).value.filterNot(Set(OldGuardJava))
-    if !(scala == Scala3 && (java == LatestJava || java == GraalVM))
+    if !(scala == Scala3 && java == LatestJava)
   } yield MatrixExclude(Map("scala" -> scala, "java" -> java.render))
 
   val windowsAndMacScalaFilters =
@@ -265,12 +258,7 @@ ThisBuild / githubWorkflowBuildMatrixExclusions := {
     )
   }
 
-  // Nice-to-haves but unreliable in CI
-  val flakyFilters = Seq(
-    MatrixExclude(Map("os" -> Windows, "java" -> GraalVM.render))
-  )
-
-  scalaJavaFilters ++ windowsAndMacScalaFilters ++ jsScalaFilters ++ jsJavaAndOSFilters ++ nativeJavaAndOSFilters ++ flakyFilters
+  scalaJavaFilters ++ windowsAndMacScalaFilters ++ jsScalaFilters ++ jsJavaAndOSFilters ++ nativeJavaAndOSFilters
 }
 
 lazy val useJSEnv =
@@ -914,8 +902,8 @@ lazy val testsJVM = tests
   )
 
 /**
- * Implementations of standard functionality (e.g. Semaphore, Console, Queue) purely in terms
- * of the typeclasses, with no dependency on IO. In most cases, the *tests* for these
+ * Implementations of standard functionality (e.g. Semaphore, Console, Queue) purely in terms of
+ * the typeclasses, with no dependency on IO. In most cases, the *tests* for these
  * implementations will require IO, and thus those tests will be located within the core
  * project.
  */
@@ -992,10 +980,14 @@ lazy val std = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         ProblemFilters.exclude[MissingClassProblem](
           "cats.effect.std.Dispatcher$Mode$Sequential$"),
         // #4052, private classes
-        ProblemFilters.exclude[MissingTypesProblem]("cats.effect.std.Dispatcher$RegState$Unstarted$"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.std.Dispatcher#RegState#Unstarted.*"),
-        ProblemFilters.exclude[FinalMethodProblem]("cats.effect.std.Dispatcher#RegState#Unstarted.toString"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.std.Dispatcher#Registration#Primary.*"),
+        ProblemFilters.exclude[MissingTypesProblem](
+          "cats.effect.std.Dispatcher$RegState$Unstarted$"),
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "cats.effect.std.Dispatcher#RegState#Unstarted.*"),
+        ProblemFilters.exclude[FinalMethodProblem](
+          "cats.effect.std.Dispatcher#RegState#Unstarted.toString"),
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "cats.effect.std.Dispatcher#Registration#Primary.*")
       )
   )
   .jsSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -137,7 +137,7 @@ val LTSJava = JavaSpec.temurin("11")
 val LatestJava = JavaSpec.temurin("17")
 val ScalaJSJava = OldGuardJava
 val ScalaNativeJava = OldGuardJava
-val GraalVM = JavaSpec.graalvm("17")
+val GraalVM = JavaSpec.graalvm("21")
 
 ThisBuild / githubWorkflowJavaVersions := Seq(OldGuardJava, LTSJava, LatestJava, GraalVM)
 ThisBuild / githubWorkflowOSes := Seq(PrimaryOS, Windows, MacOS)
@@ -153,11 +153,6 @@ ThisBuild / githubWorkflowBuildPreamble ++= Seq(
     List("npm install"),
     name = Some("Install jsdom and source-map-support"),
     cond = Some("matrix.ci == 'ciJS'")
-  ),
-  WorkflowStep.Run(
-    List("gu install native-image"),
-    name = Some("Install GraalVM Native Image"),
-    cond = Some(s"matrix.java == '${GraalVM.render}'")
   ),
   WorkflowStep.Use(
     UseRef.Public(

--- a/build.sbt
+++ b/build.sbt
@@ -137,7 +137,7 @@ val LTSJava = JavaSpec.temurin("11")
 val LatestJava = JavaSpec.temurin("17")
 val ScalaJSJava = OldGuardJava
 val ScalaNativeJava = OldGuardJava
-val GraalVM = JavaSpec.graalvm("21")
+val GraalVM = JavaSpec.graalvm("17.0.12")
 
 ThisBuild / githubWorkflowJavaVersions := Seq(OldGuardJava, LTSJava, LatestJava, GraalVM)
 ThisBuild / githubWorkflowOSes := Seq(PrimaryOS, Windows, MacOS)


### PR DESCRIPTION
GraalVM is no longer available under the free license: https://github.com/graalvm/setup-graalvm#notes-on-oracle-graalvm-for-jdk-17

sbt-typelevel already did the same: https://github.com/typelevel/sbt-typelevel/pull/763