### PR TITLE
Fix `Ticker` @implicitNotFound message to reference testkit-available API

### DIFF
--- a/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
+++ b/testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala
@@ -253,7 +253,7 @@ trait TestInstances extends ParallelFGenerators with OutcomeGenerators with Sync
   }
 
   @implicitNotFound(
-    "could not find an instance of Ticker; try using `in ticked { implicit ticker =>`")
+    "could not find an instance of Ticker; try declaring one with `implicit val ticker: Ticker = Ticker()`")
   case class Ticker(ctx: TestContext = TestContext())
 }
 


### PR DESCRIPTION
Closes #1875.

The `@implicitNotFound` message on `Ticker` in `testkit/shared/src/main/scala/cats/effect/testkit/TestInstances.scala` told users to `use \`in ticked { implicit ticker =>\``. But `ticked` is defined only in `tests/shared/src/test/scala/cats/effect/Runners.scala` (and, for property-based variants, in `tests/shared/src/test/scala/cats/effect/BaseSuite.scala`) and is not part of the published `cats-effect-testkit` artifact. A downstream user picking up the message had no way to follow it.

The new message points at the constructor that testkit actually exports:

```scala
implicit val ticker: Ticker = Ticker()
```

Doc/ergonomics only; no runtime behavior affected.