### PR TITLE
Add `AtomicMap`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1149,7 +1149,12 @@ lazy val std = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         ProblemFilters.exclude[DirectMissingMethodProblem](
           "cats.effect.std.Mutex#ConcurrentImpl.EmptyCell"),
         ProblemFilters.exclude[DirectMissingMethodProblem](
-          "cats.effect.std.Mutex#ConcurrentImpl.LockQueueCell")
+          "cats.effect.std.Mutex#ConcurrentImpl.LockQueueCell"),
+        // #4424, refactored private classes
+        ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "cats.effect.std.AtomicCell#AsyncImpl.this"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "cats.effect.std.AtomicCell#ConcurrentImpl.this")
       )
   )
   .jsSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -1154,7 +1154,16 @@ lazy val std = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         ProblemFilters.exclude[IncompatibleMethTypeProblem](
           "cats.effect.std.AtomicCell#AsyncImpl.this"),
         ProblemFilters.exclude[IncompatibleMethTypeProblem](
-          "cats.effect.std.AtomicCell#ConcurrentImpl.this")
+          "cats.effect.std.AtomicCell#ConcurrentImpl.this"),
+        // #4424, false warnings in CommonImpl due to lightbend-labs/mima#211
+        ProblemFilters.exclude[DirectAbstractMethodProblem](
+          "cats.effect.std.AtomicCell.modify"),
+        ProblemFilters.exclude[DirectAbstractMethodProblem](
+          "cats.effect.std.AtomicCell.evalUpdate"),
+        ProblemFilters.exclude[DirectAbstractMethodProblem](
+          "cats.effect.std.AtomicCell.evalGetAndUpdate"),
+        ProblemFilters.exclude[DirectAbstractMethodProblem](
+          "cats.effect.std.AtomicCell.evalUpdateAndGet")
       )
   )
   .jsSettings(

--- a/docs/std/atomic-map.md
+++ b/docs/std/atomic-map.md
@@ -1,0 +1,78 @@
+---
+id: atomic-map
+title: Atomic Map
+---
+
+A total map from `K` to `AtomicCell[F, V]`.
+
+```scala mdoc:silent
+import cats.effect.std.AtomicCell
+
+trait AtomicMap[F[_], K, V] {
+  /**
+   * Access the AtomicCell for the given key.
+   */
+  def apply(key: K): AtomicCell[F, V]
+}
+```
+
+It is conceptually similar to a `AtomicMap[F, Map[K, V]]`, but with better ergonomics when
+working on a per key basis. Note, however, that it does not support atomic updates to
+multiple keys.
+
+Additionally, it also provide less contention: since all operations are performed on
+individual key-value pairs, the pairs can be sharded by key. Thus, multiple concurrent
+updates may be executed independently to each other, as long as their keys belong to
+different shards.
+
+## Using `AtomicMap`
+
+You can think of a `AtomicMap` like a `MapRef` that supports effectual updates by locking the underlying `Ref`.
+
+```scala mdoc:reset:silent
+import cats.effect.IO
+import cats.effect.std.AtomicMap
+
+trait State
+trait Key
+
+class Service(am: AtomicMap[IO, Key, State]) {
+  def modify(key: Key)(f: State => IO[State]): IO[Unit] =
+    am(key).evalUpdate(f)
+}
+```
+
+### Example
+
+Imagine a parking tower,
+where users have access to specific floors,
+and getting a parking space involves an effectual operation _(e.g. a database call)_.
+In that case, it may be better to block than repeat the operation,
+but without blocking operations on different floors.
+
+```scala mdoc:reset:silent
+import cats.effect.IO
+import cats.effect.std.AtomicMap
+
+trait Car
+trait Floor
+trait ParkingSpace
+
+class ParkingTowerService(state: AtomicMap[IO, Floor, List[ParkingSpace]]) {
+  // Tries to park the given Car in the solicited Floor.
+  // Returns either the assigned ParkingSpace, or None if this Floor is full.
+  def parkCarInFloor(floor: Floor, car: Car): IO[Option[ParkingSpace]] =
+    state(key = floor).evalModify {
+      case firstFreeParkingSpace :: remainingParkingSpaces =>
+        markParkingSpaceAsUsed(parkingSpace = firstFreeParkingSpace, car).as(
+          remainingParkingSpaces -> Some(firstFreeParkingSpace)
+        )
+
+      case Nil =>
+        IO.pure(List.empty -> None)
+    }
+
+  private def markParkingSpaceAsUsed(parkingSpace: ParkingSpace, car: Car): IO[Unit] =
+    ???
+}
+```

--- a/docs/std/atomic-map.md
+++ b/docs/std/atomic-map.md
@@ -16,7 +16,7 @@ trait AtomicMap[F[_], K, V] {
 }
 ```
 
-It is conceptually similar to a `AtomicMap[F, Map[K, V]]`, but with better ergonomics when
+It is conceptually similar to a `AtomicCell[F, Map[K, V]]`, but with better ergonomics when
 working on a per key basis. Note, however, that it does not support atomic updates to
 multiple keys.
 

--- a/std/shared/src/main/scala/cats/effect/std/AtomicMap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/AtomicMap.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020-2025 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package std
+
+import cats.effect.kernel._
+import cats.syntax.all._
+
+/**
+ * This is a total map from `K` to `AtomicCell[F, V]`.
+ *
+ * It is conceptually similar to a `AtomicMap[F, Map[K, V]]`, but with better ergonomics when
+ * working on a per key basis. Note, however, that it does not support atomic updates to
+ * multiple keys.
+ *
+ * Additionally, it also provide less contention: since all operations are performed on
+ * individual key-value pairs, the pairs can be sharded by key. Thus, multiple concurrent
+ * updates may be executed independently to each other, as long as their keys belong to
+ * different shards.
+ */
+trait AtomicMap[F[_], K, V] extends Function1[K, AtomicCell[F, V]] {
+
+  /**
+   * Access the [[cats.effect.std.AtomicCell]] for the given `key`.
+   */
+  def apply(key: K): AtomicCell[F, V]
+}
+
+object AtomicMap {
+
+  /**
+   * Creates a new `AtomicMap`.
+   */
+  def apply[F[_], K, V](implicit F: Concurrent[F]): F[AtomicMap[F, K, Option[V]]] =
+    ???
+}

--- a/std/shared/src/main/scala/cats/effect/std/AtomicMap.scala
+++ b/std/shared/src/main/scala/cats/effect/std/AtomicMap.scala
@@ -89,4 +89,44 @@ object AtomicMap {
     override def apply(key: K): AtomicCell[F, V] =
       AtomicCell.defaultedAtomicCell(atomicCell = atomicMap(key), default)
   }
+
+  implicit def atomicMapOptionSyntax[F[_], K, V](
+      atomicMap: AtomicMap[F, K, Option[V]]
+  )(
+      implicit F: Applicative[F]
+  ): AtomicMapOptionOps[F, K, V] =
+    new AtomicMapOptionOps(atomicMap)
+
+  final class AtomicMapOptionOps[F[_], K, V] private[effect] (
+      atomicMap: AtomicMap[F, K, Option[V]]
+  )(
+      implicit F: Applicative[F]
+  ) {
+    def getOrElse(key: K, default: V): F[V] =
+      atomicMap(key).getOrElse(default)
+
+    def unsetKey(key: K): F[Unit] =
+      atomicMap(key).unset
+
+    def setValue(key: K, value: V): F[Unit] =
+      atomicMap(key).setValue(value)
+
+    def modifyValueIfSet[B](key: K)(f: V => (V, B)): F[Option[B]] =
+      atomicMap(key).modifyValueIfSet(f)
+
+    def evalModifyValueIfSet[B](key: K)(f: V => F[(V, B)]): F[Option[B]] =
+      atomicMap(key).evalModifyValueIfSet(f)
+
+    def updateValueIfSet(key: K)(f: V => V): F[Unit] =
+      atomicMap(key).updateValueIfSet(f)
+
+    def evalUpdateValueIfSet(key: K)(f: V => F[V]): F[Unit] =
+      atomicMap(key).evalUpdateValueIfSet(f)
+
+    def getAndSetValue(key: K, value: V): F[Option[V]] =
+      atomicMap(key).getAndSetValue(value)
+
+    def withDefaultValue(default: V): AtomicMap[F, K, V] =
+      defaultedAtomicMap(atomicMap, default)
+  }
 }

--- a/tests/shared/src/test/scala/cats/effect/std/AtomicMapSuite.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/AtomicMapSuite.scala
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2020-2025 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package effect
+package std
+
+import cats.syntax.all._
+
+import scala.concurrent.duration._
+
+class AtomicMapSuite extends BaseSuite {
+  tests("ConcurrentAtomicMap", AtomicMap.apply[IO, Int, Int])
+
+  def tests(name: String, atomicMap: IO[AtomicMap[IO, Int, Option[Int]]]) = {
+    real(
+      s"${name} should getAndSet successfully if the given key is free"
+    ) {
+      val p = for {
+        am <- atomicMap
+        cell = am(key = 1)
+        getAndSetResult <- cell.getAndSet(Some(1))
+        getResult <- cell.get
+      } yield getAndSetResult == None &&
+        getResult == Some(1)
+
+      p.mustEqual(true)
+    }
+
+    ticked(
+      s"${name} get should not block during concurrent modification of the same key"
+    ) { implicit ticker =>
+      val p = for {
+        am <- atomicMap
+        cell = am(key = 1)
+        gate <- IO.deferred[Unit]
+        _ <- cell.evalModify(_ => gate.complete(()) *> IO.never).start
+        _ <- gate.get
+        getResult <- cell.get
+      } yield getResult == None
+
+      assertCompleteAs(p, true)
+    }
+
+    ticked(
+      s"${name} should block action if not free in the given key"
+    ) { implicit ticker =>
+      val p = atomicMap.flatMap { am =>
+        val cell = am(key = 1)
+
+        cell.evalUpdate(_ => IO.never) >>
+          cell.evalUpdate(IO.pure)
+      }
+
+      assertNonTerminate(p)
+    }
+
+    ticked(
+      s"${name} should not block action if using a different key"
+    ) { implicit ticker =>
+      val p = atomicMap.flatMap { am =>
+        val cell1 = am(key = 1)
+        val cell2 = am(key = 2)
+
+        IO.race(
+          cell1.evalUpdate(_ => IO.never),
+          cell2.evalUpdate(IO.pure)
+        ).void
+      }
+
+      assertCompleteAs(p, ())
+    }
+
+    ticked(
+      s"${name} should support concurrent usage in the same key"
+    ) { implicit ticker =>
+      val p = atomicMap.flatMap { am =>
+        val cell = am(key = 1)
+        val usage = IO.sleep(1.second) >> cell.evalUpdate(IO.pure(_).delayBy(1.second))
+
+        (usage, usage).parTupled.void
+      }
+
+      assertCompleteAs(p, ())
+    }
+
+    ticked(
+      s"${name} should support concurrent usage in different keys"
+    ) { implicit ticker =>
+      val p = atomicMap.flatMap { am =>
+        def usage(key: Int): IO[Unit] = {
+          val cell = am(key)
+          IO.sleep(1.second) >> cell.evalUpdate(IO.pure(_).delayBy(1.second))
+        }
+
+        List.range(start = 1, end = 10).parTraverse_(usage)
+      }
+
+      assertCompleteAs(p, ())
+    }
+
+    real(
+      s"${name} should support OptionOps"
+    ) {
+      val p = for {
+        am <- atomicMap
+        key = 1
+        default = 0
+        value = 1
+        updateFunction = (x: Int) => x + 1
+        cell = am(key)
+        cellGetResultBeforeSetValue <- cell.get
+        amGetOrElseResultBeforeSetValue <- am.getOrElse(key, default)
+        _ <- am.setValue(key, value)
+        cellGetResultAfterSetValue <- cell.get
+        amGetOrElseResultAfterSetValue <- am.getOrElse(key, default)
+        _ <- am.updateValueIfSet(key)(updateFunction)
+        cellGetResultAfterUpdate <- cell.get
+        amGetOrElseResultAfterUpdate <- am.getOrElse(key, default)
+        _ <- am.unsetKey(key)
+        cellGetResultAfterUnsetKey <- cell.get
+        amGetOrElseResultAfterUnsetKey <- am.getOrElse(key, default)
+      } yield cellGetResultBeforeSetValue == None &&
+        amGetOrElseResultBeforeSetValue == default &&
+        cellGetResultAfterSetValue == Some(value) &&
+        amGetOrElseResultAfterSetValue == value &&
+        cellGetResultAfterUpdate == Some(updateFunction(value)) &&
+        amGetOrElseResultAfterUpdate == updateFunction(value) &&
+        cellGetResultAfterUnsetKey == None &&
+        amGetOrElseResultAfterUnsetKey == default
+
+      p.mustEqual(true)
+    }
+
+    real(
+      s"A defaulted ${name} cell should be consistent with its underlying AtomicCell"
+    ) {
+      val p = for {
+        am <- atomicMap
+        default = 0
+        key = 1
+        value = 1
+        cell = am(key)
+        defaultedAM = AtomicMap.defaultedAtomicMap(am, default)
+        defaultedCell = defaultedAM(key)
+        cellGetResultBeforeModification <- cell.get
+        defaultedCellGetResultBeforeModification <- defaultedCell.get
+        _ <- defaultedCell.set(value)
+        cellGetResultAfterModification <- cell.get
+        defaultedCellGetResultAfterModification <- defaultedCell.get
+        _ <- defaultedCell.set(default)
+        cellGetResultAfterClear <- cell.get
+        defaultedCellGetResultAfterClear <- defaultedCell.get
+      } yield cellGetResultBeforeModification == None &&
+        defaultedCellGetResultBeforeModification == default &&
+        cellGetResultAfterModification == Some(value) &&
+        defaultedCellGetResultAfterModification == value &&
+        cellGetResultAfterClear == None &&
+        defaultedCellGetResultAfterClear == default
+
+      p.mustEqual(true)
+    }
+  }
+}


### PR DESCRIPTION
On top of #4065 

Provides a parallel of `MapRef` for `AtomicCell`, the `AtomicMap`.
It also includes some nice improvements for `AtomicCell`, we may move these to its own PR if you prefer.