### PR TITLE
Update weaver-test organization in docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,15 +122,14 @@ class ExampleSuite extends CatsEffectSuite {
 
 ### Weaver-test
 
-[![weaver-cats Scala version support](https://index.scala-lang.org/disneystreaming/weaver-test/weaver-cats/latest-by-scala-version.svg)](https://index.scala-lang.org/disneystreaming/weaver-test/weaver-cats)
+[![weaver-cats Scala version support](https://index.scala-lang.org/typelevel/weaver-test/weaver-cats/latest-by-scala-version.svg)](https://index.scala-lang.org/typelevel/weaver-test/weaver-cats)
 
-[Weaver](https://github.com/disneystreaming/weaver-test) is a test-framework built directly on top of Cats Effect. It is designed specifically to handle thousands of tests exercising I/O layers (http, database calls) concurrently. Weaver makes heavy use of the concurrency constructs and abstractions provided by Cats Effect to safely share resources (clients) across tests and suite, and runs all tests in parallel by default.
+[Weaver](https://github.com/typelevel/weaver-test) is a test-framework built directly on top of Cats Effect. It is designed specifically to handle thousands of tests exercising I/O layers (http, database calls) concurrently. Weaver makes heavy use of the concurrency constructs and abstractions provided by Cats Effect to safely share resources (clients) across tests and suite, and runs all tests in parallel by default.
 
 To get started, add the following to your **build.sbt**:
 
 ```scala
-libraryDependencies += "com.disneystreaming" %% "weaver-cats" % "0.7.6" % Test
-testFrameworks += new TestFramework("weaver.framework.CatsEffect")
+libraryDependencies += "org.typelevel" %% "weaver-cats" % "0.10.1" % Test
 ```
 
 Similarly to MUnit, this setup allows you to write your tests directly against `IO`.


### PR DESCRIPTION
Weaver moved under the Typelevel organization in its `0.9.x` release.