### PR TITLE
Pin sbt to 1.x for Scala Steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,1 @@
+updates.pin = [ { groupId = "org.scala-sbt", artifactId = "sbt", version = "1." } ]


### PR DESCRIPTION
Steward keeps opening sbt 2.x bumps like #4657, and a major sbt migration isn't something a bot PR can land. This pins `org.scala-sbt:sbt` to the 1.x line, so 1.x updates still come through and the 2.0.x ones stop.

Whenever the sbt 2 migration happens, it can be done by hand and the pin dropped.