### PR TITLE
Switch to `windows-2022` runner tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         os:
           - ubuntu-latest
           - ubuntu-22.04-arm
-          - windows-latest
+          - windows-2022
           - macos-14
         scala: [3.3.4, 2.12.20, 2.13.15]
         java:
@@ -61,13 +61,13 @@ jobs:
             java: temurin@21
           - os: ubuntu-22.04-arm
             java: graalvm@21
-          - os: windows-latest
+          - os: windows-2022
             scala: 3.3.4
             ci: ciJVM
           - os: macos-14
             scala: 3.3.4
             ci: ciJVM
-          - os: windows-latest
+          - os: windows-2022
             scala: 2.12.20
             ci: ciJVM
           - os: macos-14
@@ -95,7 +95,7 @@ jobs:
             java: graalvm@21
           - os: ubuntu-22.04-arm
             ci: ciJS
-          - os: windows-latest
+          - os: windows-2022
             ci: ciJS
           - os: macos-14
             ci: ciJS
@@ -109,7 +109,7 @@ jobs:
             java: graalvm@21
           - os: ubuntu-22.04-arm
             ci: ciFirefox
-          - os: windows-latest
+          - os: windows-2022
             ci: ciFirefox
           - os: macos-14
             ci: ciFirefox
@@ -123,7 +123,7 @@ jobs:
             java: graalvm@21
           - os: ubuntu-22.04-arm
             ci: ciChrome
-          - os: windows-latest
+          - os: windows-2022
             ci: ciChrome
           - os: macos-14
             ci: ciChrome
@@ -135,7 +135,7 @@ jobs:
             os: ubuntu-22.04-arm
           - ci: ciNative
             java: temurin@11
-            os: windows-latest
+            os: windows-2022
           - ci: ciNative
             java: temurin@11
             os: macos-14
@@ -144,7 +144,7 @@ jobs:
             os: ubuntu-latest
           - ci: ciNative
             java: temurin@17
-            os: windows-latest
+            os: windows-2022
           - ci: ciNative
             java: temurin@21
             os: ubuntu-latest
@@ -153,7 +153,7 @@ jobs:
             os: ubuntu-22.04-arm
           - ci: ciNative
             java: temurin@21
-            os: windows-latest
+            os: windows-2022
           - ci: ciNative
             java: temurin@21
             os: macos-14
@@ -165,14 +165,14 @@ jobs:
             os: ubuntu-22.04-arm
           - ci: ciNative
             java: graalvm@21
-            os: windows-latest
+            os: windows-2022
           - ci: ciNative
             java: graalvm@21
             os: macos-14
           - os: ubuntu-22.04-arm
             ci: ciNative
             scala: 2.12.20
-          - os: windows-latest
+          - os: windows-2022
             ci: ciNative
           - os: macos-14
             ci: ciNative
@@ -275,7 +275,7 @@ jobs:
         run: npm install
 
       - name: Configure Windows Pagefile
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         uses: al-cheb/configure-pagefile-action@d298bdee6b133626425040e3788f1055a8b4cf7a
         with:
           minimum-size: 2GB

--- a/build.sbt
+++ b/build.sbt
@@ -108,7 +108,7 @@ ThisBuild / developers := List(
 
 val PrimaryOS = "ubuntu-latest"
 val ArmOS = "ubuntu-22.04-arm"
-val Windows = "windows-latest"
+val Windows = "windows-2022"
 val MacOS = "macos-14"
 
 val Scala212 = "2.12.20"


### PR DESCRIPTION
The `windows-latest` tag currently points to Windows Server 2022 but **it will be migrating to point to Windows Server 2025 starting on September 2 2025**

We can keep using the existing runner by switching to the `windows-2022` tag. This runner will have another 3 years of support and we can migrate in the future under less of a crunch. Please don't feel you have to accept this PR if you would rather make the switch now, I'm just trying to make sure maintainers are aware and not surprised like we all were with the ubuntu-latest changes.

Details about the runner change, and what other software changes are being made alongside, are documented here:
- https://github.com/actions/runner-images/issues/12677


NOTE: I'm not sure which is the correct series branch to target for these kinds of fixes? We probably want to apply the change to both branches