### PR TITLE
Poll on the 0th tick, check external queue on 32nd

### DIFF
--- a/core/jvm/src/main/java/cats/effect/unsafe/WorkStealingThreadPoolConstants.java
+++ b/core/jvm/src/main/java/cats/effect/unsafe/WorkStealingThreadPoolConstants.java
@@ -43,8 +43,12 @@ final class WorkStealingThreadPoolConstants {
   /** Used for extracting the number of unparked threads. */
   static final int UnparkMask = ~SearchMask;
 
-  /** Used for checking for new fibers from the external queue every few iterations. */
-  static final int ExternalQueueTicks = 64;
+  /** Used for checking sources of external work every few iterations. */
+  static final int ExternalWorkTicks = 32;
 
-  static final int ExternalQueueTicksMask = ExternalQueueTicks - 1;
+  static final int ExternalWorkTicksMask = ExternalWorkTicks - 1;
+
+  static final int PollingTicks = 2 * ExternalWorkTicks;
+
+  static final int PollingTicksMask = PollingTicks - 1;
 }


### PR DESCRIPTION
Refactors the worker thread runloop so that I/O polling and external queue polling are no longer part of the same tick, and instead occur at opposite ends of the loop i.e. the 0th and 32nd ticks. The goal is to reduce the chance that the local queue overflows, by giving it a chance to work on tasks in-between polling these sources.