### PR TITLE
fix: Nix development Enviroment & Readme Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ To build the documentation site locally, the following dependencies are needed, 
 - Node (14.x ideally)
 - Yarn (any version should work)
 
-NOTE: [Nix](https://nixos.org/) users can just run `nix-shell` at the root directory and follow along the next instructions.
+NOTE: [Nix](https://nixos.org/) users can just run `nix develop` at the root directory and follow along the next instructions.
 
 Next, check out the documentation branch along with its submodules.
 

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,26 @@
             native.enable = true;
             nodejs.package = pkgs.nodejs-18_x;
           };
+          packages = with pkgs; [
+            autoconf
+            automake
+            libtool
+            pkg-config  
+            gifsicle  
+            zlib
+            libpng
+          ];
+          
+          env = [
+            {
+              name = "LD_LIBRARY_PATH";
+              value = pkgs.lib.makeLibraryPath (with pkgs; [
+                zlib
+                libpng
+                stdenv.cc.cc.lib
+              ]);
+            }
+          ];
         };
       in
       rec {


### PR DESCRIPTION
./build was failing inside nix development environment.

The main issues were:

- The `gifsicle` package can't run because it's dynamically linked
- `autoreconf` is missing, which is part of the `autoconf` package


As NixOS cannot run dynamically linked executables intended for generic linux environments out of the box. For more information, see:
https://nix.dev/permalink/stub-ld