### PR TITLE
Make `IO#syncStep` interpreter stack-safe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -422,7 +422,8 @@ lazy val kernel = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.kernel.Ref$SyncRef"),
       ProblemFilters.exclude[Problem]("cats.effect.kernel.GenConcurrent#Memoize*"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.SyncStep.interpret")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.SyncStep.interpret"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.SyncStep$.interpret")
     )
   )
   .jsSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -421,9 +421,7 @@ lazy val kernel = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     ),
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.kernel.Ref$SyncRef"),
-      ProblemFilters.exclude[Problem]("cats.effect.kernel.GenConcurrent#Memoize*"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.SyncStep.interpret"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.SyncStep$.interpret")
+      ProblemFilters.exclude[Problem]("cats.effect.kernel.GenConcurrent#Memoize*")
     )
   )
   .jsSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -421,7 +421,8 @@ lazy val kernel = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     ),
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.kernel.Ref$SyncRef"),
-      ProblemFilters.exclude[Problem]("cats.effect.kernel.GenConcurrent#Memoize*")
+      ProblemFilters.exclude[Problem]("cats.effect.kernel.GenConcurrent#Memoize*"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.SyncStep.interpret")
     )
   )
   .jsSettings(

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -2334,7 +2334,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits with TuplePara
 }
 
 private object SyncStep {
-  val MaxSteps = 512 // 512 matches  with trampoline depth in IOFiber for stack safety
+  final val MaxSteps = 512 // 512 matches  with trampoline depth in IOFiber for stack safety
 
   def interpret[G[+_], B](io: IO[B], limit: Int, stepsUntilDefer: Int)(
       implicit G: Sync[G]): G[Either[IO[B], (B, Int)]] = {

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -2335,8 +2335,12 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits with TuplePara
 
 private object SyncStep {
   final val MaxSteps = 512 // 512 matches  with trampoline depth in IOFiber for stack safety
-
-  def interpret[G[+_], B](io: IO[B], limit: Int, stepsUntilDefer: Int)(
+  
+  @deprecated("retained for bincompat", "3.6.1")
+   def interpret[G[+_], B](io: IO[B], limit: Int)(implicit G: Sync[G]): G[Either[IO[B], (B, Int)]] =
+   interpret(io, limit, MaxSteps)
+  
+  @static def interpret[G[+_], B](io: IO[B], limit: Int, stepsUntilDefer: Int)(
       implicit G: Sync[G]): G[Either[IO[B], (B, Int)]] = {
     if (limit <= 0) {
       G.pure(Left(io))

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -2341,7 +2341,7 @@ private object SyncStep {
       implicit G: Sync[G]): G[Either[IO[B], (B, Int)]] =
     interpret(io, limit, MaxSteps)
 
-  @static def interpret[G[+_], B](io: IO[B], limit: Int, stepsUntilDefer: Int)(
+  def interpret[G[+_], B](io: IO[B], limit: Int, stepsUntilDefer: Int)(
       implicit G: Sync[G]): G[Either[IO[B], (B, Int)]] = {
     if (limit <= 0) {
       G.pure(Left(io))

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -2333,6 +2333,8 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits with TuplePara
 
 }
 
+private class SyncStep
+
 private object SyncStep {
   final val MaxSteps = 512 // 512 matches  with trampoline depth in IOFiber for stack safety
 
@@ -2341,7 +2343,7 @@ private object SyncStep {
       implicit G: Sync[G]): G[Either[IO[B], (B, Int)]] =
     interpret(io, limit, MaxSteps)
 
-  def interpret[G[+_], B](io: IO[B], limit: Int, stepsUntilDefer: Int)(
+  @static def interpret[G[+_], B](io: IO[B], limit: Int, stepsUntilDefer: Int)(
       implicit G: Sync[G]): G[Either[IO[B], (B, Int)]] = {
     if (limit <= 0) {
       G.pure(Left(io))

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -2335,11 +2335,12 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits with TuplePara
 
 private object SyncStep {
   final val MaxSteps = 512 // 512 matches  with trampoline depth in IOFiber for stack safety
-  
+
   @deprecated("retained for bincompat", "3.6.1")
-   def interpret[G[+_], B](io: IO[B], limit: Int)(implicit G: Sync[G]): G[Either[IO[B], (B, Int)]] =
-   interpret(io, limit, MaxSteps)
-  
+  def interpret[G[+_], B](io: IO[B], limit: Int)(
+      implicit G: Sync[G]): G[Either[IO[B], (B, Int)]] =
+    interpret(io, limit, MaxSteps)
+
   @static def interpret[G[+_], B](io: IO[B], limit: Int, stepsUntilDefer: Int)(
       implicit G: Sync[G]): G[Either[IO[B], (B, Int)]] = {
     if (limit <= 0) {

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -2135,7 +2135,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         def go(depth: Int, acc: IO[Unit] = IO.unit): IO[Unit] =
           if (depth <= 0) acc else go(depth - 1, acc.flatMap(_ => IO.unit))
         val io = go(50000)
-        io.syncStep(Int.MaxValue).unsafeRunSync() must beRight(())
+        io.syncStep(Int.MaxValue).map(_.bimap(_ => (), _ => ())) must completeAsSync(Right(()))
 
       }
 

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -2131,21 +2131,14 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         sio.map(_.bimap(_ => (), _ => ())) must completeAsSync(Right(()))
       }
 
-      "handle large Ref update chain without StackOverflowError (#4337)" in {
-        val syncStepSize = 1000000
-        val updates = 100000
-
-        val io = for {
-          ref <- Ref.of[IO, Int](0)
-          _ <- Vector.fill(updates)(1).traverse_[IO, Unit](n => ref.update(_ + n))
-          result <- ref.get
-        } yield result
-
-        io.syncStep(syncStepSize).map {
+      "handle large sequence of operations without StackOverflowError #4337" in {
+        val io = IO.unit.replicateA_(100000)
+        io.syncStep(1000000).map {
           case Left(_) => throw new RuntimeException("Expected synchronous completion")
-          case Right(n) => n
-        } must completeAsSync(updates)
+          case Right(()) => ()
+        } must completeAsSync(())
       }
+
     }
 
     "fiber repeated yielding test" in real {

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -2132,11 +2132,11 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
       }
 
       "handle large sequence of operations without StackOverflowError #4337" in {
-        val io = IO.unit.replicateA_(100000)
-        io.syncStep(1000000).map {
-          case Left(_) => throw new RuntimeException("Expected synchronous completion")
-          case Right(()) => ()
-        } must completeAsSync(())
+        def go(depth: Int, acc: IO[Unit] = IO.unit): IO[Unit] =
+          if (depth <= 0) acc else go(depth - 1, acc.flatMap(_ => IO.unit))
+        val io = go(50000)
+        io.syncStep(Int.MaxValue).unsafeRunSync() must beRight(())
+
       }
 
     }


### PR DESCRIPTION
Linked to: [#4337](https://github.com/typelevel/cats-effect/issues/4337)

This PR adds stack safety to SyncStep.interpret by wrapping execution in defer every MaxSteps steps. This prevents stack overflows in large recursive computations while still respecting the original step limit as a hard cap.

Testing:
Validated locally with a 100,000-step Ref update chain and a limit = 1,000,000 (syncStepSize). The computation now completes with Right(100000), resolving the previously observed StackOverflowError.