### PR TITLE
Retrieve suspended fiber count directly through the WSTP

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -702,7 +702,10 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       // package-private classes moved to the `cats.effect.unsafe.metrics` package
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.metrics.CpuStarvation"),
       ProblemFilters.exclude[MissingClassProblem]("cats.effect.metrics.CpuStarvation$"),
-      ProblemFilters.exclude[MissingClassProblem]("cats.effect.metrics.CpuStarvationMBean")
+      ProblemFilters.exclude[MissingClassProblem]("cats.effect.metrics.CpuStarvationMBean"),
+      // changes to the `cats.effect.unsafe` package private code, see #4406
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "cats.effect.unsafe.WorkerThread.getSuspendedFiberCount")
     ) ++ {
       if (tlIsScala3.value) {
         // Scala 3 specific exclusions

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -839,7 +839,7 @@ private[effect] final class WorkStealingThreadPool[P <: AnyRef](
     var sum = 0L
     var i = 0
     while (i < threadCount) {
-      sum += workerThreads.get(i).getSuspendedFiberCount().toLong
+      sum += fiberBags(i).size.toLong
       i += 1
     }
     sum

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -1004,19 +1004,6 @@ private[effect] final class WorkerThread[P <: AnyRef](
     blocking = false
   }
 
-  /**
-   * Returns the number of fibers which are currently asynchronously suspended and tracked by
-   * this worker thread.
-   *
-   * @note
-   *   This counter is not synchronized due to performance reasons and might be reporting
-   *   out-of-date numbers.
-   *
-   * @return
-   *   the number of asynchronously suspended fibers
-   */
-  def getSuspendedFiberCount(): Int =
-    fiberBag.size
 }
 
 private[effect] object WorkerThread {


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-effect/issues/4405.