### PR TITLE
Rewrote `parTraverseN` and `parTraverseN_` for better performance

### DIFF
--- a/benchmarks/src/main/scala/cats/effect/benchmarks/ParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/ParallelBenchmark.scala
@@ -17,9 +17,9 @@
 package cats.effect.benchmarks
 
 import cats.effect.IO
+import cats.effect.syntax.all._
 import cats.effect.unsafe.implicits.global
 import cats.implicits.{catsSyntaxParallelTraverse1, toTraverseOps}
-import cats.effect.syntax.all._
 
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole

--- a/benchmarks/src/main/scala/cats/effect/benchmarks/ParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/cats/effect/benchmarks/ParallelBenchmark.scala
@@ -19,9 +19,12 @@ package cats.effect.benchmarks
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.implicits.{catsSyntaxParallelTraverse1, toTraverseOps}
+import cats.effect.syntax.all._
 
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
+
+import scala.concurrent.duration._
 
 import java.util.concurrent.TimeUnit
 
@@ -54,6 +57,24 @@ class ParallelBenchmark {
   @Benchmark
   def parTraverse(): Unit =
     1.to(size).toList.parTraverse(_ => IO(Blackhole.consumeCPU(cpuTokens))).void.unsafeRunSync()
+
+  @Benchmark
+  def parTraverseN(): Unit =
+    1.to(size)
+      .toList
+      .parTraverseN(size / 100)(_ => IO(Blackhole.consumeCPU(cpuTokens)))
+      .void
+      .unsafeRunSync()
+
+  @Benchmark
+  def parTraverseNCancel(): Unit = {
+    val e = new RuntimeException
+    val test = 1.to(size * 100).toList.parTraverseN(size / 100) { _ =>
+      IO.sleep(100.millis) *> IO.raiseError(e)
+    }
+
+    test.attempt.void.unsafeRunSync()
+  }
 
   @Benchmark
   def traverse(): Unit =

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -139,23 +139,25 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
 
     implicit val F: GenConcurrent[F, E] = this
 
-    // TODO we need to write a test for error cancelation
     F.ref[Set[Fiber[F, ?, ?]]](Set()) flatMap { supervision =>
       MiniSemaphore[F](n) flatMap { sem =>
         val results = ta traverse { a =>
-          F.uncancelable { _ =>
+          F.uncancelable { poll =>
             F.deferred[Outcome[F, E, B]] flatMap { result =>
-              sem.acquire >> f(a)
+              val action = poll(sem.acquire) >> f(a)
                 .guaranteeCase(oc => result.complete(oc) *> sem.release)
                 .void
                 .voidError
-                .start map { fiber =>
-                supervision.update(_ + fiber) *>
+                .start
+
+              action flatMap { fiber =>
+                supervision.update(_ + fiber) map { _ =>
                   result
                     .get
-                    .flatMap(_.embedNever)
+                    .flatMap(_.embed(F.canceled *> F.never))
                     .onCancel(fiber.cancel)
                     .guarantee(supervision.update(_ - fiber))
+                }
               }
             }
           }
@@ -192,7 +194,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
                 F.unit // allow the error to be resurfaced later
 
               case None =>
-                F.uncancelable { _ =>
+                F.uncancelable { poll =>
                   // if the effect produces an error, race to kill all the rest
                   val wrapped = f(a) guaranteeCase { oc =>
                     sem.release *> oc.fold(
@@ -201,7 +203,9 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
                       _ => F.unit)
                   }
 
-                  sem.acquire >> wrapped.start flatMap { fiber =>
+                  val suppressed = wrapped.void.voidError
+
+                  poll(sem.acquire) >> suppressed.start flatMap { fiber =>
                     // supervision is handled very differently here: we never remove from the set
                     supervision.update(fiber :: _)
                   }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -159,7 +159,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
 
             states.toList parTraverse_ {
               case (fiber, result) =>
-                result.complete(causeOC) *> fiber.cancel
+                result.complete(causeOC).ifM(fiber.cancel, F.unit)
             }
           }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -293,7 +293,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
             case Some(_) => F.unit
             case None =>
               F.race(
-                preempt.get.void,
+                preempt.get.void *> cancelAll,
                 supervision.get.flatMap(_.traverse_(f => f.join.void).onCancel(cancelAll)))
                 .void
           }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -135,7 +135,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
    * first, with subsequent actions starting in order as each one completes. Actions which are
    * reached earlier in `traverse` order will be started slightly sooner than later actions, in
    * a non-blocking fashion. Any errors or self-cancelation will immediately abort the sequence.
-   * If multiple actios produce errors simultaneously, one of them will be nondeterministically
+   * If multiple actions produce errors simultaneously, one of them will be nondeterministically
    * selected for production. If all actions succeed, their results are returned in the same
    * order as their corresponding inputs, regardless of the order in which they executed.
    *
@@ -235,7 +235,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
    * first, with subsequent actions starting in order as each one completes. Actions which are
    * reached earlier in `foldLeftM` order will be started slightly sooner than later actions, in
    * a non-blocking fashion. Any errors or self-cancelation will immediately abort the sequence.
-   * If multiple actios produce errors simultaneously, one of them will be nondeterministically
+   * If multiple actions produce errors simultaneously, one of them will be nondeterministically
    * selected for production.
    *
    * The `f` function is run as part of running the action: in parallel and subject to the

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -217,11 +217,18 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
 
                       action flatMap { fiber =>
                         supervision.update(_ + ((fiber, result))) map { _ =>
-                          result
-                            .get
-                            .flatMap(_.embed(F.canceled *> F.never))
-                            .onCancel(fiber.cancel)
-                            .guarantee(supervision.update(_ - ((fiber, result))))
+                          // double-check to catch situations where preemption happens after check before supervision
+                          preempt.tryGet flatMap {
+                            case Some(Some(e)) => fiber.cancel *> F.raiseError[B](e)
+                            case Some(None) => fiber.cancel *> F.canceled *> F.never[B]
+
+                            case None =>
+                              result
+                                .get
+                                .flatMap(_.embed(F.canceled *> F.never))
+                                .onCancel(fiber.cancel)
+                                .guarantee(supervision.update(_ - ((fiber, result))))
+                          }
                         }
                       }
                     }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -277,7 +277,8 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
                       preempt.complete(None).void
                   }
 
-                  val suppressed = wrapped.void.voidError.guarantee(sem.release)
+                  // only release the semaphore if we *haven't* errored
+                  val suppressed = wrapped.void.voidError *> sem.release
 
                   poll(sem.acquire) *> suppressed.start flatMap { fiber =>
                     // supervision is handled very differently here: we never remove from the set
@@ -291,13 +292,16 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
           val awaitAll = preempt.tryGet flatMap {
             case Some(_) => F.unit
             case None =>
-              F.race(preempt.get.void, supervision.get.flatMap(_.traverse_(_.join.void))).void
+              F.race(
+                preempt.get.void,
+                supervision.get.flatMap(_.traverse_(f => f.join.void).onCancel(cancelAll)))
+                .void
           }
 
           // if we hit an error or self-cancelation in any effect, resurface it here
-          val resurface = preempt.tryGet flatMap {
+          def resurface(poll: Poll[F]) = preempt.tryGet flatMap {
             case Some(Some(e)) => F.raiseError[Unit](e)
-            case Some(None) => F.canceled
+            case Some(None) => poll(F.canceled)
             case None => F.unit
           }
 
@@ -306,7 +310,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
             case Outcome.Errored(_) | Outcome.Canceled() => preempt.complete(None) *> cancelAll
           }
 
-          work *> resurface
+          F.uncancelable(poll => poll(work) *> resurface(poll))
         }
       }
     }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -146,7 +146,8 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
           F.uncancelable { _ =>
             sem.acquire >> f(a).guarantee(sem.release).start map { fiber =>
               supervision.update(_ + fiber) *>
-                fiber.joinWithNever
+                fiber
+                  .joinWithNever
                   .onCancel(fiber.cancel)
                   .guarantee(supervision.update(_ - fiber))
             }
@@ -173,21 +174,47 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
     implicit val F: GenConcurrent[F, E] = this
 
     // TODO we need to write a test for error cancelation
-    F.ref[List[Fiber[F, ?, ?]]](Nil) flatMap { supervision =>
-      MiniSemaphore[F](n) flatMap { sem =>
-        // TODO this seems promising. we just need to sequence the errors/self-cancelation later
-        val startAll = ta traverse_ { a =>
-          F.uncancelable { _ =>
-            sem.acquire >> f(a).guarantee(sem.release).start flatMap { fiber =>
-              // supervision is handled very differently here: we never remove from the set
-              supervision.update(fiber :: _)
+    F.deferred[Option[E]] flatMap { preempt =>
+      F.ref[List[Fiber[F, ?, ?]]](Nil) flatMap { supervision =>
+        MiniSemaphore[F](n) flatMap { sem =>
+          val startAll = ta traverse_ { a =>
+            // first check to see if any of the effects have errored out
+            // don't bother starting new things if that happens
+            preempt.tryGet flatMap {
+              case Some(_) =>
+                F.unit // allow the error to be resurfaced later
+
+              case None =>
+                F.uncancelable { _ =>
+                  // if the effect produces an error, race to kill all the rest
+                  val wrapped = f(a) guaranteeCase { oc =>
+                    sem.release *> oc.fold(
+                      preempt.complete(None).void,
+                      e => preempt.complete(Some(e)).void,
+                      _ => F.unit)
+                  }
+
+                  sem.acquire >> wrapped.start flatMap { fiber =>
+                    // supervision is handled very differently here: we never remove from the set
+                    supervision.update(fiber :: _)
+                  }
+                }
             }
           }
-        }
 
-        // we block until it's all done by acquiring all the permits
-        startAll.onCancel(supervision.get.flatMap(_.parTraverse_(_.cancel))) *>
-          sem.acquire.replicateA_(n)
+          val cancelAll = supervision.get.flatMap(_.parTraverse_(_.cancel))
+
+          startAll.onCancel(cancelAll) *>
+            // we block until it's all done by acquiring all the permits
+            F.race(preempt.get *> cancelAll, sem.acquire.replicateA_(n)) *>
+            // if we hit an error or self-cancelation in any effect, resurface it here
+            // note that we can't lose errors here because of the permits: we know the fibers are done
+            preempt.tryGet flatMap {
+              case Some(Some(e)) => F.raiseError(e)
+              case Some(None) => F.canceled
+              case None => F.unit
+            }
+        }
       }
     }
   }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -141,6 +141,9 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
 
     F.deferred[Option[E]] flatMap { preempt =>
       F.ref[Set[Fiber[F, ?, ?]]](Set()) flatMap { supervision =>
+        // has to be done in parallel to avoid head of line issues
+        val cancelAllF = supervision.get.flatMap(_.toList.parTraverse_(_.cancel))
+
         MiniSemaphore[F](n) flatMap { sem =>
           val results = ta traverse { a =>
             preempt.tryGet flatMap {
@@ -154,10 +157,43 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
                   F.deferred[Outcome[F, E, B]] flatMap { result =>
                     val action = poll(sem.acquire) >> f(a)
                       .guaranteeCase { oc =>
-                        result.complete(oc) *> oc.fold(
-                          preempt.complete(None).void,
-                          e => preempt.complete(Some(e)).void,
-                          _ => F.unit) *> sem.release
+                        val completion = oc match {
+                          case Outcome.Succeeded(_) =>
+                            preempt.tryGet flatMap {
+                              case Some(Some(e)) =>
+                                result.complete(Outcome.Errored(e))
+
+                              case Some(None) =>
+                                result.complete(Outcome.Canceled())
+
+                              case None =>
+                                result.complete(oc)
+                            }
+
+                          case Outcome.Errored(e) =>
+                            preempt.complete(Some(e)) flatMap { won =>
+                              if (won)
+                                result.complete(oc) <* cancelAllF.start // avoid deadlock
+                              else
+                                preempt.get flatMap {
+                                  case Some(e) => result.complete(Outcome.Errored(e))
+                                  case None => result.complete(Outcome.Canceled())
+                                }
+                            }
+
+                          case Outcome.Canceled() =>
+                            preempt.complete(None) flatMap { won =>
+                              if (won)
+                                result.complete(oc) <* cancelAllF.start // avoid deadlock
+                              else
+                                preempt.get flatMap {
+                                  case Some(e) => result.complete(Outcome.Errored(e))
+                                  case None => result.complete(Outcome.Canceled())
+                                }
+                            }
+                        }
+
+                        completion *> sem.release
                       }
                       .void
                       .voidError
@@ -177,11 +213,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
             }
           }
 
-          results.flatMap(_.sequence) guaranteeCase {
-            case Outcome.Succeeded(_) => F.unit
-            // has to be done in parallel to avoid head of line issues
-            case _ => supervision.get.flatMap(_.toList.parTraverse_(_.cancel))
-          }
+          results.flatMap(_.sequence).onCancel(cancelAllF)
         }
       }
     }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -130,9 +130,17 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
     parTraverseN_(n)(tma)(identity)
 
   /**
-   * Like `Parallel.parTraverse`, but limits the degree of parallelism. Note that the semantics
-   * of this operation aim to maximise fairness: when a spot to execute becomes available, every
-   * task has a chance to claim it, and not only the next `n` tasks in `ta`
+   * Like `Parallel.parTraverse`, but limits the degree of parallelism. The semantics of this
+   * function are ordered based on the `Traverse`. The first ''n'' actions will be started
+   * first, with subsequent actions starting in order as each one completes. Actions which are
+   * reached earlier in `traverse` order will be started slightly sooner than later actions, in
+   * a non-blocking fashion. Any errors or self-cancelation will immediately abort the sequence.
+   * If multiple actios produce errors simultaneously, one of them will be nondeterministically
+   * selected for production. If all actions succeed, their results are returned in the same
+   * order as their corresponding inputs, regardless of the order in which they executed.
+   *
+   * The `f` function is run as part of running the action: in parallel and subject to the
+   * limit.
    */
   def parTraverseN[T[_]: Traverse, A, B](n: Int)(ta: T[A])(f: A => F[B]): F[T[B]] = {
     require(n >= 1, s"Concurrency limit should be at least 1, was: $n")
@@ -164,6 +172,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
                 case None =>
                   F.uncancelable { poll =>
                     F.deferred[Outcome[F, E, B]] flatMap { result =>
+                      // laziness is significant here, since it pushes the `f` into the fiber
                       val action = poll(sem.acquire) >> f(a)
                         .guaranteeCase { oc =>
                           val completion = oc match {
@@ -221,9 +230,16 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
   }
 
   /**
-   * Like `Parallel.parTraverse_`, but limits the degree of parallelism. Note that the semantics
-   * of this operation aim to maximise fairness: when a spot to execute becomes available, every
-   * task has a chance to claim it, and not only the next `n` tasks in `ta`
+   * Like `Parallel.parTraverse_`, but limits the degree of parallelism. The semantics of this
+   * function are ordered based on the `Foldable`. The first ''n'' actions will be started
+   * first, with subsequent actions starting in order as each one completes. Actions which are
+   * reached earlier in `foldLeftM` order will be started slightly sooner than later actions, in
+   * a non-blocking fashion. Any errors or self-cancelation will immediately abort the sequence.
+   * If multiple actios produce errors simultaneously, one of them will be nondeterministically
+   * selected for production.
+   *
+   * The `f` function is run as part of running the action: in parallel and subject to the
+   * limit.
    */
   def parTraverseN_[T[_]: Foldable, A, B](n: Int)(ta: T[A])(f: A => F[B]): F[Unit] = {
     require(n >= 1, s"Concurrency limit should be at least 1, was: $n")
@@ -262,7 +278,8 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
 
                   val suppressed = wrapped.void.voidError.guarantee(sem.release)
 
-                  poll(sem.acquire) *> suppressed.start flatMap { fiber =>
+                  // the laziness is significant here since it pushes the f into the fiber
+                  poll(sem.acquire) >> suppressed.start flatMap { fiber =>
                     // supervision is handled very differently here: we never remove from the set
                     supervision.update(fiber :: _)
                   }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -144,12 +144,19 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
       MiniSemaphore[F](n) flatMap { sem =>
         val results = ta traverse { a =>
           F.uncancelable { _ =>
-            sem.acquire >> f(a).guarantee(sem.release).start map { fiber =>
-              supervision.update(_ + fiber) *>
-                fiber
-                  .joinWithNever
-                  .onCancel(fiber.cancel)
-                  .guarantee(supervision.update(_ - fiber))
+            F.deferred[Outcome[F, E, B]] flatMap { result =>
+              sem.acquire >> f(a)
+                .guaranteeCase(oc => result.complete(oc) *> sem.release)
+                .void
+                .voidError
+                .start map { fiber =>
+                supervision.update(_ + fiber) *>
+                  result
+                    .get
+                    .flatMap(_.embedNever)
+                    .onCancel(fiber.cancel)
+                    .guarantee(supervision.update(_ - fiber))
+              }
             }
           }
         }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -140,81 +140,82 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
     implicit val F: GenConcurrent[F, E] = this
 
     F.deferred[Option[E]] flatMap { preempt =>
-      F.ref[Set[Fiber[F, ?, ?]]](Set()) flatMap { supervision =>
-        // has to be done in parallel to avoid head of line issues
-        val cancelAllF = supervision.get.flatMap(_.toList.parTraverse_(_.cancel))
+      F.ref[Set[(Fiber[F, ?, ?], Deferred[F, Outcome[F, E, B]])]](Set()) flatMap {
+        supervision =>
+          // has to be done in parallel to avoid head of line issues
+          def cancelAll(cause: Option[E]) = supervision.get flatMap { states =>
+            val causeOC: Outcome[F, E, B] = cause match {
+              case Some(e) => Outcome.Errored(e)
+              case None => Outcome.Canceled()
+            }
 
-        MiniSemaphore[F](n) flatMap { sem =>
-          val results = ta traverse { a =>
-            preempt.tryGet flatMap {
-              case Some(_) =>
-                // it's okay to produce never here because the early abort preceeds us
-                // this effect won't get sequenced, so it can be anything really
-                F.pure(F.never[B])
-
-              case None =>
-                F.uncancelable { poll =>
-                  F.deferred[Outcome[F, E, B]] flatMap { result =>
-                    val action = poll(sem.acquire) >> f(a)
-                      .guaranteeCase { oc =>
-                        val completion = oc match {
-                          case Outcome.Succeeded(_) =>
-                            preempt.tryGet flatMap {
-                              case Some(Some(e)) =>
-                                result.complete(Outcome.Errored(e))
-
-                              case Some(None) =>
-                                result.complete(Outcome.Canceled())
-
-                              case None =>
-                                result.complete(oc)
-                            }
-
-                          case Outcome.Errored(e) =>
-                            preempt.complete(Some(e)) flatMap { won =>
-                              if (won)
-                                result.complete(oc) <* cancelAllF.start // avoid deadlock
-                              else
-                                preempt.get flatMap {
-                                  case Some(e) => result.complete(Outcome.Errored(e))
-                                  case None => result.complete(Outcome.Canceled())
-                                }
-                            }
-
-                          case Outcome.Canceled() =>
-                            preempt.complete(None) flatMap { won =>
-                              if (won)
-                                result.complete(oc) <* cancelAllF.start // avoid deadlock
-                              else
-                                preempt.get flatMap {
-                                  case Some(e) => result.complete(Outcome.Errored(e))
-                                  case None => result.complete(Outcome.Canceled())
-                                }
-                            }
-                        }
-
-                        completion *> sem.release
-                      }
-                      .void
-                      .voidError
-                      .start
-
-                    action flatMap { fiber =>
-                      supervision.update(_ + fiber) map { _ =>
-                        result
-                          .get
-                          .flatMap(_.embed(F.canceled *> F.never))
-                          .onCancel(fiber.cancel)
-                          .guarantee(supervision.update(_ - fiber))
-                      }
-                    }
-                  }
-                }
+            states.toList parTraverse_ {
+              case (fiber, result) =>
+                result.complete(causeOC) *> fiber.cancel
             }
           }
 
-          results.flatMap(_.sequence).onCancel(cancelAllF)
-        }
+          MiniSemaphore[F](n) flatMap { sem =>
+            val results = ta traverse { a =>
+              preempt.tryGet flatMap {
+                case Some(Some(e)) => F.pure(F.raiseError[B](e))
+                case Some(None) => F.pure(F.canceled *> F.never[B])
+
+                case None =>
+                  F.uncancelable { poll =>
+                    F.deferred[Outcome[F, E, B]] flatMap { result =>
+                      val action = poll(sem.acquire) >> f(a)
+                        .guaranteeCase { oc =>
+                          val completion = oc match {
+                            case Outcome.Succeeded(_) =>
+                              preempt.tryGet flatMap {
+                                case Some(Some(e)) =>
+                                  result.complete(Outcome.Errored(e))
+
+                                case Some(None) =>
+                                  result.complete(Outcome.Canceled())
+
+                                case None =>
+                                  result.complete(oc)
+                              }
+
+                            case Outcome.Errored(e) =>
+                              preempt
+                                .complete(Some(e))
+                                .ifM(
+                                  result.complete(oc) <* cancelAll(Some(e)).start,
+                                  false.pure[F])
+
+                            case Outcome.Canceled() =>
+                              preempt
+                                .complete(None)
+                                .ifM(
+                                  result.complete(oc) <* cancelAll(None).start,
+                                  false.pure[F])
+                          }
+
+                          completion *> sem.release
+                        }
+                        .void
+                        .voidError
+                        .start
+
+                      action flatMap { fiber =>
+                        supervision.update(_ + ((fiber, result))) map { _ =>
+                          result
+                            .get
+                            .flatMap(_.embed(F.canceled *> F.never))
+                            .onCancel(fiber.cancel)
+                            .guarantee(supervision.update(_ - ((fiber, result))))
+                        }
+                      }
+                    }
+                  }
+              }
+            }
+
+            results.flatMap(_.sequence).onCancel(cancelAll(None))
+          }
       }
     }
   }
@@ -229,30 +230,39 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
 
     implicit val F: GenConcurrent[F, E] = this
 
-    // TODO we need to write a test for error cancelation
     F.deferred[Option[E]] flatMap { preempt =>
       F.ref[List[Fiber[F, ?, ?]]](Nil) flatMap { supervision =>
         MiniSemaphore[F](n) flatMap { sem =>
+          val cancelAll = supervision.get.flatMap(_.parTraverse_(_.cancel))
+
+          // doesn't complete until every fiber has been at least *started*
           val startAll = ta traverse_ { a =>
             // first check to see if any of the effects have errored out
             // don't bother starting new things if that happens
             preempt.tryGet flatMap {
-              case Some(_) =>
-                F.unit // allow the error to be resurfaced later
+              case Some(Some(e)) =>
+                F.raiseError[Unit](e)
+
+              case Some(None) =>
+                F.canceled
 
               case None =>
                 F.uncancelable { poll =>
-                  // if the effect produces an error, race to kill all the rest
-                  val wrapped = f(a) guaranteeCase { oc =>
-                    sem.release *> oc.fold(
-                      preempt.complete(None).void,
-                      e => preempt.complete(Some(e)).void,
-                      _ => F.unit)
+                  // if the effect produces a non-success, race to kill all the rest
+                  val wrapped = f(a) guaranteeCase {
+                    case Outcome.Succeeded(_) =>
+                      F.unit
+
+                    case Outcome.Errored(e) =>
+                      preempt.complete(Some(e)).void
+
+                    case Outcome.Canceled() =>
+                      preempt.complete(None).void
                   }
 
-                  val suppressed = wrapped.void.voidError
+                  val suppressed = wrapped.void.voidError.guarantee(sem.release)
 
-                  poll(sem.acquire) >> suppressed.start flatMap { fiber =>
+                  poll(sem.acquire) *> suppressed.start flatMap { fiber =>
                     // supervision is handled very differently here: we never remove from the set
                     supervision.update(fiber :: _)
                   }
@@ -260,18 +270,26 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
             }
           }
 
-          val cancelAll = supervision.get.flatMap(_.parTraverse_(_.cancel))
+          // we only run this when we know that supervision is full
+          val awaitAll = preempt.tryGet flatMap {
+            case Some(_) => F.unit
+            case None =>
+              F.race(preempt.get.void, supervision.get.flatMap(_.traverse_(_.join.void))).void
+          }
 
-          startAll.onCancel(cancelAll) *>
-            // we block until it's all done by acquiring all the permits
-            F.race(preempt.get *> cancelAll, sem.acquire.replicateA_(n)) *>
-            // if we hit an error or self-cancelation in any effect, resurface it here
-            // note that we can't lose errors here because of the permits: we know the fibers are done
-            preempt.tryGet flatMap {
-              case Some(Some(e)) => F.raiseError(e)
-              case Some(None) => F.canceled
-              case None => F.unit
-            }
+          // if we hit an error or self-cancelation in any effect, resurface it here
+          val resurface = preempt.tryGet flatMap {
+            case Some(Some(e)) => F.raiseError[Unit](e)
+            case Some(None) => F.canceled
+            case None => F.unit
+          }
+
+          val work = (startAll *> awaitAll) guaranteeCase {
+            case Outcome.Succeeded(_) => F.unit
+            case Outcome.Errored(_) | Outcome.Canceled() => preempt.complete(None) *> cancelAll
+          }
+
+          work *> resurface
         }
       }
     }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -227,8 +227,10 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
                                 result
                                   .get
                                   .flatMap(_.embed(F.canceled *> F.never))
-                                  .onCancel(fiber.cancel)
-                                  .guarantee(supervision.update(_ - ((fiber, result)))))
+                                  .guaranteeCase {
+                                    case Outcome.Canceled() => F.unit
+                                    case _ => supervision.update(_ - ((fiber, result)))
+                                  })
                           }
                       }
                     }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -139,7 +139,27 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
 
     implicit val F: GenConcurrent[F, E] = this
 
-    MiniSemaphore[F](n).flatMap { sem => ta.parTraverse { a => sem.withPermit(f(a)) } }
+    // TODO we need to write a test for error cancelation
+    F.ref[Set[Fiber[F, ?, ?]]](Set()) flatMap { supervision =>
+      MiniSemaphore[F](n) flatMap { sem =>
+        val results = ta traverse { a =>
+          F.uncancelable { _ =>
+            sem.acquire >> f(a).guarantee(sem.release).start map { fiber =>
+              supervision.update(_ + fiber) *>
+                fiber.joinWithNever
+                  .onCancel(fiber.cancel)
+                  .guarantee(supervision.update(_ - fiber))
+            }
+          }
+        }
+
+        results.flatMap(_.sequence) guaranteeCase {
+          case Outcome.Succeeded(_) => F.unit
+          // has to be done in parallel to avoid head of line issues
+          case _ => supervision.get.flatMap(_.toList.parTraverse_(_.cancel))
+        }
+      }
+    }
   }
 
   /**
@@ -152,7 +172,24 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
 
     implicit val F: GenConcurrent[F, E] = this
 
-    MiniSemaphore[F](n).flatMap { sem => ta.parTraverse_ { a => sem.withPermit(f(a)) } }
+    // TODO we need to write a test for error cancelation
+    F.ref[List[Fiber[F, ?, ?]]](Nil) flatMap { supervision =>
+      MiniSemaphore[F](n) flatMap { sem =>
+        // TODO this seems promising. we just need to sequence the errors/self-cancelation later
+        val startAll = ta traverse_ { a =>
+          F.uncancelable { _ =>
+            sem.acquire >> f(a).guarantee(sem.release).start flatMap { fiber =>
+              // supervision is handled very differently here: we never remove from the set
+              supervision.update(fiber :: _)
+            }
+          }
+        }
+
+        // we block until it's all done by acquiring all the permits
+        startAll.onCancel(supervision.get.flatMap(_.parTraverse_(_.cancel))) *>
+          sem.acquire.replicateA_(n)
+      }
+    }
   }
 
   override def racePair[A, B](fa: F[A], fb: F[B])

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -172,6 +172,8 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
                 case None =>
                   F.uncancelable { poll =>
                     F.deferred[Outcome[F, E, B]] flatMap { result =>
+                      // acquire the semaphore *before* creating and starting the fiber
+                      // the semaphore gates the traverse, and thus the spawning, not the execution
                       // the laziness is a poor mans defer; this ensures the f gets pushed to the fiber
                       val action = poll(sem.acquire) *> (F.unit >> f(a))
                         .guaranteeCase { oc =>
@@ -192,13 +194,16 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
                               preempt
                                 .complete(Some(e))
                                 .ifM(
-                                  result.complete(oc) <* cancelAll(Some(e)).start,
+                                  // we can't fire-and-forget this one because final results don't block on cancelation
+                                  result.complete(oc) <* cancelAll(Some(e)),
                                   false.pure[F])
 
                             case Outcome.Canceled() =>
                               preempt
                                 .complete(None)
                                 .ifM(
+                                  // we *need* to fire-and-forget this cancelation to avoid deadlock loops when we're already canceling
+                                  // we won't return prematurely because we have a final `onCancel` on the results sequence
                                   result.complete(oc) <* cancelAll(None).start,
                                   false.pure[F])
                           }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -290,8 +290,8 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
                       preempt.complete(None).void
                   }
 
-                  // only release the semaphore if we *haven't* errored
-                  val suppressed = wrapped.void.voidError *> sem.release
+                  // release the semaphore after every possible outcome
+                  val suppressed = wrapped.void.voidError.guarantee(sem.release)
 
                   poll(sem.acquire) *> suppressed.start flatMap { fiber =>
                     // supervision is handled very differently here: we never remove from the set

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -163,11 +163,9 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
             }
           }
 
-          def cancelAllOrJoin(cause: Option[E]) =
-            preempt.complete(cause).ifM(cancelAll(cause), F.unit) *>
-              supervision
-                .get
-                .flatMap(_.toList.parTraverse_ { case (fiber, _) => fiber.join.void })
+          def cancelAllAndJoin =
+            preempt.complete(None).ifM(cancelAll(None), F.unit) *>
+              supervision.get.flatMap(_.toList.traverse_ { case (fiber, _) => fiber.join.void })
 
           MiniSemaphore[F](n) flatMap { sem =>
             val results = ta traverse { a =>
@@ -244,7 +242,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
               }
             }
 
-            results.flatMap(_.sequence).onCancel(cancelAllOrJoin(None))
+            results.flatMap(_.sequence).onCancel(cancelAllAndJoin)
           }
       }
     }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -216,20 +216,20 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
                         .start
 
                       action flatMap { fiber =>
-                        supervision.update(_ + ((fiber, result))) map { _ =>
+                        supervision.update(_ + ((fiber, result))) *>
                           // double-check to catch situations where preemption happens after check before supervision
                           preempt.tryGet flatMap {
-                            case Some(Some(e)) => fiber.cancel *> F.raiseError[B](e)
-                            case Some(None) => fiber.cancel *> F.canceled *> F.never[B]
+                            case Some(Some(e)) => fiber.cancel.as(F.raiseError[B](e))
+                            case Some(None) => fiber.cancel.as(F.canceled *> F.never[B])
 
                             case None =>
-                              result
-                                .get
-                                .flatMap(_.embed(F.canceled *> F.never))
-                                .onCancel(fiber.cancel)
-                                .guarantee(supervision.update(_ - ((fiber, result))))
+                              F.pure(
+                                result
+                                  .get
+                                  .flatMap(_.embed(F.canceled *> F.never))
+                                  .onCancel(fiber.cancel)
+                                  .guarantee(supervision.update(_ - ((fiber, result)))))
                           }
-                        }
                       }
                     }
                   }
@@ -303,7 +303,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
 
           // we only run this when we know that supervision is full
           val awaitAll = preempt.tryGet flatMap {
-            case Some(_) => F.unit
+            case Some(_) => cancelAll
             case None =>
               F.race(
                 preempt.get.void *> cancelAll,

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -205,7 +205,8 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
                                   // we *need* to fire-and-forget this cancelation to avoid deadlock loops when we're already canceling
                                   // we won't return prematurely because we have a final `onCancel` on the results sequence
                                   result.complete(oc) <* cancelAll(None).start,
-                                  false.pure[F])
+                                  false.pure[F]
+                                )
                           }
 
                           completion *> sem.release

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -139,34 +139,49 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
 
     implicit val F: GenConcurrent[F, E] = this
 
-    F.ref[Set[Fiber[F, ?, ?]]](Set()) flatMap { supervision =>
-      MiniSemaphore[F](n) flatMap { sem =>
-        val results = ta traverse { a =>
-          F.uncancelable { poll =>
-            F.deferred[Outcome[F, E, B]] flatMap { result =>
-              val action = poll(sem.acquire) >> f(a)
-                .guaranteeCase(oc => result.complete(oc) *> sem.release)
-                .void
-                .voidError
-                .start
+    F.deferred[Option[E]] flatMap { preempt =>
+      F.ref[Set[Fiber[F, ?, ?]]](Set()) flatMap { supervision =>
+        MiniSemaphore[F](n) flatMap { sem =>
+          val results = ta traverse { a =>
+            preempt.tryGet flatMap {
+              case Some(_) =>
+                // it's okay to produce never here because the early abort preceeds us
+                // this effect won't get sequenced, so it can be anything really
+                F.pure(F.never[B])
 
-              action flatMap { fiber =>
-                supervision.update(_ + fiber) map { _ =>
-                  result
-                    .get
-                    .flatMap(_.embed(F.canceled *> F.never))
-                    .onCancel(fiber.cancel)
-                    .guarantee(supervision.update(_ - fiber))
+              case None =>
+                F.uncancelable { poll =>
+                  F.deferred[Outcome[F, E, B]] flatMap { result =>
+                    val action = poll(sem.acquire) >> f(a)
+                      .guaranteeCase { oc =>
+                        result.complete(oc) *> oc.fold(
+                          preempt.complete(None).void,
+                          e => preempt.complete(Some(e)).void,
+                          _ => F.unit) *> sem.release
+                      }
+                      .void
+                      .voidError
+                      .start
+
+                    action flatMap { fiber =>
+                      supervision.update(_ + fiber) map { _ =>
+                        result
+                          .get
+                          .flatMap(_.embed(F.canceled *> F.never))
+                          .onCancel(fiber.cancel)
+                          .guarantee(supervision.update(_ - fiber))
+                      }
+                    }
+                  }
                 }
-              }
             }
           }
-        }
 
-        results.flatMap(_.sequence) guaranteeCase {
-          case Outcome.Succeeded(_) => F.unit
-          // has to be done in parallel to avoid head of line issues
-          case _ => supervision.get.flatMap(_.toList.parTraverse_(_.cancel))
+          results.flatMap(_.sequence) guaranteeCase {
+            case Outcome.Succeeded(_) => F.unit
+            // has to be done in parallel to avoid head of line issues
+            case _ => supervision.get.flatMap(_.toList.parTraverse_(_.cancel))
+          }
         }
       }
     }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -252,8 +252,8 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
    * Like `Parallel.parTraverse_`, but limits the degree of parallelism. The semantics of this
    * function are ordered based on the `Foldable`. The first ''n'' actions will be started
    * first, with subsequent actions starting in order as each one completes. Actions which are
-   * reached earlier in `foldLeftM` order will be started slightly sooner than later actions, in
-   * a non-blocking fashion. Any errors or self-cancelation will immediately abort the sequence.
+   * reached earlier in `traverse_` order will be started slightly before later actions, in a
+   * non-blocking fashion. Any errors or self-cancelation will immediately abort the sequence.
    * If multiple actions produce errors simultaneously, one of them will be nondeterministically
    * selected for production.
    *
@@ -266,7 +266,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
     implicit val F: GenConcurrent[F, E] = this
 
     F.deferred[Option[E]] flatMap { preempt =>
-      F.ref[List[Fiber[F, ?, ?]]](Nil) flatMap { supervision =>
+      F.ref[List[Fiber[F, E, Unit]]](Nil) flatMap { supervision =>
         MiniSemaphore[F](n) flatMap { sem =>
           val cancelAll = supervision.get.flatMap(_.parTraverse_(_.cancel))
 
@@ -326,7 +326,8 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
 
           val work = (startAll *> awaitAll) guaranteeCase {
             case Outcome.Succeeded(_) => F.unit
-            case Outcome.Errored(_) | Outcome.Canceled() => preempt.complete(None) *> cancelAll
+            case Outcome.Errored(e) => preempt.complete(Some(e)) *> cancelAll
+            case Outcome.Canceled() => preempt.complete(None) *> cancelAll
           }
 
           F.uncancelable(poll => poll(work) *> resurface(poll))

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -172,8 +172,8 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
                 case None =>
                   F.uncancelable { poll =>
                     F.deferred[Outcome[F, E, B]] flatMap { result =>
-                      // laziness is significant here, since it pushes the `f` into the fiber
-                      val action = poll(sem.acquire) >> f(a)
+                      // the laziness is a poor mans defer; this ensures the f gets pushed to the fiber
+                      val action = poll(sem.acquire) *> (F.unit >> f(a))
                         .guaranteeCase { oc =>
                           val completion = oc match {
                             case Outcome.Succeeded(_) =>
@@ -265,7 +265,8 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
               case None =>
                 F.uncancelable { poll =>
                   // if the effect produces a non-success, race to kill all the rest
-                  val wrapped = f(a) guaranteeCase {
+                  // the laziness is a poor mans defer; this ensures the f gets pushed to the fiber
+                  val wrapped = (F.unit >> f(a)) guaranteeCase {
                     case Outcome.Succeeded(_) =>
                       F.unit
 
@@ -278,8 +279,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
 
                   val suppressed = wrapped.void.voidError.guarantee(sem.release)
 
-                  // the laziness is significant here since it pushes the f into the fiber
-                  poll(sem.acquire) >> suppressed.start flatMap { fiber =>
+                  poll(sem.acquire) *> suppressed.start flatMap { fiber =>
                     // supervision is handled very differently here: we never remove from the set
                     supervision.update(fiber :: _)
                   }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -163,6 +163,12 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
             }
           }
 
+          def cancelAllOrJoin(cause: Option[E]) =
+            preempt.complete(cause).ifM(cancelAll(cause), F.unit) *>
+              supervision
+                .get
+                .flatMap(_.toList.parTraverse_ { case (fiber, _) => fiber.join.void })
+
           MiniSemaphore[F](n) flatMap { sem =>
             val results = ta traverse { a =>
               preempt.tryGet flatMap {
@@ -203,7 +209,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
                                 .complete(None)
                                 .ifM(
                                   // we *need* to fire-and-forget this cancelation to avoid deadlock loops when we're already canceling
-                                  // we won't return prematurely because we have a final `onCancel` on the results sequence
+                                  // the final `onCancel` on the results sequence joins the supervised fibers
                                   result.complete(oc) <* cancelAll(None).start,
                                   false.pure[F]
                                 )
@@ -238,7 +244,7 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
               }
             }
 
-            results.flatMap(_.sequence).onCancel(cancelAll(None))
+            results.flatMap(_.sequence).onCancel(cancelAllOrJoin(None))
           }
       }
     }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MiniSemaphore.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MiniSemaphore.scala
@@ -27,10 +27,9 @@ import scala.collection.immutable.{Queue => ScalaQueue}
  * A cut-down version of semaphore used to implement parTraverseN
  */
 private[kernel] abstract class MiniSemaphore[F[_]] extends Serializable {
+  def acquire: F[Unit]
+  def release: F[Unit]
 
-  /**
-   * Sequence an action while holding a permit
-   */
   def withPermit[A](fa: F[A]): F[A]
 }
 

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -27,6 +27,7 @@ import cats.effect.unsafe.{
   WorkStealingThreadPool
 }
 import cats.effect.unsafe.metrics.PollerMetrics
+import cats.effect.syntax.all._
 import cats.syntax.all._
 
 import org.scalacheck.Prop.forAll
@@ -809,6 +810,26 @@ trait IOPlatformSpecification extends DetectPlatform { self: BaseSpec with Scala
         } finally {
           runtime.shutdown()
           schedShut()
+        }
+      }
+
+      "parTraverseN" >> {
+        "short-circuit on error" in real {
+          case object TestException extends RuntimeException
+          val target = 0.until(100000).toList
+          val test = target.parTraverseN(2)(_ => IO.raiseError(TestException))
+
+          test.attempt.as(ok).timeoutTo(500.millis, IO(false must beTrue))
+        }
+      }
+
+      "parTraverseN_" >> {
+        "short-circuit on error" in real {
+          case object TestException extends RuntimeException
+          val target = 0.until(100000).toList
+          val test = target.parTraverseN_(2)(_ => IO.raiseError(TestException))
+
+          test.attempt.as(ok).timeoutTo(500.millis, IO(false must beTrue))
         }
       }
 

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -824,9 +824,9 @@ trait IOPlatformSpecification extends DetectPlatform { self: BaseSpec with Scala
 
         "interrupt never on error" in ticked { implicit ticker =>
           case object TestException extends RuntimeException
-          val test = List(0, 1).parTraverseN(2) {
-            case 0 => IO.never[Unit]
-            case 1 => IO.raiseError(TestException)
+          val test = (0 to 10).toList.parTraverseN(2) { i =>
+            if (i == 5) IO.never[Unit]
+            else IO.raiseError(TestException)
           }
 
           test.attempt.void.parReplicateA_(100000) must completeAs(())

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -822,11 +822,10 @@ trait IOPlatformSpecification extends DetectPlatform { self: BaseSpec with Scala
           test.attempt.as(ok).timeoutTo(500.millis, IO(false must beTrue))
         }
 
-        "interrupt never on error" in ticked { implicit ticker =>
+        "interrupt on errors" in ticked { implicit ticker =>
           case object TestException extends RuntimeException
-          val test = (0 to 10).toList.parTraverseN(2) { i =>
-            if (i == 5) IO.never[Unit]
-            else IO.raiseError(TestException)
+          val test = (0 to 10).toList.parTraverseN(2) { _ =>
+            IO.raiseError(TestException)
           }
 
           test.attempt.void.parReplicateA_(100000) must completeAs(())

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -821,6 +821,16 @@ trait IOPlatformSpecification extends DetectPlatform { self: BaseSpec with Scala
 
           test.attempt.as(ok).timeoutTo(500.millis, IO(false must beTrue))
         }
+
+        "interrupt never on error" in ticked { implicit ticker =>
+          case object TestException extends RuntimeException
+          val test = List(0, 1).parTraverseN(2) {
+            case 0 => IO.never[Unit]
+            case 1 => IO.raiseError(TestException)
+          }
+
+          test.attempt.void.parReplicateA_(100000) must completeAs(())
+        }
       }
 
       "parTraverseN_" >> {

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -824,9 +824,7 @@ trait IOPlatformSpecification extends DetectPlatform { self: BaseSpec with Scala
 
         "interrupt on errors" in ticked { implicit ticker =>
           case object TestException extends RuntimeException
-          val test = (0 to 10).toList.parTraverseN(2) { _ =>
-            IO.raiseError(TestException)
-          }
+          val test = (0 to 10).toList.parTraverseN(2) { _ => IO.raiseError(TestException) }
 
           test.attempt.void.parReplicateA_(100000) must completeAs(())
         }

--- a/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
+++ b/tests/jvm/src/test/scala/cats/effect/IOPlatformSpecification.scala
@@ -17,6 +17,7 @@
 package cats.effect
 
 import cats.effect.std.Semaphore
+import cats.effect.syntax.all._
 import cats.effect.unsafe.{
   IORuntime,
   IORuntimeConfig,
@@ -27,7 +28,6 @@ import cats.effect.unsafe.{
   WorkStealingThreadPool
 }
 import cats.effect.unsafe.metrics.PollerMetrics
-import cats.effect.syntax.all._
 import cats.syntax.all._
 
 import org.scalacheck.Prop.forAll

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1936,6 +1936,31 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
           .void must selfCancel
       }
 
+      "not deadlock when the first task self-cancels at concurrency one" in ticked {
+        implicit ticker =>
+          val test = for {
+            firstStarted <- IO.deferred[Unit]
+            allowCancel <- IO.deferred[Unit]
+            fiber <- List(1, 2)
+              .parTraverseN_(1) {
+                case 1 =>
+                  firstStarted.complete(()).void *>
+                    allowCancel.get *>
+                    IO.canceled *>
+                    IO.never
+                case 2 =>
+                  IO.unit
+              }
+              .start
+            _ <- firstStarted.get
+            _ <- IO.sleep(1.millis)
+            _ <- allowCancel.complete(())
+            outcome <- fiber.join
+          } yield outcome.isCanceled
+
+          test must completeAs(true)
+      }
+
       "run finalizers when a task self-cancels" in ticked { implicit ticker =>
         val p = for {
           r <- IO.ref(0)

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1604,6 +1604,51 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
           .mustFailWith[RuntimeException]
       }
 
+      "not leave a worker started after error preemption running" in ticked { implicit ticker =>
+        case object TestException extends RuntimeException
+
+        val test = for {
+          errorReady <- IO.deferred[Unit]
+          allowError <- IO.deferred[Unit]
+          events <- IO.ref(Vector.empty[String])
+          releaseLate <- IO.deferred[Unit]
+          fiber <- List(1, 2, 3)
+            .parTraverseN(2) {
+              case 1 =>
+                IO.never[Int]
+              case 2 =>
+                errorReady.complete(()).void *>
+                  allowError.get *>
+                  IO.raiseError[Int](TestException)
+              case 3 =>
+                (events.update(_ :+ "started") *> releaseLate.get.as(3)).onCancel(
+                  IO.sleep(1.millis) *> events.update(_ :+ "canceled"))
+            }
+            .attempt
+            .flatTap(_ => events.update(_ :+ "outcome"))
+            .start
+          _ <- errorReady.get
+          _ <- IO.sleep(1.millis)
+          _ <- allowError.complete(())
+          outcome <- fiber.joinWithNever
+          _ <- releaseLate.complete(())
+          _ <- IO.sleep(2.millis)
+          observed <- events.get
+        } yield {
+          val exactError = outcome match {
+            case Left(error) => error eq TestException
+            case Right(_) => false
+          }
+          val workerAccountedFor =
+            observed == Vector("outcome") ||
+              observed == Vector("started", "canceled", "outcome")
+
+          (exactError, workerAccountedFor)
+        }
+
+        test must completeAs((true, true))
+      }
+
       "be cancelable" in ticked { implicit ticker =>
         val p = for {
           f <- List(1, 2, 3).parTraverseN(2)(_ => IO.never).start
@@ -1794,6 +1839,49 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
             if (n == 2) IO.raiseError(new RuntimeException) else n.pure[IO]
           }
           .mustFailWith[RuntimeException]
+      }
+
+      "not leave a worker started after error preemption running" in ticked { implicit ticker =>
+        case object TestException extends RuntimeException
+
+        val test = for {
+          errorReady <- IO.deferred[Unit]
+          allowError <- IO.deferred[Unit]
+          events <- IO.ref(Vector.empty[String])
+          releaseLate <- IO.deferred[Unit]
+          fiber <- List(1, 2)
+            .parTraverseN_(1) {
+              case 1 =>
+                errorReady.complete(()).void *>
+                  allowError.get *>
+                  IO.raiseError[Unit](TestException)
+              case 2 =>
+                (events.update(_ :+ "started") *> releaseLate.get).onCancel(
+                  IO.sleep(1.millis) *> events.update(_ :+ "canceled"))
+            }
+            .attempt
+            .flatTap(_ => events.update(_ :+ "outcome"))
+            .start
+          _ <- errorReady.get
+          _ <- IO.sleep(1.millis)
+          _ <- allowError.complete(())
+          outcome <- fiber.joinWithNever
+          _ <- releaseLate.complete(())
+          _ <- IO.sleep(2.millis)
+          observed <- events.get
+        } yield {
+          val exactError = outcome match {
+            case Left(error) => error eq TestException
+            case Right(_) => false
+          }
+          val workerAccountedFor =
+            observed == Vector("outcome") ||
+              observed == Vector("started", "canceled", "outcome")
+
+          (exactError, workerAccountedFor)
+        }
+
+        test must completeAs((true, true))
       }
 
       "be cancelable" in ticked { implicit ticker =>

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1692,6 +1692,40 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         p must completeAs(true)
       }
 
+      "cancel workers in parallel when externally canceled" in ticked { implicit ticker =>
+        val test = for {
+          firstStarted <- IO.deferred[Unit]
+          secondStarted <- IO.deferred[Unit]
+          firstCanceling <- IO.deferred[Unit]
+          secondCanceling <- IO.deferred[Unit]
+          firstFinalized <- IO.deferred[Unit]
+          secondFinalized <- IO.deferred[Unit]
+          fiber <- List(1, 2)
+            .parTraverseN(2) {
+              case 1 =>
+                (firstStarted.complete(()).void *> IO.never[Int]).onCancel(
+                  firstCanceling.complete(()).void *>
+                    secondCanceling.get *>
+                    firstFinalized.complete(()).void)
+              case 2 =>
+                (secondStarted.complete(()).void *> IO.never[Int]).onCancel(
+                  secondCanceling.complete(()).void *>
+                    firstCanceling.get *>
+                    secondFinalized.complete(()).void)
+            }
+            .start
+          _ <- firstStarted.get
+          _ <- secondStarted.get
+          _ <- IO.sleep(1.millis)
+          _ <- fiber.cancel
+          outcome <- fiber.join
+          first <- firstFinalized.tryGet
+          second <- secondFinalized.tryGet
+        } yield (outcome.isCanceled, first.nonEmpty, second.nonEmpty)
+
+        test must completeAs((true, true, true))
+      }
+
       "propagate self-cancellation" in ticked { implicit ticker =>
         List(1, 2, 3, 4)
           .parTraverseN(2) { (n: Int) =>

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1755,14 +1755,6 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         } yield ok
       }
 
-      "short-circuit on error" in real {
-        case object TestException extends RuntimeException
-        val target = 0.until(100000).toList
-        val test = target.parTraverseN(2)(_ => IO.raiseError(TestException))
-
-        test.attempt.as(ok).timeoutTo(1.second, IO(false must beTrue))
-      }
-
       "run finalizers in parallel" in ticked { implicit ticker =>
         // this test also tests to ensure that we get the errored results rather than cancels
         // note that the first two effects will have a Canceled outcome, while the third is Errored
@@ -1950,14 +1942,6 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
           }
           _ <- IO { r1 mustEqual (()) } // just trying to make sure we don't crash
         } yield ok
-      }
-
-      "short-circuit on error" in real {
-        case object TestException extends RuntimeException
-        val target = 0.until(100000).toList
-        val test = target.parTraverseN_(2)(_ => IO.raiseError(TestException))
-
-        test.attempt.as(ok).timeoutTo(1.second, IO(false must beTrue))
       }
 
       "run finalizers in parallel" in ticked { implicit ticker =>

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1868,6 +1868,38 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         p must completeAs(true)
       }
 
+      "run finalizers when a task self-cancels after everything started" in ticked { implicit ticker =>
+        val p = for {
+          ds <- IO.deferred[Unit].replicateA(3)
+          f <- ds.parTraverseN_(4) { d =>
+            (if (d eq ds(1)) IO.sleep(100.millis) *> IO.canceled
+            else IO.never).onCancel(d.complete(()).void)
+          }.start
+          _ <- IO.sleep(50.millis) // all 3 fibers start (limit is 4)
+          oc <- f.join // after another 50ms, one of them self-cancels
+          _ <- IO { oc.isCanceled mustEqual true }
+          _ <- ds.traverse_(_.get) // every finalizer must've ran, so every Deferred must be completed
+        } yield true
+
+        p must completeAs(true)
+      }
+
+      "run finalizers when a task errors after everything started" in ticked { implicit ticker =>
+        val p = for {
+          ds <- IO.deferred[Unit].replicateA(3)
+          f <- ds.parTraverseN_(4) { d =>
+            (if (d eq ds(1)) IO.sleep(100.millis) *> IO.raiseError(new Exception)
+            else IO.never).guarantee(d.complete(()).void)
+          }.start
+          _ <- IO.sleep(50.millis) // all 3 fibers start (limit is 4)
+          oc <- f.join // after another 50ms, one of them errors
+          _ <- IO { oc.isError mustEqual true }
+          _ <- ds.traverse_(_.get) // every finalizer must've ran, so every Deferred must be completed
+        } yield true
+
+        p must completeAs(true)
+      }
+
       "not run more than `n` tasks at a time" in real {
         def task(counter: Ref[IO, Int], maximum: Ref[IO, Int]): IO[Unit] = {
           val acq = counter.updateAndGet(_ + 1).flatMap { count =>

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1762,6 +1762,30 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
 
         test.attempt.timeoutTo(500.millis, IO(false must beTrue)).as(ok)
       }
+
+      "run finalizers in parallel" in ticked { implicit ticker =>
+        // this test also tests to ensure that we get the errored results rather than cancels
+        // note that the first two effects will have a Canceled outcome, while the third is Errored
+        // if we just go by first wins in sequence, then Canceled is the (incorrect) result
+        // first wins *in time* is the expected semantic here
+        val test = for {
+          latch1 <- IO.deferred[Unit]
+          latch2 <- IO.deferred[Unit]
+
+          _ <- List(1, 2, 3).parTraverseN(3) {
+            case 1 =>
+              IO.never.onCancel(latch1.complete(()) *> latch2.get)
+
+            case 2 =>
+              IO.never.onCancel(latch2.complete(()) *> latch1.get)
+
+            case 3 =>
+              IO.sleep(10.millis) *> IO.raiseError(new RuntimeException)
+          }
+        } yield ()
+
+        test.attempt.void must completeAs(())
+      }
     }
 
     "parTraverseN_" should {

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1760,7 +1760,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         val target = 0.until(100000).toList
         val test = target.parTraverseN(2)(_ => IO.raiseError(TestException))
 
-        test.attempt.timeoutTo(500.millis, IO(false must beTrue)).as(ok)
+        test.attempt.as(ok).timeoutTo(500.millis, IO(false must beTrue))
       }
 
       "run finalizers in parallel" in ticked { implicit ticker =>
@@ -1814,6 +1814,175 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         p must completeAs(true)
       }
 
+      "run finalizers when canceled" in ticked { implicit ticker =>
+        val p = for {
+          r <- IO.ref(0)
+
+          /*
+           * The exact series of steps here is:
+           *
+           * List(IO.never.onCancel, IO.unit, IO.never.onCancel)
+           *
+           * This is significant because we're limiting the parallelism to
+           * 2, meaning that we will hit a wall after IO.unit. HOWEVER,
+           * IO.unit completes immediately, so this test not only checks
+           * cancelation, it also tests that we move onto the third item
+           * after the second one completes even while the first is blocked.
+           * In other words, it's testing both cancelation and head of line
+           * behavior.
+           */
+          f <- List(1, 2, 3)
+            .parTraverseN_(2) { i =>
+              if (i == 2) IO.unit
+              else IO.never.onCancel(r.update(_ + 1))
+            }
+            .start
+
+          _ <- IO.sleep(100.millis)
+          _ <- f.cancel
+          c <- r.get
+          _ <- IO { c mustEqual 2 }
+        } yield true
+
+        p must completeAs(true)
+      }
+
+      "propagate self-cancellation" in ticked { implicit ticker =>
+        List(1, 2, 3, 4)
+          .parTraverseN_(2) { (n: Int) =>
+            if (n == 3) IO.canceled *> IO.never
+            else IO.pure(n)
+          }
+          .void must selfCancel
+      }
+
+      "run finalizers when a task self-cancels" in ticked { implicit ticker =>
+        val p = for {
+          r <- IO.ref(0)
+          fib <- List(1, 2, 3, 4)
+            .parTraverseN_(2) { (n: Int) =>
+              if (n == 3) IO.canceled *> IO.never
+              else IO.pure(n)
+            }
+            .onCancel(r.update(_ + 1))
+            .void
+            .start
+          _ <- IO.sleep(100.millis)
+          c <- r.get
+          _ <- IO { c mustEqual 1 }
+          oc <- fib.join
+        } yield oc.isCanceled
+
+        p must completeAs(true)
+      }
+
+      "not run more than `n` tasks at a time" in real {
+        def task(counter: Ref[IO, Int], maximum: Ref[IO, Int]): IO[Unit] = {
+          val acq = counter.updateAndGet(_ + 1).flatMap { count =>
+            maximum.update { max => if (count > max) count else max }
+          }
+          IO.asyncForIO.bracket(acq) { _ => IO.sleep(100.millis) }(_ => counter.update(_ - 1))
+        }
+
+        for {
+          maximum <- Ref.of[IO, Int](0)
+          counter <- Ref.of[IO, Int](0)
+          nCpu <- IO { Runtime.getRuntime().availableProcessors() }
+          n = java.lang.Math.max(nCpu, 2)
+          size = 4 * n
+          _ <- (1 to size).toList.parTraverseN_(n) { _ => task(counter, maximum) }
+          count <- counter.get
+          _ <- IO { count mustEqual 0 }
+          max <- maximum.get
+          _ <- IO { max must beLessThanOrEqualTo(n) }
+        } yield ok
+      }
+
+      "run actually in parallel" in real {
+        val n = 4
+        (1 to 2 * n)
+          .toList
+          .map(_ => IO.sleep(1.second))
+          .parSequenceN_(n)
+          .as(true)
+          .timeoutTo(3.seconds, IO.pure(false))
+          .flatMap(res => IO { res must beTrue })
+      }
+
+      "work for empty traverse" in ticked { implicit ticker =>
+        List.empty[Int].parTraverseN_(4) { _ => IO.never[String] } must completeAs(())
+      }
+
+      "work for non-empty traverse (ticked)" in ticked { implicit ticker =>
+        List(1).parTraverseN_(4) { i => IO.pure(i.toString) } must completeAs(())
+        List(1, 2).parTraverseN_(3) { i => IO.pure(i.toString) } must completeAs(())
+        List(1, 2, 3).parTraverseN_(2) { i => IO.pure(i.toString) } must completeAs(())
+        List(1, 2, 3, 4).parTraverseN_(1) { i => IO.pure(i.toString) } must completeAs(())
+      }
+
+      "work for non-empty traverse (real)" in real {
+        for {
+          _ <- List(1).parTraverseN_(4)(i => IO.pure(i.toString)).flatMap { r =>
+            IO(r.mustEqual(()))
+          }
+          _ <- List(1, 2).parTraverseN_(3)(i => IO.pure(i.toString)).flatMap { r =>
+            IO(r.mustEqual(()))
+          }
+          _ <- List(1, 2, 3).parTraverseN_(2)(i => IO.pure(i.toString)).flatMap { r =>
+            IO(r.mustEqual(()))
+          }
+          _ <- List(1, 2, 3, 4).parTraverseN_(1)(i => IO.pure(i.toString)).flatMap { r =>
+            IO(r.mustEqual(()))
+          }
+          _ <- (1 to 10000).toList.parTraverseN_(2)(i => IO.pure(i.toString)).flatMap { r =>
+            IO(r.mustEqual(()))
+          }
+        } yield ok
+      }
+
+      "be null-safe" in real {
+        for {
+          r1 <- List[String]("a", "b", null, "d", null).parTraverseN_(2) {
+            case "a" => IO.pure(null)
+            case "b" => IO.pure("x")
+            case "d" => IO.pure(null)
+            case null => IO.pure("z")
+          }
+          _ <- IO { r1 mustEqual (()) } // just trying to make sure we don't crash
+        } yield ok
+      }
+
+      "short-circuit on error" in real {
+        case object TestException extends RuntimeException
+        val target = 0.until(100000).toList
+        val test = target.parTraverseN_(2)(_ => IO.raiseError(TestException))
+
+        test.attempt.as(ok).timeoutTo(500.millis, IO(false must beTrue))
+      }
+
+      "run finalizers in parallel" in ticked { implicit ticker =>
+        // this test also tests to ensure that we get the errored results rather than cancels
+        // note that the first two effects will have a Canceled outcome, while the third is Errored
+        // if we just go by first wins in sequence, then Canceled is the (incorrect) result
+        // first wins *in time* is the expected semantic here
+        val test = for {
+          latch1 <- IO.deferred[Unit]
+          latch2 <- IO.deferred[Unit]
+
+          _ <- List(1, 2, 3).parTraverseN_(3) {
+            case 1 =>
+              IO.never.onCancel(latch1.complete(()) *> latch2.get)
+
+            case 2 =>
+              IO.never.onCancel(latch2.complete(()) *> latch1.get)
+
+            case 3 =>
+              IO.sleep(10.millis) *> IO.raiseError(new RuntimeException)
+          }
+        } yield ()
+
+        test.attempt.void must completeAs(())
+      }
     }
 
     "parallel" should {

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1752,13 +1752,6 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
             case null => IO.pure("z")
           }
           _ <- IO { r1 mustEqual List(null, "x", "z", null, "z") }
-          r2 <- List(1, 2, 3)
-            .parTraverseN(2) { i =>
-              if (i == 2) null: IO[Int]
-              else IO.pure(i)
-            }
-            .attempt
-          _ <- IO { r2 must beLike { case Left(e) => e must haveClass[NullPointerException] } }
         } yield ok
       }
     }

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1754,7 +1754,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
           _ <- IO { r1 mustEqual List(null, "x", "z", null, "z") }
           r2 <- List(1, 2, 3)
             .parTraverseN(2) { i =>
-              if (i == 2) null
+              if (i == 2) null: IO[Int]
               else IO.pure(i)
             }
             .attempt

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1760,7 +1760,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         val target = 0.until(100000).toList
         val test = target.parTraverseN(2)(_ => IO.raiseError(TestException))
 
-        test.attempt.as(ok).timeoutTo(500.millis, IO(false must beTrue))
+        test.attempt.as(ok).timeoutTo(1.second, IO(false must beTrue))
       }
 
       "run finalizers in parallel" in ticked { implicit ticker =>
@@ -1957,7 +1957,7 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         val target = 0.until(100000).toList
         val test = target.parTraverseN_(2)(_ => IO.raiseError(TestException))
 
-        test.attempt.as(ok).timeoutTo(500.millis, IO(false must beTrue))
+        test.attempt.as(ok).timeoutTo(1.second, IO(false must beTrue))
       }
 
       "run finalizers in parallel" in ticked { implicit ticker =>

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1614,6 +1614,153 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         p must completeAs(true)
       }
 
+      "run finalizers when canceled" in ticked { implicit ticker =>
+        val p = for {
+          r <- IO.ref(0)
+
+          /*
+           * The exact series of steps here is:
+           *
+           * List(IO.never.onCancel, IO.unit, IO.never.onCancel)
+           *
+           * This is significant because we're limiting the parallelism to
+           * 2, meaning that we will hit a wall after IO.unit. HOWEVER,
+           * IO.unit completes immediately, so this test not only checks
+           * cancelation, it also tests that we move onto the third item
+           * after the second one completes even while the first is blocked.
+           * In other words, it's testing both cancelation and head of line
+           * behavior.
+           */
+          f <- List(1, 2, 3)
+            .parTraverseN(2) { i =>
+              if (i == 2) IO.unit
+              else IO.never.onCancel(r.update(_ + 1))
+            }
+            .start
+
+          _ <- IO.sleep(100.millis)
+          _ <- f.cancel
+          c <- r.get
+          _ <- IO { c mustEqual 2 }
+        } yield true
+
+        p must completeAs(true)
+      }
+
+      "propagate self-cancellation" in ticked { implicit ticker =>
+        List(1, 2, 3, 4)
+          .parTraverseN(2) { (n: Int) =>
+            if (n == 3) IO.canceled *> IO.never
+            else IO.pure(n)
+          }
+          .void must selfCancel
+      }
+
+      "run finalizers when a task self-cancels" in ticked { implicit ticker =>
+        val p = for {
+          r <- IO.ref(0)
+          fib <- List(1, 2, 3, 4)
+            .parTraverseN(2) { (n: Int) =>
+              if (n == 3) IO.canceled *> IO.never
+              else IO.pure(n)
+            }
+            .onCancel(r.update(_ + 1))
+            .void
+            .start
+          _ <- IO.sleep(100.millis)
+          c <- r.get
+          _ <- IO { c mustEqual 1 }
+          oc <- fib.join
+        } yield oc.isCanceled
+
+        p must completeAs(true)
+      }
+
+      "not run more than `n` tasks at a time" in real {
+        def task(counter: Ref[IO, Int], maximum: Ref[IO, Int]): IO[Unit] = {
+          val acq = counter.updateAndGet(_ + 1).flatMap { count =>
+            maximum.update { max => if (count > max) count else max }
+          }
+          IO.asyncForIO.bracket(acq) { _ => IO.sleep(100.millis) }(_ => counter.update(_ - 1))
+        }
+
+        for {
+          maximum <- Ref.of[IO, Int](0)
+          counter <- Ref.of[IO, Int](0)
+          nCpu <- IO { Runtime.getRuntime().availableProcessors() }
+          n = java.lang.Math.max(nCpu, 2)
+          size = 4 * n
+          res <- (1 to size).toList.parTraverseN(n) { _ => task(counter, maximum) }
+          _ <- IO { res.size mustEqual size }
+          count <- counter.get
+          _ <- IO { count mustEqual 0 }
+          max <- maximum.get
+          _ <- IO { max must beLessThanOrEqualTo(n) }
+        } yield ok
+      }
+
+      "run actually in parallel" in real {
+        val n = 4
+        (1 to 2 * n)
+          .toList
+          .map { i => IO.sleep(1.second).as(i) }
+          .parSequenceN(n)
+          .timeout(3.seconds)
+          .flatMap { res => IO { res mustEqual (1 to 2 * n).toList } }
+      }
+
+      "work for empty traverse" in ticked { implicit ticker =>
+        List.empty[Int].parTraverseN(4) { _ => IO.never[String] } must completeAs(
+          List.empty[String])
+      }
+
+      "work for non-empty traverse (ticked)" in ticked { implicit ticker =>
+        List(1).parTraverseN(4) { i => IO.pure(i.toString) } must completeAs(List("1"))
+        List(1, 2).parTraverseN(3) { i => IO.pure(i.toString) } must completeAs(List("1", "2"))
+        List(1, 2, 3).parTraverseN(2) { i => IO.pure(i.toString) } must completeAs(
+          List("1", "2", "3"))
+        List(1, 2, 3, 4).parTraverseN(1) { i => IO.pure(i.toString) } must completeAs(
+          List("1", "2", "3", "4"))
+      }
+
+      "work for non-empty traverse (real)" in real {
+        for {
+          _ <- List(1).parTraverseN(4)(i => IO.pure(i.toString)).flatMap { r =>
+            IO(r mustEqual List("1"))
+          }
+          _ <- List(1, 2).parTraverseN(3)(i => IO.pure(i.toString)).flatMap { r =>
+            IO(r mustEqual List("1", "2"))
+          }
+          _ <- List(1, 2, 3).parTraverseN(2)(i => IO.pure(i.toString)).flatMap { r =>
+            IO(r mustEqual List("1", "2", "3"))
+          }
+          _ <- List(1, 2, 3, 4).parTraverseN(1)(i => IO.pure(i.toString)).flatMap { r =>
+            IO(r mustEqual List("1", "2", "3", "4"))
+          }
+          _ <- (1 to 10000).toList.parTraverseN(2)(i => IO.pure(i.toString)).flatMap { r =>
+            IO(r mustEqual (1 to 10000).map(_.toString).toList)
+          }
+        } yield ok
+      }
+
+      "be null-safe" in real {
+        for {
+          r1 <- List[String]("a", "b", null, "d", null).parTraverseN(2) {
+            case "a" => IO.pure(null)
+            case "b" => IO.pure("x")
+            case "d" => IO.pure(null)
+            case null => IO.pure("z")
+          }
+          _ <- IO { r1 mustEqual List(null, "x", "z", null, "z") }
+          r2 <- List(1, 2, 3)
+            .parTraverseN(2) { i =>
+              if (i == 2) null
+              else IO.pure(i)
+            }
+            .attempt
+          _ <- IO { r2 must beLike { case Left(e) => e must haveClass[NullPointerException] } }
+        } yield ok
+      }
     }
 
     "parTraverseN_" should {

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1754,6 +1754,14 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
           _ <- IO { r1 mustEqual List(null, "x", "z", null, "z") }
         } yield ok
       }
+
+      "short-circuit on error" in real {
+        case object TestException extends RuntimeException
+        val target = 0.until(100000).toList
+        val test = target.parTraverseN(2)(_ => IO.raiseError(TestException))
+
+        test.attempt.timeoutTo(500.millis, IO(false must beTrue)).as(ok)
+      }
     }
 
     "parTraverseN_" should {

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1868,36 +1868,46 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         p must completeAs(true)
       }
 
-      "run finalizers when a task self-cancels after everything started" in ticked { implicit ticker =>
-        val p = for {
-          ds <- IO.deferred[Unit].replicateA(3)
-          f <- ds.parTraverseN_(4) { d =>
-            (if (d eq ds(1)) IO.sleep(100.millis) *> IO.canceled
-            else IO.never).onCancel(d.complete(()).void)
-          }.start
-          _ <- IO.sleep(50.millis) // all 3 fibers start (limit is 4)
-          oc <- f.join // after another 50ms, one of them self-cancels
-          _ <- IO { oc.isCanceled mustEqual true }
-          _ <- ds.traverse_(_.get) // every finalizer must've ran, so every Deferred must be completed
-        } yield true
+      "run finalizers when a task self-cancels after everything started" in ticked {
+        implicit ticker =>
+          val p = for {
+            ds <- IO.deferred[Unit].replicateA(3)
+            f <- ds
+              .parTraverseN_(4) { d =>
+                (if (d eq ds(1)) IO.sleep(100.millis) *> IO.canceled
+                 else IO.never).onCancel(d.complete(()).void)
+              }
+              .start
+            _ <- IO.sleep(50.millis) // all 3 fibers start (limit is 4)
+            oc <- f.join // after another 50ms, one of them self-cancels
+            _ <- IO { oc.isCanceled mustEqual true }
+            _ <- ds.traverse_(
+              _.get
+            ) // every finalizer must've ran, so every Deferred must be completed
+          } yield true
 
-        p must completeAs(true)
+          p must completeAs(true)
       }
 
-      "run finalizers when a task errors after everything started" in ticked { implicit ticker =>
-        val p = for {
-          ds <- IO.deferred[Unit].replicateA(3)
-          f <- ds.parTraverseN_(4) { d =>
-            (if (d eq ds(1)) IO.sleep(100.millis) *> IO.raiseError(new Exception)
-            else IO.never).guarantee(d.complete(()).void)
-          }.start
-          _ <- IO.sleep(50.millis) // all 3 fibers start (limit is 4)
-          oc <- f.join // after another 50ms, one of them errors
-          _ <- IO { oc.isError mustEqual true }
-          _ <- ds.traverse_(_.get) // every finalizer must've ran, so every Deferred must be completed
-        } yield true
+      "run finalizers when a task errors after everything started" in ticked {
+        implicit ticker =>
+          val p = for {
+            ds <- IO.deferred[Unit].replicateA(3)
+            f <- ds
+              .parTraverseN_(4) { d =>
+                (if (d eq ds(1)) IO.sleep(100.millis) *> IO.raiseError(new Exception)
+                 else IO.never).guarantee(d.complete(()).void)
+              }
+              .start
+            _ <- IO.sleep(50.millis) // all 3 fibers start (limit is 4)
+            oc <- f.join // after another 50ms, one of them errors
+            _ <- IO { oc.isError mustEqual true }
+            _ <- ds.traverse_(
+              _.get
+            ) // every finalizer must've ran, so every Deferred must be completed
+          } yield true
 
-        p must completeAs(true)
+          p must completeAs(true)
       }
 
       "not run more than `n` tasks at a time" in real {

--- a/tests/shared/src/test/scala/cats/effect/IOSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/IOSpec.scala
@@ -1755,6 +1755,74 @@ class IOSpec extends BaseSpec with Discipline with IOPlatformSpecification {
         p must completeAs(true)
       }
 
+      "wait for sibling finalizers after a task self-cancels" in ticked { implicit ticker =>
+        val test = for {
+          events <- IO.ref(Vector.empty[String])
+          firstStarted <- IO.deferred[Unit]
+          secondStarted <- IO.deferred[Unit]
+          cancelerStarted <- IO.deferred[Unit]
+          allowSelfCancel <- IO.deferred[Unit]
+          firstCanceling <- IO.deferred[Unit]
+          secondCanceling <- IO.deferred[Unit]
+          releaseFinalizers <- IO.deferred[Unit]
+          firstFinalized <- IO.deferred[Unit]
+          secondFinalized <- IO.deferred[Unit]
+          outcome <- IO.deferred[Outcome[IO, Throwable, List[Int]]]
+          traversal <- List(1, 2, 3)
+            .parTraverseN(3) {
+              case 1 =>
+                (firstStarted.complete(()).void *> IO.never[Int]).onCancel(
+                  firstCanceling.complete(()).void *>
+                    releaseFinalizers.get *>
+                    events.update(_ :+ "first-finalized") *>
+                    firstFinalized.complete(()).void)
+              case 2 =>
+                (secondStarted.complete(()).void *> IO.never[Int]).onCancel(
+                  secondCanceling.complete(()).void *>
+                    releaseFinalizers.get *>
+                    events.update(_ :+ "second-finalized") *>
+                    secondFinalized.complete(()).void)
+              case 3 =>
+                cancelerStarted.complete(()).void *>
+                  allowSelfCancel.get *>
+                  IO.canceled *>
+                  IO.never
+            }
+            .start
+          _ <- traversal
+            .join
+            .flatMap { oc =>
+              events.update(_ :+ "outcome") *>
+                outcome.complete(oc).void
+            }
+            .start
+          _ <- firstStarted.get
+          _ <- secondStarted.get
+          _ <- cancelerStarted.get
+          _ <- IO.sleep(1.millis)
+          _ <- allowSelfCancel.complete(())
+          _ <- firstCanceling.get
+          _ <- secondCanceling.get
+          _ <- IO.sleep(1.millis)
+          beforeRelease <- events.get
+          _ <- releaseFinalizers.complete(())
+          published <- outcome.get
+          _ <- firstFinalized.get
+          _ <- secondFinalized.get
+          observed <- events.get
+        } yield {
+          val finalizersBeforeOutcome = observed match {
+            case Vector(first, second, "outcome") =>
+              Set(first, second) == Set("first-finalized", "second-finalized")
+            case _ => false
+          }
+
+          (beforeRelease.isEmpty, published.isCanceled, finalizersBeforeOutcome)
+        }
+
+        test must completeAs((true, true, true))
+      }
+
       "not run more than `n` tasks at a time" in real {
         def task(counter: Ref[IO, Int], maximum: Ref[IO, Int]): IO[Unit] = {
           val acq = counter.updateAndGet(_ + 1).flatMap { count =>


### PR DESCRIPTION
This shifts to a fully bespoke implementation of `parTraverseN` and such. There are a few things left to clean up, such as a few more tests and running some comparative benchmarks, but early results are very promising. In particular, the failure case from #4434 appears to be around two to three orders of magnitude faster with this implementation (which makes sense, since it handles early abort correctly). Kudos to @SystemFw for the core idea which makes this possible.

One of the things I'm doing here is giving up entirely on universal fairness and merely focusing on in-batch fairness. A simpler way of saying this is that we are hardened against head of line blocking, both for actions and cancelation.

Fixes #4434