### PR TITLE
Add pack count metric for `TimerHeap`

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/TimerHeap.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/TimerHeap.scala
@@ -74,6 +74,7 @@ private final class TimerHeap extends AtomicInteger {
   private[this] var totalScheduled: Long = 0L
   private[this] var totalExecuted: Long = 0L
   private[this] var totalCanceled: Long = 0L
+  private[this] var totalPacks: Long = 0L
 
   private def incrementTotalCanceled() = totalCanceled += 1
 
@@ -278,6 +279,8 @@ private final class TimerHeap extends AtomicInteger {
 
   def totalTimersCanceled(): Long = totalCanceled
 
+  def packCount(): Long = totalPacks
+
   /**
    * Returns the current number of the outstanding timers.
    */
@@ -296,6 +299,8 @@ private final class TimerHeap extends AtomicInteger {
   }
 
   private[this] def pack(removeCount: Int): Unit = {
+    totalPacks += 1
+
     val heap = this.heap // local copy
 
     // We track how many canceled nodes we removed so we can try to exit the loop early.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/metrics/WorkStealingPoolMetrics.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/metrics/WorkStealingPoolMetrics.scala
@@ -204,6 +204,11 @@ sealed trait TimerHeapMetrics {
    */
   def nextTimerDue(): Option[Long]
 
+  /**
+   * Returns the total number of times the heap packed itself to remove canceled timers.
+   */
+  def packCount(): Long
+
 }
 
 object WorkStealingPoolMetrics {
@@ -256,5 +261,6 @@ object WorkStealingPoolMetrics {
       def totalTimersExecutedCount(): Long = timerHeap.totalTimersExecuted()
       def totalTimersScheduledCount(): Long = timerHeap.totalTimersScheduled()
       def totalTimersCanceledCount(): Long = timerHeap.totalTimersCanceled()
+      def packCount(): Long = timerHeap.packCount()
     }
 }


### PR DESCRIPTION
Tracking this metric will allow us to test my hypothesis from https://github.com/typelevel/cats-effect/pull/3781#issuecomment-1707435075 that, now that we have threadlocal I/O polling, most timer cancelations should be coming in on the same thread that scheduled the timer, and thus repacks should be infrequent.