### PR TITLE
Propagate fatal errors from async/cont callbacks

### DIFF
--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -865,7 +865,13 @@ private final class IOFiber[A](
             if (!shouldFinalize()) {
               /* we weren't canceled, so resume the runloop */
               val next = result match {
-                case Left(t) => failed(t, 0)
+                case Left(t) =>
+                  // Match Error/raiseError: fatal errors delivered via cont/async resume
+                  // (including IO.fromCompletableFuture) must crash rather than become
+                  // Outcome.Errored (see #4505).
+                  if (!UnsafeNonFatal(t))
+                    onFatalFailure(t)
+                  failed(t, 0)
                 case Right(a) => succeeded(a, 0)
               }
 
@@ -1405,6 +1411,10 @@ private final class IOFiber[A](
 
   private[this] def asyncContinueFailedR(): Unit = {
     val t = objectState.pop().asInstanceOf[Throwable]
+    // Match Error/raiseError: fatal errors from async callbacks must crash the process
+    // rather than complete the fiber as Outcome.Errored (see #4505).
+    if (!UnsafeNonFatal(t))
+      onFatalFailure(t)
     runLoop(failed(t, 0), runtime.cancelationCheckThreshold, runtime.autoYieldThreshold)
   }
 

--- a/ioapp-tests/src/test/scala/IOAppSpec.scala
+++ b/ioapp-tests/src/test/scala/IOAppSpec.scala
@@ -217,6 +217,26 @@ class IOAppSpec extends Specification {
         h.stdout() must not(contain("sadness"))
       }
 
+      // https://github.com/typelevel/cats-effect/issues/4505
+      "exit on fatal error from async_" in {
+        val h = platform("FatalErrorFromAsync", List.empty)
+        h.awaitStatus() mustEqual 1
+        h.stderr() must contain("Boom!")
+        h.stdout() must not(contain("sadness"))
+      }
+
+      "exit on fatal error from CompletableFuture" in {
+        if (platform == JVM) {
+          val h = platform("FatalErrorFromCompletableFuture", List.empty)
+          h.awaitStatus() mustEqual 1
+          h.stderr() must contain("Boom!")
+          h.stdout() must not(contain("sadness"))
+        } else {
+          // CompletableFuture is JVM-only
+          ok
+        }
+      }
+
       "warn on global runtime collision" in {
         val h = platform("GlobalRacingInit", List.empty)
         h.awaitStatus() mustEqual 0

--- a/tests/jvm/src/main/scala/catseffect/examplesplatform.scala
+++ b/tests/jvm/src/main/scala/catseffect/examplesplatform.scala
@@ -92,4 +92,17 @@ package examples {
     val run =
       IO.cede.foreverM.start >> IO(Thread.sleep(2.seconds.toMillis))
   }
+
+  // https://github.com/typelevel/cats-effect/issues/4505
+  object FatalErrorFromCompletableFuture extends IOApp {
+    def run(args: List[String]): IO[ExitCode] = {
+      import java.util.concurrent.CompletableFuture
+
+      IO.fromCompletableFuture(IO(CompletableFuture.runAsync(() => {
+        throw new OutOfMemoryError("Boom!")
+      })))
+        .flatMap(_ => IO.println("sadness"))
+        .as(ExitCode.Success)
+    }
+  }
 }

--- a/tests/shared/src/main/scala/catseffect/examples.scala
+++ b/tests/shared/src/main/scala/catseffect/examples.scala
@@ -131,6 +131,14 @@ package examples {
     }
   }
 
+  // https://github.com/typelevel/cats-effect/issues/4505
+  object FatalErrorFromAsync extends IOApp {
+    def run(args: List[String]): IO[ExitCode] =
+      IO.async_[Unit] { cb => cb(Left(new OutOfMemoryError("Boom!"))) }
+        .flatMap(_ => IO.println("sadness"))
+        .as(ExitCode.Success)
+  }
+
   object Canceled extends IOApp {
     def run(args: List[String]): IO[ExitCode] =
       IO.canceled.as(ExitCode.Success)


### PR DESCRIPTION
## Description

Fixes #4505

Fatal errors (`OutOfMemoryError` and other non-`UnsafeNonFatal` throwables) delivered through an async/cont resume callback were completed as `Outcome.Errored` on the fiber instead of crashing the process. That differed from `IO.raiseError(fatal)` and from fatals thrown inside `IO.delay` / `IO` thunks, which already call `onFatalFailure`.

This shows up with `IO.fromCompletableFuture` because `CompletableFuture.handle` catches the fatal and resumes with `Left(t)`, and also with a minimized form:

```scala
IO.async_[Unit] { cb => cb(Left(new OutOfMemoryError("Boom!"))) }
```

## Approach

Detect fatal errors as soon as the cont/async result is consumed by the runloop, matching the existing `Error` / `raiseError` case:

- `asyncContinueFailedR` — async resume with `Left(fatal)`
- `IOCont.Get` when the callback already completed — synchronous cont completion with `Left(fatal)`

No change to `fromCompletableFuture` itself: rethrowing inside `CompletableFuture.handle` is unnecessary once the fiber treats the resumed fatal correctly, and avoids leaving the cont suspended if the throw is mishandled on the CF thread.

Prior attempt #4512 targeted a similar issue but was closed (hanging tests / abandoned). This PR only touches the fiber paths that consume the failure.

## Testing

- Added IOApp process tests (recommended for fatals so the shared test runtime is not shut down):
  - `exit on fatal error from async_`
  - `exit on fatal error from CompletableFuture` (JVM)
- Local: `sbt ioAppTestsJVM/testOnly cats.effect.IOAppSpec` — **28 examples, 0 failure** (Temurin 21), including both new cases