### PR TITLE
Fallback `IOLocal#unsafeThreadLocal` by a true `ThreadLocal`

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/IOLocalPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOLocalPlatform.scala
@@ -21,23 +21,32 @@ import IOFiberConstants.ioLocalPropagation
 private[effect] trait IOLocalPlatform[A] { self: IOLocal[A] =>
 
   /**
-   * Returns a [[java.lang.ThreadLocal]] view of this [[IOLocal]] that allows to unsafely get,
-   * set, and remove (aka reset) the value in the currently running fiber. The system property
-   * `cats.effect.ioLocalPropagation` must be `true`, otherwise throws an
+   * Creates a [[java.lang.ThreadLocal]] based on this [[IOLocal]]. This allows to unsafely get,
+   * set, and remove (aka reset) the [[IOLocal]]'s value in the currently running fiber. When
+   * used outside of a fiber, behaves like an ordinary `ThreadLocal`.
+   *
+   * The system property `cats.effect.ioLocalPropagation` must be `true`, otherwise throws an
    * [[java.lang.UnsupportedOperationException]].
    */
   def unsafeThreadLocal(): ThreadLocal[A] = if (ioLocalPropagation)
     new ThreadLocal[A] {
+      override def initialValue(): A = self.getOrDefault(IOLocalState.empty)
+
       override def get(): A = {
         val fiber = IOFiber.currentIOFiber()
-        val state = if (fiber ne null) fiber.getLocalState() else IOLocalState.empty
-        self.getOrDefault(state)
+        if (fiber ne null) {
+          self.getOrDefault(fiber.getLocalState())
+        } else {
+          super.get()
+        }
       }
 
       override def set(value: A): Unit = {
         val fiber = IOFiber.currentIOFiber()
         if (fiber ne null) {
           fiber.setLocalState(self.set(fiber.getLocalState(), value))
+        } else {
+          super.set(value)
         }
       }
 
@@ -45,6 +54,8 @@ private[effect] trait IOLocalPlatform[A] { self: IOLocal[A] =>
         val fiber = IOFiber.currentIOFiber()
         if (fiber ne null) {
           fiber.setLocalState(self.reset(fiber.getLocalState()))
+        } else {
+          super.remove()
         }
       }
     }

--- a/core/jvm/src/main/scala/cats/effect/IOLocalPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOLocalPlatform.scala
@@ -30,33 +30,16 @@ private[effect] trait IOLocalPlatform[A] { self: IOLocal[A] =>
    */
   def unsafeThreadLocal(): ThreadLocal[A] = if (ioLocalPropagation)
     new ThreadLocal[A] {
-      override def initialValue(): A = self.getOrDefault(IOLocalState.empty)
-
       override def get(): A = {
-        val fiber = IOFiber.currentIOFiber()
-        if (fiber ne null) {
-          self.getOrDefault(fiber.getLocalState())
-        } else {
-          super.get()
-        }
+        self.getOrDefault(IOLocal.getThreadLocalState())
       }
 
       override def set(value: A): Unit = {
-        val fiber = IOFiber.currentIOFiber()
-        if (fiber ne null) {
-          fiber.setLocalState(self.set(fiber.getLocalState(), value))
-        } else {
-          super.set(value)
-        }
+        IOLocal.setThreadLocalState(self.set(IOLocal.getThreadLocalState(), value))
       }
 
       override def remove(): Unit = {
-        val fiber = IOFiber.currentIOFiber()
-        if (fiber ne null) {
-          fiber.setLocalState(self.reset(fiber.getLocalState()))
-        } else {
-          super.remove()
-        }
+        IOLocal.setThreadLocalState(self.reset(IOLocal.getThreadLocalState()))
       }
     }
   else

--- a/core/shared/src/main/scala/cats/effect/IOLocal.scala
+++ b/core/shared/src/main/scala/cats/effect/IOLocal.scala
@@ -273,14 +273,21 @@ object IOLocal {
    */
   def isPropagating: Boolean = IOFiberConstants.ioLocalPropagation
 
-  private[effect] def getThreadLocalState() = {
-    val fiber = IOFiber.currentIOFiber()
-    if (fiber ne null) fiber.getLocalState() else IOLocalState.empty
+  private[effect] val threadLocal = new ThreadLocal[IOLocalState] {
+    override def initialValue() = IOLocalState.empty
   }
 
-  private[effect] def setThreadLocalState(state: IOLocalState) = {
+  private[effect] def getThreadLocalState(): IOLocalState = {
     val fiber = IOFiber.currentIOFiber()
-    if (fiber ne null) fiber.setLocalState(state)
+    if (fiber ne null) fiber.getLocalState() else threadLocal.get()
+  }
+
+  private[effect] def setThreadLocalState(state: IOLocalState): Unit = {
+    val fiber = IOFiber.currentIOFiber()
+    if (fiber ne null)
+      fiber.setLocalState(state)
+    else
+      threadLocal.set(state)
   }
 
   private final class IOLocalImpl[A](default: A) extends IOLocal[A] {


### PR DESCRIPTION
tl;dr is that for the `IOLocalContextStorage` in https://github.com/typelevel/otel4s/pull/214 to work for arbitrary Java libraries, it must properly implement the `ContextStorage` API even when used in a context outside of `IOFiber`. To accomplish this, we can make `ThreadLocal`s returned by `IOLocal#unsafeThreadLocal` behave as a true `ThreadLocal` when used outside of an `IOFiber`. This is not currently possible to implement in userland because there is no way to know if you are currently running in a fiber or not.