### PR TITLE
O(1) cancelation for Semaphore and MiniSemaphore

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1179,7 +1179,24 @@ lazy val std = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         ProblemFilters.exclude[DirectAbstractMethodProblem](
           "cats.effect.std.AtomicCell.evalGetAndUpdate"),
         ProblemFilters.exclude[DirectAbstractMethodProblem](
-          "cats.effect.std.AtomicCell.evalUpdateAndGet")
+          "cats.effect.std.AtomicCell.evalUpdateAndGet"),
+        // introduced by #4648, O(1) cancelation for Semaphore
+        // reworked the waiter-queue bookkeeping of `Semaphore.impl`: `Request` gained a
+        // `requested`/`remaining` split and lost `of`/`n`, and the `Action`/`Wait`/`Done`
+        // ADT was removed. All of these live inside `private class impl` and are never
+        // visible to user code; they only exist as public members at the bytecode level,
+        // so the removals cannot break binary compatibility
+        ProblemFilters.exclude[DirectMissingMethodProblem]("cats.effect.std.Semaphore#impl.*"),
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "cats.effect.std.Semaphore#impl#Request.*"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "cats.effect.std.Semaphore#impl#Request.copy$default$2"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "cats.effect.std.Semaphore#impl#Request._2"),
+        ProblemFilters.exclude[MissingTypesProblem]("cats.effect.std.Semaphore$impl$Request$"),
+        ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Semaphore$impl$Action"),
+        ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Semaphore$impl$Done$"),
+        ProblemFilters.exclude[MissingClassProblem]("cats.effect.std.Semaphore$impl$Wait$")
       )
   )
   .jsSettings(

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MiniSemaphore.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MiniSemaphore.scala
@@ -63,12 +63,7 @@ private[kernel] object MiniSemaphore {
         def acquire: F[Unit] =
           F.uncancelable { poll =>
             F.deferred[Unit].flatMap { wait =>
-              val cleanup = state.update {
-                case s @ State(waiting, permits) =>
-                  if (waiting.nonEmpty)
-                    State(waiting.filterNot(_ eq wait), permits)
-                  else s
-              }
+              val cleanup = wait.complete(()).flatMap { won => if (won) F.unit else release }
 
               state.modify {
                 case State(waiting, permits) =>
@@ -84,7 +79,9 @@ private[kernel] object MiniSemaphore {
           state.flatModify {
             case State(waiting, permits) =>
               if (waiting.nonEmpty)
-                State(waiting.tail, permits) -> waiting.head.complete(()).void
+                State(waiting.tail, permits) -> waiting.head.complete(()).flatMap { granted =>
+                  if (granted) F.unit else release
+                }
               else
                 State(waiting, permits + 1) -> ().pure[F]
           }

--- a/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
+++ b/std/shared/src/main/scala/cats/effect/std/Semaphore.scala
@@ -148,14 +148,13 @@ object Semaphore {
     def requireNonNegative(n: Long): Unit =
       require(n >= 0, s"n must be nonnegative, was: $n")
 
-    case class Request(n: Long, gate: Deferred[F, Unit]) {
-      // the number of permits can change if the request is partially fulfilled
+    case class Request(requested: Long, remaining: Long, gate: Deferred[F, Unit]) {
       def sameAs(r: Request) = r.gate eq gate
-      def of(newN: Long) = Request(newN, gate)
+      def sunk = requested - remaining
+      def withRemaining(newN: Long) = copy(remaining = newN)
       def wait_ = gate.get
       def complete = gate.complete(())
     }
-    def newRequest = F.deferred[Unit].map(Request(0, _))
 
     /*
      * Invariant:
@@ -164,45 +163,44 @@ object Semaphore {
     case class State(permits: Long, waiting: Q[Request])
     def initialState = State(n, Q())
 
-    sealed trait Action
-    case object Wait extends Action
-    case object Done extends Action
-
     def semaphore(state: Ref[F, State]) =
       new Semaphore[F] { self =>
+        private[this] def reclaim(req: Request): F[Unit] =
+          state.flatModify {
+            case State(permits, waiting) =>
+              waiting.dequeueOption match {
+                case Some((head, tail)) if head sameAs req =>
+                  State(permits, tail) -> releaseN(head.sunk)
+                case _ =>
+                  State(permits, waiting) -> F.unit
+              }
+          }
+
         def acquireN(n: Long): F[Unit] = {
           requireNonNegative(n)
 
           if (n == 0) F.unit
           else
             F.uncancelable { poll =>
-              newRequest.flatMap { req =>
+              F.deferred[Unit].flatMap { gate =>
+                val req = Request(n, n, gate)
+
+                val cleanup = req.complete.flatMap { won =>
+                  if (won) reclaim(req)
+                  else releaseN(n)
+                }
+
+                val await = poll(req.wait_).onCancel(cleanup)
+
                 state.modify {
                   case State(permits, waiting) =>
-                    val (newState, decision) =
-                      if (waiting.nonEmpty) State(0, waiting enqueue req.of(n)) -> Wait
-                      else {
-                        val diff = permits - n
-                        if (diff >= 0) State(diff, Q()) -> Done
-                        else State(0, req.of(diff.abs).pure[Q]) -> Wait
-                      }
-
-                    val cleanup = state.modify {
-                      case State(permits, waiting) =>
-                        // both hold correctly even if the Request gets canceled
-                        // after having been fulfilled
-                        val permitsAcquiredSoFar = n - waiting.find(_ sameAs req).foldMap(_.n)
-                        val waitingNow = waiting.filterNot(_ sameAs req)
-                        // releaseN is commutative, the separate Ref access is ok
-                        State(permits, waitingNow) -> releaseN(permitsAcquiredSoFar)
-                    }.flatten
-
-                    val action = decision match {
-                      case Done => F.unit
-                      case Wait => poll(req.wait_).onCancel(cleanup)
+                    if (waiting.nonEmpty)
+                      State(0, waiting.enqueue(req)) -> await
+                    else {
+                      val diff = permits - n
+                      if (diff >= 0) State(diff, Q()) -> F.unit
+                      else State(0, req.withRemaining(diff.abs).pure[Q]) -> await
                     }
-
-                    newState -> action
                 }.flatten
               }
             }
@@ -217,10 +215,10 @@ object Semaphore {
               requests: Q[Request],
               wakeup: Q[Request]): (Long, Q[Request], Q[Request]) = {
             val (req, tail) = requests.dequeue
-            if (n < req.n) // partially fulfil one request
-              (0, req.of(req.n - n) +: tail, wakeup)
+            if (n < req.remaining) // partially fulfil one request
+              (0, req.withRemaining(req.remaining - n) +: tail, wakeup)
             else { // fulfil as many requests as `n` allows
-              val newN = n - req.n
+              val newN = n - req.remaining
               val newWakeup = wakeup.enqueue(req)
 
               if (tail.isEmpty || newN == 0) (newN, tail, newWakeup)
@@ -235,7 +233,22 @@ object Semaphore {
                 if (waiting.isEmpty) State(permits + n, waiting) -> F.unit
                 else {
                   val (newN, waitingNow, wakeup) = fulfil(n, waiting, Q())
-                  State(newN, waitingNow) -> wakeup.traverse_(_.complete)
+
+                  val wake = wakeup.traverse_ { req =>
+                    req.complete.flatMap { won =>
+                      if (won) F.unit
+                      else releaseN(req.requested)
+                    }
+                  }
+
+                  val sweep = waitingNow.headOption.traverse_ { req =>
+                    req.gate.tryGet.flatMap {
+                      case Some(_) => reclaim(req)
+                      case None => F.unit
+                    }
+                  }
+
+                  State(newN, waitingNow) -> (wake *> sweep)
                 }
             }
         }
@@ -245,7 +258,7 @@ object Semaphore {
         def count: F[Long] =
           state.get.map {
             case State(permits, waiting) =>
-              if (waiting.nonEmpty) -waiting.foldMap(_.n)
+              if (waiting.nonEmpty) -waiting.foldMap(_.remaining)
               else permits
           }
 

--- a/tests/shared/src/test/scala/cats/effect/kernel/MiniSemaphoreSuite.scala
+++ b/tests/shared/src/test/scala/cats/effect/kernel/MiniSemaphoreSuite.scala
@@ -92,4 +92,21 @@ class MiniSemaphoreSuite extends BaseSuite { outer =>
     assertNonTerminate(p)
   }
 
+  ticked("skip canceled waiters when releasing") { implicit ticker =>
+    val p = for {
+      sem <- MiniSemaphore[IO](1)
+      f1 <- sem.withPermit(IO.sleep(3.seconds)).start
+      _ <- IO.sleep(500.millis)
+      f2 <- sem.withPermit(IO.unit).start
+      _ <- IO.sleep(500.millis)
+      f3 <- sem.withPermit(IO.unit).start
+      _ <- IO.sleep(500.millis)
+      _ <- f2.cancel
+      _ <- f1.joinWithNever
+      _ <- f3.joinWithNever
+    } yield ()
+
+    assertCompleteAs(p, ())
+  }
+
 }

--- a/tests/shared/src/test/scala/cats/effect/std/SemaphoreSuite.scala
+++ b/tests/shared/src/test/scala/cats/effect/std/SemaphoreSuite.scala
@@ -178,6 +178,42 @@ class SemaphoreSuite extends BaseSuite { outer =>
       assertCompleteAs(op, ())
     }
 
+    ticked(s"$name skip canceled waiters when distributing permits") { implicit ticker =>
+      val op = for {
+        s <- sc(0)
+        f1 <- s.acquire.start
+        _ <- IO.sleep(1.second)
+        f2 <- s.acquire.start
+        _ <- IO.sleep(1.second)
+        f3 <- s.acquire.start
+        _ <- IO.sleep(1.second)
+        _ <- f2.cancel
+        _ <- s.releaseN(2)
+        _ <- f1.joinWithNever
+        _ <- f3.joinWithNever
+      } yield ()
+
+      assertCompleteAs(op, ())
+    }
+
+    ticked(s"$name redistribute permits sunk into a canceled waiter") { implicit ticker =>
+      val op = for {
+        s <- sc(0)
+        f1 <- s.acquire.start
+        _ <- IO.sleep(1.second)
+        f2 <- s.acquireN(2).start
+        _ <- IO.sleep(1.second)
+        f3 <- s.acquire.start
+        _ <- IO.sleep(1.second)
+        _ <- f2.cancel
+        _ <- s.releaseN(2)
+        _ <- f1.joinWithNever
+        _ <- f3.joinWithNever
+      } yield ()
+
+      assertCompleteAs(op, ())
+    }
+
     def withLock[T](n: Long, s: Semaphore[IO], check: IO[T]): IO[(Long, T)] =
       s.acquireN(n).background.surround {
         // w/o cs.shift this hangs for coreJS


### PR DESCRIPTION
Fixes #4434. Cancelation no longer filters the waiter queue (O(n) under a CAS loop, O(n²) on mass cancelation); a canceled waiter races its gate and is lazily swept by releases. Trade-offs:                                                                                                                       
  1. Canceled waiters linger in the queue until a release reaches them.                                                                                                                                          
  2. count may transiently include them.                                                                                                                                                                         
  3. Each such waiter costs one extra release pass.