### PR TITLE
Fixed off-by-one error in other index selection

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -563,7 +563,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
             // TODO check that branch elimination makes it free when off
             val idx = index
             val threadCount = pool.getWorkerThreadCount()
-            val otherIdx = (idx + random.nextInt(threadCount - 1)) % threadCount
+            val otherIdx = (idx + random.nextInt(threadCount - 1) + 1) % threadCount
             val thread = pool.getWorkerThread(otherIdx)
             val state = thread.getState()
             val parked = thread.parked

--- a/tests/jvm/src/main/scala/catseffect/examplesplatform.scala
+++ b/tests/jvm/src/main/scala/catseffect/examplesplatform.scala
@@ -76,8 +76,8 @@ package examples {
     override protected def blockedThreadDetectionEnabled = true
 
     // Loop prevents other worker threads from being parked and hence not
-    // performing the blocked check
+    // performing the blocked check. Cedeing makes the test more deterministic
     val run =
-      IO.unit.foreverM.start >> IO(Thread.sleep(2.seconds.toMillis))
+      IO.cede.foreverM.start >> IO(Thread.sleep(2.seconds.toMillis))
   }
 }


### PR DESCRIPTION
Btw, the fact that this only seems to fail on arm64 (not x86_64) is *fascinating*! It would seem to suggest that Linux on x86 is very very unlikely to schedule things such that consecutive thread IDs are awakened for stealing. I thought that was a uniform random though, so maybe we're just getting un/lucky on core count.