### PR TITLE
Propagate Java thread interruption in `Dispatcher#unsafeRunSync`

### DIFF
--- a/std/jvm/src/main/scala/cats/effect/std/DispatcherPlatform.scala
+++ b/std/jvm/src/main/scala/cats/effect/std/DispatcherPlatform.scala
@@ -59,10 +59,7 @@ private[std] trait DispatcherPlatform[F[_]] { this: Dispatcher[F] =>
     val (fut, cancel) = unsafeToFutureCancelable(fa)
     try Await.result(fut, timeout)
     catch {
-      case t: TimeoutException =>
-        cancel()
-        throw t
-      case t: InterruptedException =>
+      case t @ (_: TimeoutException | _: InterruptedException) =>
         cancel()
         throw t
     }

--- a/std/jvm/src/main/scala/cats/effect/std/DispatcherPlatform.scala
+++ b/std/jvm/src/main/scala/cats/effect/std/DispatcherPlatform.scala
@@ -16,10 +16,9 @@
 
 package cats.effect.std
 
-import scala.concurrent.{Await, TimeoutException}
-import scala.concurrent.duration.Duration
-
 import java.util.concurrent.CompletableFuture
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, TimeoutException}
 
 private[std] trait DispatcherPlatform[F[_]] { this: Dispatcher[F] =>
 
@@ -60,6 +59,9 @@ private[std] trait DispatcherPlatform[F[_]] { this: Dispatcher[F] =>
     try Await.result(fut, timeout)
     catch {
       case t: TimeoutException =>
+        cancel()
+        throw t
+      case t: InterruptedException =>
         cancel()
         throw t
     }

--- a/std/jvm/src/main/scala/cats/effect/std/DispatcherPlatform.scala
+++ b/std/jvm/src/main/scala/cats/effect/std/DispatcherPlatform.scala
@@ -16,9 +16,10 @@
 
 package cats.effect.std
 
-import java.util.concurrent.CompletableFuture
-import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, TimeoutException}
+import scala.concurrent.duration.Duration
+
+import java.util.concurrent.CompletableFuture
 
 private[std] trait DispatcherPlatform[F[_]] { this: Dispatcher[F] =>
 

--- a/std/jvm/src/main/scala/cats/effect/std/DispatcherPlatform.scala
+++ b/std/jvm/src/main/scala/cats/effect/std/DispatcherPlatform.scala
@@ -44,16 +44,17 @@ private[std] trait DispatcherPlatform[F[_]] { this: Dispatcher[F] =>
   }
 
   /**
-   * Submits an effect to be executed and indefinitely blocks until a result is produced. This
-   * function will throw an exception if the submitted effect terminates with an error.
+   * Submits an effect to be executed and indefinitely blocks until a result is produced.
+   * Cancels the effect in case of Java thread interruption. This function will throw an
+   * exception if the submitted effect terminates with an error.
    */
   def unsafeRunSync[A](fa: F[A]): A =
     unsafeRunTimed(fa, Duration.Inf)
 
   /**
    * Submits an effect to be executed and blocks for at most the specified timeout for a result
-   * to be produced. This function will throw an exception if the submitted effect terminates
-   * with an error.
+   * to be produced. Cancels the effect both in case of timeout or Java thread interruption.
+   * This function will throw an exception if the submitted effect terminates with an error.
    */
   def unsafeRunTimed[A](fa: F[A], timeout: Duration): A = {
     val (fut, cancel) = unsafeToFutureCancelable(fa)

--- a/tests/jvm/src/test/scala/cats/effect/std/DispatcherJVMSpec.scala
+++ b/tests/jvm/src/test/scala/cats/effect/std/DispatcherJVMSpec.scala
@@ -49,10 +49,10 @@ class DispatcherJVMSpec extends BaseSpec {
       val res = Dispatcher.parallel[IO](await = true).evalMap { dispatcher =>
         for {
           canceled <- Deferred[IO, Unit]
-          io = IO.sleep(1.second).onCancel(IO.println("canceled") >> canceled.complete(()).void)
+          io = IO.sleep(1.second).onCancel(canceled.complete(()).void)
           thread = new Thread(() =>
             try dispatcher.unsafeRunSync(io)
-            catch { case _: InterruptedException => println("interrupted") })
+            catch { case _: InterruptedException => })
           _ <- IO(thread.start).as(thread)
           _ <- IO.sleep(100.millis)
           _ <- IO(thread.interrupt())


### PR DESCRIPTION
Closes #4166.