### PR TITLE
Set `mayInterruptIfRunning = true` when canceling `CompletableFuture`

### DIFF
--- a/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
+++ b/kernel/jvm/src/main/scala/cats/effect/kernel/AsyncPlatform.scala
@@ -60,7 +60,7 @@ private[kernel] trait AsyncPlatform[F[_]] extends Serializable { this: Async[F] 
               val await = G.onCancel(
                 poll(get),
                 // if cannot cancel, fallback to get
-                G.ifM(lift(delay(cf.cancel(false))))(G.unit, G.void(get))
+                G.ifM(lift(delay(cf.cancel(true))))(G.unit, G.void(get))
               )
 
               G.productR(lift(go))(await)


### PR DESCRIPTION
The `cancel` method of a `CompletableFuture` takes a boolean `mayInterruptIfRunning`.  It [is described in the oracle docs](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/concurrent/CompletableFuture.html#cancel(boolean)):

> Parameters:
> mayInterruptIfRunning - this value has no effect in this implementation because interrupts are not used to control processing.

Cats Effect has set `mayInterruptIfRunning` to `false` ever since `fromCompletableFuture` was first added: https://github.com/typelevel/cats-effect/commit/ce2b5aa945e4a2b6e1eb9e479f309b2ce508106d.  Presumably `false` was chosen because the oracle docs say that the value has no effect.

But... there is one scenario when the value has an effect!  It is in the JDK's `HttpClient`.  [The oracle documentation](https://bugs.openjdk.org/browse/JDK-8245462) for `HttpClient.sendAsync` says:

> The default HttpClient implementation returns CompletableFuture objects that are cancelable. CompletableFuture objects [derived](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/concurrent/CompletableFuture.html#newIncompleteFuture()) from cancelable futures are themselves cancelable. Invoking [cancel(true)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/concurrent/CompletableFuture.html#cancel(boolean)) on a cancelable future that is not completed, attempts to cancel the HTTP exchange in an effort to release underlying resources as soon as possible.

I have tested this out using [http4s-jdk-http-client](https://github.com/http4s/http4s-jdk-http-client) which is a wrapper around the JDK's `HttpClient`.  My test client code was like `client.expect[String](request).timeoutTo(1.second, IO.unit)` and I used a server that takes >1 second to respond.  I used wireshark to watch the network requests.

Without this PR, I can see in wireshark the HTTP request runs to completion after 5 seconds, even though `.timeoutTo` cancelled the cats-effect fiber after 1 second.  After this PR, I can see in wireshark the network request is cancelled after 1 second.  For HTTP/1 I see a `RST` which closes the TCP connection.  For HTTP/2 I see a `RST_STREAM` which cancels the request without closing the TCP connection.