### PR TITLE
Fixed the sample code inconsistency in `IOLocal` scaladoc

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOLocal.scala
+++ b/core/shared/src/main/scala/cats/effect/IOLocal.scala
@@ -42,8 +42,8 @@ import cats.mtl.Local
  * }}}
  *
  * {{{
- *  def inc(name: String, local: IOLocal[Int]): IO[Unit] =
- *    local.update(_ + 1) >> local.get.flatMap(current => IO.println(s"fiber $$name: $$current"))
+ *  def inc(n: Int, local: IOLocal[Int]): IO[Unit] =
+ *    local.update(_ + 1) >> local.get.flatMap(current => IO.println(s"update $$n: $$current"))
  *
  *  for {
  *    local   <- IOLocal(42)


### PR DESCRIPTION
The original PR #4385 
@djspiewak suggested to retarget the PR into `series/3.6.x`.

This PR fixes an inconsistency in the IOLocal documentation sample. The example previously used a string parameter for the increment function, which has now been updated to use an integer parameter for clarity and consistency.