### PR TITLE
Revert "fix: Nix development Enviroment & Readme Fix"

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ To build the documentation site locally, the following dependencies are needed, 
 - Node (14.x ideally)
 - Yarn (any version should work)
 
-NOTE: [Nix](https://nixos.org/) users can just run `nix develop` at the root directory and follow along the next instructions.
+NOTE: [Nix](https://nixos.org/) users can just run `nix-shell` at the root directory and follow along the next instructions.
 
 Next, check out the documentation branch along with its submodules.
 

--- a/flake.nix
+++ b/flake.nix
@@ -24,26 +24,6 @@
             native.enable = true;
             nodejs.package = pkgs.nodejs-18_x;
           };
-          packages = with pkgs; [
-            autoconf
-            automake
-            libtool
-            pkg-config  
-            gifsicle  
-            zlib
-            libpng
-          ];
-          
-          env = [
-            {
-              name = "LD_LIBRARY_PATH";
-              value = pkgs.lib.makeLibraryPath (with pkgs; [
-                zlib
-                libpng
-                stdenv.cc.cc.lib
-              ]);
-            }
-          ];
         };
       in
       rec {


### PR DESCRIPTION
Reverts typelevel/cats-effect#4298. I was insufficiently critical when I merged it, and a lot of things are being touched that probably don't make sense. Reverting back to baseline.