### PR TITLE
use worker thread index at startup

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -115,6 +115,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
     def run() = ()
   }
 
+  // Identifies blocked worker, used for ranking cached threads
   val nameIndex: Int = pool.blockedWorkerThreadNamingIndex.getAndIncrement()
 
   // Constructor code.
@@ -124,7 +125,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
 
     val prefix = pool.threadPrefix
     // Set the name of this thread.
-    setName(s"$prefix-$nameIndex")
+    setName(s"$prefix-$idx")
   }
 
   private[unsafe] def poller(): P = _poller


### PR DESCRIPTION
Naming of active worker threads was inconsistent: when initially created, worker threads were numbered by the pool's `blockedWorkerThreadNamingIndex` in constructor code; if they later switched back from blocking state they would use the worker thread index.

~`nameIndex` is renamed to `blockedWorkerIndex`, to make explicit the link to the counter that originates it. This is still used when naming a blocked worker, as well as for ranking `cachedThreads` in the pool.~ (edit: Rename dropped to avoid binary compatibility breakage)

With this change, the (current) worker index is used for naming both newly constructed worker threads, and threads that switch back from blocking.