### PR TITLE
SecureRandom.javaSecuritySecureRandom for two effect types

### DIFF
--- a/std/js/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
+++ b/std/js/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
@@ -114,10 +114,13 @@ private[std] trait SecureRandomCompanionPlatform {
     }
   }
 
+  @deprecated("Use 'of' instead", "3.7.0")
   def javaSecuritySecureRandom[F[_]: Sync]: F[SecureRandom[F]] =
-    javaSecuritySecureRandomGeneric
+    Sync[F].delay(unsafeJavaSecuritySecureRandom())
 
-  def javaSecuritySecureRandomGeneric[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
+  def of[F[_]: Sync]: F[SecureRandom[F]] = in[F, F]
+
+  def in[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
     Sync[F].delay(unsafeJavaSecuritySecureRandom[G]())
 
   private[effect] def unsafeJavaSecuritySecureRandom[F[_]: Sync](): SecureRandom[F] =

--- a/std/js/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
+++ b/std/js/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
@@ -115,7 +115,10 @@ private[std] trait SecureRandomCompanionPlatform {
   }
 
   def javaSecuritySecureRandom[F[_]: Sync]: F[SecureRandom[F]] =
-    Sync[F].delay(unsafeJavaSecuritySecureRandom())
+    javaSecuritySecureRandomGeneric
+
+  def javaSecuritySecureRandomGeneric[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
+    Sync[F].delay(unsafeJavaSecuritySecureRandom[G]())
 
   private[effect] def unsafeJavaSecuritySecureRandom[F[_]: Sync](): SecureRandom[F] =
     new ScalaRandom[F](Applicative[F].pure(new JavaSecureRandom())) with SecureRandom[F] {}

--- a/std/jvm/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
+++ b/std/jvm/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
@@ -44,7 +44,10 @@ private[std] trait SecureRandomCompanionPlatform {
     new ScalaRandom[F](Applicative[F].pure(random), Sync.Type.Blocking) with SecureRandom[F] {}
 
   def javaSecuritySecureRandom[F[_]: Sync]: F[SecureRandom[F]] =
-    Sync[F].delay(unsafeJavaSecuritySecureRandom())
+    javaSecuritySecureRandomGeneric
+
+  def javaSecuritySecureRandomGeneric[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
+    Sync[F].delay(unsafeJavaSecuritySecureRandom[G]())
 
   /**
    * Ported from https://github.com/http4s/http4s/.

--- a/std/jvm/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
+++ b/std/jvm/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
@@ -43,10 +43,13 @@ private[std] trait SecureRandomCompanionPlatform {
   private def javaUtilRandomBlocking[F[_]: Sync](random: JavaSecureRandom): SecureRandom[F] =
     new ScalaRandom[F](Applicative[F].pure(random), Sync.Type.Blocking) with SecureRandom[F] {}
 
+  @deprecated("Use 'of' instead", "3.7.0")
   def javaSecuritySecureRandom[F[_]: Sync]: F[SecureRandom[F]] =
-    javaSecuritySecureRandomGeneric
+    Sync[F].delay(unsafeJavaSecuritySecureRandom())
 
-  def javaSecuritySecureRandomGeneric[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
+  def of[F[_]: Sync]: F[SecureRandom[F]] = in[F, F]
+
+  def in[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
     Sync[F].delay(unsafeJavaSecuritySecureRandom[G]())
 
   /**

--- a/std/native/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
+++ b/std/native/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
@@ -58,7 +58,10 @@ private[std] trait SecureRandomCompanionPlatform {
   }
 
   def javaSecuritySecureRandom[F[_]: Sync]: F[SecureRandom[F]] =
-    Sync[F].delay(unsafeJavaSecuritySecureRandom())
+    javaSecuritySecureRandomGeneric
+
+  def javaSecuritySecureRandomGeneric[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
+    Sync[F].delay(unsafeJavaSecuritySecureRandom[G]())
 
   private[effect] def unsafeJavaSecuritySecureRandom[F[_]: Sync](): SecureRandom[F] =
     new ScalaRandom[F](Applicative[F].pure(new JavaSecureRandom())) with SecureRandom[F] {}

--- a/std/native/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
+++ b/std/native/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
@@ -57,11 +57,14 @@ private[std] trait SecureRandomCompanionPlatform {
 
   }
 
+  @deprecated("Use 'of' instead", "3.7.0")
   def javaSecuritySecureRandom[F[_]: Sync]: F[SecureRandom[F]] =
-    javaSecuritySecureRandomGeneric
+    Sync[F].delay(unsafeJavaSecuritySecureRandom())
 
-  def javaSecuritySecureRandomGeneric[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
-    Sync[F].delay(unsafeJavaSecuritySecureRandom[G]())
+  def of[F[_]: Sync]: F[SecureRandom[F]] = in[F, F]
+
+  def in[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
+    Sync[F].delay(unsafeJavaSecuritySecureRandom())
 
   private[effect] def unsafeJavaSecuritySecureRandom[F[_]: Sync](): SecureRandom[F] =
     new ScalaRandom[F](Applicative[F].pure(new JavaSecureRandom())) with SecureRandom[F] {}

--- a/std/shared/src/main/scala/cats/effect/std/SecureRandom.scala
+++ b/std/shared/src/main/scala/cats/effect/std/SecureRandom.scala
@@ -124,6 +124,9 @@ object SecureRandom extends SecureRandomCompanionPlatform {
     }
 
   /**
+   * Builds a `SecureRandom[F]` value for effect types that are [[cats.effect.kernel.Sync]] and
+   * initializes random state using the same effect type
+   *
    * On the JVM, delegates to [[java.security.SecureRandom]].
    *
    * In browsers, delegates to the
@@ -139,6 +142,10 @@ object SecureRandom extends SecureRandomCompanionPlatform {
   override def javaSecuritySecureRandom[F[_]: Sync]: F[SecureRandom[F]] =
     javaSecuritySecureRandomGeneric
 
+  /**
+   * Builds a `SecureRandom[G]` value for effect types that are [[cats.effect.kernel.Sync]] but
+   * initializes random state using another effect constructor
+   */
   override def javaSecuritySecureRandomGeneric[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
     super.javaSecuritySecureRandomGeneric[F, G]
 

--- a/std/shared/src/main/scala/cats/effect/std/SecureRandom.scala
+++ b/std/shared/src/main/scala/cats/effect/std/SecureRandom.scala
@@ -137,6 +137,9 @@ object SecureRandom extends SecureRandomCompanionPlatform {
    * errors.
    */
   override def javaSecuritySecureRandom[F[_]: Sync]: F[SecureRandom[F]] =
-    super.javaSecuritySecureRandom[F]
+    javaSecuritySecureRandomGeneric
+
+  override def javaSecuritySecureRandomGeneric[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
+    super.javaSecuritySecureRandomGeneric[F, G]
 
 }

--- a/std/shared/src/main/scala/cats/effect/std/SecureRandom.scala
+++ b/std/shared/src/main/scala/cats/effect/std/SecureRandom.scala
@@ -139,14 +139,31 @@ object SecureRandom extends SecureRandomCompanionPlatform {
    * on Linux, macOS, and BSD. Unsupported platforms such as Windows will encounter link-time
    * errors.
    */
-  override def javaSecuritySecureRandom[F[_]: Sync]: F[SecureRandom[F]] =
-    javaSecuritySecureRandomGeneric
+  override def javaSecuritySecureRandom[F[_]: Sync]: F[SecureRandom[F]] = of
+
+  /**
+   * Builds a `SecureRandom[F]` value for effect types that are [[cats.effect.kernel.Sync]] and
+   * initializes random state using the same effect type
+   *
+   * On the JVM, delegates to [[java.security.SecureRandom]].
+   *
+   * In browsers, delegates to the
+   * [[https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API Web Crypto API]].
+   *
+   * In Node.js, delegates to the [[https://nodejs.org/api/crypto.html crypto module]].
+   *
+   * On Native, delegates to
+   * [[https://man7.org/linux/man-pages/man3/getentropy.3.html getentropy]] which is supported
+   * on Linux, macOS, and BSD. Unsupported platforms such as Windows will encounter link-time
+   * errors.
+   */
+  override def of[F[_]: Sync]: F[SecureRandom[F]] = in[F, F]
 
   /**
    * Builds a `SecureRandom[G]` value for effect types that are [[cats.effect.kernel.Sync]] but
    * initializes random state using another effect constructor
    */
-  override def javaSecuritySecureRandomGeneric[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
-    super.javaSecuritySecureRandomGeneric[F, G]
+  override def in[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
+    Sync[F].delay(unsafeJavaSecuritySecureRandom[G]())
 
 }


### PR DESCRIPTION
Im not sure this is the right and idiomatic way to implement this, but this greatly helps in real app wiring when you have to create instance for some effect G(for example ConnectioIO) when the wiring is done in F(IO for example)

This is my first PR here, please let me know if this should be done somehow differently