### PR TITLE
Update documentation for MonadCancel's `guarantee` and `guaranteeCase`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1015,7 +1015,7 @@ lazy val tests: CrossProject = crossProject(JSPlatform, JVMPlatform, NativePlatf
     Compile / mainClass := Some("catseffect.examples.JSRunner"),
     // The default configured mapSourceURI is used for trace filtering
     scalacOptions ~= { _.filterNot(_.startsWith("-P:scalajs:mapSourceURI")) },
-    Test / scalaJSLinkerConfig ~= { _.withOptimizer(false) }    // scala-js/scala-js#5331
+    Test / scalaJSLinkerConfig ~= { _.withOptimizer(false) } // scala-js/scala-js#5331
   )
   .jvmSettings(
     fork := true,

--- a/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
+++ b/kernel/shared/src/main/scala/cats/effect/kernel/MonadCancel.scala
@@ -331,9 +331,9 @@ trait MonadCancel[F[_], E] extends MonadError[F, E] {
    * [[cats.MonadError!.onError onError]], and [[MonadCancel!.onCancel onCancel]].
    *
    * @param fa
-   *   The effect that is run after `fin` is registered.
+   *   The effect that is run with the guaranteed finalizer `fin`.
    * @param fin
-   *   The effect to run in the event of a cancelation or error.
+   *   The effect to run unconditionally on completion of `fa`.
    *
    * @see
    *   [[guaranteeCase]] for a more powerful variant
@@ -352,7 +352,7 @@ trait MonadCancel[F[_], E] extends MonadError[F, E] {
    * [[cats.MonadError!.onError onError]], and [[MonadCancel!.onCancel onCancel]].
    *
    * @param fa
-   *   The effect that is run after `fin` is registered.
+   *   The effect that is run, finalized by the effect chosen based on the outcome by `fin`.
    * @param fin
    *   A function that returns the effect to run based on the outcome.
    *


### PR DESCRIPTION
Minor documentation clarifications for `guarantee` and `guaranteeCase` on `MonadCancel`.

When I ran `sbt prPR` it also made a tiny formatting change in the build. I'm happy to drop that commit from the PR if requested.