### PR TITLE
Removed implicit modifiers on deprecated instance to avoid unavoidable warnings

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1302,9 +1302,7 @@ private[effect] trait ResourceHOInstances3 extends ResourceHOInstances4 {
 }
 
 private[effect] trait ResourceHOInstances4 extends ResourceHOInstances5 {
-  @deprecated(
-    "Use catsEffectMonadCancelForResource",
-    "3.6.0")
+  @deprecated("Use catsEffectMonadCancelForResource", "3.6.0")
   def catsEffectMonadErrorForResource[F[_], E](
       F0: MonadError[F, E]): MonadError[Resource[F, *], E] =
     new ResourceMonadError[F, E] {

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1305,8 +1305,8 @@ private[effect] trait ResourceHOInstances4 extends ResourceHOInstances5 {
   @deprecated(
     "Bring an implicit MonadCancelThrow[F] into scope to get the fixed Resource instance",
     "3.6.0")
-  implicit def catsEffectMonadErrorForResource[F[_], E](
-      implicit F0: MonadError[F, E]): MonadError[Resource[F, *], E] =
+  def catsEffectMonadErrorForResource[F[_], E](
+      F0: MonadError[F, E]): MonadError[Resource[F, *], E] =
     new ResourceMonadError[F, E] {
       def F = F0
     }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -1303,7 +1303,7 @@ private[effect] trait ResourceHOInstances3 extends ResourceHOInstances4 {
 
 private[effect] trait ResourceHOInstances4 extends ResourceHOInstances5 {
   @deprecated(
-    "Bring an implicit MonadCancelThrow[F] into scope to get the fixed Resource instance",
+    "Use catsEffectMonadCancelForResource",
     "3.6.0")
   def catsEffectMonadErrorForResource[F[_], E](
       F0: MonadError[F, E]): MonadError[Resource[F, *], E] =


### PR DESCRIPTION
This should fix HEAD builds.