### PR TITLE
fix: don't try to advance time by Zero

### DIFF
--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/TestContext.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/TestContext.scala
@@ -198,7 +198,10 @@ final class TestContext private (_seed: Long) extends ExecutionContext { self =>
   def tickAll(): Unit = {
     tick()
     if (!stateRef.tasks.isEmpty) {
-      advance(nextInterval())
+      val next = nextInterval()
+      if (next > Duration.Zero) {
+        advance(next)
+      }
       tickAll()
     }
   }


### PR DESCRIPTION
Correct me if that's impossible, but I suspect this caused some `requirement failed` errors to randomly occur in our CI.