### PR TITLE
Blocked thread detection fixes

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -549,6 +549,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
           if (pool.blockedThreadDetectionEnabled) {
             // TODO prefetch pool.workerThread or Thread.State.BLOCKED ?
             // TODO check that branch elimination makes it free when off
+            val idx = index
             var otherIdx = random.nextInt(pool.getWorkerThreads.length)
             if (otherIdx == idx) {
               otherIdx =

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -550,13 +550,8 @@ private[effect] final class WorkerThread[P <: AnyRef](
             // TODO prefetch pool.workerThread or Thread.State.BLOCKED ?
             // TODO check that branch elimination makes it free when off
             val idx = index
-            var otherIdx = random.nextInt(pool.getWorkerThreads.length)
-            if (otherIdx == idx) {
-              otherIdx =
-                (idx + Math.max(1, random.nextInt(pool.getWorkerThreads.length - 1))) % pool
-                  .getWorkerThreads
-                  .length
-            }
+            val threadCount = pool.getWorkerThreadCount()
+            val otherIdx = (idx + random.nextInt(threadCount - 1)) % threadCount
             val thread = pool.getWorkerThreads(otherIdx)
             val state = thread.getState()
             val parked = thread.parked


### PR DESCRIPTION
There are two small things here, both related to the blocked thread detection code:
- it was using the original thread index to check for itself, while the index will be updated after the thread converts to blocking. The fix here is to rely on the updated index, instead;
- when randomly picking another thread, it would include itself in the pool, and then pick again in case it picked itself. In this case the random choice was changed to exclude self from the choice pool.
