### PR TITLE
Use `IO.unit` in `Async[IO].unit`

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1986,6 +1986,9 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits with TuplePara
     def pure[A](x: A): IO[A] =
       IO.pure(x)
 
+    override def unit: IO[Unit] =
+      IO.unit
+
     override def guarantee[A](fa: IO[A], fin: IO[Unit]): IO[A] =
       fa.guarantee(fin)
 


### PR DESCRIPTION
The default implementation from `Applicative` is `def unit: F[Unit] = pure(())`.

Currently, `Async[IO].unit.replicate(100)` would result in 100 `IO.Pure(())`. But with override, we will reuse the same single unit instance.