### PR TITLE
Fix identity in Ref documentation

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Ref.scala
@@ -72,7 +72,7 @@ abstract class Ref[F[_], A] extends RefSource[F, A] with RefSink[F, A] {
    * setter is a noop and returns `false`.
    *
    * Satisfies: `r.access.map(_._1) == r.get` and `r.access.flatMap { case (v, setter) =>
-   * setter(f(v)) } == r.tryUpdate(f).map(_.isDefined)`.
+   * setter(f(v)) } == r.tryUpdate(f)`.
    */
   def access: F[(A, A => F[Boolean])]
 


### PR DESCRIPTION
Fixes #4464. `tryUpdate` returns F[Boolean] not F[Option]