### PR TITLE
Dynamically bypass selector polling if no I/O events are present

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/ParkedSignal.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/ParkedSignal.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020-2025 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.unsafe
+
+sealed trait ParkedSignal extends Product with Serializable
+
+object ParkedSignal {
+  case object Unparked extends ParkedSignal
+
+  case object ParkedPolling extends ParkedSignal
+  case object ParkedSimple extends ParkedSignal
+
+  case object Interrupting extends ParkedSignal
+}

--- a/core/jvm/src/main/scala/cats/effect/unsafe/ParkedSignal.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/ParkedSignal.scala
@@ -18,7 +18,7 @@ package cats.effect.unsafe
 
 private sealed abstract class ParkedSignal extends Product with Serializable
 
-object ParkedSignal {
+private object ParkedSignal {
   case object Unparked extends ParkedSignal
 
   case object ParkedPolling extends ParkedSignal

--- a/core/jvm/src/main/scala/cats/effect/unsafe/ParkedSignal.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/ParkedSignal.scala
@@ -16,7 +16,7 @@
 
 package cats.effect.unsafe
 
-sealed trait ParkedSignal extends Product with Serializable
+private sealed abstract class ParkedSignal extends Product with Serializable
 
 object ParkedSignal {
   case object Unparked extends ParkedSignal

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -638,17 +638,14 @@ private[effect] final class WorkerThread[P <: AnyRef](
       }
 
     def notifyDoneSleeping(): Unit = {
-      var st = parked.get()
+      val st = parked.get()
 
       if (st ne ParkedSignal.Unparked) {
         if (st eq ParkedSignal.Interrupting) {
           // our state is being twiddled; wait for that to finish up
           // this happens when we wake ourselves at the same moment the pool decides to wake us
 
-          while ({
-            st = parked.get()
-            st eq ParkedSignal.Interrupting
-          }) {}
+          while (parked.get() eq ParkedSignal.Interrupting) {}
         } else if (parked.compareAndSet(st, ParkedSignal.Unparked)) {
           // we won the race to awaken ourselves, so we need to let the pool know
           pool.doneSleeping()

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -645,9 +645,10 @@ private[effect] final class WorkerThread[P <: AnyRef](
           // our state is being twiddled; wait for that to finish up
           // this happens when we wake ourselves at the same moment the pool decides to wake us
 
-          do {
+          while ({
             st = parked.get()
-          } while (st eq ParkedSignal.Interrupting)
+            st eq ParkedSignal.Interrupting
+          }) {}
         } else if (parked.compareAndSet(st, ParkedSignal.Unparked)) {
           // we won the race to awaken ourselves, so we need to let the pool know
           pool.doneSleeping()
@@ -694,9 +695,10 @@ private[effect] final class WorkerThread[P <: AnyRef](
           } else if (st eq ParkedSignal.Interrupting) {
             // awakened intentionally, but waiting for the state publish
             // we have to block here to ensure we don't go back to sleep again too fast
-            do {
+            while ({
               st = parked.get()
-            } while (st eq ParkedSignal.Interrupting)
+              st eq ParkedSignal.Interrupting
+            }) {}
 
             false
           } else {
@@ -759,9 +761,11 @@ private[effect] final class WorkerThread[P <: AnyRef](
                 } else if (st eq ParkedSignal.Interrupting) {
                   // awakened intentionally, but waiting for the state publish
                   // we have to block here to ensure we don't go back to sleep again too fast
-                  do {
+                  while ({
                     st = parked.get()
-                  } while (st eq ParkedSignal.Interrupting)
+                    st eq ParkedSignal.Interrupting
+                  }) {}
+
                   false
                 } else {
                   // awakened spuriously, re-check next sleeper

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -685,17 +685,14 @@ private[effect] final class WorkerThread[P <: AnyRef](
           true
         } else {
           // Spurious wakeup check.
-          var st = parked.get()
+          val st = parked.get()
           if (st eq ParkedSignal.Unparked) {
             // awakened intentionally
             false
           } else if (st eq ParkedSignal.Interrupting) {
             // awakened intentionally, but waiting for the state publish
             // we have to block here to ensure we don't go back to sleep again too fast
-            while ({
-              st = parked.get()
-              st eq ParkedSignal.Interrupting
-            }) {}
+            while (parked.get() eq ParkedSignal.Interrupting) {}
 
             false
           } else {

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -726,7 +726,7 @@ trait IOPlatformSpecification extends DetectPlatform { self: BaseSpec with Scala
       }
 
       "handle mixed-mode poller/simple interruption with complex timers" in {
-        val delegate = unsafe.SelectorSystem()
+        val delegate = IORuntime.createDefaultPollingSystem()
 
         val (pool, poller, shutdown) = IORuntime.createWorkStealingComputeThreadPool(
           threads = 1,

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -591,7 +591,8 @@ trait IOPlatformSpecification extends DetectPlatform { self: BaseSpec with Scala
 
         def processReadyEvents(poller: Poller): Boolean = false
 
-        def needsPoll(poller: Poller): Boolean = false
+        // if we don't claim to need polling, then the worker won't bother calling it
+        def needsPoll(poller: Poller): Boolean = true
 
         def interrupt(targetThread: Thread, poller: Poller): Unit = {
           wasInterrupted.set(true)

--- a/tests/shared/src/test/scala/cats/effect/std/MutexSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/MutexSpec.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 
 final class MutexSpec extends BaseSpec with DetectPlatform {
 
-  if (System.getProperty("os.name").toLowerCase.contains("windows")) {
+  if (!isJS && System.getProperty("os.name").toLowerCase.contains("windows")) {
     // these tests seem oddly flaky on windows post #4377
     val _ = sequential
     ()

--- a/tests/shared/src/test/scala/cats/effect/std/MutexSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/MutexSpec.scala
@@ -27,6 +27,12 @@ import scala.concurrent.duration._
 
 final class MutexSpec extends BaseSpec with DetectPlatform {
 
+  if (System.getProperty("os.name").toLowerCase.contains("windows")) {
+    // these tests seem oddly flaky on windows post #4377
+    val _ = sequential
+    ()
+  }
+
   final override def executionTimeout = 2.minutes
 
   "ConcurrentMutex" should {


### PR DESCRIPTION
With this change, every time we park a thread we check to see if the underlying polling system `needsPoll`, which is a hint that is intended to be implemented by checking if any events have been registered with the underlying polling system. If it returns `false`, we don't even bother hitting the poller and instead park the worker thread the old fashioned way. This has some slightly complex concurrent coordination implications which makes this whole thing just a bit more complex and introduces a tiny spin wait, but otherwise is generally okay.

This should bring thread suspension performance for applications which are *not* using `PollingSystem` back very close to what it was in 3.5.x. The `needsPoll` call does have some overhead, and the more complex suspension state does have a cost, but it shouldn't be that severe. I'm traveling so I haven't had a chance to run benchmarks yet but that's next on my todo list.

Fixes #4328