### PR TITLE
Refactor `WorkerThread` runloop; avoid pathological starvation of pollers

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -317,7 +317,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
 
     val done = pool.done
 
-    /**
+    /*
      * This method is called when the local queue is empty, and will return only when work is
      * found.
      *

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -313,113 +313,255 @@ private[effect] final class WorkerThread[P <: AnyRef](
     random = ThreadLocalRandom.current()
     val rnd = random
 
-    /*
-     * A counter (modulo `ExternalQueueTicks`) which represents the
-     * `WorkerThread` finite state machine. The following values have special
-     * semantics explained here:
-     *
-     *   0: To increase the fairness towards fibers scheduled by threads which
-     *      are external to the `WorkStealingThreadPool`, every
-     *      `ExternalQueueTicks` number of iterations, the external queue takes
-     *      precedence over the local queue.
-     *
-     *      If a fiber is successfully dequeued from the external queue, it will
-     *      be executed immediately. If a batch of fibers is dequeued instead,
-     *      the whole batch is enqueued on the local queue and other worker
-     *      threads are notified of existing work available for stealing. The
-     *      `WorkerThread` unconditionally transitions to executing fibers from
-     *      the local queue (state value 4 and larger).
-     *
-     *      This state occurs "naturally" after a certain number of executions
-     *      from the local queue (when the state value wraps around modulo
-     *      `ExternalQueueTicks`).
-     *
-     *   1: Fall back to checking the external queue after a failed dequeue from
-     *      the local queue. Depending on the outcome of this check, the
-     *      `WorkerThread` transitions to executing fibers from the local queue
-     *      in the case of a successful dequeue from the external queue (state
-     *      value 4 and larger). Otherwise, the `WorkerThread` continues with
-     *      asking for permission to steal from other `WorkerThread`s.
-     *
-     *      Depending on the outcome of this request, the `WorkerThread` starts
-     *      looking for fibers to steal from the local queues of other worker
-     *      threads (if permission was granted, state value 2), or parks
-     *      directly. In this case, there is less bookkeeping to be done
-     *      compared to the case where a worker was searching for work prior to
-     *      parking. After the worker thread has been unparked, it transitions
-     *      to looking for work in the external queue (state value 3) while also
-     *      holding a permission to steal fibers from other worker threads.
-     *
-     *   2: The `WorkerThread` has been allowed to steal fibers from other
-     *      worker threads. If the attempt is successful, the first fiber is
-     *      executed directly and the `WorkerThread` transitions to executing
-     *      fibers from the local queue (state value 4 and larger). If the
-     *      attempt is unsuccessful, the worker thread announces to the pool
-     *      that it was unable to find any work and parks.
-     *
-     *   3: The `WorkerThread` has been unparked an is looking for work in the
-     *      external queue. If it manages to find work there, it announces to
-     *      the work stealing thread pool that it is no longer searching for
-     *      work and continues to execute fibers from the local queue (state
-     *      value 4 and larger). Otherwise, it transitions to searching for work
-     *      to steal from the local queues of other worker threads because the
-     *      permission to steal is implicitly held by threads that have been
-     *      unparked (state value 2).
-     *
-     *   4 and larger: Look for fibers to execute in the local queue. In case
-     *      of a successful dequeue from the local queue, increment the state
-     *      value. In case of a failed dequeue from the local queue, transition
-     *      to looking for fibers in the external queue (state value 1).
-     *
-     * A note on the implementation. Some of the states seem like they have
-     * overlapping logic. This is indeed true, but it is a conscious decision.
-     * The logic is carefully unrolled and compiled into a shallow `tableswitch`
-     * instead of a deeply nested sequence of `if/else` statements. This change
-     * has lead to a non-negligible 15-20% increase in single-threaded
-     * performance.
-     */
-    var state = 4
+    var iteration = 0
 
     val done = pool.done
 
-    // returns next state after parking
-    def park(): Int = {
+    /**
+     * This method is called when the local queue is empty, and will return
+     *
+     * 0: Fall back to checking the external queue after a failed dequeue from the local queue.
+     * Depending on the outcome of this check, the `WorkerThread` transitions to executing
+     * fibers from the local queue in the case of a successful dequeue from the external queue
+     * (state value 4 and larger). Otherwise, the `WorkerThread` continues with asking for
+     * permission to steal from other `WorkerThread`s.
+     *
+     * Depending on the outcome of this request, the `WorkerThread` starts looking for fibers to
+     * steal from the local queues of other worker threads (if permission was granted, state
+     * value 2), or parks directly. In this case, there is less bookkeeping to be done compared
+     * to the case where a worker was searching for work prior to parking. After the worker
+     * thread has been unparked, it transitions to looking for work in the external queue (state
+     * value 3) while also holding a permission to steal fibers from other worker threads.
+     *
+     * 1: The `WorkerThread` has been allowed to steal fibers from other worker threads. If the
+     * attempt is successful, the first fiber is executed directly and the `WorkerThread`
+     * transitions to executing fibers from the local queue (state value 4 and larger). If the
+     * attempt is unsuccessful, the worker thread announces to the pool that it was unable to
+     * find any work and parks.
+     *
+     * 2: The `WorkerThread` has been unparked an is looking for work in the external queue. If
+     * it manages to find work there, it announces to the work stealing thread pool that it is
+     * no longer searching for work and continues to execute fibers from the local queue (state
+     * value 4 and larger). Otherwise, it transitions to searching for work to steal from the
+     * local queues of other worker threads because the permission to steal is implicitly held
+     * by threads that have been unparked (state value 2).
+     *
+     * A note on the implementation. Some of the states seem like they have overlapping logic.
+     * This is indeed true, but it is a conscious decision. The logic is carefully unrolled and
+     * compiled into a shallow `tableswitch` instead of a deeply nested sequence of `if/else`
+     * statements. This change has lead to a non-negligible 15-20% increase in single-threaded
+     * performance.
+     */
+    def lookForWork(): Unit = {
+      var state = 0
+      while (!done.get()) {
+        (state: @switch) match {
+          case 0 =>
+            // Check the external queue after a failed dequeue from the local
+            // queue (due to the local queue being empty).
+            val element = external.poll(rnd)
+            if (element.isInstanceOf[Array[Runnable]]) {
+              val batch = element.asInstanceOf[Array[Runnable]]
+              // The dequeued element was a batch of fibers. Enqueue the whole
+              // batch on the local queue and execute the first fiber.
+              // It is safe to directly enqueue the whole batch because we know
+              // that in this state of the worker thread state machine, the
+              // local queue is empty.
+              val fiber = queue.enqueueBatch(batch, self)
+              // Many fibers have been exchanged between the external and the
+              // local queue. Notify other worker threads.
+              pool.notifyParked(rnd)
+              try fiber.run()
+              catch {
+                case t if NonFatal(t) => pool.reportFailure(t)
+                case t: Throwable => IOFiber.onFatalFailure(t)
+              }
+
+              // Transition to executing fibers from the local queue.
+              return
+            } else if (element.isInstanceOf[Runnable]) {
+              val fiber = element.asInstanceOf[Runnable]
+
+              if (isStackTracing) {
+                _active = fiber
+                parked.lazySet(false)
+              }
+
+              // The dequeued element is a single fiber. Execute it immediately.
+              try fiber.run()
+              catch {
+                case t if NonFatal(t) => pool.reportFailure(t)
+                case t: Throwable => IOFiber.onFatalFailure(t)
+              }
+
+              // Transition to executing fibers from the local queue.
+              return
+            } else {
+              // Could not find any fibers in the external queue. Proceed to ask
+              // for permission to steal fibers from other `WorkerThread`s.
+              if (pool.transitionWorkerToSearching()) {
+                // Permission granted, proceed to steal.
+                state = 1
+              } else {
+                // Permission denied, proceed to park.
+                // Set the worker thread parked signal.
+                if (isStackTracing) {
+                  _active = null
+                }
+
+                parked.lazySet(true)
+                // Announce that the worker thread is parking.
+                pool.transitionWorkerToParked()
+                // Park the thread.
+                if (park())
+                  return // Work found, transition to executing fibers from the local queue.
+                else
+                  state = 2
+              }
+            }
+
+          case 1 =>
+            // update the current time
+            now = System.nanoTime()
+
+            // First try to steal some expired timers:
+            if (pool.stealTimers(now, rnd)) {
+              // some stolen timer created new work for us
+              pool.transitionWorkerFromSearching(rnd)
+              return
+            } else {
+              // Try stealing fibers from other worker threads.
+              val fiber = pool.stealFromOtherWorkerThread(index, rnd, self)
+              if (fiber ne null) {
+                // Successful steal. Announce that the current thread is no longer
+                // looking for work.
+                pool.transitionWorkerFromSearching(rnd)
+                // Run the stolen fiber.
+                try fiber.run()
+                catch {
+                  case t if NonFatal(t) => pool.reportFailure(t)
+                  case t: Throwable => IOFiber.onFatalFailure(t)
+                }
+                // Transition to executing fibers from the local queue.
+                return
+              } else {
+                // Stealing attempt is unsuccessful. Park.
+                // Set the worker thread parked signal.
+                if (isStackTracing) {
+                  _active = null
+                }
+
+                parked.lazySet(true)
+                // Announce that the worker thread which was searching for work is now
+                // parking. This checks if the parking worker thread was the last
+                // actively searching thread.
+                if (pool.transitionWorkerToParkedWhenSearching()) {
+                  // If this was indeed the last actively searching thread, do another
+                  // global check of the pool. Other threads might be busy with their
+                  // local queues or new work might have arrived on the external
+                  // queue. Another thread might be able to help.
+                  pool.notifyIfWorkPending(rnd)
+                }
+                // Park the thread.
+                if (park())
+                  return // Work found, transition to executing fibers from the local queue.
+                else
+                  state = 2
+              }
+            }
+
+          case 2 =>
+            // Check the external queue after being unparked
+            val element = external.poll(rnd)
+            if (element.isInstanceOf[Array[Runnable]]) {
+              val batch = element.asInstanceOf[Array[Runnable]]
+              // Announce that the current thread is no longer looking for work.
+              pool.transitionWorkerFromSearching(rnd)
+
+              // The dequeued element was a batch of fibers. Enqueue the whole
+              // batch on the local queue and execute the first fiber.
+              // It is safe to directly enqueue the whole batch because we know
+              // that in this state of the worker thread state machine, the
+              // local queue is empty.
+              val fiber = queue.enqueueBatch(batch, self)
+              // Many fibers have been exchanged between the external and the
+              // local queue. Notify other worker threads.
+              pool.notifyParked(rnd)
+              try fiber.run()
+              catch {
+                case t if NonFatal(t) => pool.reportFailure(t)
+                case t: Throwable => IOFiber.onFatalFailure(t)
+              }
+
+              // Transition to executing fibers from the local queue.
+              return
+            } else if (element.isInstanceOf[Runnable]) {
+              val fiber = element.asInstanceOf[Runnable]
+              // Announce that the current thread is no longer looking for work.
+
+              if (isStackTracing) {
+                _active = fiber
+                parked.lazySet(false)
+              }
+
+              pool.transitionWorkerFromSearching(rnd)
+
+              // The dequeued element is a single fiber. Execute it immediately.
+              try fiber.run()
+              catch {
+                case t if NonFatal(t) => pool.reportFailure(t)
+                case t: Throwable => IOFiber.onFatalFailure(t)
+              }
+
+              // Transition to executing fibers from the local queue.
+              return
+            } else {
+              // Transition to stealing fibers from other `WorkerThread`s.
+              // The permission is held implicitly by threads right after they
+              // have been woken up.
+              state = 1
+            }
+          case _ => throw new AssertionError
+        }
+      }
+    }
+
+    // returns whether work was found
+    def park(): Boolean = {
       metrics.incrementParkedCount()
 
       val tt = sleepers.peekFirstTriggerTime()
-      val nextState = if (tt == MIN_VALUE) { // no sleepers
+      val workFound = if (tt == MIN_VALUE) { // no sleepers
         if (parkLoop()) {
           // we polled something, so go straight to local queue stuff
           pool.transitionWorkerFromSearching(rnd)
-          4
+          true
         } else {
           // we were interrupted, look for more work in the external queue
-          3
+          false
         }
       } else {
         if (parkUntilNextSleeper()) {
           // we made it to the end of our sleeping/polling, so go straight to local queue stuff
           pool.transitionWorkerFromSearching(rnd)
-          4
+          true
         } else {
           // we were interrupted, look for more work in the external queue
-          3
+          false
         }
       }
 
-      if (nextState != 4) {
+      if (!workFound) {
         // after being unparked, we re-check sleepers;
-        // if we find an already expired one, we go
-        // immediately to state 4 (local queue stuff):
         val nextTrigger = sleepers.peekFirstTriggerTime()
         if ((nextTrigger != MIN_VALUE) && (nextTrigger - now <= 0L)) {
           pool.transitionWorkerFromSearching(rnd)
-          4
+          true
         } else {
-          nextState
+          false
         }
       } else {
-        nextState
+        false
       }
     }
 
@@ -567,10 +709,10 @@ private[effect] final class WorkerThread[P <: AnyRef](
 
         // Reset the state of the thread for resumption.
         blocking = false
-        state = 4
+        iteration = 1
       }
 
-      ((state & ExternalQueueTicksMask): @switch) match {
+      ((iteration & ExternalQueueTicksMask): @switch) match {
         case 0 =>
           if (pool.blockedThreadDetectionEnabled) {
             // TODO prefetch pool.workerThread or Thread.State.BLOCKED ?
@@ -640,170 +782,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
           // update the current time
           now = System.nanoTime()
 
-          // Transition to executing fibers from the local queue.
-          state = 4
-
-        case 1 =>
-          // Check the external queue after a failed dequeue from the local
-          // queue (due to the local queue being empty).
-          val element = external.poll(rnd)
-          if (element.isInstanceOf[Array[Runnable]]) {
-            val batch = element.asInstanceOf[Array[Runnable]]
-            // The dequeued element was a batch of fibers. Enqueue the whole
-            // batch on the local queue and execute the first fiber.
-            // It is safe to directly enqueue the whole batch because we know
-            // that in this state of the worker thread state machine, the
-            // local queue is empty.
-            val fiber = queue.enqueueBatch(batch, self)
-            // Many fibers have been exchanged between the external and the
-            // local queue. Notify other worker threads.
-            pool.notifyParked(rnd)
-            try fiber.run()
-            catch {
-              case t if NonFatal(t) => pool.reportFailure(t)
-              case t: Throwable => IOFiber.onFatalFailure(t)
-            }
-
-            // Transition to executing fibers from the local queue.
-            state = 4
-          } else if (element.isInstanceOf[Runnable]) {
-            val fiber = element.asInstanceOf[Runnable]
-
-            if (isStackTracing) {
-              _active = fiber
-              parked.lazySet(false)
-            }
-
-            // The dequeued element is a single fiber. Execute it immediately.
-            try fiber.run()
-            catch {
-              case t if NonFatal(t) => pool.reportFailure(t)
-              case t: Throwable => IOFiber.onFatalFailure(t)
-            }
-
-            // Transition to executing fibers from the local queue.
-            state = 4
-          } else {
-            // Could not find any fibers in the external queue. Proceed to ask
-            // for permission to steal fibers from other `WorkerThread`s.
-            if (pool.transitionWorkerToSearching()) {
-              // Permission granted, proceed to steal.
-              state = 2
-            } else {
-              // Permission denied, proceed to park.
-              // Set the worker thread parked signal.
-              if (isStackTracing) {
-                _active = null
-              }
-
-              parked.lazySet(true)
-              // Announce that the worker thread is parking.
-              pool.transitionWorkerToParked()
-              // Park the thread.
-              state = park()
-            }
-          }
-
-        case 2 =>
-          // update the current time
-          now = System.nanoTime()
-
-          // First try to steal some expired timers:
-          if (pool.stealTimers(now, rnd)) {
-            // some stolen timer created new work for us
-            pool.transitionWorkerFromSearching(rnd)
-            state = 4
-          } else {
-            // Try stealing fibers from other worker threads.
-            val fiber = pool.stealFromOtherWorkerThread(index, rnd, self)
-            if (fiber ne null) {
-              // Successful steal. Announce that the current thread is no longer
-              // looking for work.
-              pool.transitionWorkerFromSearching(rnd)
-              // Run the stolen fiber.
-              try fiber.run()
-              catch {
-                case t if NonFatal(t) => pool.reportFailure(t)
-                case t: Throwable => IOFiber.onFatalFailure(t)
-              }
-              // Transition to executing fibers from the local queue.
-              state = 4
-            } else {
-              // Stealing attempt is unsuccessful. Park.
-              // Set the worker thread parked signal.
-              if (isStackTracing) {
-                _active = null
-              }
-
-              parked.lazySet(true)
-              // Announce that the worker thread which was searching for work is now
-              // parking. This checks if the parking worker thread was the last
-              // actively searching thread.
-              if (pool.transitionWorkerToParkedWhenSearching()) {
-                // If this was indeed the last actively searching thread, do another
-                // global check of the pool. Other threads might be busy with their
-                // local queues or new work might have arrived on the external
-                // queue. Another thread might be able to help.
-                pool.notifyIfWorkPending(rnd)
-              }
-              // Park the thread.
-              state = park()
-            }
-          }
-
-        case 3 =>
-          // Check the external queue after a failed dequeue from the local
-          // queue (due to the local queue being empty).
-          val element = external.poll(rnd)
-          if (element.isInstanceOf[Array[Runnable]]) {
-            val batch = element.asInstanceOf[Array[Runnable]]
-            // Announce that the current thread is no longer looking for work.
-            pool.transitionWorkerFromSearching(rnd)
-
-            // The dequeued element was a batch of fibers. Enqueue the whole
-            // batch on the local queue and execute the first fiber.
-            // It is safe to directly enqueue the whole batch because we know
-            // that in this state of the worker thread state machine, the
-            // local queue is empty.
-            val fiber = queue.enqueueBatch(batch, self)
-            // Many fibers have been exchanged between the external and the
-            // local queue. Notify other worker threads.
-            pool.notifyParked(rnd)
-            try fiber.run()
-            catch {
-              case t if NonFatal(t) => pool.reportFailure(t)
-              case t: Throwable => IOFiber.onFatalFailure(t)
-            }
-
-            // Transition to executing fibers from the local queue.
-            state = 4
-          } else if (element.isInstanceOf[Runnable]) {
-            val fiber = element.asInstanceOf[Runnable]
-            // Announce that the current thread is no longer looking for work.
-
-            if (isStackTracing) {
-              _active = fiber
-              parked.lazySet(false)
-            }
-
-            pool.transitionWorkerFromSearching(rnd)
-
-            // The dequeued element is a single fiber. Execute it immediately.
-            try fiber.run()
-            catch {
-              case t if NonFatal(t) => pool.reportFailure(t)
-              case t: Throwable => IOFiber.onFatalFailure(t)
-            }
-
-            // Transition to executing fibers from the local queue.
-            state = 4
-          } else {
-            // Transition to stealing fibers from other `WorkerThread`s.
-            // The permission is held implicitly by threads right after they
-            // have been woken up.
-            state = 2
-          }
-
+        // Transition to executing fibers from the local queue.
         case _ =>
           // Call all of our expired timers:
           var cont = true
@@ -835,13 +814,15 @@ private[effect] final class WorkerThread[P <: AnyRef](
               case t if NonFatal(t) => pool.reportFailure(t)
               case t: Throwable => IOFiber.onFatalFailure(t)
             }
-            // Continue executing fibers from the local queue.
-            state += 1
           } else {
             // Transition to checking the external queue.
-            state = 1
+            lookForWork()
           }
+
+        // Continue executing fibers from the local queue.
       }
+
+      iteration += 1
     }
   }
 

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -317,7 +317,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
 
     val done = pool.done
 
-    /**
+    /*
      * This method is called when the local queue is empty, and will return
      *
      * 0: Fall back to checking the external queue after a failed dequeue from the local queue.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -561,7 +561,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
           false
         }
       } else {
-        false
+        true
       }
     }
 

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -598,7 +598,11 @@ trait IOPlatformSpecification extends DetectPlatform { self: BaseSpec with Scala
               pool.execute(mkExternalWork)
               latch.countDown()
             }
-            latch.await() // wait until next task is in external queue
+            try {
+              latch.await() // wait until next task is in external queue
+            } catch {
+              case _: InterruptedException => // ignore, runtime is shutting down
+            }
           }
 
           val test = IO(mkExternalWork.run()) *>


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/4228.

At a high level, a `WorkerThread` is always in one of the following three states:

1. Working (primarily on the local queue).
2. Looking for work (external or stolen).
3. Parked.

Previously, (3) was a separate `parkLoop()`, but (1) and (2) were entangled in the top-level runloop. Now, (2) is refactored into a separate `lookForWork()` loop. Thus, the top-level runloop is only responsible for tracking "ticks", such that polling runs every 64 ticks.

![worker-runloop-fsm](https://github.com/user-attachments/assets/1e432986-9777-4618-bb02-5002f724c98e)
