### PR TITLE
Restore GraalVM Native Image test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,6 @@ jobs:
             java: temurin@11
           - scala: 3.3.4
             java: temurin@21
-          - scala: 3.3.4
-            java: graalvm@21
           - scala: 2.12.20
             java: temurin@11
           - scala: 2.12.20
@@ -324,6 +322,11 @@ jobs:
         if: matrix.ci == 'ciNative' && matrix.os == 'ubuntu-latest'
         shell: bash
         run: example/test-native.sh ${{ matrix.scala }}
+
+      - name: Test GraalVM Native Image
+        if: (matrix.scala == '2.13.15' || matrix.scala == '3.3.4') && matrix.java == 'graalvm@21' && matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: sbt '++ ${{ matrix.scala }}' graalVMExample/nativeImage graalVMExample/nativeImageRun
 
       - name: Scalafix tests
         if: matrix.scala == '2.13.15' && matrix.ci == 'ciJVM' && matrix.os == 'ubuntu-latest'

--- a/build.sbt
+++ b/build.sbt
@@ -203,6 +203,12 @@ ThisBuild / githubWorkflowBuild := Seq("JVM", "JS", "Native").map { platform =>
     name = Some("Test Example Native App Using Binary"),
     cond = Some(s"matrix.ci == 'ciNative' && matrix.os == '$PrimaryOS'")
   ),
+  WorkflowStep.Sbt(
+    List("graalVMExample/nativeImage", "graalVMExample/nativeImageRun"),
+    name = Some("Test GraalVM Native Image"),
+    cond = Some(
+      s"(matrix.scala == '$Scala213' || matrix.scala == '$Scala3') && matrix.java == '${GraalVM.render}' && matrix.os == '$PrimaryOS'")
+  ),
   WorkflowStep.Run(
     List("cd scalafix", "sbt test"),
     name = Some("Scalafix tests"),
@@ -226,7 +232,7 @@ ThisBuild / githubWorkflowBuildMatrixExclusions := {
   val scalaJavaFilters = for {
     scala <- (ThisBuild / githubWorkflowScalaVersions).value.filterNot(Set(Scala213))
     java <- (ThisBuild / githubWorkflowJavaVersions).value.filterNot(Set(OldGuardJava))
-    if !(scala == Scala3 && java == LatestJava)
+    if !(scala == Scala3 && (java == LatestJava || java == GraalVM))
   } yield MatrixExclude(Map("scala" -> scala, "java" -> java.render))
 
   val armFilters =


### PR DESCRIPTION
We lost this by mistake after https://github.com/typelevel/cats-effect/pull/4153.