### PR TITLE
can create Random instances wrapped in different effect

### DIFF
--- a/std/js/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
+++ b/std/js/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
@@ -117,6 +117,9 @@ private[std] trait SecureRandomCompanionPlatform {
   def javaSecuritySecureRandom[F[_]: Sync]: F[SecureRandom[F]] =
     Sync[F].delay(unsafeJavaSecuritySecureRandom())
 
+  def javaSecuritySecureRandomIn[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
+    Sync[F].delay(unsafeJavaSecuritySecureRandom[G]())
+
   private[effect] def unsafeJavaSecuritySecureRandom[F[_]: Sync](): SecureRandom[F] =
     new ScalaRandom[F](Applicative[F].pure(new JavaSecureRandom())) with SecureRandom[F] {}
 

--- a/std/jvm/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
+++ b/std/jvm/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
@@ -46,6 +46,9 @@ private[std] trait SecureRandomCompanionPlatform {
   def javaSecuritySecureRandom[F[_]: Sync]: F[SecureRandom[F]] =
     Sync[F].delay(unsafeJavaSecuritySecureRandom())
 
+  def javaSecuritySecureRandomIn[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
+    Sync[F].delay(unsafeJavaSecuritySecureRandom[G]())
+
   /**
    * Ported from https://github.com/http4s/http4s/.
    */

--- a/std/native/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
+++ b/std/native/src/main/scala/cats/effect/std/SecureRandomCompanionPlatform.scala
@@ -60,6 +60,9 @@ private[std] trait SecureRandomCompanionPlatform {
   def javaSecuritySecureRandom[F[_]: Sync]: F[SecureRandom[F]] =
     Sync[F].delay(unsafeJavaSecuritySecureRandom())
 
+  def javaSecuritySecureRandomIn[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
+    Sync[F].delay(unsafeJavaSecuritySecureRandom[G]())
+
   private[effect] def unsafeJavaSecuritySecureRandom[F[_]: Sync](): SecureRandom[F] =
     new ScalaRandom[F](Applicative[F].pure(new JavaSecureRandom())) with SecureRandom[F] {}
 

--- a/std/shared/src/main/scala/cats/effect/std/Random.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Random.scala
@@ -212,6 +212,12 @@ object Random extends RandomCompanionPlatform {
       new ScalaRandom[F](sRandom.pure[F]) {}
     }
 
+  def scalaUtilRandomIn[F[_]: Sync, G[_]: Sync]: F[Random[G]] =
+    Sync[F].delay {
+      val sRandom = new SRandom()
+      new ScalaRandom[G](sRandom.pure[G]) {}
+    }
+
   /**
    * [[Random]] instance built for `cats.data.EitherT` values initialized with any `F` data type
    * that also implements `Random`.
@@ -317,6 +323,12 @@ object Random extends RandomCompanionPlatform {
     Sync[F].delay {
       val sRandom = new SRandom(random)
       new ScalaRandom[F](sRandom.pure[F]) {}
+    }
+
+  def javaUtilRandomIn[F[_]: Sync, G[_]: Sync](random: java.util.Random): F[Random[G]] =
+    Sync[F].delay {
+      val sRandom = new SRandom(random)
+      new ScalaRandom[G](sRandom.pure[G]) {}
     }
 
   def javaUtilConcurrentThreadLocalRandom[F[_]: Sync]: Random[F] =

--- a/std/shared/src/main/scala/cats/effect/std/SecureRandom.scala
+++ b/std/shared/src/main/scala/cats/effect/std/SecureRandom.scala
@@ -139,4 +139,7 @@ object SecureRandom extends SecureRandomCompanionPlatform {
   override def javaSecuritySecureRandom[F[_]: Sync]: F[SecureRandom[F]] =
     super.javaSecuritySecureRandom[F]
 
+  override def javaSecuritySecureRandomIn[F[_]: Sync, G[_]: Sync]: F[SecureRandom[G]] =
+    super.javaSecuritySecureRandomIn[F, G]
+
 }


### PR DESCRIPTION
Like how you can build a `Ref` using a different effect for the wrapper, I suggest that the same functionality be enabled for `Random`/`SecureRandom`. 

I chose the suffix `In` for these methods to match that for `Ref`. This would remove the need for some extra `mapK`s in my particular use case :)
