### PR TITLE
Fix rendering of CE version on mobile site

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -1,6 +1,7 @@
 /* your custom css */
 
 .homeContainer code.hljs {
+  background: transparent;
   display: inline;
 }
 


### PR DESCRIPTION
Trivial fix for #4440 updating the css so in the header block we don't add a white background to each segment of the version. The `.homeContainer` class is only used for the main splash, so this doesn't meddle with any other code blocks

<img width="398" alt="fixed version" src="https://github.com/user-attachments/assets/e2f6783c-7662-4556-8c96-21001338d542" />
