### PR TITLE
Optimize Parallel instance in GenSpawnInstances to avoid allocation.

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/instances/GenSpawnInstances.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/instances/GenSpawnInstances.scala
@@ -16,7 +16,7 @@
 
 package cats.effect.kernel.instances
 
-import cats.{~>, Align, Applicative, CommutativeApplicative, Functor, Monad, Parallel}
+import cats.{~>, Align, Applicative, CommutativeApplicative, Functor, Id, Monad, Parallel}
 import cats.data.Ior
 import cats.effect.kernel.{GenSpawn, ParallelF}
 import cats.implicits._
@@ -32,15 +32,9 @@ trait GenSpawnInstances {
 
       def monad: Monad[M] = M
 
-      def sequential: F ~> M =
-        new (F ~> M) {
-          def apply[A](fa: F[A]): M[A] = ParallelF.value[M, A](fa)
-        }
+      def sequential: F ~> M = GenSpawnInstances.sequential[M]
 
-      def parallel: M ~> F =
-        new (M ~> F) {
-          def apply[A](ma: M[A]): F[A] = ParallelF[M, A](ma)
-        }
+      def parallel: M ~> F = GenSpawnInstances.parallel[M]
     }
 
   implicit def commutativeApplicativeForParallelF[F[_], E](
@@ -90,4 +84,22 @@ trait GenSpawnInstances {
         )
 
     }
+}
+
+private object GenSpawnInstances {
+  private[this] val cachedSequential: ParallelF[Id, *] ~> Id =
+    new (ParallelF[Id, *] ~> Id) {
+      def apply[A](fa: ParallelF[Id, A]): Id[A] = ParallelF.value[Id, A](fa)
+    }
+
+  private def sequential[M[_]]: ParallelF[M, *] ~> M =
+    cachedSequential.asInstanceOf[ParallelF[M, *] ~> M]
+
+  private[this] val cachedParallel: Id ~> ParallelF[Id, *] =
+    new (Id ~> ParallelF[Id, *]) {
+      def apply[A](ma: Id[A]): ParallelF[Id, A] = ParallelF[Id, A](ma)
+    }
+
+  private def parallel[M[_]]: M ~> ParallelF[M, *] =
+    cachedParallel.asInstanceOf[M ~> ParallelF[M, *]]
 }


### PR DESCRIPTION
### Motivation
Currently in `GenSpawnInstances`, the `Parallel` instance provides `.parallel` and `.sequential` as `def`s that instantiate a `new (M ~> F)` and `new (F ~> M)` on every invocation. 

Because operations like `cats.Parallel.parTraverse` invoke `P.parallel(ma)` and `P.sequential(ma)` for *every item in the collection*, this creates a large number of `FunctionK` object allocations during a traversal, putting unnecessary pressure on the garbage collector.

### Changes
This PR eliminates these allocations by applying the `Id` caching technique (similar to `Resource.liftK`). 
- Extracts the `FunctionK` instances into a `private object GenSpawnInstances` to act as true JVM-wide singletons (rather than trait fields).
- Uses `asInstanceOf` to cast the cached `Id` transformations to the required effect type at the call site.

### Impact
Zero-allocation `parallel` and `sequential` transformations for all effect types that implement `GenSpawn`. This reduces the memory footprint and GC overhead on hot paths involving parallel collections processing.
