### PR TITLE
Fix issue #4489

### DIFF
--- a/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/GenConcurrent.scala
@@ -176,10 +176,11 @@ trait GenConcurrent[F[_], E] extends GenSpawn[F, E] {
             _ <- canA.join
             _ <- canB.join
           } yield ())
-      } yield back match {
-        case Left(oc) => Left((oc, fibB))
-        case Right(oc) => Right((fibA, oc))
-      }
+        result <- back match {
+          case Left(oc) => fibA.join.as(Left((oc, fibB)))
+          case Right(oc) => fibB.join.as(Right((fibA, oc)))
+        }
+      } yield result
     }
   }
 }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -621,15 +621,11 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
   def start(
       implicit
       F: Concurrent[F]): Resource[F, Fiber[Resource[F, *], Throwable, A @uncheckedVariance]] = {
-    final case class State(
-        fin: F[Unit] = F.unit,
-        finalizeOnComplete: Boolean = false,
-        confirmedFinalizeOnComplete: Boolean = false)
 
     Resource {
       import Outcome._
 
-      F.ref[State](State()) flatMap { state =>
+      F.ref[Resource.FiberState[F]](Resource.FiberState(F.unit)) flatMap { state =>
         val finalized: F[A] = F uncancelable { poll =>
           poll(this.allocated) guaranteeCase {
             // confirm that we completed and we were asked to clean up
@@ -806,6 +802,11 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
 }
 
 object Resource extends ResourceFOInstances0 with ResourceHOInstances0 with ResourcePlatform {
+
+  private final case class FiberState[F[_]](
+      fin: F[Unit],
+      finalizeOnComplete: Boolean = false,
+      confirmedFinalizeOnComplete: Boolean = false)
 
   /**
    * Creates a resource from an allocating effect.

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -631,26 +631,35 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
 
       F.ref[State](State()) flatMap { state =>
         val finalized: F[A] = F uncancelable { poll =>
-          poll(this.allocated) guarantee {
+          poll(this.allocated) guaranteeCase {
             // confirm that we completed and we were asked to clean up
             // note that this will run even if the inner effect short-circuited
-            state update { s =>
-              if (s.finalizeOnComplete)
-                s.copy(confirmedFinalizeOnComplete = true)
-              else
-                s
-            }
-          } flatMap {
-            // if the inner F has a zero, we lose the finalizers, but there's no avoiding that
-            case (a, rel) =>
-              val action = state modify { s =>
-                if (s.confirmedFinalizeOnComplete)
-                  (s, rel.handleError(_ => ()))
+            case Canceled() | Errored(_) =>
+              state.update { s =>
+                if (s.finalizeOnComplete)
+                  s.copy(confirmedFinalizeOnComplete = true)
                 else
-                  (s.copy(fin = rel), F.unit)
+                  s
               }
-
-              action.flatten.as(a)
+            case Succeeded(fp) =>
+              // if the inner F has a zero, we lose the finalizers, but there's no avoiding that
+              fp.flatMap {
+                case (_, rel) =>
+                  val action = state.modify { s =>
+                    if (s.finalizeOnComplete) {
+                      // finalize immediately
+                      (s.copy(confirmedFinalizeOnComplete = true), rel.voidError)
+                    } else {
+                      // save the finalizer for later
+                      (s.copy(fin = rel), F.unit)
+                    }
+                  }
+                  action.flatten
+              }
+          } map {
+            case (a, _) =>
+              // Note: we've already saved/used the finalizer, see above
+              a
           }
         }
 

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -663,41 +663,43 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
           }
         }
 
-        F.start(finalized).map { outer =>
-          val fiber = new Fiber[Resource[F, *], Throwable, A] {
-            def cancel =
-              Resource eval {
-                F uncancelable { poll =>
-                  // technically cancel is uncancelable, but separation of concerns and what not
-                  poll(outer.cancel) *> state.update(_.copy(finalizeOnComplete = true))
+        F.start(finalized)
+          .map { outer =>
+            val fiber = new Fiber[Resource[F, *], Throwable, A] {
+              def cancel =
+                Resource eval {
+                  F uncancelable { poll =>
+                    // technically cancel is uncancelable, but separation of concerns and what not
+                    poll(outer.cancel) *> state.update(_.copy(finalizeOnComplete = true))
+                  }
                 }
-              }
 
-            def join =
-              Resource eval {
-                outer.join.flatMap[Outcome[Resource[F, *], Throwable, A]] {
-                  case Canceled() =>
-                    Outcome.canceled[Resource[F, *], Throwable, A].pure[F]
+              def join =
+                Resource eval {
+                  outer.join.flatMap[Outcome[Resource[F, *], Throwable, A]] {
+                    case Canceled() =>
+                      Outcome.canceled[Resource[F, *], Throwable, A].pure[F]
 
-                  case Errored(e) =>
-                    Outcome.errored[Resource[F, *], Throwable, A](e).pure[F]
+                    case Errored(e) =>
+                      Outcome.errored[Resource[F, *], Throwable, A](e).pure[F]
 
-                  case Succeeded(fp) =>
-                    state.get map { s =>
-                      if (s.confirmedFinalizeOnComplete)
-                        Outcome.canceled[Resource[F, *], Throwable, A]
-                      else
-                        Outcome.succeeded(Resource.eval(fp))
-                    }
+                    case Succeeded(fp) =>
+                      state.get map { s =>
+                        if (s.confirmedFinalizeOnComplete)
+                          Outcome.canceled[Resource[F, *], Throwable, A]
+                        else
+                          Outcome.succeeded(Resource.eval(fp))
+                      }
+                  }
                 }
-              }
+            }
+
+            val finalizeOuter =
+              state.modify(s => (s.copy(finalizeOnComplete = true), s.fin)).flatten
+
+            (fiber, finalizeOuter)
           }
-
-          val finalizeOuter =
-            state.modify(s => (s.copy(finalizeOnComplete = true), s.fin)).flatten
-
-          (fiber, finalizeOuter)
-        }.uncancelable
+          .uncancelable
       }
     }
   }

--- a/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala
@@ -663,7 +663,7 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
           }
         }
 
-        F.start(finalized) map { outer =>
+        F.start(finalized).map { outer =>
           val fiber = new Fiber[Resource[F, *], Throwable, A] {
             def cancel =
               Resource eval {
@@ -697,7 +697,7 @@ sealed abstract class Resource[F[_], +A] extends Serializable {
             state.modify(s => (s.copy(finalizeOnComplete = true), s.fin)).flatten
 
           (fiber, finalizeOuter)
-        }
+        }.uncancelable
       }
     }
   }

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -1283,7 +1283,7 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
         }
       }
 
-      test.replicateA_(500).as(ok)
+      test.parReplicateA_(1000).as(ok)
     }
   }
 

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -1283,7 +1283,7 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
         }
       }
 
-      test.replicateA_(1000).as(ok)
+      test.replicateA_(500).as(ok)
     }
   }
 

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -1242,6 +1242,25 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
 
       test.replicateA_(1000).as(ok)
     }
+
+    // issue #4059 test (1) specialized to Resource
+    "propagate successful result from a completed effect" in real {
+      Resource.catsEffectTemporalForResource[IO].sleep(50.millis).as(true).uncancelable.timeout(10.millis).use { res =>
+        IO(res must beTrue)
+      }
+    }
+
+    // issue #4059 test (2) specialized to Resource
+    "propagate error from a completed effect" in real {
+      Resource.catsEffectTemporalForResource[IO].sleep(50.millis).flatMap { _ =>
+        Resource.raiseError[IO, Unit, Throwable](new RuntimeException)
+      }.uncancelable
+        .timeout(10.millis)
+        .attempt
+        .use { res =>
+          IO(res must beLike { case Left(e) => e must haveClass[RuntimeException] })
+        }
+    }
   }
 
   "attempt" >> {

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -1245,16 +1245,22 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
 
     // issue #4059 test (1) specialized to Resource
     "propagate successful result from a completed effect" in real {
-      Resource.catsEffectTemporalForResource[IO].sleep(50.millis).as(true).uncancelable.timeout(10.millis).use { res =>
-        IO(res must beTrue)
-      }
+      Resource
+        .catsEffectTemporalForResource[IO]
+        .sleep(50.millis)
+        .as(true)
+        .uncancelable
+        .timeout(10.millis)
+        .use { res => IO(res must beTrue) }
     }
 
     // issue #4059 test (2) specialized to Resource
     "propagate error from a completed effect" in real {
-      Resource.catsEffectTemporalForResource[IO].sleep(50.millis).flatMap { _ =>
-        Resource.raiseError[IO, Unit, Throwable](new RuntimeException)
-      }.uncancelable
+      Resource
+        .catsEffectTemporalForResource[IO]
+        .sleep(50.millis)
+        .flatMap { _ => Resource.raiseError[IO, Unit, Throwable](new RuntimeException) }
+        .uncancelable
         .timeout(10.millis)
         .attempt
         .use { res =>
@@ -1265,9 +1271,10 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
     // additional #4059 test for Resource
     "timeout finalizer (#4059)" in real {
       val test = IO.ref(false).flatMap { ref =>
-        val program = Resource.make(ref.set(true) *> IO.sleep(10.millis)) { _ =>
-          ref.set(false)
-        }.timeout(10.millis).use_
+        val program = Resource
+          .make(ref.set(true) *> IO.sleep(10.millis)) { _ => ref.set(false) }
+          .timeout(10.millis)
+          .use_
         program.attempt.flatMap {
           case Left(_) =>
             ref.get.ifM(IO.raiseError(new Exception("not released")), IO.unit)

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -1248,7 +1248,7 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
       Resource
         .catsEffectTemporalForResource[IO]
         .sleep(50.millis)
-        .as(true)
+        .map(_ => true)
         .uncancelable
         .timeout(10.millis)
         .use { res => IO(res must beTrue) }

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -1275,11 +1275,8 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
           .make(ref.set(true) *> IO.sleep(10.millis)) { _ => ref.set(false) }
           .timeout(10.millis)
           .use_
-        program.attempt.flatMap {
-          case Left(_) =>
-            ref.get.ifM(IO.raiseError(new Exception("not released")), IO.unit)
-          case Right(_) =>
-            IO.unit // no timeout
+        program.attempt.flatMap { _ =>
+          ref.get.ifM(IO.raiseError(new Exception("not released")), IO.unit)
         }
       }
 

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -1261,6 +1261,23 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
           IO(res must beLike { case Left(e) => e must haveClass[RuntimeException] })
         }
     }
+
+    // additional #4059 test for Resource
+    "timeout finalizer (#4059)" in real {
+      val test = IO.ref(false).flatMap { ref =>
+        val program = Resource.make(ref.set(true) *> IO.sleep(10.millis)) { _ =>
+          ref.set(false)
+        }.timeout(10.millis).use_
+        program.attempt.flatMap {
+          case Left(_) =>
+            ref.get.ifM(IO.raiseError(new Exception("not released")), IO.unit)
+          case Right(_) =>
+            IO.unit // no timeout
+        }
+      }
+
+      test.replicateA_(1000).as(ok)
+    }
   }
 
   "attempt" >> {

--- a/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
+++ b/tests/shared/src/test/scala/cats/effect/ResourceSpec.scala
@@ -1193,6 +1193,55 @@ class ResourceSpec extends BaseSpec with ScalaCheck with Discipline {
 
       run(go) == Outcome.succeeded(Some(true))
     }.pendingUntilFixed
+
+    // issue #4489 repro (1)
+    "timeout finalizer (start/release race)" in real {
+      val test: IO[Unit] = IO.ref(false).flatMap { ref =>
+        val res = Resource.make(ref.set(true))(_ => ref.set(false))
+        val timedRes = res.timeout(1.hour)
+        timedRes.use_ *> ref.get.ifM(IO.raiseError(new Exception("not released")), IO.unit)
+      }
+
+      test.replicateA_(1000).as(ok)
+    }
+
+    // issue #4489 repro (2)
+    "racePair finalizer (start/release race)" in real {
+      val test: IO[Unit] = IO.ref(false).flatMap { ref =>
+        val res = Resource.make(ref.set(true))(_ => ref.set(false))
+        val racedRes = Spawn[Resource[IO, *]].racePair(res, Resource.never)
+        racedRes.use_ *> ref.get.ifM(IO.raiseError(new Exception("not released")), IO.unit)
+      }
+
+      test.replicateA_(1000).as(ok)
+    }
+
+    // issue #4489 repro (2) variant (never actually failed)
+    "racePair finalizer (start/cancel race)" in real {
+      val test: IO[Unit] = IO.ref(false).flatMap { ref =>
+        val res = Resource.make(ref.set(true))(_ => ref.set(false))
+        val racedRes = Spawn[Resource[IO, *]].racePair(res, Resource.unit).flatMap {
+          case Left((_, fib)) => fib.cancel
+          case Right((fib, _)) => fib.cancel
+        }
+        racedRes.use_ *> ref.get.ifM(IO.raiseError(new Exception("not released")), IO.unit)
+      }
+
+      test.parReplicateA_(1000).as(ok)
+    }
+
+    // issue #4489 repro (3)
+    "racePair finalizer variant (start/release race)" in real {
+      val test: IO[Unit] = IO.ref(false).flatMap { ref =>
+        IO.deferred[Unit].flatMap { d =>
+          val res = Resource.make(ref.set(true))(_ => ref.set(false) <* d.complete(()))
+          val racedRes = Spawn[Resource[IO, *]].racePair(res, Resource.never)
+          racedRes.use_ *> ref.get.ifM(d.get, IO.unit) // hangs if finalizer doesn't run
+        }
+      }
+
+      test.replicateA_(1000).as(ok)
+    }
   }
 
   "attempt" >> {


### PR DESCRIPTION
This was obviously a can of worms, but I think I've finally fixed #4489. All three issues identified there:

1. A finalizer running "late". Two tests on this branch, `timeout finalizer (start/release race)` and `racePair finalizer (start/release race)` successfully reproduce this issue (on my machine). These tests are based on the reproducers by @armanbilge.
2. A finalizer not running at all. The test `racePair finalizer variant (start/release race)` here reproduces this issue successfully, the tests hangs (it is based on my own reproducer in the original issue).
3. The issue fixed by #4059. I've added two tests, `propagate successful result from a completed effect` and `propagate error from a completed effect`. These are variants of the tests originally added by #4059, but here specialized to `Resource`. (The approach of #4617 seems to make these tests fail/hang.)

---

First 2.: `Resource#start` previously changed the state in a `Ref` in 2 separate steps (a `guarantee`, then a `flatMap`). This leaves an opportunity for `finalizeOuter` to run between these 2 steps. The fix is to do the thing atomically (a single `modify` in a `guaranteeCase`). This fixes the hanging test specifically added for this issue.

Interestingly, the "finalizer running late" issue (1.) doesn't seem to be caused by the unintuitive behavior of `Resource`. (I remember believing last year that that was the cause, but I don't remember what convinced me of that.) Investigation now revealed, that the cause is... `GenConcurrent#racePair`. It previously didn't `join` the _winner_ fiber; the winner fiber just completed a `Deferred` in a `guaranteeCase`. But what could possibly still run after that `guaranteeCase`? I'm glad you asked. (Narrator: "nobody asked.") The state-modifying code of `Resource#start` (mentioned in the previous paragraph). Due to `racePair` not `join`ing the winner, that state-modfying code sometimes runs concurrently with anything _after_ `racePair`. The fix is for `racePair` to `join` the winner. Technically, this change also fixes 2., not just 1. (because then `finalizeOuter` becomes ordered after the state-modification. But I still think it's good to do the other fix too; atomicity is good. (Obviously, changing a fundamental thing like `racePair` is risky, so I'm interested in thoughts about whether this will bite us somewhere else. But intuitively it seems logically correct to me, that `racePair` would join the winner.)

---

An open question: a #4059 regression test, as formulated by @djspiewak [here](https://github.com/typelevel/cats-effect/pull/4617#issuecomment-4759851288) does _not_ pass with this branch. (I've added a variant here, `timeout finalizer (#4059)`, which does pass.) ~~The reason for that seems completely different: some existing [code](https://github.com/typelevel/cats-effect/blob/903caa7efc5aa3128e44da8ca9697e7ebbc58c77/kernel/shared/src/main/scala/cats/effect/kernel/Resource.scala#L679) in `Resource#start` _converts_ a `Succeeded` to a `Canceled`.~~ I did not dare change that logic, as the whole `finalizeOnComplete` and `confirmedFinalizeOnComplete` seems very intentional. What I tried to do here was to preserve the existing logic, and make it tighter wrt cancellability and atomicity. (~~This is arguably a regression in this branch. Although, arguably, the `onCancel` is in the "wrong place" in that test.~~)

---

Besides these fixes, there is another one: an additional `.uncancelable` in `Resource#start`. I was not able to actually write a test that definitively shows that is necessary, but it seems to me that it could be a problem, so I've added it.

---

Note: this is against `series/3.6.x`, as #4489 was originally reported for that. I'm not sure if we still care about 3.6.x. If not, I can retarget this for 3.7.x. If yes, we should nevertheless merge this forward, and do a 3.7.1. (After proper review, of course.)