### PR TITLE
Update `race` docs for new 3.5 semantics

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -377,18 +377,16 @@ trait GenSpawn[F[_], E] extends MonadCancel[F, E] with Unique[F] {
 
   /**
    * Races the evaluation of two fibers that returns the result of the winner, except in the
-   * case of cancelation.
+   * case of cancelation which cancels the whole race.
    *
    * The semantics of [[race]] are described by the following rules:
    *
    *   1. If the winner completes with [[Outcome.Succeeded]], the race returns the successful
    *      value. The loser is canceled before returning. 2. If the winner completes with
    *      [[Outcome.Errored]], the race raises the error. The loser is canceled before
-   *      returning. 3. If the winner completes with [[Outcome.Canceled]], the race returns the
-   *      result of the loser, consistent with the first two rules. 4. If both the winner and
-   *      loser complete with [[Outcome.Canceled]], the race is canceled. 8. If the race is
-   *      masked and is canceled because both participants canceled, the fiber will block
-   *      indefinitely.
+   *      returning. 3. If the winner completes with [[Outcome.Canceled]], the loser is canceled
+   *      immediately but its outcome is returned if already completed. 4. If the race is masked
+   *      and is canceled because both participants canceled, the fiber will block indefinitely.
    *
    * @param fa
    *   the effect for the first racing fiber


### PR DESCRIPTION
I am attempting to clarify the documentation for `race` after the semantic change in 3.5.0, introduced in https://github.com/typelevel/cats-effect/pull/3453

Namely, the following is now incorrect:
> If the winner completes with [[Outcome.Canceled]], the race returns the result of the loser, consistent with the first two rules.

Nailing down this language is tricky.
With less rigidity, here's my understanding of the current behaviour:

If winner `Succeeded` we cancel loser and return winning value!
If winner `Errored` we cancel loser and raise the error.
If the winner is `Canceled`, most of the time we are going to get `Canceled` overall. The exception is if the loser has managed to also complete, at which point, we already have the loser's value, so why not dish it out.
In other words, Loser is always getting canceled, but if completed prior to that cancelation, we'll let it share its results with the world.

I admit I don't really grok the importance of rule 4 here:
> If the race is masked and is canceled because both participants canceled, the fiber will block indefinitely.

Is this a detail that users need in this documentation? I honestly don't know
