### PR TITLE
Reprioritize UUIDGen.fromSecureRandom to avoid ambiguity on Scala 2.12

### DIFF
--- a/core/shared/src/test/scala/cats/effect/ImplicitPriorityPlayground.scala
+++ b/core/shared/src/test/scala/cats/effect/ImplicitPriorityPlayground.scala
@@ -16,21 +16,16 @@
 
 package cats.effect.std
 
-import cats.effect.kernel.Sync
+import cats.data._
+import cats.effect._
 
 import java.util.UUID
 
-private[std] trait UUIDGenCompanionPlatform extends UUIDGenCompanionPlatformMediumPriority
+object ImplicitPriorityPlayground {
 
-private[std] trait UUIDGenCompanionPlatformLowPriority {
+  def foo[F[_]: UUIDGen]: F[UUID] = UUIDGen[F].randomUUID
 
-  @deprecated(
-    "Put an implicit `SecureRandom.javaSecuritySecureRandom` into scope to get a more efficient `UUIDGen`, or directly call `UUIDGen.fromSecureRandom`",
-    "3.6.0"
-  )
-  implicit def fromSync[F[_]](implicit ev: Sync[F]): UUIDGen[F] = new UUIDGen[F] {
-    override final val randomUUID: F[UUID] =
-      ev.blocking(UUID.randomUUID())
+  SecureRandom.javaSecuritySecureRandom[IO].flatMap { implicit random =>
+    foo[Kleisli[IO, String, *]].run("hello world")
   }
-
 }

--- a/std/js-native/src/main/scala/cats/effect/std/UUIDGenCompanionPlatform.scala
+++ b/std/js-native/src/main/scala/cats/effect/std/UUIDGenCompanionPlatform.scala
@@ -30,7 +30,7 @@ package cats.effect.std
 
 import cats.effect.kernel.Sync
 
-private[std] trait UUIDGenCompanionPlatform extends UUIDGenCompanionPlatformLowPriority
+private[std] trait UUIDGenCompanionPlatform extends UUIDGenCompanionPlatformMediumPriority
 
 private[std] trait UUIDGenCompanionPlatformLowPriority {
 

--- a/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
+++ b/std/shared/src/main/scala/cats/effect/std/UUIDGen.scala
@@ -26,7 +26,7 @@ import cats.data.{
   OptionT,
   WriterT
 }
-import cats.implicits._
+import cats.syntax.all._
 
 import java.util.UUID
 
@@ -118,6 +118,16 @@ object UUIDGen extends UUIDGenCompanionPlatform {
   ]: UUIDGen[IndexedReaderWriterStateT[F, E, L, S, S, *]] =
     UUIDGen[F].mapK(IndexedReaderWriterStateT.liftK)
 
+  private[std] final class TranslatedUUIDGen[F[_], G[_]](self: UUIDGen[F])(f: F ~> G)
+      extends UUIDGen[G] {
+    override def randomUUID: G[UUID] =
+      f(self.randomUUID)
+
+  }
+}
+
+private[std] trait UUIDGenCompanionPlatformMediumPriority
+    extends UUIDGenCompanionPlatformLowPriority {
   implicit def fromSecureRandom[F[_]: Functor: SecureRandom]: UUIDGen[F] =
     new UUIDGen[F] {
       override final val randomUUID: F[UUID] =
@@ -137,11 +147,4 @@ object UUIDGen extends UUIDGenCompanionPlatform {
         new UUID(msb, lsb)
       }
     }
-
-  private[std] final class TranslatedUUIDGen[F[_], G[_]](self: UUIDGen[F])(f: F ~> G)
-      extends UUIDGen[G] {
-    override def randomUUID: G[UUID] =
-      f(self.randomUUID)
-
-  }
 }


### PR DESCRIPTION
Fixes #4397. 

The way the diff is presented is a little misleading; I moved `fromSecureRandom` into its own trait, but it looks like I moved `TranslatedUUIDGen` around. (Which isn't wrong, just not as useful of a way to think about it IMO.)

I'm expecting bike-shedding on `ImplicitPriorityPlayground`, at least, which is why I marked this as a draft PR for now.