### PR TITLE
Add `WorkerThread`-specific metrics

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -91,6 +91,7 @@ private[effect] final class WorkStealingThreadPool[P <: AnyRef](
   private[unsafe] val fiberBags: Array[WeakBag[Runnable]] = new Array(threadCount)
   private[unsafe] val pollers: Array[P] =
     new Array[AnyRef](threadCount).asInstanceOf[Array[P]]
+  private[unsafe] val metrices: Array[WorkerThread.Metrics] = new Array(threadCount)
 
   def accessPoller(cb: P => Unit): Unit = {
 
@@ -160,6 +161,8 @@ private[effect] final class WorkStealingThreadPool[P <: AnyRef](
       fiberBags(i) = fiberBag
       val poller = system.makePoller()
       pollers(i) = poller
+      val metrics = new WorkerThread.Metrics
+      metrices(i) = metrics
 
       val thread =
         new WorkerThread(
@@ -171,6 +174,7 @@ private[effect] final class WorkStealingThreadPool[P <: AnyRef](
           sleepersHeap,
           system,
           poller,
+          metrics,
           this)
 
       workerThreads(i) = thread

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -867,6 +867,8 @@ private[effect] final class WorkerThread[P <: AnyRef](
       // This `WorkerThread` has already been prepared for blocking.
       // There is no need to spawn another `WorkerThread`.
     } else {
+      metrics.incrementBlockingCount()
+
       // Spawn a new `WorkerThread` to take the place of this thread, as the
       // current thread prepares to execute a blocking action.
 
@@ -902,6 +904,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
         // a worker thread about to run blocking code is **not** parked, and
         // therefore, another worker thread would not even see it as a candidate
         // for unparking.
+        metrics.incrementRespawnCount()
         val idx = index
         val clone =
           new WorkerThread(
@@ -971,6 +974,14 @@ private[effect] object WorkerThread {
     private[this] var idleTime: Long = 0
     def getIdleTime(): Long = idleTime
     def addIdleTime(x: Long): Unit = idleTime += x
+
+    private[this] var blockingCount: Long = 0
+    def getBlockingCount(): Long = blockingCount
+    def incrementBlockingCount(): Unit = blockingCount += 1
+
+    private[this] var respawnCount: Long = 0
+    def getRespawnCount(): Long = respawnCount
+    def incrementRespawnCount(): Unit = respawnCount += 1
   }
 
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -952,6 +952,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
     parked = pool.parkedSignals(newIdx)
     fiberBag = pool.fiberBags(newIdx)
     _poller = pool.pollers(newIdx)
+    metrics = pool.metrices(newIdx)
 
     // Reset the name of the thread to the regular prefix.
     val prefix = pool.threadPrefix

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -383,6 +383,8 @@ private[effect] final class WorkerThread[P <: AnyRef](
 
     // returns next state after parking
     def park(): Int = {
+      metrics.incrementParkedCount()
+
       val tt = sleepers.peekFirstTriggerTime()
       val nextState = if (tt == MIN_VALUE) { // no sleepers
         if (parkLoop()) {
@@ -974,6 +976,10 @@ private[effect] object WorkerThread {
     private[this] var idleTime: Long = 0
     def getIdleTime(): Long = idleTime
     def addIdleTime(x: Long): Unit = idleTime += x
+
+    private[this] var parkedCount: Long = 0
+    def getParkedCount(): Long = parkedCount
+    def incrementParkedCount(): Unit = parkedCount += 1
 
     private[this] var blockingCount: Long = 0
     def getBlockingCount(): Long = blockingCount

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/WorkStealingPoolMetrics.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/WorkStealingPoolMetrics.scala
@@ -104,6 +104,11 @@ trait WorkerThreadMetrics {
   def idleTime(): Long
 
   /**
+   * The total number of times that this WorkerThread has parked.
+   */
+  def parkedCount(): Long
+
+  /**
    * The total number of times that this WorkerThread has switched to a blocking thread and been
    * replaced.
    */
@@ -256,6 +261,7 @@ object WorkStealingPoolMetrics {
 
     private val metrics = wstp.metrices(idx)
     def idleTime(): Long = metrics.getIdleTime()
+    def parkedCount(): Long = metrics.getParkedCount()
     def blockingCount(): Long = metrics.getBlockingCount()
     def respawnCount(): Long = metrics.getBlockingCount()
 

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/WorkStealingPoolMetrics.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/WorkStealingPoolMetrics.scala
@@ -109,6 +109,11 @@ trait WorkerThreadMetrics {
   def parkedCount(): Long
 
   /**
+   * The total number of times that this WorkerThread has polled for I/O events.
+   */
+  def polledCount(): Long
+
+  /**
    * The total number of times that this WorkerThread has switched to a blocking thread and been
    * replaced.
    */
@@ -262,6 +267,7 @@ object WorkStealingPoolMetrics {
     private val metrics = wstp.metrices(idx)
     def idleTime(): Long = metrics.getIdleTime()
     def parkedCount(): Long = metrics.getParkedCount()
+    def polledCount(): Long = metrics.getPolledCount()
     def blockingCount(): Long = metrics.getBlockingCount()
     def respawnCount(): Long = metrics.getBlockingCount()
 

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/WorkStealingPoolMetrics.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/WorkStealingPoolMetrics.scala
@@ -99,6 +99,11 @@ trait WorkerThreadMetrics {
   def index: Int
 
   /**
+   * The total amount of time in nanoseconds that this WorkerThread has been parked.
+   */
+  def idleTime(): Long
+
+  /**
    * LocalQueue-specific metrics of this WorkerThread.
    */
   def localQueue: LocalQueueMetrics
@@ -236,6 +241,10 @@ object WorkStealingPoolMetrics {
       idx: Int
   ): WorkerThreadMetrics = new WorkerThreadMetrics {
     val index: Int = idx
+
+    private val metrics = wstp.metrices(idx)
+    def idleTime(): Long = metrics.getIdleTime()
+
     val localQueue: LocalQueueMetrics = localQueueMetrics(wstp.localQueues(index))
     val timerHeap: TimerHeapMetrics = timerHeapMetrics(wstp.sleepers(index))
   }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/WorkStealingPoolMetrics.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/WorkStealingPoolMetrics.scala
@@ -104,6 +104,18 @@ trait WorkerThreadMetrics {
   def idleTime(): Long
 
   /**
+   * The total number of times that this WorkerThread has switched to a blocking thread and been
+   * replaced.
+   */
+  def blockingCount(): Long
+
+  /**
+   * The total number of times that this WorkerThread has been replaced by a newly spawned
+   * thread.
+   */
+  def respawnCount(): Long
+
+  /**
    * LocalQueue-specific metrics of this WorkerThread.
    */
   def localQueue: LocalQueueMetrics
@@ -244,6 +256,8 @@ object WorkStealingPoolMetrics {
 
     private val metrics = wstp.metrices(idx)
     def idleTime(): Long = metrics.getIdleTime()
+    def blockingCount(): Long = metrics.getBlockingCount()
+    def respawnCount(): Long = metrics.getBlockingCount()
 
     val localQueue: LocalQueueMetrics = localQueueMetrics(wstp.localQueues(index))
     val timerHeap: TimerHeapMetrics = timerHeapMetrics(wstp.sleepers(index))

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/WorkStealingPoolMetrics.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/WorkStealingPoolMetrics.scala
@@ -269,7 +269,7 @@ object WorkStealingPoolMetrics {
     def parkedCount(): Long = metrics.getParkedCount()
     def polledCount(): Long = metrics.getPolledCount()
     def blockingCount(): Long = metrics.getBlockingCount()
-    def respawnCount(): Long = metrics.getBlockingCount()
+    def respawnCount(): Long = metrics.getRespawnCount()
 
     val localQueue: LocalQueueMetrics = localQueueMetrics(wstp.localQueues(index))
     val timerHeap: TimerHeapMetrics = timerHeapMetrics(wstp.sleepers(index))


### PR DESCRIPTION
The idle time metric is inspired by libuv and measures the total time the worker thread has been parked. We also report the number of times it has parked.
https://docs.libuv.org/en/v1.x/metrics.html#c.uv_metrics_idle_time

The blocking / respawn metrics count the number of times the worker thread (represented by this index) became a blocking thread and was swapped out, and the number of times this swapping required spawning a new thread (instead of using a cached thread).

Lastly, we count the number of times the thread polled for I/O.

cc @iRevive 