### PR TITLE
Remove unnecessary String interpolation from function showUnknown().

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Outcome.scala
@@ -127,8 +127,8 @@ private[kernel] trait LowPriorityImplicits {
   implicit def showUnknown[F[_], E, A](implicit E: Show[E]): Show[Outcome[F, E, A]] =
     Show show {
       case Canceled() => "Canceled"
-      case Errored(left) => s"Errored(${left.show})"
-      case Succeeded(_) => s"Succeeded(...)"
+      case Errored(e) => s"Errored(${e.show})"
+      case Succeeded(_) => "Succeeded(...)"
     }
 
   implicit def eq[F[_], E: Eq, A](implicit FA: Eq[F[A]]): Eq[Outcome[F, E, A]] =


### PR DESCRIPTION
Remove unnecessary String interpolation from function showUnknown().

Also rename local variable to what it really is (an error), to make this use consistent with the rest of file.
