### PR TITLE
Fix memory leak in `Supervisor` internal state

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1104,7 +1104,10 @@ lazy val std = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         ProblemFilters.exclude[FinalMethodProblem](
           "cats.effect.std.Dispatcher#RegState#Unstarted.toString"),
         ProblemFilters.exclude[DirectMissingMethodProblem](
-          "cats.effect.std.Dispatcher#Registration#Primary.*")
+          "cats.effect.std.Dispatcher#Registration#Primary.*"),
+        // #4500, private class:
+        ProblemFilters.exclude[ReversedMissingMethodProblem](
+          "cats.effect.std.Supervisor#State.numberOfFibers")
       )
   )
   .jsSettings(

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -141,7 +141,7 @@ object Supervisor {
   def apply[F[_]: Concurrent]: Resource[F, Supervisor[F]] =
     apply[F](false)
 
-  private sealed abstract class State[F[_]] {
+  private[std] sealed abstract class State[F[_]] {
 
     def remove(token: Unique.Token): F[Unit]
 
@@ -149,6 +149,8 @@ object Supervisor {
      * Must return `false` (and might not insert) if `Supervisor` is already closed
      */
     def add(token: Unique.Token, fiber: Fiber[F, Throwable, ?]): F[Boolean]
+
+    private[std] def numberOfFibers: F[Int] // for testing
 
     // these are allowed to destroy the state, since they're only called during closing:
     val joinAll: F[Unit]
@@ -169,153 +171,160 @@ object Supervisor {
         case (st, _) =>
           doneR.set(true) *> st.cancelAll
       }
-    } yield new Supervisor[F] {
+    } yield new SupervisorImpl[F](checkRestart, doneR, state)
+  }
 
-      def supervise[A](fa: F[A]): F[Fiber[F, Throwable, A]] =
-        F.uncancelable { _ =>
-          val monitor: (F[A], F[Unit]) => F[Fiber[F, Throwable, A]] = checkRestart match {
-            case Some(restart) => { (fa, fin) =>
-              F.deferred[Outcome[F, Throwable, A]] flatMap { resultR =>
-                F.ref(false) flatMap { canceledR =>
-                  F.deferred[Fiber[F, Throwable, A]].flatMap { firstCurrent =>
-                    // `currentR` holds (a `Deferred` to) the current
-                    // incarnation of the fiber executing `fa`:
-                    F.ref(firstCurrent).flatMap { currentR =>
-                      def action(current: Deferred[F, Fiber[F, Throwable, A]]): F[Unit] = {
-                        F uncancelable { _ =>
-                          val started = F start {
-                            fa guaranteeCase { oc =>
-                              F.deferred[Fiber[F, Throwable, A]].flatMap { newCurrent =>
-                                // we're replacing the `Deferred` holding
-                                // the current fiber with a new one before
-                                // the current fiber finishes, and even
-                                // before we check for the cancel signal;
-                                // this guarantees, that the fiber reachable
-                                // through `currentR` is the last one (or
-                                // null, see below):
-                                currentR.set(newCurrent) *> {
-                                  canceledR.get flatMap { canceled =>
-                                    doneR.get flatMap { done =>
-                                      if (!canceled && !done && restart(oc)) {
-                                        action(newCurrent)
-                                      } else {
-                                        // we must complete `newCurrent`,
-                                        // because `cancel` below may wait
-                                        // for it; we signal that it is not
-                                        // restarted with `null`:
-                                        newCurrent.complete(null) *> fin.guarantee(
-                                          resultR.complete(oc).void)
-                                      }
+  private[std] final class SupervisorImpl[F[_]](
+    checkRestart: Option[Outcome[F, Throwable, ?] => Boolean],
+    doneR: Ref[F, Boolean],
+    private[std] val state: State[F],
+  )(implicit F: Concurrent[F]) extends Supervisor[F] {
+
+    def supervise[A](fa: F[A]): F[Fiber[F, Throwable, A]] =
+      F.uncancelable { _ =>
+        val monitor: (F[A], F[Unit]) => F[Fiber[F, Throwable, A]] = checkRestart match {
+          case Some(restart) => { (fa, fin) =>
+            F.deferred[Outcome[F, Throwable, A]] flatMap { resultR =>
+              F.ref(false) flatMap { canceledR =>
+                F.deferred[Fiber[F, Throwable, A]].flatMap { firstCurrent =>
+                  // `currentR` holds (a `Deferred` to) the current
+                  // incarnation of the fiber executing `fa`:
+                  F.ref(firstCurrent).flatMap { currentR =>
+                    def action(current: Deferred[F, Fiber[F, Throwable, A]]): F[Unit] = {
+                      F uncancelable { _ =>
+                        val started = F start {
+                          fa guaranteeCase { oc =>
+                            F.deferred[Fiber[F, Throwable, A]].flatMap { newCurrent =>
+                              // we're replacing the `Deferred` holding
+                              // the current fiber with a new one before
+                              // the current fiber finishes, and even
+                              // before we check for the cancel signal;
+                              // this guarantees, that the fiber reachable
+                              // through `currentR` is the last one (or
+                              // null, see below):
+                              currentR.set(newCurrent) *> {
+                                canceledR.get flatMap { canceled =>
+                                  doneR.get flatMap { done =>
+                                    if (!canceled && !done && restart(oc)) {
+                                      action(newCurrent)
+                                    } else {
+                                      // we must complete `newCurrent`,
+                                      // because `cancel` below may wait
+                                      // for it; we signal that it is not
+                                      // restarted with `null`:
+                                      newCurrent.complete(null) *> fin.guarantee(
+                                        resultR.complete(oc).void)
                                     }
                                   }
                                 }
                               }
                             }
                           }
-
-                          started flatMap { f => current.complete(f).void }
                         }
+
+                        started flatMap { f => current.complete(f).void }
                       }
-
-                      action(firstCurrent).as(
-                        new Fiber[F, Throwable, A] {
-
-                          private[this] val delegateF = currentR.get.flatMap(_.get)
-
-                          val cancel: F[Unit] = F uncancelable { _ =>
-                            // after setting `canceledR`, at
-                            // most one restart happens, and
-                            // the fiber we get through `delegateF`
-                            // is the final one:
-                            canceledR.set(true) *> delegateF flatMap {
-                              case null =>
-                                // ok, task wasn't restarted, but we
-                                // wait for the result to be completed
-                                // (and the finalizer to run):
-                                resultR.get.void
-                              case fiber =>
-                                fiber.cancel *> fiber.join flatMap {
-                                  case Outcome.Canceled() =>
-                                    // cancel successful (or self-canceled),
-                                    // but we don't know if the `guaranteeCase`
-                                    // above ran so we need to double check:
-                                    delegateF.flatMap {
-                                      case null =>
-                                        // ok, the `guaranteeCase`
-                                        // certainly executed/ing:
-                                        resultR.get.void
-                                      case fiber2 =>
-                                        // we cancelled the fiber before it did
-                                        // anything, so the finalizer didn't run,
-                                        // we need to do it now:
-                                        val cleanup = fin.guarantee(
-                                          resultR.complete(Outcome.Canceled()).void
-                                        )
-                                        if (fiber2 eq fiber) {
-                                          cleanup
-                                        } else {
-                                          // this should never happen
-                                          cleanup *> F.raiseError(new AssertionError(
-                                            "unexpected fiber (this is a bug in Supervisor)"))
-                                        }
-                                    }
-                                  case _ =>
-                                    // finished in error/success,
-                                    // the outcome will certainly
-                                    // be completed:
-                                    resultR.get.void
-                                }
-                            }
-                          }
-
-                          def join = resultR.get
-                        }
-                      )
                     }
+
+                    action(firstCurrent).as(
+                      new Fiber[F, Throwable, A] {
+
+                        private[this] val delegateF = currentR.get.flatMap(_.get)
+
+                        val cancel: F[Unit] = F uncancelable { _ =>
+                          // after setting `canceledR`, at
+                          // most one restart happens, and
+                          // the fiber we get through `delegateF`
+                          // is the final one:
+                          canceledR.set(true) *> delegateF flatMap {
+                            case null =>
+                              // ok, task wasn't restarted, but we
+                              // wait for the result to be completed
+                              // (and the finalizer to run):
+                              resultR.get.void
+                            case fiber =>
+                              fiber.cancel *> fiber.join flatMap {
+                                case Outcome.Canceled() =>
+                                  // cancel successful (or self-canceled),
+                                  // but we don't know if the `guaranteeCase`
+                                  // above ran so we need to double check:
+                                  delegateF.flatMap {
+                                    case null =>
+                                      // ok, the `guaranteeCase`
+                                      // certainly executed/ing:
+                                      resultR.get.void
+                                    case fiber2 =>
+                                      // we cancelled the fiber before it did
+                                      // anything, so the finalizer didn't run,
+                                      // we need to do it now:
+                                      val cleanup = fin.guarantee(
+                                        resultR.complete(Outcome.Canceled()).void
+                                      )
+                                      if (fiber2 eq fiber) {
+                                        cleanup
+                                      } else {
+                                        // this should never happen
+                                        cleanup *> F.raiseError(new AssertionError(
+                                          "unexpected fiber (this is a bug in Supervisor)"))
+                                      }
+                                  }
+                                case _ =>
+                                  // finished in error/success,
+                                  // the outcome will certainly
+                                  // be completed:
+                                  resultR.get.void
+                              }
+                          }
+                        }
+
+                        def join = resultR.get
+                      }
+                    )
                   }
                 }
               }
             }
-
-            case None => (fa, fin) => F.start(fa.guarantee(fin))
           }
 
-          for {
-            done <- F.ref(false)
-            insertResult <- F.deferred[Boolean]
-            token <- F.unique
-            cleanup = state.remove(token)
-            fiber <- monitor(
-              // if the supervisor have been (or is now)
-              // shutting down, inserting into state will
-              // fail; so we need to wait for the positive result
-              // of inserting, before actually doing the task:
-              insertResult
-                .get
-                .ifM(
-                  fa,
-                  F.canceled *> F.raiseError[A](new AssertionError(
-                    "supervised fiber couldn't cancel (this is a bug in Supervisor)"))
-                ),
-              done.set(true) *> cleanup
-            )
-            insertOk <- state.add(token, fiber)
-            _ <- insertResult.complete(insertOk)
-            // `cleanup` could run BEFORE the `state.add`
-            // (if `fa` is very fast), in which case it doesn't
-            // remove the fiber from the state, so we re-check:
-            _ <- done.get.ifM(cleanup, F.unit)
-            _ <- {
-              if (!insertOk) {
-                F.raiseError(new IllegalStateException("supervisor already shutdown"))
-              } else {
-                F.unit
-              }
-            }
-          } yield fiber
+          case None => (fa, fin) => F.start(fa.guarantee(fin))
         }
-    }
+
+        for {
+          done <- F.ref(false)
+          insertResult <- F.deferred[Boolean]
+          token <- F.unique
+          cleanup = state.remove(token)
+          fiber <- monitor(
+            // if the supervisor have been (or is now)
+            // shutting down, inserting into state will
+            // fail; so we need to wait for the positive result
+            // of inserting, before actually doing the task:
+            insertResult
+              .get
+              .ifM(
+                fa,
+                F.canceled *> F.raiseError[A](new AssertionError(
+                  "supervised fiber couldn't cancel (this is a bug in Supervisor)"))
+              ),
+            done.set(true) *> cleanup
+          )
+          insertOk <- state.add(token, fiber)
+          _ <- insertResult.complete(insertOk)
+          // `cleanup` could run BEFORE the `state.add`
+          // (if `fa` is very fast), in which case it doesn't
+          // remove the fiber from the state, so we re-check:
+          _ <- done.get.ifM(cleanup, F.unit)
+          _ <- {
+            if (!insertOk) {
+              F.raiseError(new IllegalStateException("supervisor already shutdown"))
+            } else {
+              F.unit
+            }
+          }
+        } yield fiber
+      }
   }
+
 
   private[effect] def applyForConcurrent[F[_]](
       await: Boolean,
@@ -334,6 +343,9 @@ object Supervisor {
             case null => (null, false)
             case map => (map.updated(token, fiber), true)
           }
+
+        private[std] final override def numberOfFibers: F[Int] = // for testing
+          stateRef.get.map(_.size)
 
         private[this] val allFibers: F[List[Fiber[F, Throwable, ?]]] = {
           // we're closing, so we won't need the state any more,
@@ -370,6 +382,9 @@ object Supervisor {
           // shutting down anyway.
           F.delay(state.put(token, fiber)) *> doneR.get.map(!_)
         }
+
+        private[std] final override def numberOfFibers: F[Int] = // for testing
+          F.delay { state.size() }
 
         private[this] val allFibers: F[List[Fiber[F, Throwable, ?]]] =
           F delay {

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -175,10 +175,11 @@ object Supervisor {
   }
 
   private[std] final class SupervisorImpl[F[_]](
-    checkRestart: Option[Outcome[F, Throwable, ?] => Boolean],
-    doneR: Ref[F, Boolean],
-    private[std] val state: State[F],
-  )(implicit F: Concurrent[F]) extends Supervisor[F] {
+      checkRestart: Option[Outcome[F, Throwable, ?] => Boolean],
+      doneR: Ref[F, Boolean],
+      private[std] val state: State[F]
+  )(implicit F: Concurrent[F])
+      extends Supervisor[F] {
 
     def supervise[A](fa: F[A]): F[Fiber[F, Throwable, A]] =
       F.uncancelable { _ =>
@@ -288,9 +289,7 @@ object Supervisor {
 
           case None => { (fa, fin) =>
             F.start(fa).flatMap { fib =>
-              F.start(F.uncancelable { _ =>
-                fib.join.guarantee(fin)
-              }).as(fib)
+              F.start(F.uncancelable { _ => fib.join.guarantee(fin) }).as(fib)
             }
           }
         }
@@ -330,7 +329,6 @@ object Supervisor {
         } yield fiber
       }
   }
-
 
   private[effect] def applyForConcurrent[F[_]](
       await: Boolean,

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -288,9 +288,7 @@ object Supervisor {
           }
 
           case None => { (fa, fin) =>
-            F.start(fa).flatMap { fib =>
-              F.start(fib.join.guarantee(fin)).as(fib)
-            }
+            F.start(fa).flatMap { fib => F.start(fib.join.guarantee(fin)).as(fib) }
           }
         }
 

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -286,7 +286,13 @@ object Supervisor {
             }
           }
 
-          case None => (fa, fin) => F.start(fa.guarantee(fin))
+          case None => { (fa, fin) =>
+            F.start(fa).flatMap { fib =>
+              F.start(F.uncancelable { _ =>
+                fib.join.guarantee(fin)
+              }).as(fib)
+            }
+          }
         }
 
         for {

--- a/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Supervisor.scala
@@ -289,7 +289,7 @@ object Supervisor {
 
           case None => { (fa, fin) =>
             F.start(fa).flatMap { fib =>
-              F.start(F.uncancelable { _ => fib.join.guarantee(fin) }).as(fib)
+              F.start(fib.join.guarantee(fin)).as(fib)
             }
           }
         }

--- a/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
@@ -294,5 +294,26 @@ class SupervisorSpec extends BaseSpec with DetectPlatform {
 
       tsk.parReplicateA_(if (isJVM) 1000 else 1).as(ok)
     }
+
+    def superviseCancelRace(mkSupervisor: Resource[IO, Supervisor[IO]]) = {
+      val N = 1000
+      val M = 20
+      val tsk = mkSupervisor.use { supervisor =>
+        supervisor.supervise(IO.unit).flatMap(_.cancel).replicateA_(N).parReplicateA_(M).flatMap { _ =>
+          // let's wait for cleanup to happen:
+          IO.sleep(1.second) *> {
+            val st = supervisor.asInstanceOf[Supervisor.SupervisorImpl[IO]].state
+            st.numberOfFibers.flatMap { numFibs =>
+              IO(numFibs mustEqual 0)
+            }
+          }
+        }
+      }
+      tsk.as(ok)
+    }
+
+    "supervise / cancel race cleanup" in real {
+      superviseCancelRace(constructor(false, None))
+    }
   }
 }

--- a/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
@@ -315,5 +315,9 @@ class SupervisorSpec extends BaseSpec with DetectPlatform {
     "supervise / cancel race cleanup" in real {
       superviseCancelRace(constructor(false, None))
     }
+
+    "supervise / cancel race cleanup (with restart)" in real {
+      superviseCancelRace(constructor(false, Some(_ => true)))
+    }
   }
 }

--- a/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
@@ -300,9 +300,10 @@ class SupervisorSpec extends BaseSpec with DetectPlatform {
       val M = 20
       val tsk = mkSupervisor.use { supervisor =>
         supervisor.supervise(IO.unit).flatMap(_.cancel).replicateA_(N).parReplicateA_(M).flatMap { _ =>
-          // let's wait for cleanup to happen:
-          IO.sleep(1.second) *> {
+          // let's wait a bit (for cleanup to happen):
+          IO.sleep(0.2.second) *> {
             val st = supervisor.asInstanceOf[Supervisor.SupervisorImpl[IO]].state
+            // the supervised fibers must've been cleaned up from the internal state:
             st.numberOfFibers.flatMap { numFibs =>
               IO(numFibs mustEqual 0)
             }

--- a/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
@@ -296,8 +296,8 @@ class SupervisorSpec extends BaseSpec with DetectPlatform {
     }
 
     def superviseCancelRace(mkSupervisor: Resource[IO, Supervisor[IO]]) = {
-      val N = 1000
-      val M = 20
+      val N = if (isJVM) 1000 else 5
+      val M = if (isJVM) 20 else 2
       val tsk = mkSupervisor.use { supervisor =>
         supervisor
           .supervise(IO.unit)

--- a/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/SupervisorSpec.scala
@@ -299,16 +299,19 @@ class SupervisorSpec extends BaseSpec with DetectPlatform {
       val N = 1000
       val M = 20
       val tsk = mkSupervisor.use { supervisor =>
-        supervisor.supervise(IO.unit).flatMap(_.cancel).replicateA_(N).parReplicateA_(M).flatMap { _ =>
-          // let's wait a bit (for cleanup to happen):
-          IO.sleep(0.2.second) *> {
-            val st = supervisor.asInstanceOf[Supervisor.SupervisorImpl[IO]].state
-            // the supervised fibers must've been cleaned up from the internal state:
-            st.numberOfFibers.flatMap { numFibs =>
-              IO(numFibs mustEqual 0)
+        supervisor
+          .supervise(IO.unit)
+          .flatMap(_.cancel)
+          .replicateA_(N)
+          .parReplicateA_(M)
+          .flatMap { _ =>
+            // let's wait a bit (for cleanup to happen):
+            IO.sleep(0.2.second) *> {
+              val st = supervisor.asInstanceOf[Supervisor.SupervisorImpl[IO]].state
+              // the supervised fibers must've been cleaned up from the internal state:
+              st.numberOfFibers.flatMap { numFibs => IO(numFibs mustEqual 0) }
             }
           }
-        }
       }
       tsk.as(ok)
     }


### PR DESCRIPTION
Should fix issue #4490.

Reproducing that issue with the repro in the description there:
```
[info] Memory taken: 6 MB
[info] Memory taken: 520 MB
```

With this PR:
```
[info] Memory taken: 6 MB
[info] Memory taken: 7 MB
```

This issue also adds an (ugly) unittest, which inspects the internal state of the `Supervisor`. We could remove that, if we're satisfied with the fix, but I think it's useful to have it.

~~(Draft, because the test is racy, so I'm waiting for any possible CI failures.)~~