### PR TITLE
docs(#523): Automate version numbers in documentation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1221,4 +1221,22 @@ lazy val docs = project
   .in(file("site-docs"))
   .dependsOn(core.jvm)
   .enablePlugins(MdocPlugin)
-  .settings(tlFatalWarnings := { if (tlIsScala3.value) false else tlFatalWarnings.value })
+  .settings(
+    tlFatalWarnings := { if (tlIsScala3.value) false else tlFatalWarnings.value },
+    mdocVariables := {
+      import scala.sys.process._
+      val latestVersion = try {
+        val tags = "git tag --sort=-version:refname".!!.trim.split("\n")
+        val versionTags = tags.filter(_.matches("v\\d+\\.\\d+\\.\\d+.*"))
+        if (versionTags.nonEmpty) versionTags.head.drop(1) else version.value
+      } catch { case _: Exception => version.value }
+      
+      val latestVersion2x = try {
+        val tags = "git tag --sort=-version:refname".!!.trim.split("\n")
+        val version2xTags = tags.filter(_.matches("v2\\.\\d+\\.\\d+.*"))
+        if (version2xTags.nonEmpty) version2xTags.head.drop(1) else "2.5.5"
+      } catch { case _: Exception => "2.5.5" }
+      
+      Map("VERSION_3X" -> latestVersion, "VERSION_2X" -> latestVersion2x)
+    }
+  )

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ title: Getting Started
 Add the following to your **build.sbt**:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-effect" % "3.6.3"
+libraryDependencies += "org.typelevel" %% "cats-effect" % "@VERSION_3X@"
 ```
 
 Naturally, if you're using ScalaJS, you should replace the double `%%` with a triple `%%%`. If you're on Scala 2, it is *highly* recommended that you enable the [better-monadic-for](https://github.com/oleg-py/better-monadic-for) plugin, which fixes a number of surprising elements of the `for`-comprehension syntax in the Scala language:


### PR DESCRIPTION
## Description
Fixes #523 

This PR addresses the issue by implementing automatic version detection and substitution in the documentation build process.

### Testing
Verified locally that @VERSION_3X@ is correctly substituted with the current version (3.7-fd2f83f-20251010T213229Z-SNAPSHOT) during `docs/mdoc` generation.