### PR TITLE
Use _exit instead of System.exit in fatal cases

### DIFF
--- a/core/native/src/main/scala/cats/effect/IOApp.scala
+++ b/core/native/src/main/scala/cats/effect/IOApp.scala
@@ -23,6 +23,7 @@ import cats.syntax.all._
 
 import scala.concurrent.{blocking, CancellationException, ExecutionContext}
 import scala.scalanative.meta.LinktimeInfo._
+import scala.scalanative.posix.unistd._exit
 
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.atomic.AtomicInteger
@@ -448,14 +449,8 @@ trait IOApp {
     }
   }
 
-  private[this] def halt(status: Int): Unit = {
-    // TODO: This should be `Runtime#halt` (i.e.,
-    // TODO: not call shutdown hooks), but that is
-    // TODO: unavailable on scala-native. Note,
-    // TODO: that `stdlib.exit` seems to be the
-    // TODO: same as `System.exit` currently.
-    System.exit(status)
-  }
+  // bypasses shutdown hooks
+  private[this] def halt(status: Int): Unit = _exit(status)
 }
 
 object IOApp {

--- a/ioapp-tests/src/test/scala/IOAppSuite.scala
+++ b/ioapp-tests/src/test/scala/IOAppSuite.scala
@@ -387,6 +387,14 @@ class IOAppSuite extends FunSuite {
       }
     }
 
+    if (platform == Native || platform == JVM) {
+      test("skip shutdown hooks on fatal error") {
+        val h = platform("SkipShutdownHooksFatalError", List.empty)
+        assertEquals(h.awaitStatus(), 1)
+        assert(!h.stdout().contains("canceled"))
+        assert(h.stderr().contains("OutOfMemoryError"))
+      }
+    }
   }
 
   trait Handle {

--- a/tests/jvm-native/src/main/scala/catseffect/examplesjvmnative.scala
+++ b/tests/jvm-native/src/main/scala/catseffect/examplesjvmnative.scala
@@ -21,6 +21,7 @@ import cats.effect.{ExitCode, IO, IOApp}
 import java.io.{File, FileWriter}
 
 package examples {
+
   object Finalizers extends IOApp {
 
     def writeToFile(string: String, file: File): IO[Unit] =
@@ -30,6 +31,14 @@ package examples {
     def run(args: List[String]): IO[ExitCode] =
       (IO(println("Started")) >> IO.never)
         .onCancel(writeToFile("canceled", new File(args.head)))
+        .as(ExitCode.Success)
+  }
+
+  object SkipShutdownHooksFatalError extends IOApp {
+    def run(args: List[String]): IO[ExitCode] =
+      IO(throw new OutOfMemoryError)
+        .evalOn(MainThread)
+        .onCancel(IO(println("canceled")))
         .as(ExitCode.Success)
   }
 }

--- a/tests/native/src/main/scala/catseffect/examplesplatform.scala
+++ b/tests/native/src/main/scala/catseffect/examplesplatform.scala
@@ -55,6 +55,7 @@ package examples {
     register(LeakedFiber)
     register(CustomRuntime)
     register(CpuStarvation)
+    register(SkipShutdownHooksFatalError)
 
     def main(args: Array[String]): Unit = {
       val app = args(0)


### PR DESCRIPTION
The test doesn't actually fail because of race conditions that I couldn't find an obvious way to bypass, but it's the spirit of the thing.

Fixes #4354 