### PR TITLE
Change tutorial CopyFile object name

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -336,7 +336,7 @@ method can look like this:
 import cats.effect._
 import java.io.File
 
-object Main extends IOApp {
+object CopyFile extends IOApp {
 
   // copy as defined before
   def copy(origin: File, destination: File): IO[Long] = ???


### PR DESCRIPTION
In the tutorial and in the sample code on GitHub (https://github.com/lrodero/cats-effect-tutorial/blob/series/3.x/src/main/scala/catseffecttutorial/copyfile/CopyFile.scala), the object created to copy a file is called CopyFile and not Main.

The instructions in the tutorial assume the object is called CopyFile, so to keep the instructions correct, I've updated the object name in the code fragment.