### PR TITLE
Make `IOFiber#{_join,_cancel}` volatile on Native

### DIFF
--- a/core/js/src/main/scala/cats/effect/Platform.scala
+++ b/core/js/src/main/scala/cats/effect/Platform.scala
@@ -22,4 +22,5 @@ private object Platform {
   final val isNative = false
 
   class static extends scala.annotation.Annotation
+  final class safePublish extends scala.annotation.Annotation
 }

--- a/core/js/src/main/scala/cats/effect/Platform.scala
+++ b/core/js/src/main/scala/cats/effect/Platform.scala
@@ -22,5 +22,5 @@ private object Platform {
   final val isNative = false
 
   class static extends scala.annotation.Annotation
-  final class safePublish extends scala.annotation.Annotation
+  final class volatileNative extends scala.annotation.Annotation
 }

--- a/core/jvm/src/main/scala/cats/effect/Platform.scala
+++ b/core/jvm/src/main/scala/cats/effect/Platform.scala
@@ -22,5 +22,5 @@ private object Platform {
   final val isNative = false
 
   type static = org.typelevel.scalaccompat.annotation.static3
-  class safePublish extends scala.annotation.Annotation
+  final class safePublish extends scala.annotation.Annotation
 }

--- a/core/jvm/src/main/scala/cats/effect/Platform.scala
+++ b/core/jvm/src/main/scala/cats/effect/Platform.scala
@@ -23,4 +23,5 @@ private object Platform {
 
   type static = org.typelevel.scalaccompat.annotation.static3
   final class safePublish extends scala.annotation.Annotation
+  final class volatileNative extends scala.annotation.Annotation
 }

--- a/core/native/src/main/scala/cats/effect/Platform.scala
+++ b/core/native/src/main/scala/cats/effect/Platform.scala
@@ -23,4 +23,5 @@ private object Platform {
 
   class static extends scala.annotation.Annotation
   type safePublish = scala.scalanative.annotation.safePublish
+  type volatileNative = scala.volatile
 }

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -62,7 +62,7 @@ import scala.util.{Failure, Success, Try}
 import java.util.UUID
 import java.util.concurrent.Executor
 
-import Platform.static
+import Platform.{static, safePublish}
 
 /**
  * A pure abstraction representing the intention to perform a side effect, where the result of
@@ -2202,6 +2202,7 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits with TuplePara
 
   // implementations
 
+  @safePublish
   private[effect] final case class Pure[+A](value: A) extends IO[A] {
     def tag = 0
     override def toString: String = s"IO($value)"

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -62,7 +62,7 @@ import scala.util.{Failure, Success, Try}
 import java.util.UUID
 import java.util.concurrent.Executor
 
-import Platform.{static, safePublish}
+import Platform.static
 
 /**
  * A pure abstraction representing the intention to perform a side effect, where the result of
@@ -2202,7 +2202,6 @@ object IO extends IOCompanionPlatform with IOLowPriorityImplicits with TuplePara
 
   // implementations
 
-  @safePublish
   private[effect] final case class Pure[+A](value: A) extends IO[A] {
     def tag = 0
     override def toString: String = s"IO($value)"

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.atomic.AtomicBoolean
 
-import Platform.{ static, volatileNative }
+import Platform.{static, volatileNative}
 
 /*
  * Rationale on memory barrier exploitation in this class...

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.atomic.AtomicBoolean
 
-import Platform.static
+import Platform.{ static, volatileNative }
 
 /*
  * Rationale on memory barrier exploitation in this class...
@@ -138,6 +138,7 @@ private final class IOFiber[A](
   /* backing fields for `cancel` and `join` */
 
   /* this is swapped for an `IO.unit` when we complete */
+  @volatileNative
   private[this] var _cancel: IO[Unit] = IO uncancelable { _ =>
     canceled = true
 
@@ -174,6 +175,7 @@ private final class IOFiber[A](
   }
 
   /* this is swapped for an `IO.pure(outcome)` when we complete */
+  @volatileNative
   private[this] var _join: IO[OutcomeIO[A]] = IO.asyncCheckAttempt { cb =>
     IO {
       if (outcome == null) {


### PR DESCRIPTION
The `_join` and `_cancel` fields of `IOFiber` are written without synchronization here: https://github.com/typelevel/cats-effect/blob/74cdc89c355fe3239d8e4e56e261fcca1c01ebb4/core/shared/src/main/scala/cats/effect/IOFiber.scala#L1092-L1093

I'm not even sure this is enough, because I don't think the _initial value_ is guaranteed to be safely published...
