### PR TITLE
Fix MapRef.fromSeqRefs vulnerability

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/MapRef.scala
+++ b/std/shared/src/main/scala/cats/effect/std/MapRef.scala
@@ -91,12 +91,10 @@ object MapRef extends MapRefCompanionPlatform {
       shardCount: Int
   ): G[MapRef[F, K, Option[V]]] = {
     if (shardCount >= 1) {
-      Sync[G].defer {
-        List
-          .fill(shardCount)(())
-          .traverse(_ => Ref.in[G, F, Map[K, V]](Map.empty))
-          .map(lst => fromNonEmptySeqRefs(NonEmptySeq.fromSeqUnsafe(lst)))
-      }
+      List
+        .fill(shardCount)(())
+        .traverse(_ => Ref.in[G, F, Map[K, V]](Map.empty))
+        .map(lst => fromNonEmptySeqRefs(NonEmptySeq.fromSeqUnsafe(lst)))
     } else {
       ApplicativeError[G, Throwable].raiseError(
         new IllegalArgumentException("Shards count should be greater then zero")

--- a/std/shared/src/main/scala/cats/effect/std/MapRef.scala
+++ b/std/shared/src/main/scala/cats/effect/std/MapRef.scala
@@ -114,7 +114,7 @@ object MapRef extends MapRefCompanionPlatform {
       seq: scala.collection.immutable.Seq[Ref[F, Map[K, V]]]
   ): MapRef[F, K, Option[V]] = {
     val array = seq.toArray
-    val shardCount = seq.size
+    val shardCount = array.length
     val refFunction = { (k: K) =>
       val location = Math.abs(k.## % shardCount)
       array(location)
@@ -131,7 +131,7 @@ object MapRef extends MapRefCompanionPlatform {
       seq: NonEmptySeq[Ref[F, Map[K, V]]]
   ): MapRef[F, K, Option[V]] = {
     val array = seq.toSeq.toArray
-    val shardCount = seq.length
+    val shardCount = array.length
     val refFunction = { (k: K) =>
       val location = Math.abs(k.## % shardCount)
       array(location)

--- a/std/shared/src/main/scala/cats/effect/std/MapRef.scala
+++ b/std/shared/src/main/scala/cats/effect/std/MapRef.scala
@@ -59,7 +59,7 @@ object MapRef extends MapRefCompanionPlatform {
   }
 
   private def noShardsException = new IllegalArgumentException(
-    "Shards count should be greater then zero")
+    "Shards count should be greater than zero")
 
   /**
    * Creates a sharded map ref to reduce atomic contention on the Map, given an efficient and

--- a/std/shared/src/main/scala/cats/effect/std/MapRef.scala
+++ b/std/shared/src/main/scala/cats/effect/std/MapRef.scala
@@ -72,7 +72,7 @@ object MapRef extends MapRefCompanionPlatform {
       List
         .fill(shardCount)(())
         .traverse(_ => Concurrent[F].ref[Map[K, V]](Map.empty))
-        .map(fromNonEmptySeqRefs[F, K, V] compose NonEmptySeq.fromSeqUnsafe)
+        .map(lst => fromNonEmptySeqRefs(NonEmptySeq.fromSeqUnsafe(lst)))
     } else {
       ApplicativeError[F, Throwable].raiseError(
         new IllegalArgumentException("Shards count should be greater then zero")
@@ -95,7 +95,7 @@ object MapRef extends MapRefCompanionPlatform {
         List
           .fill(shardCount)(())
           .traverse(_ => Ref.in[G, F, Map[K, V]](Map.empty))
-          .map(fromNonEmptySeqRefs[F, K, V] compose NonEmptySeq.fromSeqUnsafe)
+          .map(lst => fromNonEmptySeqRefs(NonEmptySeq.fromSeqUnsafe(lst)))
       }
     } else {
       ApplicativeError[G, Throwable].raiseError(

--- a/std/shared/src/main/scala/cats/effect/std/MapRef.scala
+++ b/std/shared/src/main/scala/cats/effect/std/MapRef.scala
@@ -58,7 +58,8 @@ object MapRef extends MapRefCompanionPlatform {
 
   }
 
-  private def noShardsException = new IllegalArgumentException("Shards count should be greater then zero")
+  private def noShardsException = new IllegalArgumentException(
+    "Shards count should be greater then zero")
 
   /**
    * Creates a sharded map ref to reduce atomic contention on the Map, given an efficient and

--- a/std/shared/src/main/scala/cats/effect/std/MapRef.scala
+++ b/std/shared/src/main/scala/cats/effect/std/MapRef.scala
@@ -107,7 +107,7 @@ object MapRef extends MapRefCompanionPlatform {
    *
    * This uses universal hashCode and equality on K.
    */
-  @deprecated("Use fromNonEmptySeqRefs instead", "3.5.0")
+  @deprecated("Use fromNonEmptySeqRefs instead", "3.6.0")
   def fromSeqRefs[F[_]: Functor, K, V](
       seq: scala.collection.immutable.Seq[Ref[F, Map[K, V]]]
   ): MapRef[F, K, Option[V]] = {


### PR DESCRIPTION
I just fix `fromSeqRefs` constructor of `MapRef`. There it was possible to call this method with an empty list of shards, which resulted in a divide by zero exception. Now you can call it with _nonempty_ sequence of shards only. That constructor is only used in two other constructors in the code base. So it no needs to fix some tests or docs, I think.