### PR TITLE
Optimize `liftOutcome` in `KleisliGenSpawn` to avoid allocation

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenSpawn.scala
@@ -16,7 +16,7 @@
 
 package cats.effect.kernel
 
-import cats.{~>, Applicative, Monoid, Semigroup}
+import cats.{Applicative, Monoid, Semigroup}
 import cats.data.{EitherT, Ior, IorT, Kleisli, OptionT, WriterT}
 import cats.effect.kernel.syntax.monadCancel._
 import cats.syntax.all._
@@ -851,12 +851,11 @@ object GenSpawn {
       }
 
     private def liftOutcome[A](oc: Outcome[F, E, A]): Outcome[Kleisli[F, R, *], E, A] = {
-
-      val nat: F ~> Kleisli[F, R, *] = new ~>[F, Kleisli[F, R, *]] {
-        def apply[B](fa: F[B]) = Kleisli.liftF(fa)
+      oc match {
+        case Outcome.Canceled() => Outcome.Canceled()
+        case Outcome.Errored(e) => Outcome.Errored(e)
+        case Outcome.Succeeded(fa) => Outcome.Succeeded(Kleisli.liftF(fa))
       }
-
-      oc.mapK(nat)
     }
 
     private def liftFiber[A](fib: Fiber[F, E, A]): Fiber[Kleisli[F, R, *], E, A] =


### PR DESCRIPTION
Calling `bothOutcome` or `racePair` on a `Kleisli` evaluates `liftOutcome`, 
which currently instantiates a new `FunctionK` and routes it through `mapK`.

This commit replaces the `mapK` invocation with a direct pattern match 
on the `Outcome`. This optimization:
1. Eliminates the `FunctionK` allocation on every invocation.
2. Bypasses the evaluation overhead of `mapK`.
3. Aligns the `Kleisli` implementation with `OptionT`, `EitherT`, `IorT`, 
   and `WriterT` in `GenSpawn.scala`, which already use this exact 
   pattern-matching technique.