### PR TITLE
Make deprecated `IO.onError` package private

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -591,7 +591,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
     IO.OnCancel(this, fin)
 
   @deprecated("Use onError with PartialFunction argument", "3.6.0")
-  def onError(f: Throwable => IO[Unit]): IO[A] = {
+  private[effect] def onError(f: Throwable => IO[Unit]): IO[A] = {
     val pf: PartialFunction[Throwable, IO[Unit]] = { case t => f(t).reportError }
     onError(pf)
   }

--- a/tests/shared/src/test/scala-2.13+/not/cats/effect/IOCompilationSpec.scala
+++ b/tests/shared/src/test/scala-2.13+/not/cats/effect/IOCompilationSpec.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020-2025 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package not.cats.effect // verifies scoping outside of CE
+
+import cats.effect.{BaseSpec, IO}
+
+class IOCompilationSpec extends BaseSpec {
+  "Can use total function in PartialFunction IO.onError" in { // compilation test
+    IO.pure(5).onError(_ => IO.unit)
+    true
+  }
+}


### PR DESCRIPTION
This is a repeat of #4341 targeting `series/3.6.x` instead. Fine with closing this one or the other one, no worries :) 

closes #4329

This is a source breaking change for Scala 2.12