### PR TITLE
Shutdown the runtime only when unforked

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -217,7 +217,6 @@ trait IOApp {
               IOApp.this.reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime)
 
             case t =>
-              runtime.shutdown()
               queue.clear()
               queue.put(t)
           }
@@ -504,7 +503,7 @@ trait IOApp {
 
       // Clean up after ourselves, relevant for running IOApps in sbt,
       // otherwise scheduler threads will accumulate over time.
-      runtime.shutdown()
+      if (!isForked) runtime.shutdown()
     }
 
     val hook = new Thread(() => handleShutdown())
@@ -527,7 +526,7 @@ trait IOApp {
           case ec: ExitCode =>
             // Clean up after ourselves, relevant for running IOApps in sbt,
             // otherwise scheduler threads will accumulate over time.
-            runtime.shutdown()
+            if (!isForked) runtime.shutdown()
             if (ec == ExitCode.Success) {
               // Return naturally from main. This allows any non-daemon
               // threads to gracefully complete their work, and managed

--- a/tests/jvm/src/main/scala/catseffect/examplesplatform.scala
+++ b/tests/jvm/src/main/scala/catseffect/examplesplatform.scala
@@ -35,8 +35,7 @@ package examples {
     override protected def runtimeConfig =
       super.runtimeConfig.copy(shutdownHookTimeout = Duration.Zero)
 
-    val run: IO[Unit] =
-      IO.blocking(System.exit(0)).uncancelable
+    val run: IO[Unit] = IO(System.exit(0))
   }
 
   object FatalErrorUnsafeRun extends IOApp {


### PR DESCRIPTION
It's already explained in the code comment: shutting down the runtime is really only relevant for unforked scenarios.

https://github.com/typelevel/cats-effect/blob/a49a0286b1530047f7aaf1e0964339d88c73dce8/core/jvm/src/main/scala/cats/effect/IOApp.scala#L505-L507

By not aggressively shutting down the runtime in the shutdown handler, we fix some gotchas e.g. deadlock if you attempted to execute `System.exit` on the runtime.