### PR TITLE
Check target array length before allocating

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/ArrayStackBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/ArrayStackBenchmark.scala
@@ -17,7 +17,8 @@
 package cats.effect.benchmarks
 
 import cats.effect.ArrayStack
-import org.openjdk.jmh.annotations.*
+
+import org.openjdk.jmh.annotations._
 
 import java.util.concurrent.TimeUnit
 

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/ArrayStackBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/ArrayStackBenchmark.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020-2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.benchmarks
+
+import cats.effect.ArrayStack
+import org.openjdk.jmh.annotations.*
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * To do comparative benchmarks between versions:
+ *
+ * benchmarks/run-benchmark ArrayStackBenchmark
+ *
+ * This will generate results in `benchmarks/results`.
+ *
+ * Or to run the benchmark from within sbt:
+ *
+ * Jmh / run -i 10 -wi 10 -f 2 -t 1 cats.effect.benchmarks.ArrayStackBenchmark
+ *
+ * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread". Please note that
+ * benchmarks should be usually executed at least in 10 iterations (as a rule of thumb), but
+ * more is better.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class ArrayStackBenchmark {
+
+  @Param(Array("1000000"))
+  var size: Int = _
+
+  @Benchmark
+  def push(): Unit = {
+    val stack: ArrayStack[Integer] = ArrayStack[Integer](size)
+
+    var i = 0
+    while (i < size) {
+      stack.push(i)
+      i += 1
+    }
+  }
+}

--- a/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
@@ -19,7 +19,7 @@ package cats.effect
 import Platform.static
 import PlatformStatics.VM_MaxArraySize
 
-private final class ArrayStack[A <: AnyRef](
+private[effect] final class ArrayStack[A <: AnyRef](
     private[this] var buffer: Array[AnyRef],
     private[this] var index: Int) {
 

--- a/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
@@ -16,8 +16,9 @@
 
 package cats.effect
 
-import Platform.static
 import PlatformStatics.VM_MaxArraySize
+
+import Platform.static
 
 private[effect] final class ArrayStack[A <: AnyRef](
     private[this] var buffer: Array[AnyRef],

--- a/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
@@ -17,7 +17,6 @@
 package cats.effect
 
 import PlatformStatics.VM_MaxArraySize
-
 import Platform.static
 
 private[effect] final class ArrayStack[A <: AnyRef](

--- a/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala
@@ -17,6 +17,7 @@
 package cats.effect
 
 import Platform.static
+import PlatformStatics.VM_MaxArraySize
 
 private final class ArrayStack[A <: AnyRef](
     private[this] var buffer: Array[AnyRef],
@@ -72,7 +73,17 @@ private final class ArrayStack[A <: AnyRef](
   private[this] def checkAndGrow(): Unit =
     if (index >= buffer.length) {
       val len = buffer.length
-      val buffer2 = new Array[AnyRef](len * 2)
+      val targetLen = len * 2
+
+      val resizeLen =
+        if (targetLen < 0)
+          throw new Exception(s"Overflow while resizing array. Request length: $targetLen")
+        else if (len > VM_MaxArraySize / 2)
+          VM_MaxArraySize
+        else
+          targetLen
+
+      val buffer2 = new Array[AnyRef](resizeLen)
       System.arraycopy(buffer, 0, buffer2, 0, len)
       buffer = buffer2
     }

--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -20,8 +20,7 @@ import scala.annotation.tailrec
 
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
-import CallbackStack.Handle
-import CallbackStack.Node
+import CallbackStack.{Handle, Node}
 import Platform.static
 
 private final class CallbackStack[A](private[this] var callback: A => Unit)

--- a/core/jvm-native/src/main/scala/cats/effect/PlatformStatics.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/PlatformStatics.scala
@@ -1,0 +1,8 @@
+package cats.effect
+
+// copy from scala.runtime.PStatics
+private[effect] object PlatformStatics {
+  // `Int.MaxValue - 8` traditional soft limit to maximize compatibility with diverse JVMs
+  // See https://stackoverflow.com/a/8381338 for example
+  final val VM_MaxArraySize = 2147483639
+}

--- a/core/jvm-native/src/main/scala/cats/effect/PlatformStatics.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/PlatformStatics.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020-2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cats.effect
 
 // copy from scala.runtime.PStatics

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -36,6 +36,7 @@ import cats.{
   StackSafeMonad,
   Traverse
 }
+import cats.data.Ior
 import cats.effect.instances.spawn
 import cats.effect.kernel.CancelScope
 import cats.effect.kernel.GenTemporal.handleDuration
@@ -55,8 +56,6 @@ import java.util.UUID
 import java.util.concurrent.Executor
 
 import Platform.static
-
-import cats.data.Ior
 
 /**
  * A pure abstraction representing the intention to perform a side effect, where the result of

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -36,7 +36,6 @@ import cats.{
   StackSafeMonad,
   Traverse
 }
-import cats.data.Ior
 import cats.effect.instances.spawn
 import cats.effect.kernel.CancelScope
 import cats.effect.kernel.GenTemporal.handleDuration
@@ -56,6 +55,8 @@ import java.util.UUID
 import java.util.concurrent.Executor
 
 import Platform.static
+
+import cats.data.Ior
 
 /**
  * A pure abstraction representing the intention to perform a side effect, where the result of


### PR DESCRIPTION
The current implementation of the array inside `ArrayStack` does not verify the length of the new array, and this may lead to overflow problem.

https://github.com/typelevel/cats-effect/blob/ecf93db298c7fdb33df3be96dbe24e8f9bf90b9c/core/jvm-native/src/main/scala/cats/effect/ArrayStack.scala#L72-L78

Here we add a check on
- Int overflow
- Array length exceed VM limit

see also: https://github.com/typelevel/cats-effect/pull/4135