### PR TITLE
Fix #4382: Fix thread leak in WSTP by replacing LinkedTransferQueue with SynchronousQueue and ConcurrentHashMap

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -751,7 +751,7 @@ private[effect] final class WorkStealingThreadPool[P <: AnyRef](
 
       var t: WorkerThread[P] = null
       while ({
-        t = cachedThreads.pollLast()
+        t = cachedThreads.pollFirst()
         t ne null
       }) {
         t.interrupt()

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -39,7 +39,7 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
 
 import java.time.Instant
 import java.time.temporal.ChronoField
-import java.util.concurrent.{LinkedTransferQueue, ThreadLocalRandom}
+import java.util.concurrent.{LinkedBlockingDeque, ThreadLocalRandom}
 import java.util.concurrent.atomic.{
   AtomicBoolean,
   AtomicInteger,
@@ -131,8 +131,8 @@ private[effect] final class WorkStealingThreadPool[P <: AnyRef](
    */
   private[this] val state: AtomicInteger = new AtomicInteger(threadCount << UnparkShift)
 
-  private[unsafe] val cachedThreads: LinkedTransferQueue[WorkerThread[P]] =
-    new LinkedTransferQueue
+  private[unsafe] val cachedThreads: LinkedBlockingDeque[WorkerThread[P]] =
+    new LinkedBlockingDeque
 
   /**
    * The shutdown latch of the work stealing thread pool.
@@ -751,7 +751,7 @@ private[effect] final class WorkStealingThreadPool[P <: AnyRef](
 
       var t: WorkerThread[P] = null
       while ({
-        t = cachedThreads.poll()
+        t = cachedThreads.pollLast()
         t ne null
       }) {
         t.interrupt()

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -132,7 +132,7 @@ private[effect] final class WorkStealingThreadPool[P <: AnyRef](
   private[this] val state: AtomicInteger = new AtomicInteger(threadCount << UnparkShift)
 
   private[unsafe] val cachedThreads: LinkedBlockingDeque[WorkerThread[P]] =
-    new LinkedBlockingDeque
+    new LinkedBlockingDeque(1)
 
   /**
    * The shutdown latch of the work stealing thread pool.

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -732,7 +732,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
           // by another thread in the future.
           val len = runtimeBlockingExpiration.length
           val unit = runtimeBlockingExpiration.unit
-          if (pool.cachedThreads.tryTransfer(this, len, unit)) {
+          if (pool.cachedThreads.offerFirst(this, len, unit)) {
             // Someone accepted the transfer of this thread and will transfer the state soon.
             val newState = stateTransfer.take()
             init(newState)
@@ -928,7 +928,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
       // Set the name of this thread to a blocker prefixed name.
       setName(s"$prefix-$nameIndex")
 
-      val cached = pool.cachedThreads.poll()
+      val cached = pool.cachedThreads.pollLast()
       if (cached ne null) {
         // There is a cached worker thread that can be reused.
         val idx = index

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -928,7 +928,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
       // Set the name of this thread to a blocker prefixed name.
       setName(s"$prefix-$nameIndex")
 
-      val cached = pool.cachedThreads.pollLast()
+      val cached = pool.cachedThreads.pollFirst()
       if (cached ne null) {
         // There is a cached worker thread that can be reused.
         val idx = index

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -940,11 +940,11 @@ private[effect] final class WorkerThread[P <: AnyRef](
       transferState.index = idx
       transferState.tick = tick + 1
 
+      // Register this thread in the blockerThreads map
       val _ = pool.blockerThreads.put(this, java.lang.Boolean.TRUE)
 
       if (pool.transferStateQueue.offer(transferState)) {
         // If successful, a waiting thread will pick it up
-        // Register this thread in the blockerThreads map
 
       } else {
         // Spawn a new `WorkerThread`, a literal clone of this one. It is safe to
@@ -970,7 +970,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
             system,
             _poller,
             metrics,
-            new WorkerThread.TransferState,
+            transferState,
             pool)
         // Make sure the clone gets our old name:
         val clonePrefix = pool.threadPrefix


### PR DESCRIPTION
**Description:**
This PR fixes a thread leak in the Work Stealing Thread Pool (Issue #4382), previously caused by FIFO-based reuse of cached blocker threads (introduced in #4295). This FIFO behavior could prevent older cached threads from timing out and exiting during periods of low load, when the number of cached threads exceeds the number of blocking tasks.
The implemented solution transitions to a LIFO-like reuse strategy for cached blocker threads. This is achieved by using a `SynchronousQueue` for state hand-off between threads (leveraging its typically LIFO behavior for waiting pollers in non-fair mode) and a `ConcurrentHashMap` for tracking these blocker threads.
**Changes:**
1.  **`SynchronousQueue<TransferState>` for State Hand-off:**
    *   `WorkerThreads` becoming blockers `offer` their `TransferState` to this pool-level queue.
    *   Cached (previously blocker) `WorkerThreads` `poll` this queue to acquire new state. In its non-fair implementation, the JDK's `SynchronousQueue` typically services waiting pollers in a LIFO manner, prioritizing more recently cached threads for reuse.
    *   If an `offer` isn't immediately taken, the thread preparing to block spawns a new replacement worker to maintain active pool size.
2.  **`ConcurrentHashMap<WorkerThread, Boolean>` for Tracking:**
    *   All threads that enter the blocker/cached state are now tracked in this map.
3.  **`WorkerThread` Blocker Logic Update:**
    *   After its  blocking call, a blocker thread attempts to `poll` the `SynchronousQueue` for new `TransferState` with a timeout (`runtimeBlockingExpiration`).
    *   Successful polling leads to re-initialization as an active worker. If the poll times out, the thread terminates and is removed from tracking.
4.  **Shutdown Logic Modification:**
    *   `WorkStealingThreadPool.shutdown()` now iterates and interrupts all threads currently tracked in the `blockerThreads` map.