### PR TITLE
Clean up and DRY IOApp implementations

### DIFF
--- a/core/js/src/main/scala/cats/effect/IOApp.scala
+++ b/core/js/src/main/scala/cats/effect/IOApp.scala
@@ -143,7 +143,7 @@ import scala.util.Try
  * @see
  *   [[IOApp.Simple]]
  */
-trait IOApp {
+trait IOApp extends IOAppPlatform {
 
   private[this] var _runtime: unsafe.IORuntime = null
 

--- a/core/js/src/main/scala/cats/effect/IOApp.scala
+++ b/core/js/src/main/scala/cats/effect/IOApp.scala
@@ -205,17 +205,7 @@ trait IOApp extends IOAppPlatform {
     val installed = if (runtime == null) {
       import unsafe.IORuntime
 
-      val installed = IORuntime installGlobal {
-        val compute = IORuntime.createBatchingMacrotaskExecutor(reportFailure = t =>
-          reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime))
-
-        IORuntime(
-          compute,
-          compute,
-          IORuntime.defaultScheduler,
-          () => IORuntime.resetGlobal(),
-          runtimeConfig)
-      }
+      val installed = IORuntime installGlobal defaultGlobalRuntime
 
       _runtime = IORuntime.global
 

--- a/core/js/src/main/scala/cats/effect/IOApp.scala
+++ b/core/js/src/main/scala/cats/effect/IOApp.scala
@@ -144,6 +144,7 @@ import scala.util.Try
  *   [[IOApp.Simple]]
  */
 trait IOApp extends IOAppPlatform {
+
   /**
    * The runtime which will be used by `IOApp` to evaluate the [[IO]] produced by the `run`
    * method. This may be overridden by `IOApp` implementations which have extremely specialized

--- a/core/js/src/main/scala/cats/effect/IOApp.scala
+++ b/core/js/src/main/scala/cats/effect/IOApp.scala
@@ -144,9 +144,6 @@ import scala.util.Try
  *   [[IOApp.Simple]]
  */
 trait IOApp extends IOAppPlatform {
-
-  private[this] var _runtime: unsafe.IORuntime = null
-
   /**
    * The runtime which will be used by `IOApp` to evaluate the [[IO]] produced by the `run`
    * method. This may be overridden by `IOApp` implementations which have extremely specialized
@@ -160,7 +157,7 @@ trait IOApp extends IOAppPlatform {
    *
    * This value is guaranteed to be equal to [[unsafe.IORuntime.global]].
    */
-  protected def runtime: unsafe.IORuntime = _runtime
+  protected def runtime: unsafe.IORuntime = installedRuntime
 
   /**
    * The configuration used to initialize the [[runtime]] which will evaluate the [[IO]]
@@ -202,24 +199,7 @@ trait IOApp extends IOAppPlatform {
   def run(args: List[String]): IO[ExitCode]
 
   final def main(args: Array[String]): Unit = {
-    val installed = if (runtime == null) {
-      import unsafe.IORuntime
-
-      val installed = IORuntime installGlobal defaultGlobalRuntime
-
-      _runtime = IORuntime.global
-
-      installed
-    } else {
-      unsafe.IORuntime.installGlobal(runtime)
-    }
-
-    if (!installed) {
-      System
-        .err
-        .println(
-          "WARNING: Cats Effect global runtime already initialized; custom configurations will be ignored")
-    }
+    setupGlobalRuntime()
 
     if (LinkingInfo.developmentMode && isStackTracing) {
       val listener: js.Function0[Unit] = () =>

--- a/core/js/src/main/scala/cats/effect/IOAppPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOAppPlatform.scala
@@ -16,4 +16,20 @@
 
 package cats.effect
 
-trait IOAppPlatform extends IOAppCommon {}
+import cats.effect.unsafe.IORuntime
+
+trait IOAppPlatform extends IOAppCommon {
+  this: IOApp =>
+
+  private[effect] def defaultGlobalRuntime: IORuntime = {
+    val compute = IORuntime.createBatchingMacrotaskExecutor(reportFailure = t =>
+      reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime))
+
+    IORuntime(
+      compute,
+      compute,
+      IORuntime.defaultScheduler,
+      () => IORuntime.resetGlobal(),
+      runtimeConfig)
+  }
+}

--- a/core/js/src/main/scala/cats/effect/IOAppPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/IOAppPlatform.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020-2025 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+trait IOAppPlatform extends IOAppCommon {}

--- a/core/jvm-native/src/main/scala/cats/effect/IOAppMultiThreaded.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/IOAppMultiThreaded.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020-2025 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+trait IOAppMultiThreaded {}

--- a/core/jvm-native/src/main/scala/cats/effect/IOAppMultiThreaded.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/IOAppMultiThreaded.scala
@@ -16,4 +16,18 @@
 
 package cats.effect
 
-trait IOAppMultiThreaded {}
+import scala.concurrent.ExecutionContext
+
+import java.util.concurrent.ArrayBlockingQueue
+
+trait IOAppMultiThreaded {
+  // arbitrary constant is arbitrary
+  private[effect] lazy val queue = new ArrayBlockingQueue[AnyRef](32)
+
+  private[effect] def handleTerminalFailure(t: Throwable): Unit = {
+    queue.clear()
+    queue.put(t)
+  }
+
+  private[effect] def defaultMainThread: ExecutionContext
+}

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -201,7 +201,7 @@ trait IOApp extends IOAppPlatform {
   // arbitrary constant is arbitrary
   private[this] lazy val queue = new ArrayBlockingQueue[AnyRef](32)
 
-  private[this] def handleTerminalFailure(t: Throwable): Unit = {
+  private[effect] def handleTerminalFailure(t: Throwable): Unit = {
     queue.clear()
     queue.put(t)
   }
@@ -398,35 +398,7 @@ trait IOApp extends IOAppPlatform {
     val installed = if (runtime == null) {
       import unsafe.IORuntime
 
-      val installed = IORuntime installGlobal {
-        val (compute, poller, compDown) =
-          IORuntime.createWorkStealingComputeThreadPool(
-            threads = computeWorkerThreadCount,
-            reportFailure = t => reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime),
-            blockedThreadDetectionEnabled = blockedThreadDetectionEnabled,
-            pollingSystem = pollingSystem,
-            uncaughtExceptionHandler = (_, t) => handleTerminalFailure(t)
-          )
-
-        val (blocking, blockDown) =
-          IORuntime.createDefaultBlockingExecutionContext(
-            threadPrefix = "io-blocking",
-            reportFailure =
-              (t: Throwable) => reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime)
-          )
-
-        IORuntime(
-          compute,
-          blocking,
-          compute,
-          List(poller),
-          { () =>
-            compDown()
-            blockDown()
-            IORuntime.resetGlobal()
-          },
-          runtimeConfig)
-      }
+      val installed = IORuntime installGlobal defaultGlobalRuntime
 
       _runtime = IORuntime.global
 

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -141,6 +141,7 @@ import java.util.concurrent.atomic.AtomicInteger
  *   [[IOApp.Simple]]
  */
 trait IOApp extends IOAppPlatform {
+
   /**
    * The runtime which will be used by `IOApp` to evaluate the [[IO]] produced by the `run`
    * method. This may be overridden by `IOApp` implementations which have extremely specialized

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -141,9 +141,6 @@ import java.util.concurrent.atomic.AtomicInteger
  *   [[IOApp.Simple]]
  */
 trait IOApp extends IOAppPlatform {
-
-  private[this] var _runtime: unsafe.IORuntime = null
-
   /**
    * The runtime which will be used by `IOApp` to evaluate the [[IO]] produced by the `run`
    * method. This may be overridden by `IOApp` implementations which have extremely specialized
@@ -157,7 +154,7 @@ trait IOApp extends IOAppPlatform {
    *
    * This value is guaranteed to be equal to [[unsafe.IORuntime.global]].
    */
-  protected def runtime: unsafe.IORuntime = _runtime
+  protected def runtime: unsafe.IORuntime = installedRuntime
 
   /**
    * The configuration used to initialize the [[runtime]] which will evaluate the [[IO]]
@@ -395,24 +392,7 @@ trait IOApp extends IOAppPlatform {
     val isForked = Thread.currentThread().getId() == 1
     if (!isForked) onNonMainThreadDetected()
 
-    val installed = if (runtime == null) {
-      import unsafe.IORuntime
-
-      val installed = IORuntime installGlobal defaultGlobalRuntime
-
-      _runtime = IORuntime.global
-
-      installed
-    } else {
-      unsafe.IORuntime.installGlobal(runtime)
-    }
-
-    if (!installed) {
-      System
-        .err
-        .println(
-          "WARNING: Cats Effect global runtime already initialized; custom configurations will be ignored")
-    }
+    setupGlobalRuntime()
 
     if (isStackTracing) {
       val liveFiberSnapshotSignal = sys

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -25,7 +25,7 @@ import cats.syntax.all._
 import scala.concurrent.{blocking, CancellationException, ExecutionContext}
 import scala.concurrent.duration._
 
-import java.util.concurrent.{ArrayBlockingQueue, CountDownLatch}
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -196,14 +196,6 @@ trait IOApp extends IOAppPlatform {
   protected def computeWorkerThreadCount: Int =
     Math.max(2, Runtime.getRuntime().availableProcessors())
 
-  // arbitrary constant is arbitrary
-  private[this] lazy val queue = new ArrayBlockingQueue[AnyRef](32)
-
-  private[effect] def handleTerminalFailure(t: Throwable): Unit = {
-    queue.clear()
-    queue.put(t)
-  }
-
   /**
    * Executes the provided actions on the JVM's `main` thread. Note that this is, by definition,
    * a single-threaded executor, and should not be used for anything which requires a meaningful
@@ -219,27 +211,7 @@ trait IOApp extends IOAppPlatform {
    * calling thread (for example, LWJGL). In these scenarios, it is recommended that the
    * absolute minimum possible amount of work is handed off to the main thread.
    */
-  protected def MainThread: ExecutionContext =
-    if (queue eq queue)
-      new ExecutionContext {
-        def reportFailure(t: Throwable): Unit =
-          t match {
-            case t if UnsafeNonFatal(t) =>
-              IOApp.this.reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime)
-
-            case t =>
-              handleTerminalFailure(t)
-          }
-
-        def execute(r: Runnable): Unit =
-          if (!queue.offer(r)) {
-            runtime.blocking.execute(() => queue.put(r))
-          }
-      }
-    else
-      throw new UnsupportedOperationException(
-        "Your IOApp's super class has not been recompiled against Cats Effect 3.4.0+."
-      )
+  protected def MainThread: ExecutionContext = defaultMainThread
 
   /**
    * Configures the action to perform when unhandled errors are caught by the runtime. An

--- a/core/jvm/src/main/scala/cats/effect/IOApp.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOApp.scala
@@ -140,7 +140,7 @@ import java.util.concurrent.atomic.AtomicInteger
  * @see
  *   [[IOApp.Simple]]
  */
-trait IOApp {
+trait IOApp extends IOAppPlatform {
 
   private[this] var _runtime: unsafe.IORuntime = null
 

--- a/core/jvm/src/main/scala/cats/effect/IOAppPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOAppPlatform.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020-2025 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+trait IOAppPlatform extends IOAppCommon with IOAppMultiThreaded {}

--- a/core/jvm/src/main/scala/cats/effect/IOAppPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOAppPlatform.scala
@@ -16,4 +16,38 @@
 
 package cats.effect
 
-trait IOAppPlatform extends IOAppCommon with IOAppMultiThreaded {}
+import cats.effect.unsafe.IORuntime
+
+trait IOAppPlatform extends IOAppCommon with IOAppMultiThreaded {
+  this: IOApp =>
+
+  private[effect] def defaultGlobalRuntime: IORuntime = {
+    val (compute, poller, compDown) =
+      IORuntime.createWorkStealingComputeThreadPool(
+        threads = computeWorkerThreadCount,
+        reportFailure = t => reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime),
+        blockedThreadDetectionEnabled = blockedThreadDetectionEnabled,
+        pollingSystem = pollingSystem,
+        uncaughtExceptionHandler = (_, t) => handleTerminalFailure(t)
+      )
+
+    val (blocking, blockDown) =
+      IORuntime.createDefaultBlockingExecutionContext(
+        threadPrefix = "io-blocking",
+        reportFailure =
+          (t: Throwable) => reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime)
+      )
+
+    IORuntime(
+      compute,
+      blocking,
+      compute,
+      List(poller),
+      { () =>
+        compDown()
+        blockDown()
+        IORuntime.resetGlobal()
+      },
+      runtimeConfig)
+  }
+}

--- a/core/jvm/src/main/scala/cats/effect/IOAppPlatform.scala
+++ b/core/jvm/src/main/scala/cats/effect/IOAppPlatform.scala
@@ -16,10 +16,35 @@
 
 package cats.effect
 
-import cats.effect.unsafe.IORuntime
+import cats.effect.unsafe.{IORuntime, UnsafeNonFatal}
+
+import scala.concurrent.ExecutionContext
 
 trait IOAppPlatform extends IOAppCommon with IOAppMultiThreaded {
   this: IOApp =>
+
+  private[effect] def defaultMainThread: ExecutionContext = {
+    if (queue eq queue)
+      new ExecutionContext {
+        def reportFailure(t: Throwable): Unit =
+          t match {
+            case t if UnsafeNonFatal(t) =>
+              IOAppPlatform.this.reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime)
+
+            case t =>
+              handleTerminalFailure(t)
+          }
+
+        def execute(r: Runnable): Unit =
+          if (!queue.offer(r)) {
+            runtime.blocking.execute(() => queue.put(r))
+          }
+      }
+    else
+      throw new UnsupportedOperationException(
+        "Your IOApp's super class has not been recompiled against Cats Effect 3.4.0+."
+      )
+  }
 
   private[effect] def defaultGlobalRuntime: IORuntime = {
     val (compute, poller, compDown) =

--- a/core/native/src/main/scala/cats/effect/IOApp.scala
+++ b/core/native/src/main/scala/cats/effect/IOApp.scala
@@ -140,6 +140,7 @@ import java.util.concurrent.atomic.AtomicInteger
  *   [[IOApp.Simple]]
  */
 trait IOApp extends IOAppPlatform {
+
   /**
    * The runtime which will be used by `IOApp` to evaluate the [[IO]] produced by the `run`
    * method. This may be overridden by `IOApp` implementations which have extremely specialized

--- a/core/native/src/main/scala/cats/effect/IOApp.scala
+++ b/core/native/src/main/scala/cats/effect/IOApp.scala
@@ -139,7 +139,7 @@ import java.util.concurrent.atomic.AtomicInteger
  * @see
  *   [[IOApp.Simple]]
  */
-trait IOApp {
+trait IOApp extends IOAppPlatform {
 
   private[this] var _runtime: unsafe.IORuntime = null
 

--- a/core/native/src/main/scala/cats/effect/IOApp.scala
+++ b/core/native/src/main/scala/cats/effect/IOApp.scala
@@ -289,34 +289,7 @@ trait IOApp extends IOAppPlatform {
     val installed = if (runtime == null) {
       import unsafe.IORuntime
 
-      val installed = IORuntime installGlobal {
-        val (compute, poller, compDown) =
-          IORuntime.createWorkStealingComputeThreadPool(
-            threads = computeWorkerThreadCount,
-            reportFailure = t => reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime),
-            blockedThreadDetectionEnabled = false, // TODO
-            pollingSystem = pollingSystem
-          )
-
-        val (blocking, blockDown) =
-          IORuntime.createDefaultBlockingExecutionContext(
-            threadPrefix = "io-blocking",
-            reportFailure =
-              (t: Throwable) => reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime)
-          )
-
-        IORuntime(
-          compute,
-          blocking,
-          compute,
-          List(poller),
-          { () =>
-            compDown()
-            blockDown()
-            IORuntime.resetGlobal()
-          },
-          runtimeConfig)
-      }
+      val installed = IORuntime installGlobal defaultGlobalRuntime
 
       _runtime = IORuntime.global
 

--- a/core/native/src/main/scala/cats/effect/IOApp.scala
+++ b/core/native/src/main/scala/cats/effect/IOApp.scala
@@ -24,7 +24,6 @@ import cats.syntax.all._
 import scala.concurrent.{blocking, CancellationException, ExecutionContext}
 import scala.scalanative.meta.LinktimeInfo._
 
-import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -195,14 +194,6 @@ trait IOApp extends IOAppPlatform {
   protected def computeWorkerThreadCount: Int =
     Math.max(2, Runtime.getRuntime().availableProcessors())
 
-  // arbitrary constant is arbitrary
-  private[this] lazy val queue = new ArrayBlockingQueue[AnyRef](32)
-
-  private[this] def handleTerminalFailure(t: Throwable): Unit = {
-    queue.clear()
-    queue.put(t)
-  }
-
   /**
    * Executes the provided actions on the main thread. Note that this is, by definition, a
    * single-threaded executor, and should not be used for anything which requires a meaningful
@@ -218,22 +209,7 @@ trait IOApp extends IOAppPlatform {
    * calling thread (for example, LWJGL). In these scenarios, it is recommended that the
    * absolute minimum possible amount of work is handed off to the main thread.
    */
-  protected def MainThread: ExecutionContext =
-    new ExecutionContext {
-      def reportFailure(t: Throwable): Unit =
-        t match {
-          case t if UnsafeNonFatal(t) =>
-            IOApp.this.reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime)
-
-          case t =>
-            handleTerminalFailure(t)
-        }
-
-      def execute(r: Runnable): Unit =
-        if (!queue.offer(r)) {
-          runtime.blocking.execute(() => queue.put(r))
-        }
-    }
+  protected def MainThread: ExecutionContext = defaultMainThread
 
   /**
    * Configures the action to perform when unhandled errors are caught by the runtime. An

--- a/core/native/src/main/scala/cats/effect/IOApp.scala
+++ b/core/native/src/main/scala/cats/effect/IOApp.scala
@@ -140,9 +140,6 @@ import java.util.concurrent.atomic.AtomicInteger
  *   [[IOApp.Simple]]
  */
 trait IOApp extends IOAppPlatform {
-
-  private[this] var _runtime: unsafe.IORuntime = null
-
   /**
    * The runtime which will be used by `IOApp` to evaluate the [[IO]] produced by the `run`
    * method. This may be overridden by `IOApp` implementations which have extremely specialized
@@ -156,7 +153,7 @@ trait IOApp extends IOAppPlatform {
    *
    * This value is guaranteed to be equal to [[unsafe.IORuntime.global]].
    */
-  protected def runtime: unsafe.IORuntime = _runtime
+  protected def runtime: unsafe.IORuntime = installedRuntime
 
   /**
    * The configuration used to initialize the [[runtime]] which will evaluate the [[IO]]
@@ -286,24 +283,7 @@ trait IOApp extends IOAppPlatform {
   def run(args: List[String]): IO[ExitCode]
 
   final def main(args: Array[String]): Unit = {
-    val installed = if (runtime == null) {
-      import unsafe.IORuntime
-
-      val installed = IORuntime installGlobal defaultGlobalRuntime
-
-      _runtime = IORuntime.global
-
-      installed
-    } else {
-      unsafe.IORuntime.installGlobal(runtime)
-    }
-
-    if (!installed) {
-      System
-        .err
-        .println(
-          "WARNING: Cats Effect global runtime already initialized; custom configurations will be ignored")
-    }
+    setupGlobalRuntime()
 
     val counter = new AtomicInteger(1)
 

--- a/core/native/src/main/scala/cats/effect/IOAppPlatform.scala
+++ b/core/native/src/main/scala/cats/effect/IOAppPlatform.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020-2025 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+trait IOAppPlatform extends IOAppCommon with IOAppMultiThreaded {}

--- a/core/native/src/main/scala/cats/effect/IOAppPlatform.scala
+++ b/core/native/src/main/scala/cats/effect/IOAppPlatform.scala
@@ -16,10 +16,30 @@
 
 package cats.effect
 
-import cats.effect.unsafe.IORuntime
+import cats.effect.unsafe.{IORuntime, UnsafeNonFatal}
+
+import scala.concurrent.ExecutionContext
 
 trait IOAppPlatform extends IOAppCommon with IOAppMultiThreaded {
   this: IOApp =>
+
+  private[effect] def defaultMainThread: ExecutionContext = {
+    new ExecutionContext {
+      def reportFailure(t: Throwable): Unit =
+        t match {
+          case t if UnsafeNonFatal(t) =>
+            IOAppPlatform.this.reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime)
+
+          case t =>
+            handleTerminalFailure(t)
+        }
+
+      def execute(r: Runnable): Unit =
+        if (!queue.offer(r)) {
+          runtime.blocking.execute(() => queue.put(r))
+        }
+    }
+  }
 
   private[effect] def defaultGlobalRuntime: IORuntime = {
     val (compute, poller, compDown) =

--- a/core/native/src/main/scala/cats/effect/IOAppPlatform.scala
+++ b/core/native/src/main/scala/cats/effect/IOAppPlatform.scala
@@ -16,4 +16,37 @@
 
 package cats.effect
 
-trait IOAppPlatform extends IOAppCommon with IOAppMultiThreaded {}
+import cats.effect.unsafe.IORuntime
+
+trait IOAppPlatform extends IOAppCommon with IOAppMultiThreaded {
+  this: IOApp =>
+
+  private[effect] def defaultGlobalRuntime: IORuntime = {
+    val (compute, poller, compDown) =
+      IORuntime.createWorkStealingComputeThreadPool(
+        threads = computeWorkerThreadCount,
+        reportFailure = t => reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime),
+        blockedThreadDetectionEnabled = false, // TODO
+        pollingSystem = pollingSystem
+      )
+
+    val (blocking, blockDown) =
+      IORuntime.createDefaultBlockingExecutionContext(
+        threadPrefix = "io-blocking",
+        reportFailure =
+          (t: Throwable) => reportFailure(t).unsafeRunAndForgetWithoutCallback()(runtime)
+      )
+
+    IORuntime(
+      compute,
+      blocking,
+      compute,
+      List(poller),
+      { () =>
+        compDown()
+        blockDown()
+        IORuntime.resetGlobal()
+      },
+      runtimeConfig)
+  }
+}

--- a/core/shared/src/main/scala/cats/effect/IOAppCommon.scala
+++ b/core/shared/src/main/scala/cats/effect/IOAppCommon.scala
@@ -19,5 +19,32 @@ package cats.effect
 import cats.effect.unsafe.IORuntime
 
 trait IOAppCommon {
+  this: IOApp =>
+
+  private[this] var _runtime: unsafe.IORuntime = null
+
+  private[effect] def installedRuntime: unsafe.IORuntime = _runtime
+
   private[effect] def defaultGlobalRuntime: IORuntime
+
+  private[effect] def setupGlobalRuntime(): Unit = {
+    val installed = if (runtime == null) {
+      import unsafe.IORuntime
+
+      val installed = IORuntime installGlobal defaultGlobalRuntime
+
+      _runtime = IORuntime.global
+
+      installed
+    } else {
+      unsafe.IORuntime.installGlobal(runtime)
+    }
+
+    if (!installed) {
+      System
+        .err
+        .println(
+          "WARNING: Cats Effect global runtime already initialized; custom configurations will be ignored")
+    }
+  }
 }

--- a/core/shared/src/main/scala/cats/effect/IOAppCommon.scala
+++ b/core/shared/src/main/scala/cats/effect/IOAppCommon.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020-2025 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect
+
+trait IOAppCommon {}

--- a/core/shared/src/main/scala/cats/effect/IOAppCommon.scala
+++ b/core/shared/src/main/scala/cats/effect/IOAppCommon.scala
@@ -16,4 +16,8 @@
 
 package cats.effect
 
-trait IOAppCommon {}
+import cats.effect.unsafe.IORuntime
+
+trait IOAppCommon {
+  private[effect] def defaultGlobalRuntime: IORuntime
+}

--- a/core/shared/src/main/scala/cats/effect/IOAppCommon.scala
+++ b/core/shared/src/main/scala/cats/effect/IOAppCommon.scala
@@ -16,16 +16,12 @@
 
 package cats.effect
 
-import cats.effect.unsafe.IORuntime
-
 trait IOAppCommon {
   this: IOApp =>
 
   private[this] var _runtime: unsafe.IORuntime = null
 
   private[effect] def installedRuntime: unsafe.IORuntime = _runtime
-
-  private[effect] def defaultGlobalRuntime: IORuntime
 
   private[effect] def setupGlobalRuntime(): Unit = {
     val installed = if (runtime == null) {


### PR DESCRIPTION
After taking a few initial passes through the various platform `IOApp` implementations, I've come up with an approach I am going to take. I plan on adding two layers of traits for a total of three new traits. Here is a rough diagram.

![IOApp Decomposition](https://github.com/user-attachments/assets/881c461b-1627-415e-a5dc-1dc08abb7e81)

* `IOAppCommon` - This will contain method signatures common to all implementations, but with different implementation.
* `IOAppMultiThreaded` - This will contain method signatures common between JVM and Native, as they have a lot of extra bells and whistles not present in the SJS implementation.
* `IOAppPlatform` - This will contain platform specific method definitions, there will be three different versions of these, one per platform.

I'm attempting to move things around over the course of the PR to the point where all three current `IOApp` implementations will be identical, at which point create a single definition in `shared`. A few goals I have in mind as I refactor things:
* De-duplicate methods or add a method signature on a lower level trait so that documentation won't be duplicated.
* Clean up code organization in `IOApp` to make it more approachable to people trying to understand what's going on in `IOApp`.
* ~~Hide methods people are better off not over-riding (such as `pollingSystem` or `computeWorkerThreadCount`) farther down the type hierarchy so library adopters will be less likely to notice / play around with them.~~ _Probably not possible due to bin-compat issues._


This PR will resolve [Issue 4333](https://github.com/typelevel/cats-effect/issues/4333)