### PR TITLE
Fix typo in documentation of function tryOfferN of QueueSink and PQueueSink.

### DIFF
--- a/std/shared/src/main/scala/cats/effect/std/PQueue.scala
+++ b/std/shared/src/main/scala/cats/effect/std/PQueue.scala
@@ -262,7 +262,7 @@ trait PQueueSink[F[_], A] extends QueueSink[F, A] {
    * @param list
    *   the elements to be put in the PQueue
    * @return
-   *   an effect that contains the remaining valus that could not be offered.
+   *   an effect that contains the remaining elements that could not be offered.
    */
   override def tryOfferN(list: List[A])(implicit F: Monad[F]): F[List[A]] =
     QueueSink.tryOfferN(list, tryOffer)

--- a/std/shared/src/main/scala/cats/effect/std/QueueSink.scala
+++ b/std/shared/src/main/scala/cats/effect/std/QueueSink.scala
@@ -52,7 +52,7 @@ trait QueueSink[F[_], A] {
    * @param list
    *   the elements to be put at the back of the queue
    * @return
-   *   an effect that contains the remaining valus that could not be offered.
+   *   an effect that contains the remaining elements that could not be offered.
    */
   def tryOfferN(list: List[A])(implicit F: Monad[F]): F[List[A]] =
     QueueSink.tryOfferN(list, tryOffer)


### PR DESCRIPTION
Documentation was referring to valus (it was mistyped) to describe the remaining elements, while in the rest of the docs they were referred to as elements.  So fixing a typo and making the doc more consistent.
