### PR TITLE
Run finalizers in `IO#unsafeRunTimed`

### DIFF
--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -51,22 +51,26 @@ trait IOPlatformSpecification extends DetectPlatform { self: BaseSpec with Scala
     "platform" should {
 
       "unsafeRunTimed cancels task if timed-out" in {
-        val latch = new CountDownLatch(1)
-        val task = IO.never.onCancel(IO.sleep(100.millis) *> IO(latch.countDown()))
+        val latch1 = new CountDownLatch(1)
+        val latch2 = new CountDownLatch(1)
+        val task = IO.never.onCancel(IO.blocking(latch1.await()) *> IO(latch2.countDown()))
         task.unsafeRunTimed(100.millis)(runtime())
-        latch.getCount() must beEqualTo(1) // didn't backpressure on finalizer
-        latch.await(1, SECONDS) must beTrue // but it does eventually run
+        latch1.countDown() // didn't backpressure on finalizer
+        latch2.await(1, SECONDS) must beTrue // but it does eventually run
       }
 
       "unsafeRunSync cancels task if interrupted" in realWithRuntime { implicit rt =>
         for {
-          latch <- IO(new CountDownLatch(1))
-          task = IO.never.as(false).onCancel(IO.sleep(100.millis) *> IO(latch.countDown()))
-          result <- IO.interruptible(task.unsafeRunSync()).timeoutTo(100.millis, IO.pure(true))
-          _ <- IO(result must beTrue) // timed-out
-          _ <- IO(latch.getCount() must beEqualTo(1)) // didn't backpressure on finalizer
-          _ <- // but it does eventually run
-            IO.interruptible(latch.await(1, SECONDS) must beTrue)
+          latch1 <- IO.deferred[Unit]
+          latch2 <- IO.deferred[Unit]
+          latch3 <- IO.deferred[Unit]
+          task = (latch1.complete(()) *> IO.never.as(false))
+            .onCancel(latch2.get *> latch3.complete(()).void)
+          fiber <- IO.interruptible(task.unsafeRunSync()).start
+          result <- latch1.get *> fiber.cancel *> fiber.joinWith(IO.pure(true))
+          _ <- IO(result must beTrue) // canceled
+          _ <- latch2.complete(()) // didn't backpressure on finalizer
+          _ <- latch3.get // but it does eventually run
         } yield ok
       }
 


### PR DESCRIPTION
Follow-up to https://github.com/typelevel/cats-effect/pull/4167#issuecomment-2472346690. Runs finalizers `IO#unsafeRunTimed` if it times-out or is interrupted, but doesn't backpressure on their completion.