### PR TITLE
Sync `SyncIO.realTime*` methods with `Clock` implementation

### DIFF
--- a/core/js/src/main/scala/cats/effect/SyncIOCompanionPlatform.scala
+++ b/core/js/src/main/scala/cats/effect/SyncIOCompanionPlatform.scala
@@ -19,5 +19,5 @@ package cats.effect
 import scala.scalajs.js
 
 private[effect] trait SyncIOCompanionPlatform { this: SyncIO.type =>
-  final def realTimeDate: SyncIO[js.Date] = realTime.map(d => new js.Date(d.toMillis.toDouble))
+  final def realTimeDate: SyncIO[js.Date] = syncForSyncIO.realTimeDate
 }

--- a/core/jvm-native/src/main/scala/cats/effect/SyncIOCompanionPlatform.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/SyncIOCompanionPlatform.scala
@@ -16,9 +16,11 @@
 
 package cats.effect
 
-import java.time.Instant
+import java.time.{Instant, ZonedDateTime}
 
 private[effect] trait SyncIOCompanionPlatform { this: SyncIO.type =>
-  final def realTimeInstant: SyncIO[Instant] =
-    realTime.map(d => Instant.ofEpochMilli(d.toMillis))
+
+  final def realTimeInstant: SyncIO[Instant] = syncForSyncIO.realTimeInstant
+
+  final def realTimeZonedDateTime: SyncIO[ZonedDateTime] = syncForSyncIO.realTimeZonedDateTime
 }

--- a/tests/jvm-native/src/test/scala/cats/effect/SyncIOPlatformSuite.scala
+++ b/tests/jvm-native/src/test/scala/cats/effect/SyncIOPlatformSuite.scala
@@ -16,8 +16,6 @@
 
 package cats.effect
 
-import java.time.ZoneOffset
-
 trait SyncIOPlatformSuite { self: BaseSuite =>
   def platformTests() = {
 
@@ -45,7 +43,7 @@ trait SyncIOPlatformSuite { self: BaseSuite =>
         now.getOffset.getTotalSeconds
       )
 
-      assertCompleteAsSync(op, (true, ZoneOffset.UTC.getTotalSeconds))
+      assertCompleteAsSync(op, (true, 0))
     }
 
   }

--- a/tests/jvm-native/src/test/scala/cats/effect/SyncIOPlatformSuite.scala
+++ b/tests/jvm-native/src/test/scala/cats/effect/SyncIOPlatformSuite.scala
@@ -16,6 +16,8 @@
 
 package cats.effect
 
+import java.time.ZoneOffset
+
 trait SyncIOPlatformSuite { self: BaseSuite =>
   def platformTests() = {
 
@@ -28,6 +30,22 @@ trait SyncIOPlatformSuite { self: BaseSuite =>
       } yield (now.toEpochMilli - realTime.toMillis) <= 10000
 
       assertCompleteAsSync(op, true)
+    }
+
+    testUnit(
+      "realTimeZonedDateTime should return a ZonedDateTime constructed from realTime with UTC offset") {
+
+      // Unfortunately since SyncIO doesn't use on a controllable
+      // clock source, so a diff best we can do
+      val op = for {
+        realTime <- SyncIO.realTime
+        now <- SyncIO.realTimeZonedDateTime
+      } yield (
+        (now.toInstant.toEpochMilli - realTime.toMillis) <= 10000,
+        now.getOffset.getTotalSeconds
+      )
+
+      assertCompleteAsSync(op, (true, ZoneOffset.UTC.getTotalSeconds))
     }
 
   }


### PR DESCRIPTION
Otherwise, `Clock[SyncIO].realTimeInstant` might not be the same as `SyncIO.realTimeInstant`.
Discussed [on Discord](https://discord.com/channels/632277896739946517/839263556754472990/1435348765547692052).

Also adds `SyncIO.realTimeZonedDateTime`, similar to `IO.realTimeZonedDateTime`.
