### PR TITLE
Introduce `PollResult`, `PollingSystem#processReadyEvents`

### DIFF
--- a/core/jvm-native/src/main/scala/cats/effect/unsafe/PollingSystem.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/unsafe/PollingSystem.scala
@@ -72,6 +72,8 @@ abstract class PollingSystem {
   def closePoller(poller: Poller): Unit
 
   /**
+   * Blocks the thread until an event is polled, the timeout expires, or interrupted.
+   *
    * @param poller
    *   the thread-local [[Poller]] used to poll events.
    *
@@ -79,18 +81,28 @@ abstract class PollingSystem {
    *   the maximum duration for which to block, where `nanos == -1` indicates to block
    *   indefinitely.
    *
-   * @param reportFailure
-   *   callback that handles any failures that occur during polling.
+   * @return
+   *   whether any events are ready. e.g. if the method returned due to timeout, this should be
+   *   `false`. If `true`, [[processReadyEvents]] must be called before calling any other method
+   *   on this poller.
+   */
+  def poll(poller: Poller, nanos: Long): Boolean
+
+  /**
+   * Processes ready events e.g. collects their results and resumes the corresponding tasks.
+   * This method should only be called after [[poll]] and only if it returned `true`.
+   *
+   * @param poller
+   *   the thread-local [[Poller]] with ready events
    *
    * @return
-   *   whether any events were polled. e.g. if the method returned due to timeout, this should
-   *   be `false`.
+   *   whether any of the ready events caused tasks to be rescheduled on the runtime
    */
-  def poll(poller: Poller, nanos: Long, reportFailure: Throwable => Unit): Boolean
+  def processReadyEvents(poller: Poller): Boolean
 
   /**
    * @return
-   *   whether poll should be called again (i.e., there are more events to be polled)
+   *   whether [[poll]] should be called again (i.e., there are more events to be polled)
    */
   def needsPoll(poller: Poller): Boolean
 

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SelectorSystem.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SelectorSystem.scala
@@ -41,7 +41,7 @@ final class SelectorSystem private (provider: SelectorProvider) extends PollingS
   def closePoller(poller: Poller): Unit =
     poller.selector.close()
 
-  def poll(poller: Poller, nanos: Long): Boolean = {
+  def poll(poller: Poller, nanos: Long): PollResult = {
     val millis = if (nanos >= 0) nanos / 1000000 else -1
     val selector = poller.selector
 
@@ -50,7 +50,10 @@ final class SelectorSystem private (provider: SelectorProvider) extends PollingS
     else selector.select()
 
     // closing selector interrupts select
-    selector.isOpen() && !selector.selectedKeys().isEmpty()
+    if (selector.isOpen() && !selector.selectedKeys().isEmpty())
+      PollResult.Complete
+    else
+      PollResult.Interrupted
   }
 
   def processReadyEvents(poller: Poller): Boolean = {

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SleepSystem.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SleepSystem.scala
@@ -34,14 +34,14 @@ object SleepSystem extends PollingSystem {
 
   def closePoller(Poller: Poller): Unit = ()
 
-  def poll(poller: Poller, nanos: Long): Boolean = {
+  def poll(poller: Poller, nanos: Long): PollResult = {
     if (nanos < 0)
       LockSupport.park()
     else if (nanos > 0)
       LockSupport.parkNanos(nanos)
     else
       ()
-    false
+    PollResult.Interrupted
   }
 
   def processReadyEvents(poller: Poller): Boolean = false

--- a/core/jvm/src/main/scala/cats/effect/unsafe/SleepSystem.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/SleepSystem.scala
@@ -34,7 +34,7 @@ object SleepSystem extends PollingSystem {
 
   def closePoller(Poller: Poller): Unit = ()
 
-  def poll(poller: Poller, nanos: Long, reportFailure: Throwable => Unit): Boolean = {
+  def poll(poller: Poller, nanos: Long): Boolean = {
     if (nanos < 0)
       LockSupport.park()
     else if (nanos > 0)
@@ -43,6 +43,8 @@ object SleepSystem extends PollingSystem {
       ()
     false
   }
+
+  def processReadyEvents(poller: Poller): Boolean = false
 
   def needsPoll(poller: Poller): Boolean = false
 

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -421,24 +421,34 @@ private[effect] final class WorkerThread[P <: AnyRef](
       }
     }
 
+    @tailrec
+    def drainReadyEvents(result: PollResult, acc: Boolean): Boolean =
+      if (result ne PollResult.Interrupted) {
+        val tasksScheduled = system.processReadyEvents(_poller) | acc
+        if (result eq PollResult.Complete) tasksScheduled
+        else drainReadyEvents(system.poll(_poller, 0), tasksScheduled)
+      } else {
+        acc
+      }
+
     // returns true if polled event, false if unparked
     def parkLoop(): Boolean = {
       while (!done.get()) {
         // Park the thread until further notice.
         val start = System.nanoTime()
         metrics.incrementPolledCount()
-        val polled = system.poll(_poller, -1)
+        val pollResult = system.poll(_poller, -1)
         now = System.nanoTime() // update now
         metrics.addIdleTime(now - start)
 
         // the only way we can be interrupted here is if it happened *externally* (probably sbt)
         if (isInterrupted()) {
           pool.shutdown()
-        } else if (polled) {
+        } else if (pollResult ne PollResult.Interrupted) {
           if (parked.getAndSet(false))
             pool.doneSleeping()
           // TODO, if no tasks scheduled could fastpath back to park?
-          val _ = system.processReadyEvents(_poller)
+          val _ = drainReadyEvents(pollResult, false)
           return true
         } else if (!parked.get()) { // Spurious wakeup check.
           return false
@@ -465,7 +475,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
           if (nanos > 0L) {
             val start = now
             metrics.incrementPolledCount()
-            val polled = system.poll(_poller, nanos)
+            val pollResult = system.poll(_poller, nanos)
             // we already parked and time passed, so update time again
             // it doesn't matter if we timed out or were awakened, the update is free-ish
             now = System.nanoTime()
@@ -476,13 +486,14 @@ private[effect] final class WorkerThread[P <: AnyRef](
               false // we know `done` is `true`
             } else {
               // no matter why we woke up, there may be timers or events ready
+              val polled = pollResult ne PollResult.Interrupted
               if (polled || (triggerTime - now <= 0)) {
                 // we timed out or polled an event
                 if (parked.getAndSet(false)) {
                   pool.doneSleeping()
                 }
                 if (polled) { // TODO, if no tasks scheduled and no timers could fastpath back to park?
-                  val _ = system.processReadyEvents(_poller)
+                  val _ = drainReadyEvents(pollResult, false)
                 }
                 true
               } else { // we were either awakened spuriously or intentionally
@@ -583,8 +594,8 @@ private[effect] final class WorkerThread[P <: AnyRef](
           sleepers.packIfNeeded()
           // give the polling system a chance to discover events
           metrics.incrementPolledCount()
-          if (system.needsPoll(_poller) && system.poll(_poller, 0)) {
-            val _ = system.processReadyEvents(_poller)
+          if (system.needsPoll(_poller)) {
+            val _ = drainReadyEvents(system.poll(_poller, 0), false)
           }
 
           // Obtain a fiber or batch of fibers from the external queue.

--- a/core/native/src/main/scala/cats/effect/unsafe/EpollSystem.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/EpollSystem.scala
@@ -30,7 +30,7 @@ import scala.scalanative.meta.LinktimeInfo
 import scala.scalanative.posix.errno._
 import scala.scalanative.posix.string._
 import scala.scalanative.posix.unistd
-import scala.scalanative.runtime._
+import scala.scalanative.runtime.{Array => _, _}
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 
@@ -60,8 +60,11 @@ object EpollSystem extends PollingSystem {
 
   def closePoller(poller: Poller): Unit = poller.close()
 
-  def poll(poller: Poller, nanos: Long, reportFailure: Throwable => Unit): Boolean =
+  def poll(poller: Poller, nanos: Long): Boolean =
     poller.poll(nanos)
+
+  def processReadyEvents(poller: Poller): Boolean =
+    poller.processReadyEvents()
 
   def needsPoll(poller: Poller): Boolean = poller.needsPoll()
 
@@ -182,44 +185,50 @@ object EpollSystem extends PollingSystem {
     private[this] val handles: Set[PollHandle] =
       Collections.newSetFromMap(new IdentityHashMap)
 
+    private[this] val eventsArray = new Array[Byte](sizeof[epoll_event].toInt * MaxEvents)
+    @inline private[this] def events = eventsArray.atUnsafe(0).asInstanceOf[Ptr[epoll_event]]
+    private[this] var readyEventCount: Int = 0
+
     private[EpollSystem] def close(): Unit =
       if (unistd.close(epfd) != 0)
         throw new IOException(fromCString(strerror(errno)))
 
     private[EpollSystem] def poll(timeout: Long): Boolean = {
 
-      val events = stackalloc[epoll_event](MaxEvents.toULong)
-      var polled = false
+      val timeoutMillis = if (timeout == -1) -1 else (timeout / 1000000).toInt
+      val rtn = epoll_wait(epfd, events, MaxEvents, timeoutMillis)
+      if (rtn >= 0) {
+        readyEventCount = rtn
+        rtn > 0
+      } else if (errno == EINTR) { // spurious wake-up by signal
+        false
+      } else {
+        throw new IOException(fromCString(strerror(errno)))
+      }
+    }
 
-      @tailrec
-      def processEvents(timeout: Int): Unit = {
-
-        val triggeredEvents = epoll_wait(epfd, events, MaxEvents, timeout)
-
-        if (triggeredEvents >= 0) {
-          polled = true
-
-          var i = 0
-          while (i < triggeredEvents) {
-            val event = events + i.toLong
-            val handle = fromPtr(event.data)
-            handle.notify(event.events.toInt)
-            i += 1
-          }
-        } else if (errno != EINTR) { // spurious wake-up by signal
-          throw new IOException(fromCString(strerror(errno)))
-        }
-
-        if (triggeredEvents >= MaxEvents)
-          processEvents(0) // drain the ready list
-        else
-          ()
+    @tailrec
+    private[EpollSystem] def processReadyEvents(): Boolean = {
+      var i = 0
+      while (i < readyEventCount) {
+        val event = events + i.toLong
+        val handle = fromPtr(event.data)
+        handle.notify(event.events.toInt)
+        i += 1
       }
 
-      val timeoutMillis = if (timeout == -1) -1 else (timeout / 1000000).toInt
-      processEvents(timeoutMillis)
-
-      polled
+      if (readyEventCount >= MaxEvents) { // drain the ready list
+        val rtn = epoll_wait(epfd, events, MaxEvents, 0)
+        if (rtn >= 0) {
+          readyEventCount = rtn
+          processReadyEvents()
+        } else {
+          throw new IOException(fromCString(strerror(errno)))
+        }
+      } else {
+        readyEventCount = 0
+        true
+      }
     }
 
     private[EpollSystem] def needsPoll(): Boolean = !handles.isEmpty()

--- a/core/native/src/main/scala/cats/effect/unsafe/EventLoopExecutorScheduler.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/EventLoopExecutorScheduler.scala
@@ -17,6 +17,7 @@
 package cats.effect
 package unsafe
 
+import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 import scala.concurrent.duration._
 import scala.scalanative.libc.errno._
@@ -128,9 +129,13 @@ private[effect] final class EventLoopExecutorScheduler[P](
        * test framework, including MUnit, specs2, and Weaver.
        */
       if (system.needsPoll(poller) || timeout != -1) {
-        if (system.poll(poller, timeout)) {
-          val _ = system.processReadyEvents(poller)
-        }
+        @tailrec def loop(result: PollResult): Unit =
+          if (result ne PollResult.Interrupted) {
+            system.processReadyEvents(poller)
+            if (result eq PollResult.Incomplete) loop(system.poll(poller, 0))
+          }
+
+        loop(system.poll(poller, timeout))
       }
 
       continue = !executeQueue.isEmpty() || !sleepQueue.isEmpty() || system.needsPoll(poller)

--- a/core/native/src/main/scala/cats/effect/unsafe/EventLoopExecutorScheduler.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/EventLoopExecutorScheduler.scala
@@ -127,9 +127,11 @@ private[effect] final class EventLoopExecutorScheduler[P](
        * the Scala Native global `ExecutionContext` which is currently hard-coded into every
        * test framework, including MUnit, specs2, and Weaver.
        */
-      if (system.needsPoll(poller) || timeout != -1)
-        system.poll(poller, timeout, reportFailure)
-      else ()
+      if (system.needsPoll(poller) || timeout != -1) {
+        if (system.poll(poller, timeout)) {
+          val _ = system.processReadyEvents(poller)
+        }
+      }
 
       continue = !executeQueue.isEmpty() || !sleepQueue.isEmpty() || system.needsPoll(poller)
     }

--- a/core/native/src/main/scala/cats/effect/unsafe/PollingExecutorScheduler.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/PollingExecutorScheduler.scala
@@ -37,7 +37,7 @@ abstract class PollingExecutorScheduler(pollEvery: Int)
       def makeApi(ctx: PollingContext[Poller]): Api = outer
       def makePoller(): Poller = outer
       def closePoller(poller: Poller): Unit = ()
-      def poll(poller: Poller, nanos: Long, reportFailure: Throwable => Unit): Boolean = {
+      def poll(poller: Poller, nanos: Long): Boolean = {
         needsPoll =
           if (nanos == -1)
             poller.poll(Duration.Inf)
@@ -45,6 +45,7 @@ abstract class PollingExecutorScheduler(pollEvery: Int)
             poller.poll(nanos.nanos)
         true
       }
+      def processReadyEvents(poller: Poller): Boolean = true
       def needsPoll(poller: Poller) = needsPoll
       def interrupt(targetThread: Thread, targetPoller: Poller): Unit = ()
       def metrics(poller: Poller): PollerMetrics = PollerMetrics.noop

--- a/core/native/src/main/scala/cats/effect/unsafe/PollingExecutorScheduler.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/PollingExecutorScheduler.scala
@@ -37,13 +37,13 @@ abstract class PollingExecutorScheduler(pollEvery: Int)
       def makeApi(ctx: PollingContext[Poller]): Api = outer
       def makePoller(): Poller = outer
       def closePoller(poller: Poller): Unit = ()
-      def poll(poller: Poller, nanos: Long): Boolean = {
+      def poll(poller: Poller, nanos: Long): PollResult = {
         needsPoll =
           if (nanos == -1)
             poller.poll(Duration.Inf)
           else
             poller.poll(nanos.nanos)
-        true
+        PollResult.Complete
       }
       def processReadyEvents(poller: Poller): Boolean = true
       def needsPoll(poller: Poller) = needsPoll

--- a/core/native/src/main/scala/cats/effect/unsafe/SleepSystem.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/SleepSystem.scala
@@ -32,11 +32,13 @@ object SleepSystem extends PollingSystem {
 
   def closePoller(poller: Poller): Unit = ()
 
-  def poll(poller: Poller, nanos: Long, reportFailure: Throwable => Unit): Boolean = {
+  def poll(poller: Poller, nanos: Long): Boolean = {
     if (nanos > 0)
       Thread.sleep(nanos / 1000000, (nanos % 1000000).toInt)
     false
   }
+
+  def processReadyEvents(poller: Poller): Boolean = false
 
   def needsPoll(poller: Poller): Boolean = false
 

--- a/core/native/src/main/scala/cats/effect/unsafe/SleepSystem.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/SleepSystem.scala
@@ -32,10 +32,10 @@ object SleepSystem extends PollingSystem {
 
   def closePoller(poller: Poller): Unit = ()
 
-  def poll(poller: Poller, nanos: Long): Boolean = {
+  def poll(poller: Poller, nanos: Long): PollResult = {
     if (nanos > 0)
       Thread.sleep(nanos / 1000000, (nanos % 1000000).toInt)
-    false
+    PollResult.Interrupted
   }
 
   def processReadyEvents(poller: Poller): Boolean = false

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -21,6 +21,7 @@ import cats.effect.unsafe.{
   IORuntime,
   IORuntimeConfig,
   PollingContext,
+  PollResult,
   PollingSystem,
   SleepSystem,
   WorkStealingThreadPool
@@ -508,7 +509,7 @@ trait IOPlatformSpecification extends DetectPlatform { self: BaseSpec with Scala
           poller.get() match {
             case Nil =>
               SleepSystem.poll(SleepSystem.makePoller(), nanos)
-            case _ => true
+            case _ => PollResult.Complete
           }
         }
 

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -17,15 +17,7 @@
 package cats.effect
 
 import cats.effect.std.Semaphore
-import cats.effect.unsafe.{
-  IORuntime,
-  IORuntimeConfig,
-  PollingContext,
-  PollResult,
-  PollingSystem,
-  SleepSystem,
-  WorkStealingThreadPool
-}
+import cats.effect.unsafe.{IORuntime, IORuntimeConfig, PollResult, PollingContext, PollingSystem, SleepSystem, WorkStealingThreadPool}
 import cats.effect.unsafe.metrics.PollerMetrics
 import cats.syntax.all._
 

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -486,46 +486,54 @@ trait IOPlatformSpecification extends DetectPlatform { self: BaseSpec with Scala
         ok
       }
 
-      "wake parked thread for polled events" in {
+      trait DummyPoller {
+        def poll: IO[Unit]
+      }
 
-        trait DummyPoller {
-          def poll: IO[Unit]
+      object DummySystem extends PollingSystem {
+        type Api = DummyPoller
+        type Poller = AtomicReference[List[Either[Throwable, Unit] => Unit]]
+
+        def close() = ()
+
+        def makePoller() = new AtomicReference(List.empty[Either[Throwable, Unit] => Unit])
+        def needsPoll(poller: Poller) = poller.get.nonEmpty
+        def closePoller(poller: Poller) = ()
+        def metrics(poller: Poller): PollerMetrics = PollerMetrics.noop
+
+        def interrupt(targetThread: Thread, targetPoller: Poller) =
+          SleepSystem.interrupt(targetThread, SleepSystem.makePoller())
+
+        def poll(poller: Poller, nanos: Long) = {
+          poller.get() match {
+            case Nil =>
+              SleepSystem.poll(SleepSystem.makePoller(), nanos)
+            case _ => true
+          }
         }
 
-        object DummySystem extends PollingSystem {
-          type Api = DummyPoller
-          type Poller = AtomicReference[List[Either[Throwable, Unit] => Unit]]
-
-          def close() = ()
-
-          def makePoller() = new AtomicReference(List.empty[Either[Throwable, Unit] => Unit])
-          def needsPoll(poller: Poller) = poller.get.nonEmpty
-          def closePoller(poller: Poller) = ()
-          def metrics(poller: Poller): PollerMetrics = PollerMetrics.noop
-
-          def interrupt(targetThread: Thread, targetPoller: Poller) =
-            SleepSystem.interrupt(targetThread, SleepSystem.makePoller())
-
-          def poll(poller: Poller, nanos: Long, reportFailure: Throwable => Unit) = {
-            poller.getAndSet(Nil) match {
-              case Nil =>
-                SleepSystem.poll(SleepSystem.makePoller(), nanos, reportFailure)
-              case cbs =>
-                cbs.foreach(_.apply(Right(())))
-                true
-            }
+        def processReadyEvents(poller: Poller) = {
+          poller.getAndSet(Nil) match {
+            case Nil =>
+              false
+            case cbs =>
+              cbs.foreach(_.apply(Right(())))
+              true
           }
+        }
 
-          def makeApi(ctx: PollingContext[Poller]): DummySystem.Api =
-            new DummyPoller {
-              def poll = IO.async_[Unit] { cb =>
-                ctx.accessPoller { poller =>
-                  poller.getAndUpdate(cb :: _)
-                  ()
-                }
+        def makeApi(ctx: PollingContext[Poller]): DummySystem.Api =
+          new DummyPoller {
+            def poll = IO.async_[Unit] { cb =>
+              ctx.accessPoller { poller =>
+                poller.getAndUpdate(cb :: _)
+                ()
               }
             }
-        }
+          }
+      }
+
+      "wake parked thread for polled events" in {
 
         val (pool, poller, shutdown) = IORuntime.createWorkStealingComputeThreadPool(
           threads = 2,
@@ -547,45 +555,6 @@ trait IOPlatformSpecification extends DetectPlatform { self: BaseSpec with Scala
       }
 
       "poll punctually on a single-thread runtime with concurrent sleepers" in {
-
-        trait DummyPoller {
-          def poll: IO[Unit]
-        }
-
-        object DummySystem extends PollingSystem {
-          type Api = DummyPoller
-          type Poller = AtomicReference[List[Either[Throwable, Unit] => Unit]]
-
-          def close() = ()
-
-          def makePoller() = new AtomicReference(List.empty[Either[Throwable, Unit] => Unit])
-          def needsPoll(poller: Poller) = poller.get.nonEmpty
-          def closePoller(poller: Poller) = ()
-          def metrics(poller: Poller): PollerMetrics = PollerMetrics.noop
-
-          def interrupt(targetThread: Thread, targetPoller: Poller) =
-            SleepSystem.interrupt(targetThread, SleepSystem.makePoller())
-
-          def poll(poller: Poller, nanos: Long, reportFailure: Throwable => Unit) = {
-            poller.getAndSet(Nil) match {
-              case Nil =>
-                SleepSystem.poll(SleepSystem.makePoller(), nanos, reportFailure)
-              case cbs =>
-                cbs.foreach(_.apply(Right(())))
-                true
-            }
-          }
-
-          def makeApi(ctx: PollingContext[Poller]): DummySystem.Api =
-            new DummyPoller {
-              def poll = IO.async_[Unit] { cb =>
-                ctx.accessPoller { poller =>
-                  poller.getAndUpdate(cb :: _)
-                  ()
-                }
-              }
-            }
-        }
 
         val (pool, poller, shutdown) = IORuntime.createWorkStealingComputeThreadPool(
           threads = 1,

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -17,7 +17,15 @@
 package cats.effect
 
 import cats.effect.std.Semaphore
-import cats.effect.unsafe.{IORuntime, IORuntimeConfig, PollResult, PollingContext, PollingSystem, SleepSystem, WorkStealingThreadPool}
+import cats.effect.unsafe.{
+  IORuntime,
+  IORuntimeConfig,
+  PollResult,
+  PollingContext,
+  PollingSystem,
+  SleepSystem,
+  WorkStealingThreadPool
+}
 import cats.effect.unsafe.metrics.PollerMetrics
 import cats.syntax.all._
 


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/4229.

`PollingSystem#poll` is now split into `poll` and `processReadyEvents`, where `poll` does the blocking syscall (and nothing more) and `processReadyEvents` handles rescheduling of fibers on the runtime. This enables the `WorkerThread` to unpark after `poll` and before `processReadyEvents`, so that it is in the appropriate state for receiving new work on its local queue.