### PR TITLE
Update `onNonMainThreadDetected()` warning

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -350,7 +350,11 @@ trait IOApp {
           """|[WARNING] IOApp `main` is running on a thread other than the main thread.
              |This may prevent correct resource cleanup after `main` completes.
              |This condition could be caused by executing `run` in an interactive sbt session with `fork := false`.
-             |Set `Compile / run / fork := true` in this project to resolve this.
+             |To ensure proper cleanup, either
+             |  - set `Compile / run / fork := true` in this project
+             |  - use `fgRun` instead of `run`
+             |  - use 'bgStop` to terminiate `run`
+             |  - update sbt to a version after 1.10.5
              |
              |To silence this warning set the system property:
              |`-Dcats.effect.warnOnNonMainThreadDetected=false`.

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -353,7 +353,7 @@ trait IOApp {
              |To ensure proper cleanup, either
              |  - set `Compile / run / fork := true` in this project
              |  - use `fgRun` instead of `run`
-             |  - use 'bgStop` to terminiate `run`
+             |  - use 'bgStop` to terminate `run`
              |  - update sbt to a version after 1.10.5
              |
              |To silence this warning set the system property:


### PR DESCRIPTION
Updates the warning to reflect the latest understanding of https://github.com/typelevel/cats-effect/issues/2251 from https://discord.com/channels/632277896739946517/632277897448652844/1310909184937824287

@djspiewak 