### PR TITLE
Avoid allocations when calling Resource.liftK

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -993,7 +993,7 @@ object Resource extends ResourceFOInstances0 with ResourceHOInstances0 with Reso
   def onFinalizeCase[F[_]: Applicative](release: ExitCase => F[Unit]): Resource[F, Unit] =
     unit.onFinalizeCase(release)
 
-  private val cachedLiftK: Id ~> Resource[Id, *] =
+  private[this] val cachedLiftK: Id ~> Resource[Id, *] =
     new (Id ~> Resource[Id, *]) {
       def apply[A](fa: Id[A]): Resource[Id, A] = Resource.eval(fa)
     }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -993,13 +993,16 @@ object Resource extends ResourceFOInstances0 with ResourceHOInstances0 with Reso
   def onFinalizeCase[F[_]: Applicative](release: ExitCase => F[Unit]): Resource[F, Unit] =
     unit.onFinalizeCase(release)
 
+  private val cachedLiftK: Id ~> Resource[Id, *] =
+    new (Id ~> Resource[Id, *]) {
+      def apply[A](fa: Id[A]): Resource[Id, A] = Resource.eval(fa)
+    }
+
   /**
    * Lifts an applicative into a resource as a `FunctionK`. The resource has a no-op release.
    */
   def liftK[F[_]]: F ~> Resource[F, *] =
-    new (F ~> Resource[F, *]) {
-      def apply[A](fa: F[A]): Resource[F, A] = Resource.eval(fa)
-    }
+    cachedLiftK.asInstanceOf[F ~> Resource[F, *]]
 
   /**
    * Allocates two resources concurrently, and combines their results in a tuple.


### PR DESCRIPTION
Create a cached version of liftK so avoid allocations when method Resource.liftK is called.  This is using the usual trick (relying on erasure).

This is a minor optimization (every little helps), but feel free to close the PR if you don't feel it's worth it.
