### PR TITLE
Introduce `PollerMetrics`

### DIFF
--- a/core/jvm-native/src/main/scala/cats/effect/unsafe/PollingSystem.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/unsafe/PollingSystem.scala
@@ -17,6 +17,8 @@
 package cats.effect
 package unsafe
 
+import cats.effect.unsafe.metrics.PollerMetrics
+
 /**
  * Represents a stateful system for managing and interacting with a polling system. Polling
  * systems are typically used in scenarios such as handling multiplexed blocking I/O or other
@@ -101,6 +103,8 @@ abstract class PollingSystem {
    *   is the poller to be interrupted.
    */
   def interrupt(targetThread: Thread, targetPoller: Poller): Unit
+
+  def metrics(poller: Poller): PollerMetrics
 
 }
 

--- a/core/jvm-native/src/main/scala/cats/effect/unsafe/metrics/PollerMetrics.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/unsafe/metrics/PollerMetrics.scala
@@ -146,7 +146,7 @@ trait PollerMetrics {
 }
 
 object PollerMetrics {
-  private[unsafe] object noop extends PollerMetrics {
+  private[effect] object noop extends PollerMetrics {
     def operationsOutstandingCount(): Int = 0
     def totalOperationsSubmittedCount(): Long = 0
     def totalOperationsCompletedCount(): Long = 0

--- a/core/jvm-native/src/main/scala/cats/effect/unsafe/metrics/PollerMetrics.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/unsafe/metrics/PollerMetrics.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2020-2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.unsafe.metrics
+
+trait PollerMetrics {
+
+  /**
+   * The current number of outstanding I/O operations.
+   */
+  def operationsOutstandingCount(): Int
+
+  /**
+   * The total number of I/O operations submitted.
+   */
+  def totalOperationsSubmittedCount(): Long
+
+  /**
+   * The total number of I/O operations completed.
+   */
+  def totalOperationsCompletedCount(): Long
+
+  /**
+   * The total number of I/O operations errored.
+   */
+  def totalOperationsErroredCount(): Long
+
+  /**
+   * The total number of I/O operations canceled.
+   */
+  def totalOperationsCanceledCount(): Long
+
+  /**
+   * The current number of outstanding accept operations.
+   */
+  def acceptOperationsOutstandingCount(): Int
+
+  /**
+   * The total number of accept operations submitted.
+   */
+  def totalAcceptOperationsSubmittedCount(): Long
+
+  /**
+   * The total number of accept operations completed.
+   */
+  def totalAcceptOperationsCompletedCount(): Long
+
+  /**
+   * The total number of accept operations errored.
+   */
+  def totalAcceptOperationsErroredCount(): Long
+
+  /**
+   * The total number of accept operations canceled.
+   */
+  def totalAcceptOperationsCanceledCount(): Long
+
+  /**
+   * The current number of outstanding connect operations.
+   */
+  def connectOperationsOutstandingCount(): Int
+
+  /**
+   * The total number of connect operations submitted.
+   */
+  def totalConnectOperationsSubmittedCount(): Long
+
+  /**
+   * The total number of connect operations completed.
+   */
+  def totalConnectOperationsCompletedCount(): Long
+
+  /**
+   * The total number of connect operations errored.
+   */
+  def totalConnectOperationsErroredCount(): Long
+
+  /**
+   * The total number of connect operations canceled.
+   */
+  def totalConnectOperationsCanceledCount(): Long
+
+  /**
+   * The current number of outstanding read operations.
+   */
+  def readOperationsOutstandingCount(): Int
+
+  /**
+   * The total number of read operations submitted.
+   */
+  def totalReadOperationsSubmittedCount(): Long
+
+  /**
+   * The total number of read operations completed.
+   */
+  def totalReadOperationsCompletedCount(): Long
+
+  /**
+   * The total number of read operations errored.
+   */
+  def totalReadOperationsErroredCount(): Long
+
+  /**
+   * The total number of read operations canceled.
+   */
+  def totalReadOperationsCanceledCount(): Long
+
+  /**
+   * The current number of outstanding write operations.
+   */
+  def writeOperationsOutstandingCount(): Int
+
+  /**
+   * The total number of write operations submitted.
+   */
+  def totalWriteOperationsSubmittedCount(): Long
+
+  /**
+   * The total number of write operations completed.
+   */
+  def totalWriteOperationsCompletedCount(): Long
+
+  /**
+   * The total number of write operations errored.
+   */
+  def totalWriteOperationsErroredCount(): Long
+
+  /**
+   * The total number of write operations canceled.
+   */
+  def totalWriteOperationsCanceledCount(): Long
+
+}
+
+object PollerMetrics {
+  private[unsafe] object noop extends PollerMetrics {
+    def operationsOutstandingCount(): Int = 0
+    def totalOperationsSubmittedCount(): Long = 0
+    def totalOperationsCompletedCount(): Long = 0
+    def totalOperationsErroredCount(): Long = 0
+    def totalOperationsCanceledCount(): Long = 0
+    def acceptOperationsOutstandingCount(): Int = 0
+    def totalAcceptOperationsSubmittedCount(): Long = 0
+    def totalAcceptOperationsCompletedCount(): Long = 0
+    def totalAcceptOperationsErroredCount(): Long = 0
+    def totalAcceptOperationsCanceledCount(): Long = 0
+    def connectOperationsOutstandingCount(): Int = 0
+    def totalConnectOperationsSubmittedCount(): Long = 0
+    def totalConnectOperationsCompletedCount(): Long = 0
+    def totalConnectOperationsErroredCount(): Long = 0
+    def totalConnectOperationsCanceledCount(): Long = 0
+    def readOperationsOutstandingCount(): Int = 0
+    def totalReadOperationsSubmittedCount(): Long = 0
+    def totalReadOperationsCompletedCount(): Long = 0
+    def totalReadOperationsErroredCount(): Long = 0
+    def totalReadOperationsCanceledCount(): Long = 0
+    def writeOperationsOutstandingCount(): Int = 0
+    def totalWriteOperationsSubmittedCount(): Long = 0
+    def totalWriteOperationsCompletedCount(): Long = 0
+    def totalWriteOperationsErroredCount(): Long = 0
+    def totalWriteOperationsCanceledCount(): Long = 0
+  }
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SelectorSystem.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SelectorSystem.scala
@@ -17,9 +17,11 @@
 package cats.effect
 package unsafe
 
+import cats.effect.unsafe.metrics.PollerMetrics
+
 import scala.util.control.NonFatal
 
-import java.nio.channels.SelectableChannel
+import java.nio.channels.{SelectableChannel, SelectionKey}
 import java.nio.channels.spi.{AbstractSelector, SelectorProvider}
 import java.util.Iterator
 
@@ -80,6 +82,10 @@ final class SelectorSystem private (provider: SelectorProvider) extends PollingS
             if (cb != null) {
               cb(value)
               polled = true
+              if (error ne null) poller.countCompletedOperation(readyOps)
+              else poller.countErroredOperation(node.interest)
+            } else {
+              poller.countCanceledOperation(node.interest)
             }
           }
         }
@@ -99,6 +105,8 @@ final class SelectorSystem private (provider: SelectorProvider) extends PollingS
     ()
   }
 
+  def metrics(poller: Poller): PollerMetrics = poller
+
   final class SelectorImpl private[SelectorSystem] (
       ctx: PollingContext[Poller],
       val provider: SelectorProvider
@@ -110,6 +118,8 @@ final class SelectorSystem private (provider: SelectorProvider) extends PollingS
           try {
             val selector = poller.selector
             val key = ch.keyFor(selector)
+
+            poller.countSubmittedOperation(ops)
 
             val node = if (key eq null) { // not yet registered on this selector
               val cbs = new Callbacks
@@ -123,14 +133,20 @@ final class SelectorSystem private (provider: SelectorProvider) extends PollingS
             }
 
             val cancel = IO {
-              if (ctx.ownPoller(poller))
+              if (ctx.ownPoller(poller)) {
+                poller.countCanceledOperation(ops)
                 node.remove()
-              else
+              } else {
                 node.clear()
+              }
             }
 
             cb(Right(Some(cancel)))
-          } catch { case ex if NonFatal(ex) => cb(Left(ex)) }
+          } catch {
+            case ex if NonFatal(ex) =>
+              poller.countErroredOperation(ops)
+              cb(Left(ex))
+          }
         }
       }
     }
@@ -139,7 +155,149 @@ final class SelectorSystem private (provider: SelectorProvider) extends PollingS
 
   final class Poller private[SelectorSystem] (
       private[SelectorSystem] val selector: AbstractSelector
-  )
+  ) extends PollerMetrics {
+
+    private[this] var outstandingOperations: Int = 0
+    private[this] var outstandingAccepts: Int = 0
+    private[this] var outstandingConnects: Int = 0
+    private[this] var outstandingReads: Int = 0
+    private[this] var outstandingWrites: Int = 0
+    private[this] var submittedOperations: Long = 0
+    private[this] var submittedAccepts: Long = 0
+    private[this] var submittedConnects: Long = 0
+    private[this] var submittedReads: Long = 0
+    private[this] var submittedWrites: Long = 0
+    private[this] var completedOperations: Long = 0
+    private[this] var completedAccepts: Long = 0
+    private[this] var completedConnects: Long = 0
+    private[this] var completedReads: Long = 0
+    private[this] var completedWrites: Long = 0
+    private[this] var erroredOperations: Long = 0
+    private[this] var erroredAccepts: Long = 0
+    private[this] var erroredConnects: Long = 0
+    private[this] var erroredReads: Long = 0
+    private[this] var erroredWrites: Long = 0
+    private[this] var canceledOperations: Long = 0
+    private[this] var canceledAccepts: Long = 0
+    private[this] var canceledConnects: Long = 0
+    private[this] var canceledReads: Long = 0
+    private[this] var canceledWrites: Long = 0
+
+    def countSubmittedOperation(ops: Int): Unit = {
+      outstandingOperations += 1
+      submittedOperations += 1
+      if (isAccept(ops)) {
+        outstandingAccepts += 1
+        submittedAccepts += 1
+      }
+      if (isConnect(ops)) {
+        outstandingConnects += 1
+        submittedConnects += 1
+      }
+      if (isRead(ops)) {
+        outstandingReads += 1
+        submittedReads += 1
+      }
+      if (isWrite(ops)) {
+        outstandingWrites += 1
+        submittedWrites += 1
+      }
+    }
+
+    def countCompletedOperation(ops: Int): Unit = {
+      outstandingOperations -= 1
+      completedOperations += 1
+      if (isAccept(ops)) {
+        outstandingAccepts -= 1
+        completedAccepts += 1
+      }
+      if (isConnect(ops)) {
+        outstandingConnects -= 1
+        completedConnects += 1
+      }
+      if (isRead(ops)) {
+        outstandingReads -= 1
+        completedReads += 1
+      }
+      if (isWrite(ops)) {
+        outstandingWrites -= 1
+        completedWrites += 1
+      }
+    }
+
+    def countErroredOperation(ops: Int): Unit = {
+      outstandingOperations -= 1
+      erroredOperations += 1
+      if (isAccept(ops)) {
+        outstandingAccepts -= 1
+        erroredAccepts += 1
+      }
+      if (isConnect(ops)) {
+        outstandingConnects -= 1
+        erroredConnects += 1
+      }
+      if (isRead(ops)) {
+        outstandingReads -= 1
+        erroredReads += 1
+      }
+      if (isWrite(ops)) {
+        outstandingWrites -= 1
+        erroredWrites += 1
+      }
+    }
+
+    def countCanceledOperation(ops: Int): Unit = {
+      outstandingOperations -= 1
+      canceledOperations += 1
+      if (isAccept(ops)) {
+        outstandingAccepts -= 1
+        canceledAccepts += 1
+      }
+      if (isConnect(ops)) {
+        outstandingConnects -= 1
+        canceledConnects += 1
+      }
+      if (isRead(ops)) {
+        outstandingReads -= 1
+        canceledReads += 1
+      }
+      if (isWrite(ops)) {
+        outstandingWrites -= 1
+        canceledWrites += 1
+      }
+    }
+
+    private[this] def isAccept(ops: Int): Boolean = (ops & SelectionKey.OP_ACCEPT) != 0
+    private[this] def isConnect(ops: Int): Boolean = (ops & SelectionKey.OP_CONNECT) != 0
+    private[this] def isRead(ops: Int): Boolean = (ops & SelectionKey.OP_READ) != 0
+    private[this] def isWrite(ops: Int): Boolean = (ops & SelectionKey.OP_WRITE) != 0
+
+    def operationsOutstandingCount(): Int = outstandingOperations
+    def totalOperationsSubmittedCount(): Long = submittedOperations
+    def totalOperationsCompletedCount(): Long = completedOperations
+    def totalOperationsErroredCount(): Long = erroredOperations
+    def totalOperationsCanceledCount(): Long = canceledOperations
+    def acceptOperationsOutstandingCount(): Int = outstandingAccepts
+    def totalAcceptOperationsSubmittedCount(): Long = submittedAccepts
+    def totalAcceptOperationsCompletedCount(): Long = completedAccepts
+    def totalAcceptOperationsErroredCount(): Long = erroredAccepts
+    def totalAcceptOperationsCanceledCount(): Long = canceledAccepts
+    def connectOperationsOutstandingCount(): Int = outstandingConnects
+    def totalConnectOperationsSubmittedCount(): Long = submittedConnects
+    def totalConnectOperationsCompletedCount(): Long = completedConnects
+    def totalConnectOperationsErroredCount(): Long = erroredConnects
+    def totalConnectOperationsCanceledCount(): Long = canceledConnects
+    def readOperationsOutstandingCount(): Int = outstandingReads
+    def totalReadOperationsSubmittedCount(): Long = submittedReads
+    def totalReadOperationsCompletedCount(): Long = completedReads
+    def totalReadOperationsErroredCount(): Long = erroredReads
+    def totalReadOperationsCanceledCount(): Long = canceledReads
+    def writeOperationsOutstandingCount(): Int = outstandingWrites
+    def totalWriteOperationsSubmittedCount(): Long = submittedWrites
+    def totalWriteOperationsCompletedCount(): Long = completedWrites
+    def totalWriteOperationsErroredCount(): Long = erroredWrites
+    def totalWriteOperationsCanceledCount(): Long = canceledWrites
+  }
 
 }
 

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SleepSystem.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SleepSystem.scala
@@ -17,6 +17,8 @@
 package cats.effect
 package unsafe
 
+import cats.effect.unsafe.metrics.PollerMetrics
+
 import java.util.concurrent.locks.LockSupport
 
 object SleepSystem extends PollingSystem {
@@ -46,5 +48,7 @@ object SleepSystem extends PollingSystem {
 
   def interrupt(targetThread: Thread, targetPoller: Poller): Unit =
     LockSupport.unpark(targetThread)
+
+  def metrics(poller: Poller): PollerMetrics = PollerMetrics.noop
 
 }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -68,7 +68,7 @@ private[effect] final class WorkStealingThreadPool[P <: AnyRef](
     private[unsafe] val runtimeBlockingExpiration: Duration,
     private[unsafe] val blockedThreadDetectionEnabled: Boolean,
     shutdownTimeout: Duration,
-    system: PollingSystem.WithPoller[P],
+    private[unsafe] val system: PollingSystem.WithPoller[P],
     reportFailure0: Throwable => Unit
 ) extends ExecutionContextExecutor
     with Scheduler

--- a/core/native/src/main/scala/cats/effect/unsafe/EpollSystem.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/EpollSystem.scala
@@ -18,6 +18,7 @@ package cats.effect
 package unsafe
 
 import cats.effect.std.Mutex
+import cats.effect.unsafe.metrics.PollerMetrics
 import cats.syntax.all._
 
 import org.typelevel.scalaccompat.annotation._
@@ -65,6 +66,8 @@ object EpollSystem extends PollingSystem {
   def needsPoll(poller: Poller): Boolean = poller.needsPoll()
 
   def interrupt(targetThread: Thread, targetPoller: Poller): Unit = ()
+
+  def metrics(poller: Poller): PollerMetrics = PollerMetrics.noop
 
   private final class FileDescriptorPollerImpl private[EpollSystem] (
       ctx: PollingContext[Poller])

--- a/core/native/src/main/scala/cats/effect/unsafe/KqueueSystem.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/KqueueSystem.scala
@@ -18,6 +18,7 @@ package cats.effect
 package unsafe
 
 import cats.effect.std.Mutex
+import cats.effect.unsafe.metrics.PollerMetrics
 import cats.syntax.all._
 
 import org.typelevel.scalaccompat.annotation._
@@ -65,6 +66,8 @@ object KqueueSystem extends PollingSystem {
     poller.needsPoll()
 
   def interrupt(targetThread: Thread, targetPoller: Poller): Unit = ()
+
+  def metrics(poller: Poller): PollerMetrics = PollerMetrics.noop
 
   private final class FileDescriptorPollerImpl private[KqueueSystem] (
       ctx: PollingContext[Poller]

--- a/core/native/src/main/scala/cats/effect/unsafe/PollingExecutorScheduler.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/PollingExecutorScheduler.scala
@@ -17,6 +17,8 @@
 package cats.effect
 package unsafe
 
+import cats.effect.unsafe.metrics.PollerMetrics
+
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
 
@@ -45,6 +47,7 @@ abstract class PollingExecutorScheduler(pollEvery: Int)
       }
       def needsPoll(poller: Poller) = needsPoll
       def interrupt(targetThread: Thread, targetPoller: Poller): Unit = ()
+      def metrics(poller: Poller): PollerMetrics = PollerMetrics.noop
     }
   )
 

--- a/core/native/src/main/scala/cats/effect/unsafe/SleepSystem.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/SleepSystem.scala
@@ -17,6 +17,8 @@
 package cats.effect
 package unsafe
 
+import cats.effect.unsafe.metrics.PollerMetrics
+
 object SleepSystem extends PollingSystem {
 
   type Api = AnyRef
@@ -39,5 +41,7 @@ object SleepSystem extends PollingSystem {
   def needsPoll(poller: Poller): Boolean = false
 
   def interrupt(targetThread: Thread, targetPoller: Poller): Unit = ()
+
+  def metrics(poller: Poller): PollerMetrics = PollerMetrics.noop
 
 }

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -25,6 +25,7 @@ import cats.effect.unsafe.{
   SleepSystem,
   WorkStealingThreadPool
 }
+import cats.effect.unsafe.metrics.PollerMetrics
 import cats.syntax.all._
 
 import org.scalacheck.Prop.forAll
@@ -500,6 +501,7 @@ trait IOPlatformSpecification extends DetectPlatform { self: BaseSpec with Scala
           def makePoller() = new AtomicReference(List.empty[Either[Throwable, Unit] => Unit])
           def needsPoll(poller: Poller) = poller.get.nonEmpty
           def closePoller(poller: Poller) = ()
+          def metrics(poller: Poller): PollerMetrics = PollerMetrics.noop
 
           def interrupt(targetThread: Thread, targetPoller: Poller) =
             SleepSystem.interrupt(targetThread, SleepSystem.makePoller())


### PR DESCRIPTION
Closes https://github.com/typelevel/cats-effect/issues/3686. cc @iRevive

We now track:
- current outstanding operations
- total submitted operations
- total completed operations
- total errored operations
- total canceled operations

for the following:
- generic operations
- server socket accepts
- client socket connects
- reads
- writes

I think this covers the main things that are useful, interesting, and widely-supported. JDK NIO and io_uring can report on accepts and connects, but for epoll/kqueue those will be bundled under reads and writes, respectively.

In the future we can add a mechanism for polling systems to expose their own custom metrics, in addition to these.

I didn't implement metrics on the Native side yet. We can do during/following the Native multi-threading work.

Bikeshed: "completed" -> "succeeded" ? that would be more consistent with our terminology in CE, I reached for "completed" as in "I/O completions"