### PR TITLE
Fix `size` updates in `Dequeue` state machine

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/Dequeue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dequeue.scala
@@ -187,7 +187,7 @@ object Dequeue {
       state.flatModify {
         case State(queue, size, takers, offerers) if takers.nonEmpty =>
           val (taker, rest) = takers.dequeue
-          State(update(queue), size, rest, offerers) -> taker.complete(()).as(true)
+          State(update(queue), size + 1, rest, offerers) -> taker.complete(()).as(true)
 
         case State(queue, size, takers, offerers) if size < capacity =>
           State(update(queue), size + 1, takers, offerers) -> F.pure(true)

--- a/std/shared/src/main/scala/cats/effect/std/Dequeue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Dequeue.scala
@@ -158,7 +158,7 @@ object Dequeue {
           state.modify {
             case State(queue, size, takers, offerers) if takers.nonEmpty =>
               val (taker, rest) = takers.dequeue
-              State(update(queue), size, rest, offerers) -> taker.complete(()).void
+              State(update(queue), size + 1, rest, offerers) -> taker.complete(()).void
 
             case State(queue, size, takers, offerers) if size < capacity =>
               State(update(queue), size + 1, takers, offerers) -> F.unit

--- a/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
@@ -965,5 +965,11 @@ trait QueueTests[Q[_[_], _]] { self: BaseSpec =>
         r <- IO(v2 must beEqualTo(2))
       } yield r
     }
+
+    "should return the queue size when take precedes offer" in ticked { implicit ticker =>
+      constructor(10).flatMap { q =>
+        take(q).background.use { took => IO.sleep(1.second) *> offer(q, 1) *> took *> size(q) }
+      } must completeAs(0)
+    }
   }
 }

--- a/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
@@ -974,7 +974,9 @@ trait QueueTests[Q[_[_], _]] { self: BaseSpec =>
 
     "should return the queue size when take precedes tryOffer" in ticked { implicit ticker =>
       constructor(10).flatMap { q =>
-        take(q).background.use { took => IO.sleep(1.second) *> tryOffer(q, 1) *> took *> size(q) }
+        take(q).background.use { took =>
+          IO.sleep(1.second) *> tryOffer(q, 1) *> took *> size(q)
+        }
       } must completeAs(0)
     }
   }

--- a/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/QueueSpec.scala
@@ -971,5 +971,11 @@ trait QueueTests[Q[_[_], _]] { self: BaseSpec =>
         take(q).background.use { took => IO.sleep(1.second) *> offer(q, 1) *> took *> size(q) }
       } must completeAs(0)
     }
+
+    "should return the queue size when take precedes tryOffer" in ticked { implicit ticker =>
+      constructor(10).flatMap { q =>
+        take(q).background.use { took => IO.sleep(1.second) *> tryOffer(q, 1) *> took *> size(q) }
+      } must completeAs(0)
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/4170, h/t @reardonj for identifying the problematic logic.