### PR TITLE
Fix source compatibility with Scala 3.6

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -1234,9 +1234,11 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits with TuplePara
   }
 
   implicit class IOSequenceOps[T[_], A](tioa: T[IO[A]]) {
-    def sequence(implicit T: Traverse[T], G: Applicative[IO]): IO[T[A]] = T.sequence(tioa)(G)
+    def sequence(implicit T: Traverse[T], G: Applicative[IO]): IO[T[A]] =
+      T.sequence(tioa)(using G)
 
-    def sequence_(implicit F: Foldable[T], G: Applicative[IO]): IO[Unit] = F.sequence_(tioa)(G)
+    def sequence_(implicit F: Foldable[T], G: Applicative[IO]): IO[Unit] =
+      F.sequence_(tioa)(using G)
   }
 
   @static private[this] val _alignForIO = new IOAlign

--- a/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/Generators.scala
+++ b/kernel-testkit/shared/src/main/scala/cats/effect/kernel/testkit/Generators.scala
@@ -132,8 +132,8 @@ trait ApplicativeErrorGenerators[F[_], E] extends ApplicativeGenerators[F] {
   override protected def recursiveGen[A](
       deeper: GenK[F])(implicit AA: Arbitrary[A], AC: Cogen[A]): List[(String, Gen[F[A]])] =
     List(
-      "handleErrorWith" -> genHandleErrorWith[A](deeper)(AA, AC)
-    ) ++ super.recursiveGen(deeper)(AA, AC)
+      "handleErrorWith" -> genHandleErrorWith[A](deeper)(using AA, AC)
+    ) ++ super.recursiveGen(deeper)(using AA, AC)
 
   private def genRaiseError[A]: Gen[F[A]] =
     arbitrary[E].map(F.raiseError[A](_))
@@ -295,7 +295,7 @@ trait AsyncGenerators[F[_]] extends GenTemporalGenerators[F, Throwable] with Syn
       result <- arbitrary[Either[Throwable, A]]
 
       fo <- deeper[Option[F[Unit]]](
-        Arbitrary(Gen.option[F[Unit]](deeper[Unit])),
+        using Arbitrary(Gen.option[F[Unit]](deeper[Unit])),
         Cogen.cogenOption(cogenFU))
     } yield F
       .async[A](k => F.delay(k(result)) >> fo)
@@ -323,7 +323,7 @@ trait AsyncGeneratorsWithoutEvalShift[F[_]]
       result <- arbitrary[Either[Throwable, A]]
 
       fo <- deeper[Option[F[Unit]]](
-        Arbitrary(Gen.option[F[Unit]](deeper[Unit])),
+        using Arbitrary(Gen.option[F[Unit]](deeper[Unit])),
         Cogen.cogenOption(cogenFU))
     } yield F
       .async[A](k => F.delay(k(result)) >> fo)

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Clock.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Clock.scala
@@ -127,7 +127,7 @@ object Clock {
       C0: Clock[F],
       D0: Defer[F]): Clock[ContT[F, R, *]] =
     new ContTClock[F, R] {
-      def applicative: Applicative[ContT[F, R, *]] = ContT.catsDataContTMonad(D)
+      def applicative: Applicative[ContT[F, R, *]] = ContT.catsDataContTMonad(using D)
       implicit override def F: Monad[F] = F0
       implicit override def C: Clock[F] = C0
       implicit override def D: Defer[F] = D0

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
@@ -141,9 +141,9 @@ private[kernel] trait LowPriorityImplicits {
 
   implicit def applicativeError[F[_], E](
       implicit F: Applicative[F]): ApplicativeError[Outcome[F, E, *], E] =
-    new OutcomeApplicativeError[F, E]
+    new OutcomeApplicativeError[F, E]()
 
-  protected class OutcomeApplicativeError[F[_]: Applicative, E]
+  protected class OutcomeApplicativeError[F[_]: Applicative, E]()
       extends ApplicativeError[Outcome[F, E, *], E]
       with Bifunctor[Outcome[F, *, *]] {
 
@@ -217,7 +217,7 @@ object Outcome extends LowPriorityImplicits {
   implicit def monadError[F[_], E](
       implicit F: Monad[F],
       FT: Traverse[F]): MonadError[Outcome[F, E, *], E] =
-    new OutcomeApplicativeError[F, E]()(F) with MonadError[Outcome[F, E, *], E] {
+    new OutcomeApplicativeError[F, E]()(using F) with MonadError[Outcome[F, E, *], E] {
 
       override def map[A, B](fa: Outcome[F, E, A])(f: A => B): Outcome[F, E, B] =
         bimap(fa)(identity, f)

--- a/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/AsyncTests.scala
@@ -198,7 +198,7 @@ trait AsyncTests[F[_]] extends GenTemporalTests[F, Throwable] with SyncTests[F] 
       val bases: Seq[(String, Laws#RuleSet)] = Nil
       val parents = Seq(
         temporal[A, B, C](tolerance)(
-          implicitly[Arbitrary[A]],
+          using implicitly[Arbitrary[A]],
           implicitly[Eq[A]],
           implicitly[Arbitrary[B]],
           implicitly[Eq[B]],

--- a/laws/shared/src/main/scala/cats/effect/laws/GenSpawnTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenSpawnTests.scala
@@ -72,7 +72,7 @@ trait GenSpawnTests[F[_], E] extends MonadCancelTests[F, E] with UniqueTests[F] 
       val bases: Seq[(String, Laws#RuleSet)] = Nil
       val parents = Seq(
         monadCancel[A, B, C](
-          implicitly[Arbitrary[A]],
+          using implicitly[Arbitrary[A]],
           implicitly[Eq[A]],
           implicitly[Arbitrary[B]],
           implicitly[Eq[B]],
@@ -163,7 +163,7 @@ trait GenSpawnTests[F[_], E] extends MonadCancelTests[F, E] with UniqueTests[F] 
       val bases: Seq[(String, Laws#RuleSet)] = Nil
       val parents = Seq(
         monadCancel[A, B, C](
-          implicitly[Arbitrary[A]],
+          using implicitly[Arbitrary[A]],
           implicitly[Eq[A]],
           implicitly[Arbitrary[B]],
           implicitly[Eq[B]],

--- a/laws/shared/src/main/scala/cats/effect/laws/GenTemporalTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/GenTemporalTests.scala
@@ -88,7 +88,7 @@ trait GenTemporalTests[F[_], E] extends GenSpawnTests[F, E] with ClockTests[F] {
       val bases: Seq[(String, Laws#RuleSet)] = Nil
       val parents = Seq(
         spawn[A, B, C](
-          implicitly[Arbitrary[A]],
+          using implicitly[Arbitrary[A]],
           implicitly[Eq[A]],
           implicitly[Arbitrary[B]],
           implicitly[Eq[B]],
@@ -181,7 +181,7 @@ trait GenTemporalTests[F[_], E] extends GenSpawnTests[F, E] with ClockTests[F] {
       val bases: Seq[(String, Laws#RuleSet)] = Nil
       val parents = Seq(
         spawn[A, B, C](
-          implicitly[Arbitrary[A]],
+          using implicitly[Arbitrary[A]],
           implicitly[Eq[A]],
           implicitly[Arbitrary[B]],
           implicitly[Eq[B]],

--- a/laws/shared/src/main/scala/cats/effect/laws/MonadCancelTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/MonadCancelTests.scala
@@ -58,7 +58,7 @@ trait MonadCancelTests[F[_], E] extends MonadErrorTests[F, E] {
       fuPP: F[Unit] => Pretty,
       ePP: E => Pretty): RuleSet =
     monadCancel[A, B, C](
-      implicitly[Arbitrary[A]],
+      using implicitly[Arbitrary[A]],
       implicitly[Eq[A]],
       implicitly[Arbitrary[B]],
       implicitly[Eq[B]],

--- a/laws/shared/src/main/scala/cats/effect/laws/SyncTests.scala
+++ b/laws/shared/src/main/scala/cats/effect/laws/SyncTests.scala
@@ -62,7 +62,7 @@ trait SyncTests[F[_]]
       val bases: Seq[(String, Laws#RuleSet)] = Nil
       val parents = Seq(
         monadCancel[A, B, C](
-          implicitly[Arbitrary[A]],
+          using implicitly[Arbitrary[A]],
           implicitly[Eq[A]],
           implicitly[Arbitrary[B]],
           implicitly[Eq[B]],

--- a/std/js-native/src/main/scala/cats/effect/std/UUIDGenCompanionPlatform.scala
+++ b/std/js-native/src/main/scala/cats/effect/std/UUIDGenCompanionPlatform.scala
@@ -39,7 +39,7 @@ private[std] trait UUIDGenCompanionPlatformLowPriority {
     "3.6.0"
   )
   implicit def fromSync[F[_]](implicit ev: Sync[F]): UUIDGen[F] = {
-    UUIDGen.fromSecureRandom[F](ev, SecureRandom.unsafeJavaSecuritySecureRandom())
+    UUIDGen.fromSecureRandom[F](using ev, SecureRandom.unsafeJavaSecuritySecureRandom())
   }
 
 }

--- a/std/shared/src/main/scala/cats/effect/std/MapRef.scala
+++ b/std/shared/src/main/scala/cats/effect/std/MapRef.scala
@@ -52,7 +52,7 @@ object MapRef extends MapRefCompanionPlatform {
   def apply[F[_]: Concurrent, K, V]: F[MapRef[F, K, Option[V]]] = {
     Concurrent[F] match {
       case s: Sync[F] =>
-        ofConcurrentHashMap()(s)
+        ofConcurrentHashMap()(using s)
       case _ =>
         ofShardedImmutableMap[F, K, V](shardCount = Runtime.getRuntime.availableProcessors())
     }

--- a/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
+++ b/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
@@ -58,7 +58,7 @@ object UUIDGen extends UUIDGenCompanionPlatform {
 
   def randomUUID[F[_]: UUIDGen]: F[UUID] = UUIDGen[F].randomUUID
   def randomString[F[_]](implicit gen: UUIDGen[F], F: Functor[F]): F[String] =
-    randomUUID(gen).map(_.toString)
+    randomUUID(using gen).map(_.toString)
 
   /**
    * [[UUIDGen]] instance built for `cats.data.EitherT` values initialized with any `F` data

--- a/tests/shared/src/test/scala/cats/effect/ResourceSuite.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSuite.scala
@@ -1348,7 +1348,7 @@ class ResourceSuite extends BaseScalaCheckSuite with DisciplineSuite {
     checkAll(
       "Resource[PureConc, *]",
       DeferTests[Resource[F, *]].defer[Int](
-        implicitly,
+        using implicitly,
         arbitraryPureConcResource,
         implicitly,
         implicitly

--- a/tests/shared/src/test/scala/cats/effect/kernel/AsyncSuite.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/AsyncSuite.scala
@@ -127,7 +127,7 @@ class AsyncSuite extends BaseSuite with DisciplineSuite {
     def realTime: AsyncIO[FiniteDuration] = liftIO(IO.realTime)
 
     def ref[A](a: A): AsyncIO[Ref[AsyncIO, A]] = delay(Ref.unsafe(a)(this))
-    def deferred[A]: AsyncIO[Deferred[AsyncIO, A]] = delay(Deferred.unsafe(this))
+    def deferred[A]: AsyncIO[Deferred[AsyncIO, A]] = delay(Deferred.unsafe(using this))
 
     def evalOn[A](fa: AsyncIO[A], ec: ExecutionContext): AsyncIO[A] = wrapIO(fa)(_.evalOn(ec))
 


### PR DESCRIPTION
This PR enables compiling cats-effect with Scala 3.6. See the Cats PR (https://github.com/typelevel/cats/pull/4737) for the detailed explanations.