### PR TITLE
Clarify how `MapRef` can be total

### DIFF
--- a/docs/std/mapref.md
+++ b/docs/std/mapref.md
@@ -35,7 +35,7 @@ value or return a `MapRef[F, K, Option[V]]`.
 This is probably one of the most common uses of this datatype.
 
 ```scala mdoc:reset:silent
-//> using lib "org.typelevel::cats-effect::3.6.3"
+//> using lib "org.typelevel::cats-effect:3.6.3"
 
 import cats.effect.IO
 import cats.effect.std.MapRef

--- a/docs/std/mapref.md
+++ b/docs/std/mapref.md
@@ -27,12 +27,15 @@ the pairs can be sharded by key.
 Thus, multiple concurrent updates may be executed independently to each other,
 as long as their keys belong to different shards.
 
+Since `MapRef` is a total map, constructors of `MapRef` either take a default
+value or return a `MapRef[F, K, Option[V]]`.
+
 ### In-Memory database
 
 This is probably one of the most common uses of this datatype.
 
 ```scala mdoc:reset:silent
-//> using lib "org.typelevel::cats-effect:3.6.3"
+//> using lib "org.typelevel::cats-effect::3.6.3"
 
 import cats.effect.IO
 import cats.effect.std.MapRef
@@ -46,7 +49,7 @@ object DatabaseClient {
   def inMemory[Id, Data]: IO[DatabaseClient[IO, Id, Data]] =
     MapRef.ofShardedImmutableMap[IO, Id, Data](
       shardCount = 5 // Arbitrary number of shards just for demonstration.
-    ).map { mapRef =>
+    ).map { (mapRef: MapRef[IO, Id, Option[Data]]) =>
       new DatabaseClient[IO, Id, Data] {
         override def getDataById(id: Id): IO[Option[Data]] =
           mapRef(id).get


### PR DESCRIPTION
Clarify how `MapRef` can be a total map by describing the constructors and adding a type annotation in the code example.