### PR TITLE
Only remove error callback if we've added it

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1012,15 +1012,21 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
       oc =>
         oc.fold(
           {
-            runtime.fiberErrorCbs.remove(failure)
+            if (registerCallback) {
+              runtime.fiberErrorCbs.remove(failure)
+            }
             canceled
           },
           { t =>
-            runtime.fiberErrorCbs.remove(failure)
+            if (registerCallback) {
+              runtime.fiberErrorCbs.remove(failure)
+            }
             failure(t)
           },
           { ioa =>
-            runtime.fiberErrorCbs.remove(failure)
+            if (registerCallback) {
+              runtime.fiberErrorCbs.remove(failure)
+            }
             success(ioa.asInstanceOf[IO.Pure[A]].value)
           }
         ),

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1009,27 +1009,16 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
 
     val fiber = new IOFiber[A](
       Map.empty,
-      oc =>
+      { oc =>
+        if (registerCallback) {
+          runtime.fiberErrorCbs.remove(failure)
+        }
         oc.fold(
-          {
-            if (registerCallback) {
-              runtime.fiberErrorCbs.remove(failure)
-            }
-            canceled
-          },
-          { t =>
-            if (registerCallback) {
-              runtime.fiberErrorCbs.remove(failure)
-            }
-            failure(t)
-          },
-          { ioa =>
-            if (registerCallback) {
-              runtime.fiberErrorCbs.remove(failure)
-            }
-            success(ioa.asInstanceOf[IO.Pure[A]].value)
-          }
-        ),
+          canceled,
+          failure,
+          { ioa => success(ioa.asInstanceOf[IO.Pure[A]].value) },
+        )
+      },
       this,
       runtime.compute,
       runtime

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1016,7 +1016,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
         oc.fold(
           canceled,
           failure,
-          { ioa => success(ioa.asInstanceOf[IO.Pure[A]].value) },
+          { ioa => success(ioa.asInstanceOf[IO.Pure[A]].value) }
         )
       },
       this,


### PR DESCRIPTION
This was probably just an oversight in #2869. It's probably not a big deal, but also, why do unnecessary work...

FIXME: is "enhancement" the correct label for this? Or should it be "backstage"?