### PR TITLE
Derive MaxEvents from PollingTicks in Epoll and Kqueue polling systems

### DIFF
--- a/core/native/src/main/scala/cats/effect/unsafe/EpollSystem.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/EpollSystem.scala
@@ -40,7 +40,7 @@ object EpollSystem extends PollingSystem {
   import epoll._
   import epollImplicits._
 
-  private[this] final val MaxEvents = 64
+  private[this] final val MaxEvents = WorkStealingThreadPoolConstants.PollingTicks
 
   type Api = FileDescriptorPoller
 

--- a/core/native/src/main/scala/cats/effect/unsafe/KqueueSystem.scala
+++ b/core/native/src/main/scala/cats/effect/unsafe/KqueueSystem.scala
@@ -39,7 +39,7 @@ object KqueueSystem extends PollingSystem {
   import event._
   import eventImplicits._
 
-  private final val MaxEvents = 64
+  private final val MaxEvents = WorkStealingThreadPoolConstants.PollingTicks
 
   type Api = Kqueue
 


### PR DESCRIPTION
Replace the magic `MaxEvents = 64` literal in `EpollSystem` and `KqueueSystem` with `WorkStealingThreadPoolConstants.PollingTicks`.

Spun out from @armanbilge's review comment on the io_uring polling system PR (#4584).