### PR TITLE
Add `UUIDGen` inductive materializers for monad transformers

### DIFF
--- a/std/jvm/src/main/scala/cats/effect/std/UUIDGenCompanionPlatform.scala
+++ b/std/jvm/src/main/scala/cats/effect/std/UUIDGenCompanionPlatform.scala
@@ -16,8 +16,16 @@
 
 package cats.effect.std
 
-import cats.Functor
-import cats.data.OptionT
+import cats.{Applicative, Functor, Monoid}
+import cats.data.{
+  EitherT,
+  IndexedReaderWriterStateT,
+  IndexedStateT,
+  IorT,
+  Kleisli,
+  OptionT,
+  WriterT
+}
 import cats.effect.kernel.Sync
 
 import java.util.UUID
@@ -36,10 +44,61 @@ private[std] trait UUIDGenCompanionPlatformLowPriority {
   }
 
   /**
+   * [[UUIDGen]] instance built for `cats.data.EitherT` values initialized with any `F` data
+   * type that also implements `UUIDGen`.
+   */
+  implicit def catsEitherTUUIDGen[F[_]: UUIDGen: Functor, L]: UUIDGen[EitherT[F, L, *]] =
+    UUIDGen[F].mapK(EitherT.liftK)
+
+  /**
+   * [[UUIDGen]] instance built for `cats.data.Kleisli` values initialized with any `F` data
+   * type that also implements `UUIDGen`.
+   */
+  implicit def catsKleisliUUIDGen[F[_]: UUIDGen, R]: UUIDGen[Kleisli[F, R, *]] =
+    UUIDGen[F].mapK(Kleisli.liftK)
+
+  /**
    * [[UUIDGen]] instance built for `cats.data.OptionT` values initialized with any `F` data
    * type that also implements `UUIDGen`.
    */
   implicit def catsOptionTUUIDGen[F[_]: UUIDGen: Functor]: UUIDGen[OptionT[F, *]] =
     UUIDGen[F].mapK(OptionT.liftK)
+
+  /**
+   * [[UUIDGen]] instance built for `cats.data.IndexedStateT` values initialized with any `F`
+   * data type that also implements `UUIDGen`.
+   */
+  implicit def catsIndexedStateTUUIDGen[F[_]: UUIDGen: Applicative, S]
+      : UUIDGen[IndexedStateT[F, S, S, *]] =
+    UUIDGen[F].mapK(IndexedStateT.liftK)
+
+  /**
+   * [[UUIDGen]] instance built for `cats.data.WriterT` values initialized with any `F` data
+   * type that also implements `UUIDGen`.
+   */
+  implicit def catsWriterTUUIDGen[
+      F[_]: UUIDGen: Applicative,
+      L: Monoid
+  ]: UUIDGen[WriterT[F, L, *]] =
+    UUIDGen[F].mapK(WriterT.liftK)
+
+  /**
+   * [[UUIDGen]] instance built for `cats.data.IorT` values initialized with any `F` data type
+   * that also implements `UUIDGen`.
+   */
+  implicit def catsIorTUUIDGen[F[_]: UUIDGen: Functor, L]: UUIDGen[IorT[F, L, *]] =
+    UUIDGen[F].mapK(IorT.liftK)
+
+  /**
+   * [[UUIDGen]] instance built for `cats.data.IndexedReaderWriterStateT` values initialized
+   * with any `F` data type that also implements `UUIDGen`.
+   */
+  implicit def catsIndexedReaderWriterStateTUUIDGen[
+      F[_]: UUIDGen: Applicative,
+      E,
+      L: Monoid,
+      S
+  ]: UUIDGen[IndexedReaderWriterStateT[F, E, L, S, S, *]] =
+    UUIDGen[F].mapK(IndexedReaderWriterStateT.liftK)
 
 }

--- a/std/jvm/src/main/scala/cats/effect/std/UUIDGenCompanionPlatform.scala
+++ b/std/jvm/src/main/scala/cats/effect/std/UUIDGenCompanionPlatform.scala
@@ -16,6 +16,8 @@
 
 package cats.effect.std
 
+import cats.Functor
+import cats.data.OptionT
 import cats.effect.kernel.Sync
 
 import java.util.UUID
@@ -32,5 +34,12 @@ private[std] trait UUIDGenCompanionPlatformLowPriority {
     override final val randomUUID: F[UUID] =
       ev.blocking(UUID.randomUUID())
   }
+
+  /**
+   * [[UUIDGen]] instance built for `cats.data.OptionT` values initialized with any `F` data
+   * type that also implements `UUIDGen`.
+   */
+  implicit def catsOptionTUUIDGen[F[_]: UUIDGen: Functor]: UUIDGen[OptionT[F, *]] =
+    UUIDGen[F].mapK(OptionT.liftK)
 
 }

--- a/std/jvm/src/main/scala/cats/effect/std/UUIDGenCompanionPlatform.scala
+++ b/std/jvm/src/main/scala/cats/effect/std/UUIDGenCompanionPlatform.scala
@@ -16,16 +16,6 @@
 
 package cats.effect.std
 
-import cats.{Applicative, Functor, Monoid}
-import cats.data.{
-  EitherT,
-  IndexedReaderWriterStateT,
-  IndexedStateT,
-  IorT,
-  Kleisli,
-  OptionT,
-  WriterT
-}
 import cats.effect.kernel.Sync
 
 import java.util.UUID
@@ -42,63 +32,5 @@ private[std] trait UUIDGenCompanionPlatformLowPriority {
     override final val randomUUID: F[UUID] =
       ev.blocking(UUID.randomUUID())
   }
-
-  /**
-   * [[UUIDGen]] instance built for `cats.data.EitherT` values initialized with any `F` data
-   * type that also implements `UUIDGen`.
-   */
-  implicit def catsEitherTUUIDGen[F[_]: UUIDGen: Functor, L]: UUIDGen[EitherT[F, L, *]] =
-    UUIDGen[F].mapK(EitherT.liftK)
-
-  /**
-   * [[UUIDGen]] instance built for `cats.data.Kleisli` values initialized with any `F` data
-   * type that also implements `UUIDGen`.
-   */
-  implicit def catsKleisliUUIDGen[F[_]: UUIDGen, R]: UUIDGen[Kleisli[F, R, *]] =
-    UUIDGen[F].mapK(Kleisli.liftK)
-
-  /**
-   * [[UUIDGen]] instance built for `cats.data.OptionT` values initialized with any `F` data
-   * type that also implements `UUIDGen`.
-   */
-  implicit def catsOptionTUUIDGen[F[_]: UUIDGen: Functor]: UUIDGen[OptionT[F, *]] =
-    UUIDGen[F].mapK(OptionT.liftK)
-
-  /**
-   * [[UUIDGen]] instance built for `cats.data.IndexedStateT` values initialized with any `F`
-   * data type that also implements `UUIDGen`.
-   */
-  implicit def catsIndexedStateTUUIDGen[F[_]: UUIDGen: Applicative, S]
-      : UUIDGen[IndexedStateT[F, S, S, *]] =
-    UUIDGen[F].mapK(IndexedStateT.liftK)
-
-  /**
-   * [[UUIDGen]] instance built for `cats.data.WriterT` values initialized with any `F` data
-   * type that also implements `UUIDGen`.
-   */
-  implicit def catsWriterTUUIDGen[
-      F[_]: UUIDGen: Applicative,
-      L: Monoid
-  ]: UUIDGen[WriterT[F, L, *]] =
-    UUIDGen[F].mapK(WriterT.liftK)
-
-  /**
-   * [[UUIDGen]] instance built for `cats.data.IorT` values initialized with any `F` data type
-   * that also implements `UUIDGen`.
-   */
-  implicit def catsIorTUUIDGen[F[_]: UUIDGen: Functor, L]: UUIDGen[IorT[F, L, *]] =
-    UUIDGen[F].mapK(IorT.liftK)
-
-  /**
-   * [[UUIDGen]] instance built for `cats.data.IndexedReaderWriterStateT` values initialized
-   * with any `F` data type that also implements `UUIDGen`.
-   */
-  implicit def catsIndexedReaderWriterStateTUUIDGen[
-      F[_]: UUIDGen: Applicative,
-      E,
-      L: Monoid,
-      S
-  ]: UUIDGen[IndexedReaderWriterStateT[F, E, L, S, S, *]] =
-    UUIDGen[F].mapK(IndexedReaderWriterStateT.liftK)
 
 }

--- a/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
+++ b/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
@@ -50,7 +50,7 @@ trait UUIDGen[F[_]] { self =>
    *   a [[UUIDGen]] in the new context obtained by mapping the current one using `f`
    */
   def mapK[G[_]](f: F ~> G): UUIDGen[G] =
-    new UUIDGen.TranslatedUUIDGen[F, G](self)(f) {}
+    new UUIDGen.TranslatedUUIDGen[F, G](self)(f)
 }
 
 object UUIDGen extends UUIDGenCompanionPlatform {
@@ -138,7 +138,7 @@ object UUIDGen extends UUIDGenCompanionPlatform {
       }
     }
 
-  private[std] abstract class TranslatedUUIDGen[F[_], G[_]](self: UUIDGen[F])(f: F ~> G)
+  private[std] final class TranslatedUUIDGen[F[_], G[_]](self: UUIDGen[F])(f: F ~> G)
       extends UUIDGen[G] {
     override def randomUUID: G[UUID] =
       f(self.randomUUID)

--- a/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
+++ b/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
@@ -16,7 +16,16 @@
 
 package cats.effect.std
 
-import cats.{~>, Functor}
+import cats.{~>, Applicative, Functor, Monoid}
+import cats.data.{
+  EitherT,
+  IndexedReaderWriterStateT,
+  IndexedStateT,
+  IorT,
+  Kleisli,
+  OptionT,
+  WriterT
+}
 import cats.implicits._
 
 import java.util.UUID
@@ -50,6 +59,64 @@ object UUIDGen extends UUIDGenCompanionPlatform {
   def randomUUID[F[_]: UUIDGen]: F[UUID] = UUIDGen[F].randomUUID
   def randomString[F[_]](implicit gen: UUIDGen[F], F: Functor[F]): F[String] =
     randomUUID(gen).map(_.toString)
+
+  /**
+   * [[UUIDGen]] instance built for `cats.data.EitherT` values initialized with any `F` data
+   * type that also implements `UUIDGen`.
+   */
+  implicit def catsEitherTUUIDGen[F[_]: UUIDGen: Functor, L]: UUIDGen[EitherT[F, L, *]] =
+    UUIDGen[F].mapK(EitherT.liftK)
+
+  /**
+   * [[UUIDGen]] instance built for `cats.data.Kleisli` values initialized with any `F` data
+   * type that also implements `UUIDGen`.
+   */
+  implicit def catsKleisliUUIDGen[F[_]: UUIDGen, R]: UUIDGen[Kleisli[F, R, *]] =
+    UUIDGen[F].mapK(Kleisli.liftK)
+
+  /**
+   * [[UUIDGen]] instance built for `cats.data.OptionT` values initialized with any `F` data
+   * type that also implements `UUIDGen`.
+   */
+  implicit def catsOptionTUUIDGen[F[_]: UUIDGen: Functor]: UUIDGen[OptionT[F, *]] =
+    UUIDGen[F].mapK(OptionT.liftK)
+
+  /**
+   * [[UUIDGen]] instance built for `cats.data.IndexedStateT` values initialized with any `F`
+   * data type that also implements `UUIDGen`.
+   */
+  implicit def catsIndexedStateTUUIDGen[F[_]: UUIDGen: Applicative, S]
+      : UUIDGen[IndexedStateT[F, S, S, *]] =
+    UUIDGen[F].mapK(IndexedStateT.liftK)
+
+  /**
+   * [[UUIDGen]] instance built for `cats.data.WriterT` values initialized with any `F` data
+   * type that also implements `UUIDGen`.
+   */
+  implicit def catsWriterTUUIDGen[
+      F[_]: UUIDGen: Applicative,
+      L: Monoid
+  ]: UUIDGen[WriterT[F, L, *]] =
+    UUIDGen[F].mapK(WriterT.liftK)
+
+  /**
+   * [[UUIDGen]] instance built for `cats.data.IorT` values initialized with any `F` data type
+   * that also implements `UUIDGen`.
+   */
+  implicit def catsIorTUUIDGen[F[_]: UUIDGen: Functor, L]: UUIDGen[IorT[F, L, *]] =
+    UUIDGen[F].mapK(IorT.liftK)
+
+  /**
+   * [[UUIDGen]] instance built for `cats.data.IndexedReaderWriterStateT` values initialized
+   * with any `F` data type that also implements `UUIDGen`.
+   */
+  implicit def catsIndexedReaderWriterStateTUUIDGen[
+      F[_]: UUIDGen: Applicative,
+      E,
+      L: Monoid,
+      S
+  ]: UUIDGen[IndexedReaderWriterStateT[F, E, L, S, S, *]] =
+    UUIDGen[F].mapK(IndexedReaderWriterStateT.liftK)
 
   implicit def fromSecureRandom[F[_]: Functor: SecureRandom]: UUIDGen[F] =
     new UUIDGen[F] {


### PR DESCRIPTION
This PR adds the `UUIDGen` materializer for `OptionT`.

UPD: Added materializers also for other monad transformers.