### PR TITLE
Fix ownsPoller and ownsTimers for blocking threads

### DIFF
--- a/core/jvm-native/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -301,10 +301,10 @@ private[effect] final class WorkerThread[P <: AnyRef](
   }
 
   private[unsafe] def ownsPoller(poller: P): Boolean =
-    poller eq _poller
+    (poller eq _poller) && (!blocking)
 
   private[unsafe] def ownsTimers(timers: TimerHeap): Boolean =
-    sleepers eq timers
+    (sleepers eq timers) && (!blocking)
 
   /**
    * The run loop of the [[WorkerThread]].


### PR DESCRIPTION
This PR fixes the `ownsPoller` and `ownsTimers` methods of `WorkerThread`, to take into account blocking threads.

A blocking thread, which only very recently became blocking can still have its `_poller` field point to a poller, which is logically not its own. The reason for that is that `_poller` is only nulled out at the next iteration of the main loop of the worker thread, specifically here: https://github.com/typelevel/cats-effect/blob/a48cac09ce5d236ff1e0857bc2e2722b3a6f82b1/core/jvm-native/src/main/scala/cats/effect/unsafe/WorkerThread.scala#L798

`ownsPoller` is used by `SelectorSystem` to cancel callbacks in a smart way. Callbacks are stored in a doubly-linked list, here: https://github.com/typelevel/cats-effect/blob/a48cac09ce5d236ff1e0857bc2e2722b3a6f82b1/core/jvm/src/main/scala/cats/effect/unsafe/SelectorSystem.scala#L318

When cancelling a callback, we first check if the current thread owns the poller:
https://github.com/typelevel/cats-effect/blob/a48cac09ce5d236ff1e0857bc2e2722b3a6f82b1/core/jvm/src/main/scala/cats/effect/unsafe/SelectorSystem.scala#L141

If yes, we directly unlink the node from the linked list (`remove`). If not, we just null out the callback field (`clear`).

Due to `ownsPoller` being incorrect for a new blocker thread, that thread may "think" it owns a poller when it is executing a cancel. That can cause it to (incorrectly) unlink a node. The way this unlinking works is not thread-safe (that's why it is incorrect to call it from a non-owner thread).

---

I tried to write a test/reproducer for this, and didn't succeed. What I could confirm, is that a blocker thread can indeed (incorrectly) unlink a node which it doesn't own. I couldn't confirm this causing any observable problem.

However, my theory is that #4628 is caused by this. I can't be sure, but a non-threadsafe linked list running an append and an unlink on 2 threads simultaneously _could_, in theory, cause the append to be "lost". And that would cause something like #4628, where a fiber which should be resumed isn't. (Because the cb is not called, because it was lost from the linked list.)