### PR TITLE
Fix the spinlock from #4377 and probably also fix #4448

### DIFF
--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -636,6 +636,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
         acc
       }
 
+    @tailrec
     def notifyDoneSleeping(): Unit = {
       val st = parked.get()
 
@@ -645,9 +646,15 @@ private[effect] final class WorkerThread[P <: AnyRef](
           // this happens when we wake ourselves at the same moment the pool decides to wake us
 
           while (parked.get() eq ParkedSignal.Interrupting) {}
-        } else if (parked.compareAndSet(st, ParkedSignal.Unparked)) {
-          // we won the race to awaken ourselves, so we need to let the pool know
-          pool.doneSleeping()
+        } else {
+          if (parked.compareAndSet(st, ParkedSignal.Unparked)) {
+            // we won the race to awaken ourselves, so we need to let the pool know
+            pool.doneSleeping()
+          } else {
+            // lost CAS race, possibly concurrent `Interrupting``,
+            // we'll need to re-read `parked`:
+            notifyDoneSleeping()
+          }
         }
       }
     }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -651,7 +651,7 @@ private[effect] final class WorkerThread[P <: AnyRef](
             // we won the race to awaken ourselves, so we need to let the pool know
             pool.doneSleeping()
           } else {
-            // lost CAS race, possibly concurrent `Interrupting``,
+            // lost CAS race, possibly concurrent `Interrupting`,
             // we'll need to re-read `parked`:
             notifyDoneSleeping()
           }


### PR DESCRIPTION
So, #4377 added a spinlock for interrupting a sleeping/polling WorkerThread. That spinlock is incorrect, i.e., a worker thread doesn't necessarily waits (spins) until the spinlock is released by WSTP#notifyParked. The incorrect scenario is when the worker thread observes `parked` being "parked", tries to CAS it to "unparked", and the CAS fails. The current implementation in this case simply goes on, as if the lock is free. While in fact it may not be free; it's likely that the CAS failed exactly because the spinlock was acquired.

This PR fixes the spinlock, so in this case the worker thread re-reads `parked`, and correctly waits for the lock to be free.

Now, I think this is the reason for the bug #4448. I think what happens there is that the worker thread goes on while the spinlock is locked by WSTP#notifyParked; the worker thread goes to sleep (`parked` becomes "parked"); WSTP#notifyParked "releases" the lock it thinks it still holds, thus `parked` changes state directly from "parked" -> "unparked", _without a corresponding doneSleeping_ (in normal (correct) operation, a doneSleeping call is always made when `parked` moves out from "parked"). Thus, a `doneSleeping` call is, in effect "missing". The `state` 0xfffeffff[^1] observed in #4448 is exactly the missing doneSleeping call (i.e., `-DeltaSearching`).

That's why I believe this should fix #4448. I don't know how to write a test for that (the only way I could observe the issue locally is by putting `Thread.yield`s in various places in the WSTP). However, I believe the occasional `MutexSpec` failures were exactly because of this problem.

[^1]: 0xfffeffff is the (65534, 65535) = (ActiveThreadCount, SearchingThreadCount) reported in #4448.