### PR TITLE
Fix #4367: Wrap tracingEvents in Option to handle NPE

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1548,7 +1548,11 @@ private final class IOFiber[A](
     // but we don't worry about those since we are just looking for a single `TraceEvent`
     // which references user-land code
     val opAndCallSite =
-      Tracing.getFrames(tracingEvents).headOption.map(frame => s": $frame").getOrElse("")
+      Option(tracingEvents)
+        .flatMap { tracingEvents =>
+          Tracing.getFrames(tracingEvents).headOption.map(frame => s": $frame")
+        }
+        .getOrElse("")
 
     s"cats.effect.IOFiber@${System.identityHashCode(this).toHexString} $state$opAndCallSite"
   }


### PR DESCRIPTION
**Description**:
This PR addresses Issue #4367 by fixing a `NullPointerException` in `IOFiber#toString` when `tracingEvents` is `null` (e.g., with `Tracing.none`). The change wraps `tracingEvents` in an `Option`, using `flatMap` and `getOrElse("")` to safely handle the null case, ensuring `toString` returns a valid string without crashing.

**Changes**:
- Wrap `tracingEvents` in `Option` to avoid NPE in `toString`.